### PR TITLE
Ignore intermittent throttling

### DIFF
--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestBase.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestBase.cs
@@ -14,6 +14,7 @@ namespace Azure.AI.Language.Conversations.Tests
         ConversationsClientOptions.ServiceVersion.V2022_10_01_Preview,
         ConversationsClientOptions.ServiceVersion.V2022_05_15_Preview,
         ConversationsClientOptions.ServiceVersion.V2022_05_01)]
+    [IgnoreServiceError(429, "429")]
     public abstract class ConversationAnalysisTestBase<TClient> : RecordedTestBase<ConversationAnalysisTestEnvironment> where TClient : class
     {
         protected ConversationAnalysisTestBase(bool isAsync, ConversationsClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode)

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Infrastructure/QuestionAnsweringTestBase.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Infrastructure/QuestionAnsweringTestBase.cs
@@ -13,6 +13,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests
     [ClientTestFixture(
         QuestionAnsweringClientOptions.ServiceVersion.V2021_10_01
     )]
+    [IgnoreServiceError(429, "429")]
     public abstract class QuestionAnsweringTestBase<TClient> : RecordedTestBase<QuestionAnsweringTestEnvironment> where TClient : class
     {
         protected QuestionAnsweringTestBase(bool isAsync, QuestionAnsweringClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode)


### PR DESCRIPTION
Get 2 or 3 429s a night with Cognitive Language SDKs, but everything else works currently.
