### PR TITLE
Clarify that Verbose logging level is needed to log content

### DIFF
--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -42,6 +42,9 @@ using AzureEventSourceListener traceListener = AzureEventSourceListener.CreateTr
 By default only URI and headers are logged. To enable content logging, set the `Diagnostics.IsLoggingContentEnabled` client option:
 
 ```C# Snippet:LoggingContent
+// Content is logged as Verbose event level
+using AzureEventSourceListener listener = AzureEventSourceListener.CreateTraceLogger(EventLevel.Verbose);
+
 SecretClientOptions options = new SecretClientOptions()
 {
     Diagnostics =

--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -39,7 +39,7 @@ using AzureEventSourceListener traceListener = AzureEventSourceListener.CreateTr
 
 ### Enabling content logging
 
-By default only URI and headers are logged. To enable content logging, set the `Diagnostics.IsLoggingContentEnabled` client option:
+By default only URI and headers are logged. To enable content logging, set the `Diagnostics.IsLoggingContentEnabled` client option and specify a minimum log level of `Verbose`.
 
 ```C# Snippet:LoggingContent
 // Content is logged as Verbose event level


### PR DESCRIPTION
Clarifying that content logging uses Verbose logging level will save time to developers