### PR TITLE
Update snippet-generator

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,6 +2,12 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "Azure.Sdk.Tools.SnippetGenerator": {
+      "version": "1.0.0-dev.20230124.1",
+      "commands": [
+        "snippet-generator"
+      ]
+    },
     "dotnet-reportgenerator-globaltool": {
       "version": "4.8.0",
       "commands": [

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -182,7 +182,7 @@ jobs:
         inputs:
           command: custom
           custom: 'tool'
-          arguments: 'install --global --add-source "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" --version "1.0.0-dev.20211119.1" "Azure.Sdk.Tools.SnippetGenerator"'
+          arguments: 'restore'
           workingDirectory: '$(Agent.BuildDirectory)'
 
       - task: PowerShell@2

--- a/eng/scripts/Update-Snippets.ps1
+++ b/eng/scripts/Update-Snippets.ps1
@@ -5,43 +5,23 @@ param (
     [string] $ServiceDirectory,
 
     [Parameter()]
-    [switch] $StrictMode,
-
-    [Parameter()]
-    [string] $SnippetToolPath=''
+    [switch] $StrictMode = !(Test-Path Env:TF_BUILD)
 )
 
 $root = "$PSScriptRoot/../../sdk"
 
 # special casing * here because single invocation of SnippetGenerator is much faster than
 # running it per service directory
-if ($ServiceDirectory -and ($ServiceDirectory -ne "*")) {
+if ($ServiceDirectory -and ($ServiceDirectory -ne '*')) {
     $root += '/' + $ServiceDirectory
 }
 
-if (-not (Test-Path Env:TF_BUILD)) 
-{
-    $StrictMode = $true
-
-    dotnet tool install --global `
-    --add-source "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" `
-    --version "1.0.0-dev.20211119.1" `
-    "Azure.Sdk.Tools.SnippetGenerator"
-}
-else
-{
-    if ($Env:AGENT_OS -match "Windows.*")
-    {
-        $SnippetToolPath = "%USERPROFILE%\.dotnet\tools\"
-    }
-    else
-    {
-        $SnippetToolPath = "$HOME/.dotnet/tools/"
-    }
+[string[]] $additionalArgs = @()
+if ($StrictMode) {
+    $additionalArgs += '-sm'
 }
 
-if($StrictMode) {
-    Resolve-Path "$root" | %{ & "${SnippetToolPath}snippet-generator" -b "$_" -sm}
-} else {
-    Resolve-Path "$root" | %{ & "${SnippetToolPath}snippet-generator" -b "$_" }
+dotnet tool restore
+Resolve-Path $root | ForEach-Object {
+    dotnet tool run snippet-generator -b "$_" $additionalArgs
 }

--- a/sdk/template/.content/packageResource/README.md
+++ b/sdk/template/.content/packageResource/README.md
@@ -63,6 +63,7 @@ You can familiarize yourself with different APIs using [Samples](https://github.
 You can create a client and call the client's `<operation>` method.
 
 ```C# Snippet:Azure_Template_Scenario
+Console.WriteLine("Hello, world!");
 ```
 
 ## Troubleshooting

--- a/sdk/template/.content/samples/Sample1_HelloWorld.md
+++ b/sdk/template/.content/samples/Sample1_HelloWorld.md
@@ -6,10 +6,7 @@ To use these samples, you'll first need to set up resources. See [getting starte
 
 You can create a client and call the client's `<operation>` method
 
-```C# Snippet:Azure_Template_Scenario
-```
-
-To see the full example source files, see:
-* [HelloWorld](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/template/Azure.Template/tests/Samples/Sample1_HelloWorld.cs))
-
 <!-- please refer to <SampleReadmeLink> to write sample readme file. -->
+```C# Snippet:Azure_Template_Scenario
+Console.WriteLine("Hello, world!");
+```

--- a/sdk/template/.content/samples/Sample1_HelloWorldAsync.md
+++ b/sdk/template/.content/samples/Sample1_HelloWorldAsync.md
@@ -6,10 +6,7 @@ To use these samples, you'll first need to set up resources. See [getting starte
 
 You can create a client and call the client's `<operation>` method
 
-```C# Snippet:Azure_Template_ScenarioAsync
-```
-
-To see the full example source files, see:
-* [HelloWorld](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/template/Azure.Template/tests/Samples/Sample1_HelloWorldAsync.cs))
-
 <!-- please refer to <AsyncSampleReadmeLink> to write sample readme file. -->
+```C# Snippet:Azure_Template_ScenarioAsync
+Console.WriteLine("Hello, world!");
+```

--- a/sdk/template/.content/tests/Samples/Sample1_HelloWorld.cs
+++ b/sdk/template/.content/tests/Samples/Sample1_HelloWorld.cs
@@ -14,8 +14,13 @@ namespace Azure.Template.Tests.Samples
     public partial class TemplateSamples: SamplesBase<TemplateClientTestEnvironment>
     {
         /* please refer to SamplesLink to write samples. */
-        #region Snippet:Azure_Template_Scenario
-
-        #endregion
+        [Test]
+        [SyncOnly]
+        public void Scenario()
+        {
+            #region Snippet:Azure_Template_Scenario
+            Console.WriteLine("Hello, world!");
+            #endregion
+        }
     }
 }

--- a/sdk/template/.content/tests/Samples/Sample1_HelloWorldAsync.cs
+++ b/sdk/template/.content/tests/Samples/Sample1_HelloWorldAsync.cs
@@ -14,8 +14,15 @@ namespace Azure.Template.Tests.Samples
     public partial class TemplateSamples: SamplesBase<TemplateClientTestEnvironment>
     {
         /* please refer to AsyncSamplesLink to write samples. */
-        #region Snippet:Azure_Template_ScenarioAsync
+        [Test]
+        [AsyncOnly]
+        public async Task ScenarioAsync()
+        {
+            #region Snippet:Azure_Template_ScenarioAsync
+            Console.WriteLine("Hello, world!");
+            #endregion
 
-        #endregion
+            await Task.Yield();
+        }
     }
 }


### PR DESCRIPTION
Pulls in the fix for Azure/azure-sdk-tools#5207 and fixes Azure/azure-sdk-tools#1991 while making sure snippet-generator is always updated. It wasn't before because `dotnet tool install` will not upgrade an installed tool and the .NET SDK team decided to add `dotnet tool update` in favor of adding a `--force` to `dotnet tool install`, thus making installation and updating more complicated.

Instead, `dotnet tool restore` does both and is fast if the tool is already installed. Additionally, running most (or any?) `dotnet` commands restores the tool automatically.