### PR TITLE
Azure Monitor Exporter - Refactor OpenTelemetry Resource

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -18,8 +18,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
-        private readonly ResourceParser _resourceParser;
         private readonly AzureMonitorPersistentStorage _persistentStorage;
+        private AzureMonitorResource _resource;
 
         public AzureMonitorLogExporter(AzureMonitorExporterOptions options, TokenCredential credential = null) : this(new AzureMonitorTransmitter(options, credential))
         {
@@ -29,13 +29,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             _transmitter = transmitter;
             _instrumentationKey = transmitter.InstrumentationKey;
-            _resourceParser = new ResourceParser();
 
             if (transmitter is AzureMonitorTransmitter azureMonitorTransmitter && azureMonitorTransmitter._fileBlobProvider != null)
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
         }
+
+        internal AzureMonitorResource LogResource => _resource ??= ParentProvider.GetResource().UpdateRoleNameAndInstance();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<LogRecord> batch)
@@ -47,13 +48,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
-                {
-                    var resource = ParentProvider.GetResource();
-                    _resourceParser.UpdateRoleNameAndInstance(resource);
-                }
-
-                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
+                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey);
                 var exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
                 _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -18,8 +18,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
-        private readonly ResourceParser _resourceParser;
         private readonly AzureMonitorPersistentStorage _persistentStorage;
+        private AzureMonitorResource _resource;
 
         public AzureMonitorMetricExporter(AzureMonitorExporterOptions options, TokenCredential credential = null) : this(new AzureMonitorTransmitter(options, credential))
         {
@@ -29,13 +29,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             _transmitter = transmitter;
             _instrumentationKey = transmitter.InstrumentationKey;
-            _resourceParser = new ResourceParser();
 
             if (transmitter is AzureMonitorTransmitter azureMonitorTransmitter && azureMonitorTransmitter._fileBlobProvider != null)
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
         }
+
+        internal AzureMonitorResource MetricResource => _resource ??= ParentProvider.GetResource().UpdateRoleNameAndInstance();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Metric> batch)
@@ -52,12 +53,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 // even if there are no items in batch
                 if (batch.Count > 0)
                 {
-                    if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
-                    {
-                        var resource = ParentProvider.GetResource();
-                        _resourceParser.UpdateRoleNameAndInstance(resource);
-                    }
-                    var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
+                    var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, MetricResource, _instrumentationKey);
                     exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -18,8 +18,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
-        private readonly ResourceParser _resourceParser;
         private readonly AzureMonitorPersistentStorage _persistentStorage;
+        private AzureMonitorResource _resource;
 
         public AzureMonitorTraceExporter(AzureMonitorExporterOptions options, TokenCredential credential = null) : this(new AzureMonitorTransmitter(options, credential))
         {
@@ -29,13 +29,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             _transmitter = transmitter;
             _instrumentationKey = transmitter.InstrumentationKey;
-            _resourceParser = new ResourceParser();
 
             if (transmitter is AzureMonitorTransmitter azureMonitorTransmitter && azureMonitorTransmitter._fileBlobProvider != null)
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
         }
+
+        internal AzureMonitorResource TraceResource => _resource ??= ParentProvider.GetResource().UpdateRoleNameAndInstance();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Activity> batch)
@@ -47,13 +48,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                if (_resourceParser.RoleName is null && _resourceParser.RoleInstance is null)
-                {
-                    var resource = ParentProvider.GetResource();
-                    _resourceParser.UpdateRoleNameAndInstance(resource);
-                }
-
-                var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, _resourceParser.RoleName, _resourceParser.RoleInstance, _instrumentationKey);
+                var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, TraceResource, _instrumentationKey);
                 var exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
                 _persistentStorage?.StopExporterTimerAndTransmitFromStorage();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class TelemetryItem
     {
-        public TelemetryItem(Activity activity, ref TagEnumerationState monitorTags, string roleName, string roleInstance, string instrumentationKey) :
+        public TelemetryItem(Activity activity, ref TagEnumerationState monitorTags, AzureMonitorResource resource, string instrumentationKey) :
             this(activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency", FormatUtcTimestamp(activity.StartTimeUtc))
         {
             if (activity.ParentSpanId != default)
@@ -41,7 +41,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 Tags[ContextTagKeys.AiLocationIp.ToString()] = TraceHelper.GetLocationIp(ref monitorTags.MappedTags);
             }
 
-            SetResourceSdkVersionAndIkey(roleName, roleInstance, instrumentationKey);
+            SetResourceSdkVersionAndIkey(resource, instrumentationKey);
             if (AzMonList.GetTagValue(ref monitorTags.MappedTags, "sampleRate") is float sampleRate)
             {
                 SampleRate = sampleRate;
@@ -75,7 +75,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             SampleRate = telemetryItem.SampleRate;
         }
 
-        public TelemetryItem (LogRecord logRecord, string roleName, string roleInstance, string instrumentationKey) :
+        public TelemetryItem (LogRecord logRecord, AzureMonitorResource resource, string instrumentationKey) :
             this(logRecord.Exception != null ? "Exception" : "Message", FormatUtcTimestamp(logRecord.Timestamp))
         {
             if (logRecord.TraceId != default)
@@ -89,20 +89,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             }
 
             InstrumentationKey = instrumentationKey;
-            SetResourceSdkVersionAndIkey(roleName, roleInstance, instrumentationKey);
+            SetResourceSdkVersionAndIkey(resource, instrumentationKey);
         }
 
-        public TelemetryItem(DateTime time, string roleName, string roleInstance, string instrumentationKey) : this("Metric", FormatUtcTimestamp(time))
+        public TelemetryItem(DateTime time, AzureMonitorResource resource, string instrumentationKey) : this("Metric", FormatUtcTimestamp(time))
         {
-            SetResourceSdkVersionAndIkey(roleName, roleInstance, instrumentationKey);
+            SetResourceSdkVersionAndIkey(resource, instrumentationKey);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetResourceSdkVersionAndIkey(string roleName, string roleInstance, string instrumentationKey)
+        private void SetResourceSdkVersionAndIkey(AzureMonitorResource resource, string instrumentationKey)
         {
             InstrumentationKey = instrumentationKey;
-            Tags[ContextTagKeys.AiCloudRole.ToString()] = roleName;
-            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = roleInstance;
+            Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName;
+            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance;
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion;
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     internal class AzureMonitorResource
     {
-        internal string RoleName { get; set; }
+        internal string? RoleName { get; set; }
 
-        internal string RoleInstance { get; set; }
+        internal string? RoleInstance { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable // TODO: remove and fix errors
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    internal class AzureMonitorResource
+    {
+        internal string RoleName { get; set; }
+
+        internal string RoleInstance { get; set; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -26,14 +26,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private static readonly ConcurrentDictionary<int, string> DepthCache = new ConcurrentDictionary<int, string>();
         private static readonly Func<int, string> ConvertDepthToStringRef = ConvertDepthToString;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, string roleName, string roleInstance, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource resource, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
 
             foreach (var logRecord in batchLogRecord)
             {
-                telemetryItem = new TelemetryItem(logRecord, roleName, roleInstance, instrumentationKey);
+                telemetryItem = new TelemetryItem(logRecord, resource, instrumentationKey);
                 if (logRecord.Exception != null)
                 {
                     telemetryItem.Data = new MonitorBase

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
@@ -14,14 +14,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         private const int Version = 2;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorMetrics(Batch<Metric> batch, string roleName, string roleInstance, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorMetrics(Batch<Metric> batch, AzureMonitorResource resource, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new();
             foreach (var metric in batch)
             {
                 foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
-                    telemetryItems.Add(new TelemetryItem(metricPoint.EndTime.UtcDateTime, roleName, roleInstance, instrumentationKey)
+                    telemetryItems.Add(new TelemetryItem(metricPoint.EndTime.UtcDateTime, resource, instrumentationKey)
                     {
                         Data = new MonitorBase
                         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -1,32 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Net;
-
-using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-
 using OpenTelemetry.Resources;
 
-namespace Azure.Monitor.OpenTelemetry.Exporter
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
-    internal class ResourceParser
+    internal static class ResourceExtensions
     {
-        internal string RoleName { get; private set; }
-
-        internal string RoleInstance { get; private set; }
-
-        internal void UpdateRoleNameAndInstance(Resource resource)
+        internal static AzureMonitorResource? UpdateRoleNameAndInstance(this Resource resource)
         {
             if (resource == null)
             {
-                return;
+                return null;
             }
 
-            string serviceName = null;
-            string serviceNamespace = null;
+            AzureMonitorResource resourceParser = new AzureMonitorResource();
+            string? serviceName = null;
+            string? serviceNamespace = null;
 
             foreach (var attribute in resource.Attributes)
             {
@@ -40,31 +32,33 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 }
                 else if (attribute.Key == SemanticConventions.AttributeServiceInstance && attribute.Value is string)
                 {
-                    RoleInstance = attribute.Value.ToString();
+                    resourceParser.RoleInstance = attribute.Value.ToString();
                 }
             }
 
             // TODO: Check if service.name as unknown_service should be sent.
             if (serviceName != null && serviceNamespace != null)
             {
-                RoleName = string.Concat(serviceNamespace, "/", serviceName);
+                resourceParser.RoleName = string.Concat(serviceNamespace, "/", serviceName);
             }
             else
             {
-                RoleName = serviceName;
+                resourceParser.RoleName = serviceName;
             }
 
-            if (RoleInstance == null)
+            if (resourceParser.RoleInstance == null)
             {
                 try
                 {
-                    RoleInstance = Dns.GetHostName();
+                    resourceParser.RoleInstance = Dns.GetHostName();
                 }
                 catch (Exception ex)
                 {
                     AzureMonitorExporterEventSource.Log.WriteError("ErrorInitializingRoleInstanceToHostName", ex);
                 }
             }
+
+            return resourceParser;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -21,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private const int Version = 2;
         private const int MaxlinksAllowed = 100;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorTrace(Batch<Activity> batchActivity, string roleName, string roleInstance, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorTrace(Batch<Activity> batchActivity, AzureMonitorResource resource, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
@@ -29,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             foreach (var activity in batchActivity)
             {
                 var monitorTags = EnumerateActivityTags(activity);
-                telemetryItem = new TelemetryItem(activity, ref monitorTags, roleName, roleInstance, instrumentationKey);
+                telemetryItem = new TelemetryItem(activity, ref monitorTags, resource, instrumentationKey);
 
                 // Check for Exceptions events
                 if (activity.Events.Any())

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -204,12 +204,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 logger.LogWarning(new Exception("Test Exception"), "Test Exception");
             }
 
-            var telemetryItem = LogsHelper.OtelToAzureMonitorLogs(new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count), "roleName", "roleInstance", "Ikey");
+            var logResource = new AzureMonitorResource()
+            {
+                RoleName = "roleName",
+                RoleInstance = "roleInstance"
+            };
+            var telemetryItem = LogsHelper.OtelToAzureMonitorLogs(new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count), logResource, "Ikey");
 
             Assert.Equal(type, telemetryItem[0].Data.BaseType);
             Assert.Equal("Ikey", telemetryItem[0].InstrumentationKey);
-            Assert.Equal("roleName", telemetryItem[0].Tags[ContextTagKeys.AiCloudRole.ToString()]);
-            Assert.Equal("roleInstance", telemetryItem[0].Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
+            Assert.Equal(logResource.RoleName, telemetryItem[0].Tags[ContextTagKeys.AiCloudRole.ToString()]);
+            Assert.Equal(logResource.RoleInstance, telemetryItem[0].Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricHelperTests.cs
@@ -32,12 +32,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             doubleCounter.Add(123.45);
             provider.ForceFlush();
 
-            var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(new Batch<Metric>(metrics.ToArray(), 1), "testRoleName", "testRoleInstance", "00000000-0000-0000-0000-000000000000");
+            var metricResource = new AzureMonitorResource()
+            {
+                RoleName = "testRoleName",
+                RoleInstance = "testRoleInstance"
+            };
+            var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(new Batch<Metric>(metrics.ToArray(), 1), metricResource, "00000000-0000-0000-0000-000000000000");
             Assert.Single(telemetryItems);
             Assert.Equal("MetricData", telemetryItems[0].Data.BaseType);
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItems[0].InstrumentationKey);
-            Assert.Equal("testRoleName", telemetryItems[0].Tags[ContextTagKeys.AiCloudRole.ToString()]);
-            Assert.Equal("testRoleInstance", telemetryItems[0].Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
+            Assert.Equal(metricResource.RoleName, telemetryItems[0].Tags[ContextTagKeys.AiCloudRole.ToString()]);
+            Assert.Equal(metricResource.RoleInstance, telemetryItems[0].Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
 
             var metricsData = (MetricsData)telemetryItems[0].Data.BaseData;
             Assert.Equal(2, metricsData.Version);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -191,7 +191,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         private static TelemetryItem CreateTelemetryItem(Activity activity)
         {
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            return new TelemetryItem(activity, ref monitorTags, null, null, null);
+            return new TelemetryItem(activity, ref monitorTags, null, null);
         }
 
         private class MockFileProvider : PersistentBlobProvider

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -5,87 +5,81 @@
 
 using System.Collections.Generic;
 using System.Net;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using OpenTelemetry.Resources;
 using Xunit;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 {
-    public class ResourceParserTests
+    public class ResourceExtensionsTests
     {
         [Fact]
         public void NullResource()
         {
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(null);
+            Resource resource = null;
+            var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.Null(resourceParser.RoleName);
-            Assert.Null(resourceParser.RoleInstance);
+            Assert.Null(azMonResource);
         }
 
         [Fact]
         public void DefaultResource()
         {
             var resource = CreateTestResource();
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
+            var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.StartsWith("unknown_service", resourceParser.RoleName);
-            Assert.Equal(Dns.GetHostName(), resourceParser.RoleInstance);
+            Assert.StartsWith("unknown_service", azMonResource.RoleName);
+            Assert.Equal(Dns.GetHostName(), azMonResource.RoleInstance);
         }
 
         [Fact]
         public void ServiceNameFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service");
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
+            var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.Equal("my-service", resourceParser.RoleName);
-            Assert.Equal(Dns.GetHostName(), resourceParser.RoleInstance);
+            Assert.Equal("my-service", azMonResource.RoleName);
+            Assert.Equal(Dns.GetHostName(), azMonResource.RoleInstance);
         }
 
         [Fact]
         public void ServiceInstanceFromResource()
         {
             var resource = CreateTestResource(serviceInstance: "my-instance");
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
+            var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.StartsWith("unknown_service", resourceParser.RoleName);
-            Assert.Equal("my-instance", resourceParser.RoleInstance);
+            Assert.StartsWith("unknown_service", azMonResource.RoleName);
+            Assert.Equal("my-instance", azMonResource.RoleInstance);
         }
 
         [Fact]
         public void ServiceNamespaceFromResource()
         {
             var resource = CreateTestResource(serviceNamespace: "my-namespace");
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
+            var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.StartsWith("[my-namespace]/unknown_service", resourceParser.RoleName);
-            Assert.Equal(Dns.GetHostName(), resourceParser.RoleInstance);
+            Assert.StartsWith("[my-namespace]/unknown_service", azMonResource.RoleName);
+            Assert.Equal(Dns.GetHostName(), azMonResource.RoleInstance);
         }
 
         [Fact]
         public void ServiceNameAndInstanceFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
+            var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.Equal("my-service", resourceParser.RoleName);
-            Assert.Equal("my-instance", resourceParser.RoleInstance);
+            Assert.Equal("my-service", azMonResource.RoleName);
+            Assert.Equal("my-instance", azMonResource.RoleInstance);
         }
 
         [Fact]
         public void ServiceNameAndInstanceAndNamespaceFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service", serviceNamespace: "my-namespace", serviceInstance: "my-instance");
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
+            var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.Equal("[my-namespace]/my-service", resourceParser.RoleName);
-            Assert.Equal("my-instance", resourceParser.RoleInstance);
+            Assert.Equal("[my-namespace]/my-service", azMonResource.RoleName);
+            Assert.Equal("my-instance", azMonResource.RoleInstance);
         }
 
         /// <summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 tags: new Dictionary<string, object>() { ["sampleRate"] = SampleRate });
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, "RoleName", "RoleInstance", "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, "00000000-0000-0000-0000-000000000000");
             var expTelemetryItem = new TelemetryItem("Exception", telemetryItem, default, default, default);
 
             if (SampleRate is float)
@@ -86,7 +86,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 tags: new Dictionary<string, object>() { ["sampleRate"] = SampleRate });
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, "RoleName", "RoleInstance", "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, "00000000-0000-0000-0000-000000000000");
 
             if (SampleRate is float)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -46,9 +46,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var traceResource = resource.UpdateRoleNameAndInstance();
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -73,9 +72,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
 
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var traceResource = resource.UpdateRoleNameAndInstance();
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -98,10 +96,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var traceResource = resource.UpdateRoleNameAndInstance();
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -124,7 +120,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
-            var resource = CreateTestResource();
 
             activity.DisplayName = "/getaction";
 
@@ -143,7 +138,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             }
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.Equal(expectedOperationName, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -157,7 +152,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
-            var resource = CreateTestResource();
 
             activity.DisplayName = "displayname";
 
@@ -165,7 +159,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/path?id=1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.Equal("GET /path", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -179,12 +173,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Server,
                 null,
                 startTime: DateTime.UtcNow);
-            var resource = CreateTestResource();
 
             activity.DisplayName = "displayname";
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.Equal("displayname", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -202,7 +195,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpClientIP, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -220,7 +213,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeNetPeerIp, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -239,7 +232,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUserAgent, userAgent);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.Equal(userAgent, telemetryItem.Tags["ai.user.userAgent"]);
         }
@@ -255,7 +248,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.Null(telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -271,7 +264,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
 
             Assert.False(telemetryItem.Tags.TryGetValue("ai.user.userAgent", out var userAgent));
         }
@@ -288,10 +281,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var traceResource = resource.UpdateRoleNameAndInstance();
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(Dns.GetHostName(), telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
         }
@@ -308,10 +299,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(null, null, "serviceinstance");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-
-            var resourceParser = new ResourceParser();
-            resourceParser.UpdateRoleNameAndInstance(resource);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, resourceParser.RoleName, resourceParser.RoleInstance, "00000000-0000-0000-0000-000000000000");
+            var traceResource = resource.UpdateRoleNameAndInstance();
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("serviceinstance", telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
         }
@@ -334,7 +323,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, httpMethod);
             }
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
             var requestData = new RequestData(2, activity, ref monitorTags);
 
             Assert.Equal(requestData.Name, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
@@ -234,8 +234,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Activity[] activityList = new Activity[1];
             activityList[0] = activity;
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
+            var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, "roleName", "roleInstance", "00000000-0000-0000-0000-000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(2, telemetryItems.Count());
             Assert.Equal("Exception", telemetryItems[0].Name);
@@ -266,8 +267,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Activity[] activityList = new Activity[1];
             activityList[0] = activity;
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
+            var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, "roleName", "roleInstance", "00000000-0000-0000-0000-000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(2, telemetryItems.Count());
             Assert.Equal("Message", telemetryItems[0].Name);
@@ -294,8 +296,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Activity[] activityList = new Activity[1];
             activityList[0] = activity;
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
+            var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, "roleName", "roleInstance", "00000000 - 0000 - 0000 - 0000 - 000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000 - 0000 - 0000 - 0000 - 000000000000");
 
             Assert.Single(telemetryItems);
             Assert.Equal("Request", (IEnumerable<char>)telemetryItems[0].Name);
@@ -324,8 +327,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Activity[] activityList = new Activity[1];
             activityList[0] = activity;
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
+            var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, "roleName", "roleInstance", "00000000 - 0000 - 0000 - 0000 - 000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000 - 0000 - 0000 - 0000 - 000000000000");
 
             Assert.Single(telemetryItems);
             Assert.Equal("Request", telemetryItems[0].Name);


### PR DESCRIPTION
- Moved Resource extraction outside of `Export` method
- Split `ResourceParser` into 2 different classes `ResourceExtensions` and `AzureMonitorResource`
- Modified string parameters of rolename and roleinstance to `AzureMonitorResource` in all 3 exporters
- Updated tests
