### PR TITLE
[DevCenter] Azure.Developer.DevCenter 1.0.0-beta.2

### DIFF
--- a/sdk/devcenter/Azure.Developer.DevCenter/CHANGELOG.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## 1.0.0-beta.2 (2023-02-07)
 This release updates the Azure DevCenter library to use the 2022-11-11-preview API.
 
-### Features Added
+### Breaking Changes
 
 - `DevBoxClient`, `DevCenterClient`, and `EnvironmentsClient` now accept an endpoint URI on construction rather than tenant ID + dev center name.
+
+### Features Added
+
 - Added upcoming actions APIs to dev boxes.
     - `DelayUpcomingAction`
     - `GetUpcomingAction`
@@ -13,11 +16,9 @@ This release updates the Azure DevCenter library to use the 2022-11-11-preview A
     - `SkipUpcomingAction`
 
 ### Bugs Fixed
+
 - Invalid response types removed from `DeleteDevBox`, `StartDevBox`, and `StopDevBox` APIs.
 - Invalid `DeleteEnvironmentAction` API removed from `EnvironmentsClient`.
-
-### Other Changes
-
 - Unimplemented artifacts APIs removed from `EnvironmentsClient`.
 
 ## 1.0.0-beta.1 (2022-11-11)

--- a/sdk/devcenter/Azure.Developer.DevCenter/CHANGELOG.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/CHANGELOG.md
@@ -3,5 +3,22 @@
 ## 1.0.0-beta.2 (2023-02-07)
 This release updates the Azure DevCenter library to use the 2022-11-11-preview API.
 
+### Features Added
+
+- `DevBoxClient`, `DevCenterClient`, and `EnvironmentsClient` now accept an endpoint URI on construction rather than tenant ID + dev center name.
+- Added upcoming actions APIs to dev boxes.
+    - `DelayUpcomingAction`
+    - `GetUpcomingAction`
+    - `GetUpcomingActions`
+    - `SkipUpcomingAction`
+
+### Bugs Fixed
+- Invalid response types removed from `DeleteDevBox`, `StartDevBox`, and `StopDevBox` APIs.
+- Invalid `DeleteEnvironmentAction` API removed from `EnvironmentsClient`.
+
+### Other Changes
+
+- Unimplemented artifacts APIs removed from `EnvironmentsClient`.
+
 ## 1.0.0-beta.1 (2022-11-11)
 This is the initial release of the Azure DevCenter library.

--- a/sdk/devcenter/Azure.Developer.DevCenter/CHANGELOG.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/CHANGELOG.md
@@ -1,14 +1,7 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+## 1.0.0-beta.2 (2023-02-07)
+This release updates the Azure DevCenter library to use the 2022-11-11-preview API.
 
 ## 1.0.0-beta.1 (2022-11-11)
 This is the initial release of the Azure DevCenter library.

--- a/sdk/devcenter/Azure.Developer.DevCenter/README.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/README.md
@@ -75,7 +75,7 @@ You can familiarize yourself with different APIs using [Samples](https://github.
 ### Build a client and get projects
 ```C# Snippet:Azure_DevCenter_GetProjects_Scenario
 var credential = new DefaultAzureCredential();
-var devCenterClient = new DevCenterClient(tenantId, devCenterName, credential);
+var devCenterClient = new DevCenterClient(endpoint, credential);
 string targetProjectName = null;
 await foreach (BinaryData data in devCenterClient.GetProjectsAsync(filter: null, maxCount: 1))
 {
@@ -86,7 +86,7 @@ await foreach (BinaryData data in devCenterClient.GetProjectsAsync(filter: null,
 
 ### List available Dev Box Pools
 ```C# Snippet:Azure_DevCenter_GetPools_Scenario
-var devBoxesClient = new DevBoxesClient(tenantId, devCenterName, targetProjectName, credential);
+var devBoxesClient = new DevBoxesClient(endpoint, targetProjectName, credential);
 string targetPoolName = null;
 await foreach (BinaryData data in devBoxesClient.GetPoolsAsync(filter: null, maxCount: 1))
 {
@@ -125,7 +125,7 @@ Console.WriteLine($"Completed dev box deletion.");
 ### Get Catalog Items
 
 ```C# Snippet:Azure_DevCenter_GetCatalogItems_Scenario
-var environmentsClient = new EnvironmentsClient(tenantId, devCenterName, projectName, credential);
+var environmentsClient = new EnvironmentsClient(endpoint, projectName, credential);
 string catalogItemName = null;
 await foreach (BinaryData data in environmentsClient.GetCatalogItemsAsync(maxCount: 1))
 {

--- a/sdk/devcenter/Azure.Developer.DevCenter/README.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/README.md
@@ -37,12 +37,8 @@ You will also need to register a new AAD application, or run locally or in an en
 If using an application, set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET.
 
 ```
-string tenantId = "<tenant-id>";
-string devCenterName = "<dev-center-name>";
-var client = new DevCenterClient(
-                tenantId,
-                devCenterName,
-                new DefaultAzureCredential());
+Uri endpoint = new Uri("<dev-center-uri>");
+var client = new DevCenterClient(endpoint, new DefaultAzureCredential());
 ```
 
 ## Key concepts

--- a/sdk/devcenter/Azure.Developer.DevCenter/api/Azure.Developer.DevCenter.netstandard2.0.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/api/Azure.Developer.DevCenter.netstandard2.0.cs
@@ -3,8 +3,8 @@ namespace Azure.Developer.DevCenter
     public partial class DevBoxesClient
     {
         protected DevBoxesClient() { }
-        public DevBoxesClient(string endpoint, string projectName, Azure.Core.TokenCredential credential) { }
-        public DevBoxesClient(string endpoint, string projectName, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
+        public DevBoxesClient(System.Uri endpoint, string projectName, Azure.Core.TokenCredential credential) { }
+        public DevBoxesClient(System.Uri endpoint, string projectName, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Operation<System.BinaryData> CreateDevBox(Azure.WaitUntil waitUntil, string devBoxName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
@@ -40,8 +40,8 @@ namespace Azure.Developer.DevCenter
     public partial class DevCenterClient
     {
         protected DevCenterClient() { }
-        public DevCenterClient(string endpoint, Azure.Core.TokenCredential credential) { }
-        public DevCenterClient(string endpoint, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
+        public DevCenterClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
+        public DevCenterClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Pageable<System.BinaryData> GetAllDevBoxes(string filter = null, int? maxCount = default(int?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.AsyncPageable<System.BinaryData> GetAllDevBoxesAsync(string filter = null, int? maxCount = default(int?), Azure.RequestContext context = null) { throw null; }
@@ -63,8 +63,8 @@ namespace Azure.Developer.DevCenter
     public partial class EnvironmentsClient
     {
         protected EnvironmentsClient() { }
-        public EnvironmentsClient(string endpoint, string projectName, Azure.Core.TokenCredential credential) { }
-        public EnvironmentsClient(string endpoint, string projectName, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
+        public EnvironmentsClient(System.Uri endpoint, string projectName, Azure.Core.TokenCredential credential) { }
+        public EnvironmentsClient(System.Uri endpoint, string projectName, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Operation<System.BinaryData> CreateOrUpdateEnvironment(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateOrUpdateEnvironmentAsync(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }

--- a/sdk/devcenter/Azure.Developer.DevCenter/api/Azure.Developer.DevCenter.netstandard2.0.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/api/Azure.Developer.DevCenter.netstandard2.0.cs
@@ -3,13 +3,15 @@ namespace Azure.Developer.DevCenter
     public partial class DevBoxesClient
     {
         protected DevBoxesClient() { }
-        public DevBoxesClient(string tenantId, string devCenter, string projectName, Azure.Core.TokenCredential credential) { }
-        public DevBoxesClient(string tenantId, string devCenter, string projectName, Azure.Core.TokenCredential credential, string devCenterDnsSuffix, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
+        public DevBoxesClient(string endpoint, string projectName, Azure.Core.TokenCredential credential) { }
+        public DevBoxesClient(string endpoint, string projectName, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Operation<System.BinaryData> CreateDevBox(Azure.WaitUntil waitUntil, string devBoxName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.Operation<System.BinaryData> DeleteDevBox(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> DeleteDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Response DelayUpcomingAction(string devBoxName, string upcomingActionId, System.DateTimeOffset delayUntil, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> DelayUpcomingActionAsync(string devBoxName, string upcomingActionId, System.DateTimeOffset delayUntil, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Operation DeleteDevBox(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Operation> DeleteDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response GetDevBoxByUser(string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> GetDevBoxByUserAsync(string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Pageable<System.BinaryData> GetDevBoxesByUser(string userId = "me", string filter = null, int? maxCount = default(int?), Azure.RequestContext context = null) { throw null; }
@@ -24,16 +26,22 @@ namespace Azure.Developer.DevCenter
         public virtual System.Threading.Tasks.Task<Azure.Response> GetScheduleByPoolAsync(string poolName, string scheduleName, Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Pageable<System.BinaryData> GetSchedulesByPool(string poolName, int? maxCount = default(int?), string filter = null, Azure.RequestContext context = null) { throw null; }
         public virtual Azure.AsyncPageable<System.BinaryData> GetSchedulesByPoolAsync(string poolName, int? maxCount = default(int?), string filter = null, Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.Operation<System.BinaryData> StartDevBox(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> StartDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.Operation<System.BinaryData> StopDevBox(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> StopDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Response GetUpcomingAction(string devBoxName, string upcomingActionId, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> GetUpcomingActionAsync(string devBoxName, string upcomingActionId, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Pageable<System.BinaryData> GetUpcomingActions(string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.AsyncPageable<System.BinaryData> GetUpcomingActionsAsync(string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Response SkipUpcomingAction(string devBoxName, string upcomingActionId, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> SkipUpcomingActionAsync(string devBoxName, string upcomingActionId, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Operation StartDevBox(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Operation> StartDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", Azure.RequestContext context = null) { throw null; }
+        public virtual Azure.Operation StopDevBox(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", bool? hibernate = default(bool?), Azure.RequestContext context = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Operation> StopDevBoxAsync(Azure.WaitUntil waitUntil, string devBoxName, string userId = "me", bool? hibernate = default(bool?), Azure.RequestContext context = null) { throw null; }
     }
     public partial class DevCenterClient
     {
         protected DevCenterClient() { }
-        public DevCenterClient(string tenantId, string devCenter, Azure.Core.TokenCredential credential) { }
-        public DevCenterClient(string tenantId, string devCenter, Azure.Core.TokenCredential credential, string devCenterDnsSuffix, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
+        public DevCenterClient(string endpoint, Azure.Core.TokenCredential credential) { }
+        public DevCenterClient(string endpoint, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Pageable<System.BinaryData> GetAllDevBoxes(string filter = null, int? maxCount = default(int?), Azure.RequestContext context = null) { throw null; }
         public virtual Azure.AsyncPageable<System.BinaryData> GetAllDevBoxesAsync(string filter = null, int? maxCount = default(int?), Azure.RequestContext context = null) { throw null; }
@@ -46,32 +54,26 @@ namespace Azure.Developer.DevCenter
     }
     public partial class DevCenterClientOptions : Azure.Core.ClientOptions
     {
-        public DevCenterClientOptions(Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion version = Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion.V2022_03_01_Preview) { }
+        public DevCenterClientOptions(Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion version = Azure.Developer.DevCenter.DevCenterClientOptions.ServiceVersion.V2022_11_11_Preview) { }
         public enum ServiceVersion
         {
-            V2022_03_01_Preview = 1,
+            V2022_11_11_Preview = 1,
         }
     }
     public partial class EnvironmentsClient
     {
         protected EnvironmentsClient() { }
-        public EnvironmentsClient(string tenantId, string devCenter, string projectName, Azure.Core.TokenCredential credential) { }
-        public EnvironmentsClient(string tenantId, string devCenter, string projectName, Azure.Core.TokenCredential credential, string devCenterDnsSuffix, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
+        public EnvironmentsClient(string endpoint, string projectName, Azure.Core.TokenCredential credential) { }
+        public EnvironmentsClient(string endpoint, string projectName, Azure.Core.TokenCredential credential, Azure.Developer.DevCenter.DevCenterClientOptions options) { }
         public virtual Azure.Core.Pipeline.HttpPipeline Pipeline { get { throw null; } }
         public virtual Azure.Operation<System.BinaryData> CreateOrUpdateEnvironment(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Operation<System.BinaryData>> CreateOrUpdateEnvironmentAsync(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Operation CustomEnvironmentAction(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Operation> CustomEnvironmentActionAsync(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Operation DeleteEnvironment(Azure.WaitUntil waitUntil, string environmentName, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.Operation DeleteEnvironmentAction(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Operation> DeleteEnvironmentActionAsync(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Operation> DeleteEnvironmentAsync(Azure.WaitUntil waitUntil, string environmentName, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Operation DeployEnvironmentAction(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Operation> DeployEnvironmentActionAsync(Azure.WaitUntil waitUntil, string environmentName, Azure.Core.RequestContent content, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.Pageable<System.BinaryData> GetArtifactsByEnvironment(string environmentName, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.Pageable<System.BinaryData> GetArtifactsByEnvironmentAndPath(string environmentName, string artifactPath, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.AsyncPageable<System.BinaryData> GetArtifactsByEnvironmentAndPathAsync(string environmentName, string artifactPath, string userId = "me", Azure.RequestContext context = null) { throw null; }
-        public virtual Azure.AsyncPageable<System.BinaryData> GetArtifactsByEnvironmentAsync(string environmentName, string userId = "me", Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Response GetCatalogItem(string catalogItemId, Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> GetCatalogItemAsync(string catalogItemId, Azure.RequestContext context = null) { throw null; }
         public virtual Azure.Pageable<System.BinaryData> GetCatalogItems(int? maxCount = default(int?), Azure.RequestContext context = null) { throw null; }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the DevCenter client library for developing .NET applications with rich experience.</Description>
     <AssemblyTitle>Azure SDK Code Generation DevCenter for Azure Data Plane</AssemblyTitle>
-    <Version>1.0.0-beta.2</Version>
+    <Version>1.0.0-beta.3</Version>
     <PackageTags>Azure DevCenter</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Azure.Developer.DevCenter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the DevCenter client library for developing .NET applications with rich experience.</Description>
     <AssemblyTitle>Azure SDK Code Generation DevCenter for Azure Data Plane</AssemblyTitle>
-    <Version>1.0.0-beta.3</Version>
+    <Version>1.0.0-beta.2</Version>
     <PackageTags>Azure DevCenter</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevBoxesClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevBoxesClient.cs
@@ -20,10 +20,8 @@ namespace Azure.Developer.DevCenter
         private static readonly string[] AuthorizationScopes = new string[] { "https://devcenter.azure.com/.default" };
         private readonly TokenCredential _tokenCredential;
         private readonly HttpPipeline _pipeline;
-        private readonly string _tenantId;
-        private readonly string _devCenter;
+        private readonly string _endpoint;
         private readonly string _projectName;
-        private readonly string _devCenterDnsSuffix;
         private readonly string _apiVersion;
 
         /// <summary> The ClientDiagnostics is used to provide tracing support for the client library. </summary>
@@ -38,41 +36,34 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary> Initializes a new instance of DevBoxesClient. </summary>
-        /// <param name="tenantId"> The tenant to operate on. </param>
-        /// <param name="devCenter"> The DevCenter to operate on. </param>
+        /// <param name="endpoint"> The DevCenter-specific URI to operate on. </param>
         /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="tenantId"/>, <paramref name="devCenter"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public DevBoxesClient(string tenantId, string devCenter, string projectName, TokenCredential credential) : this(tenantId, devCenter, projectName, credential, "devcenter.azure.com", new DevCenterClientOptions())
+        public DevBoxesClient(string endpoint, string projectName, TokenCredential credential) : this(endpoint, projectName, credential, new DevCenterClientOptions())
         {
         }
 
         /// <summary> Initializes a new instance of DevBoxesClient. </summary>
-        /// <param name="tenantId"> The tenant to operate on. </param>
-        /// <param name="devCenter"> The DevCenter to operate on. </param>
+        /// <param name="endpoint"> The DevCenter-specific URI to operate on. </param>
         /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
-        /// <param name="devCenterDnsSuffix"> The DNS suffix used as the base for all devcenter requests. </param>
         /// <param name="options"> The options for configuring the client. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="tenantId"/>, <paramref name="devCenter"/>, <paramref name="projectName"/>, <paramref name="credential"/> or <paramref name="devCenterDnsSuffix"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public DevBoxesClient(string tenantId, string devCenter, string projectName, TokenCredential credential, string devCenterDnsSuffix, DevCenterClientOptions options)
+        public DevBoxesClient(string endpoint, string projectName, TokenCredential credential, DevCenterClientOptions options)
         {
-            Argument.AssertNotNull(tenantId, nameof(tenantId));
-            Argument.AssertNotNull(devCenter, nameof(devCenter));
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNullOrEmpty(projectName, nameof(projectName));
             Argument.AssertNotNull(credential, nameof(credential));
-            Argument.AssertNotNull(devCenterDnsSuffix, nameof(devCenterDnsSuffix));
             options ??= new DevCenterClientOptions();
 
             ClientDiagnostics = new ClientDiagnostics(options, true);
             _tokenCredential = credential;
             _pipeline = HttpPipelineBuilder.Build(options, Array.Empty<HttpPipelinePolicy>(), new HttpPipelinePolicy[] { new BearerTokenAuthenticationPolicy(_tokenCredential, AuthorizationScopes) }, new ResponseClassifier());
-            _tenantId = tenantId;
-            _devCenter = devCenter;
+            _endpoint = endpoint;
             _projectName = projectName;
-            _devCenterDnsSuffix = devCenterDnsSuffix;
             _apiVersion = options.Version;
         }
 
@@ -296,6 +287,188 @@ namespace Azure.Developer.DevCenter
             }
         }
 
+        /// <summary> Gets an Upcoming Action. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="upcomingActionId"> The upcoming action id. </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. Details of the response body schema are in the Remarks section below. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='GetUpcomingActionAsync(String,String,String,RequestContext)']/*" />
+        public virtual async Task<Response> GetUpcomingActionAsync(string devBoxName, string upcomingActionId, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(upcomingActionId, nameof(upcomingActionId));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            using var scope = ClientDiagnostics.CreateScope("DevBoxesClient.GetUpcomingAction");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetUpcomingActionRequest(devBoxName, upcomingActionId, userId, context);
+                return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Gets an Upcoming Action. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="upcomingActionId"> The upcoming action id. </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. Details of the response body schema are in the Remarks section below. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='GetUpcomingAction(String,String,String,RequestContext)']/*" />
+        public virtual Response GetUpcomingAction(string devBoxName, string upcomingActionId, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(upcomingActionId, nameof(upcomingActionId));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            using var scope = ClientDiagnostics.CreateScope("DevBoxesClient.GetUpcomingAction");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetUpcomingActionRequest(devBoxName, upcomingActionId, userId, context);
+                return _pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Skips an Upcoming Action. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="upcomingActionId"> The upcoming action id. </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='SkipUpcomingActionAsync(String,String,String,RequestContext)']/*" />
+        public virtual async Task<Response> SkipUpcomingActionAsync(string devBoxName, string upcomingActionId, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(upcomingActionId, nameof(upcomingActionId));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            using var scope = ClientDiagnostics.CreateScope("DevBoxesClient.SkipUpcomingAction");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateSkipUpcomingActionRequest(devBoxName, upcomingActionId, userId, context);
+                return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Skips an Upcoming Action. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="upcomingActionId"> The upcoming action id. </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='SkipUpcomingAction(String,String,String,RequestContext)']/*" />
+        public virtual Response SkipUpcomingAction(string devBoxName, string upcomingActionId, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(upcomingActionId, nameof(upcomingActionId));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            using var scope = ClientDiagnostics.CreateScope("DevBoxesClient.SkipUpcomingAction");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateSkipUpcomingActionRequest(devBoxName, upcomingActionId, userId, context);
+                return _pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Delays an Upcoming Action. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="upcomingActionId"> The upcoming action id. </param>
+        /// <param name="delayUntil"> The delayed action time (UTC). </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. Details of the response body schema are in the Remarks section below. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='DelayUpcomingActionAsync(String,String,DateTimeOffset,String,RequestContext)']/*" />
+        public virtual async Task<Response> DelayUpcomingActionAsync(string devBoxName, string upcomingActionId, DateTimeOffset delayUntil, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(upcomingActionId, nameof(upcomingActionId));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            using var scope = ClientDiagnostics.CreateScope("DevBoxesClient.DelayUpcomingAction");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateDelayUpcomingActionRequest(devBoxName, upcomingActionId, delayUntil, userId, context);
+                return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Delays an Upcoming Action. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="upcomingActionId"> The upcoming action id. </param>
+        /// <param name="delayUntil"> The delayed action time (UTC). </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/>, <paramref name="upcomingActionId"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The response returned from the service. Details of the response body schema are in the Remarks section below. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='DelayUpcomingAction(String,String,DateTimeOffset,String,RequestContext)']/*" />
+        public virtual Response DelayUpcomingAction(string devBoxName, string upcomingActionId, DateTimeOffset delayUntil, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(upcomingActionId, nameof(upcomingActionId));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            using var scope = ClientDiagnostics.CreateScope("DevBoxesClient.DelayUpcomingAction");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateDelayUpcomingActionRequest(devBoxName, upcomingActionId, delayUntil, userId, context);
+                return _pipeline.ProcessMessage(message, context);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         /// <summary> Lists available pools. </summary>
         /// <param name="maxCount"> The maximum number of resources to return from the operation. Example: &apos;top=10&apos;. </param>
         /// <param name="filter"> An OData filter clause to apply to the operation. </param>
@@ -400,6 +573,44 @@ namespace Azure.Developer.DevCenter
             return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "DevBoxesClient.GetDevBoxesByUser", "value", "nextLink", context);
         }
 
+        /// <summary> Lists upcoming actions on a Dev Box. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The <see cref="AsyncPageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='GetUpcomingActionsAsync(String,String,RequestContext)']/*" />
+        public virtual AsyncPageable<BinaryData> GetUpcomingActionsAsync(string devBoxName, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetUpcomingActionsRequest(devBoxName, userId, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetUpcomingActionsNextPageRequest(nextLink, devBoxName, userId, context);
+            return PageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "DevBoxesClient.GetUpcomingActions", "value", "nextLink", context);
+        }
+
+        /// <summary> Lists upcoming actions on a Dev Box. </summary>
+        /// <param name="devBoxName"> The name of a Dev Box. </param>
+        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
+        /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
+        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
+        /// <returns> The <see cref="Pageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='GetUpcomingActions(String,String,RequestContext)']/*" />
+        public virtual Pageable<BinaryData> GetUpcomingActions(string devBoxName, string userId = "me", RequestContext context = null)
+        {
+            Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
+            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
+
+            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetUpcomingActionsRequest(devBoxName, userId, context);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetUpcomingActionsNextPageRequest(nextLink, devBoxName, userId, context);
+            return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "DevBoxesClient.GetUpcomingActions", "value", "nextLink", context);
+        }
+
         /// <summary> Creates or updates a Dev Box. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="devBoxName"> The name of a Dev Box. </param>
@@ -470,9 +681,9 @@ namespace Azure.Developer.DevCenter
         /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation{T}"/> from the service that will contain a <see cref="BinaryData"/> object once the asynchronous operation on the service has completed. Details of the body schema for the operation's final value are in the Remarks section below. </returns>
+        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
         /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='DeleteDevBoxAsync(WaitUntil,String,String,RequestContext)']/*" />
-        public virtual async Task<Operation<BinaryData>> DeleteDevBoxAsync(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
+        public virtual async Task<Operation> DeleteDevBoxAsync(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
             Argument.AssertNotNullOrEmpty(userId, nameof(userId));
@@ -482,7 +693,7 @@ namespace Azure.Developer.DevCenter
             try
             {
                 using HttpMessage message = CreateDeleteDevBoxRequest(devBoxName, userId, context);
-                return await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DevBoxesClient.DeleteDevBox", OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
+                return await ProtocolOperationHelpers.ProcessMessageWithoutResponseValueAsync(_pipeline, message, ClientDiagnostics, "DevBoxesClient.DeleteDevBox", OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -499,9 +710,9 @@ namespace Azure.Developer.DevCenter
         /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation{T}"/> from the service that will contain a <see cref="BinaryData"/> object once the asynchronous operation on the service has completed. Details of the body schema for the operation's final value are in the Remarks section below. </returns>
+        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
         /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='DeleteDevBox(WaitUntil,String,String,RequestContext)']/*" />
-        public virtual Operation<BinaryData> DeleteDevBox(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
+        public virtual Operation DeleteDevBox(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
             Argument.AssertNotNullOrEmpty(userId, nameof(userId));
@@ -511,7 +722,7 @@ namespace Azure.Developer.DevCenter
             try
             {
                 using HttpMessage message = CreateDeleteDevBoxRequest(devBoxName, userId, context);
-                return ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DevBoxesClient.DeleteDevBox", OperationFinalStateVia.Location, context, waitUntil);
+                return ProtocolOperationHelpers.ProcessMessageWithoutResponseValue(_pipeline, message, ClientDiagnostics, "DevBoxesClient.DeleteDevBox", OperationFinalStateVia.Location, context, waitUntil);
             }
             catch (Exception e)
             {
@@ -528,9 +739,9 @@ namespace Azure.Developer.DevCenter
         /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation{T}"/> from the service that will contain a <see cref="BinaryData"/> object once the asynchronous operation on the service has completed. Details of the body schema for the operation's final value are in the Remarks section below. </returns>
+        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
         /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='StartDevBoxAsync(WaitUntil,String,String,RequestContext)']/*" />
-        public virtual async Task<Operation<BinaryData>> StartDevBoxAsync(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
+        public virtual async Task<Operation> StartDevBoxAsync(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
             Argument.AssertNotNullOrEmpty(userId, nameof(userId));
@@ -540,7 +751,7 @@ namespace Azure.Developer.DevCenter
             try
             {
                 using HttpMessage message = CreateStartDevBoxRequest(devBoxName, userId, context);
-                return await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StartDevBox", OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
+                return await ProtocolOperationHelpers.ProcessMessageWithoutResponseValueAsync(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StartDevBox", OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -557,9 +768,9 @@ namespace Azure.Developer.DevCenter
         /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation{T}"/> from the service that will contain a <see cref="BinaryData"/> object once the asynchronous operation on the service has completed. Details of the body schema for the operation's final value are in the Remarks section below. </returns>
+        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
         /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='StartDevBox(WaitUntil,String,String,RequestContext)']/*" />
-        public virtual Operation<BinaryData> StartDevBox(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
+        public virtual Operation StartDevBox(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
             Argument.AssertNotNullOrEmpty(userId, nameof(userId));
@@ -569,7 +780,7 @@ namespace Azure.Developer.DevCenter
             try
             {
                 using HttpMessage message = CreateStartDevBoxRequest(devBoxName, userId, context);
-                return ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StartDevBox", OperationFinalStateVia.Location, context, waitUntil);
+                return ProtocolOperationHelpers.ProcessMessageWithoutResponseValue(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StartDevBox", OperationFinalStateVia.Location, context, waitUntil);
             }
             catch (Exception e)
             {
@@ -582,13 +793,14 @@ namespace Azure.Developer.DevCenter
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="devBoxName"> The name of a Dev Box. </param>
         /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="hibernate"> Optional parameter to hibernate the dev box. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation{T}"/> from the service that will contain a <see cref="BinaryData"/> object once the asynchronous operation on the service has completed. Details of the body schema for the operation's final value are in the Remarks section below. </returns>
-        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='StopDevBoxAsync(WaitUntil,String,String,RequestContext)']/*" />
-        public virtual async Task<Operation<BinaryData>> StopDevBoxAsync(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
+        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='StopDevBoxAsync(WaitUntil,String,String,Boolean,RequestContext)']/*" />
+        public virtual async Task<Operation> StopDevBoxAsync(WaitUntil waitUntil, string devBoxName, string userId = "me", bool? hibernate = null, RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
             Argument.AssertNotNullOrEmpty(userId, nameof(userId));
@@ -597,8 +809,8 @@ namespace Azure.Developer.DevCenter
             scope.Start();
             try
             {
-                using HttpMessage message = CreateStopDevBoxRequest(devBoxName, userId, context);
-                return await ProtocolOperationHelpers.ProcessMessageAsync(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StopDevBox", OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
+                using HttpMessage message = CreateStopDevBoxRequest(devBoxName, userId, hibernate, context);
+                return await ProtocolOperationHelpers.ProcessMessageWithoutResponseValueAsync(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StopDevBox", OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -611,13 +823,14 @@ namespace Azure.Developer.DevCenter
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="devBoxName"> The name of a Dev Box. </param>
         /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
+        /// <param name="hibernate"> Optional parameter to hibernate the dev box. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="devBoxName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation{T}"/> from the service that will contain a <see cref="BinaryData"/> object once the asynchronous operation on the service has completed. Details of the body schema for the operation's final value are in the Remarks section below. </returns>
-        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='StopDevBox(WaitUntil,String,String,RequestContext)']/*" />
-        public virtual Operation<BinaryData> StopDevBox(WaitUntil waitUntil, string devBoxName, string userId = "me", RequestContext context = null)
+        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
+        /// <include file="Docs/DevBoxesClient.xml" path="doc/members/member[@name='StopDevBox(WaitUntil,String,String,Boolean,RequestContext)']/*" />
+        public virtual Operation StopDevBox(WaitUntil waitUntil, string devBoxName, string userId = "me", bool? hibernate = null, RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(devBoxName, nameof(devBoxName));
             Argument.AssertNotNullOrEmpty(userId, nameof(userId));
@@ -626,8 +839,8 @@ namespace Azure.Developer.DevCenter
             scope.Start();
             try
             {
-                using HttpMessage message = CreateStopDevBoxRequest(devBoxName, userId, context);
-                return ProtocolOperationHelpers.ProcessMessage(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StopDevBox", OperationFinalStateVia.Location, context, waitUntil);
+                using HttpMessage message = CreateStopDevBoxRequest(devBoxName, userId, hibernate, context);
+                return ProtocolOperationHelpers.ProcessMessageWithoutResponseValue(_pipeline, message, ClientDiagnostics, "DevBoxesClient.StopDevBox", OperationFinalStateVia.Location, context, waitUntil);
             }
             catch (Exception e)
             {
@@ -642,12 +855,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools", false);
@@ -671,12 +879,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools/", false);
@@ -693,12 +896,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools/", false);
@@ -724,12 +922,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools/", false);
@@ -748,12 +941,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -779,12 +967,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -803,12 +986,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -825,16 +1003,11 @@ namespace Azure.Developer.DevCenter
 
         internal HttpMessage CreateDeleteDevBoxRequest(string devBoxName, string userId, RequestContext context)
         {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200202204);
+            var message = _pipeline.CreateMessage(context, ResponseClassifier202204);
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -849,16 +1022,11 @@ namespace Azure.Developer.DevCenter
 
         internal HttpMessage CreateStartDevBoxRequest(string devBoxName, string userId, RequestContext context)
         {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200202);
+            var message = _pipeline.CreateMessage(context, ResponseClassifier202);
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -872,18 +1040,13 @@ namespace Azure.Developer.DevCenter
             return message;
         }
 
-        internal HttpMessage CreateStopDevBoxRequest(string devBoxName, string userId, RequestContext context)
+        internal HttpMessage CreateStopDevBoxRequest(string devBoxName, string userId, bool? hibernate, RequestContext context)
         {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200202);
+            var message = _pipeline.CreateMessage(context, ResponseClassifier202);
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -892,6 +1055,10 @@ namespace Azure.Developer.DevCenter
             uri.AppendPath(devBoxName, true);
             uri.AppendPath(":stop", false);
             uri.AppendQuery("api-version", _apiVersion, true);
+            if (hibernate != null)
+            {
+                uri.AppendQuery("hibernate", hibernate.Value, true);
+            }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;
@@ -903,12 +1070,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -922,18 +1084,99 @@ namespace Azure.Developer.DevCenter
             return message;
         }
 
+        internal HttpMessage CreateGetUpcomingActionsRequest(string devBoxName, string userId, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/projects/", false);
+            uri.AppendPath(_projectName, true);
+            uri.AppendPath("/users/", false);
+            uri.AppendPath(userId, true);
+            uri.AppendPath("/devboxes/", false);
+            uri.AppendPath(devBoxName, true);
+            uri.AppendPath("/upcomingActions", false);
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
+        internal HttpMessage CreateGetUpcomingActionRequest(string devBoxName, string upcomingActionId, string userId, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/projects/", false);
+            uri.AppendPath(_projectName, true);
+            uri.AppendPath("/users/", false);
+            uri.AppendPath(userId, true);
+            uri.AppendPath("/devboxes/", false);
+            uri.AppendPath(devBoxName, true);
+            uri.AppendPath("/upcomingActions/", false);
+            uri.AppendPath(upcomingActionId, true);
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
+        internal HttpMessage CreateSkipUpcomingActionRequest(string devBoxName, string upcomingActionId, string userId, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier204);
+            var request = message.Request;
+            request.Method = RequestMethod.Post;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/projects/", false);
+            uri.AppendPath(_projectName, true);
+            uri.AppendPath("/users/", false);
+            uri.AppendPath(userId, true);
+            uri.AppendPath("/devboxes/", false);
+            uri.AppendPath(devBoxName, true);
+            uri.AppendPath("/upcomingActions/", false);
+            uri.AppendPath(upcomingActionId, true);
+            uri.AppendPath(":skip", false);
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
+        internal HttpMessage CreateDelayUpcomingActionRequest(string devBoxName, string upcomingActionId, DateTimeOffset delayUntil, string userId, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Post;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/projects/", false);
+            uri.AppendPath(_projectName, true);
+            uri.AppendPath("/users/", false);
+            uri.AppendPath(userId, true);
+            uri.AppendPath("/devboxes/", false);
+            uri.AppendPath(devBoxName, true);
+            uri.AppendPath("/upcomingActions/", false);
+            uri.AppendPath(upcomingActionId, true);
+            uri.AppendPath(":delay", false);
+            uri.AppendQuery("delayUntil", delayUntil, "O", true);
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
         internal HttpMessage CreateGetPoolsNextPageRequest(string nextLink, int? maxCount, string filter, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -946,12 +1189,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -964,12 +1202,20 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendRawNextLink(nextLink, false);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
+        internal HttpMessage CreateGetUpcomingActionsNextPageRequest(string nextLink, string devBoxName, string userId, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -980,9 +1226,11 @@ namespace Azure.Developer.DevCenter
         private static ResponseClassifier ResponseClassifier200 => _responseClassifier200 ??= new StatusCodeClassifier(stackalloc ushort[] { 200 });
         private static ResponseClassifier _responseClassifier200201;
         private static ResponseClassifier ResponseClassifier200201 => _responseClassifier200201 ??= new StatusCodeClassifier(stackalloc ushort[] { 200, 201 });
-        private static ResponseClassifier _responseClassifier200202204;
-        private static ResponseClassifier ResponseClassifier200202204 => _responseClassifier200202204 ??= new StatusCodeClassifier(stackalloc ushort[] { 200, 202, 204 });
-        private static ResponseClassifier _responseClassifier200202;
-        private static ResponseClassifier ResponseClassifier200202 => _responseClassifier200202 ??= new StatusCodeClassifier(stackalloc ushort[] { 200, 202 });
+        private static ResponseClassifier _responseClassifier202204;
+        private static ResponseClassifier ResponseClassifier202204 => _responseClassifier202204 ??= new StatusCodeClassifier(stackalloc ushort[] { 202, 204 });
+        private static ResponseClassifier _responseClassifier202;
+        private static ResponseClassifier ResponseClassifier202 => _responseClassifier202 ??= new StatusCodeClassifier(stackalloc ushort[] { 202 });
+        private static ResponseClassifier _responseClassifier204;
+        private static ResponseClassifier ResponseClassifier204 => _responseClassifier204 ??= new StatusCodeClassifier(stackalloc ushort[] { 204 });
     }
 }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevBoxesClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevBoxesClient.cs
@@ -20,7 +20,7 @@ namespace Azure.Developer.DevCenter
         private static readonly string[] AuthorizationScopes = new string[] { "https://devcenter.azure.com/.default" };
         private readonly TokenCredential _tokenCredential;
         private readonly HttpPipeline _pipeline;
-        private readonly string _endpoint;
+        private readonly Uri _endpoint;
         private readonly string _projectName;
         private readonly string _apiVersion;
 
@@ -41,7 +41,7 @@ namespace Azure.Developer.DevCenter
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public DevBoxesClient(string endpoint, string projectName, TokenCredential credential) : this(endpoint, projectName, credential, new DevCenterClientOptions())
+        public DevBoxesClient(Uri endpoint, string projectName, TokenCredential credential) : this(endpoint, projectName, credential, new DevCenterClientOptions())
         {
         }
 
@@ -52,7 +52,7 @@ namespace Azure.Developer.DevCenter
         /// <param name="options"> The options for configuring the client. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public DevBoxesClient(string endpoint, string projectName, TokenCredential credential, DevCenterClientOptions options)
+        public DevBoxesClient(Uri endpoint, string projectName, TokenCredential credential, DevCenterClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNullOrEmpty(projectName, nameof(projectName));
@@ -855,7 +855,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools", false);
@@ -879,7 +879,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools/", false);
@@ -896,7 +896,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools/", false);
@@ -922,7 +922,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/pools/", false);
@@ -941,7 +941,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -967,7 +967,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -986,7 +986,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1007,7 +1007,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1026,7 +1026,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1046,7 +1046,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1070,7 +1070,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1090,7 +1090,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1110,7 +1110,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1131,7 +1131,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1153,7 +1153,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1176,7 +1176,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1189,7 +1189,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1202,7 +1202,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1215,7 +1215,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClient.cs
@@ -20,9 +20,7 @@ namespace Azure.Developer.DevCenter
         private static readonly string[] AuthorizationScopes = new string[] { "https://devcenter.azure.com/.default" };
         private readonly TokenCredential _tokenCredential;
         private readonly HttpPipeline _pipeline;
-        private readonly string _tenantId;
-        private readonly string _devCenter;
-        private readonly string _devCenterDnsSuffix;
+        private readonly string _endpoint;
         private readonly string _apiVersion;
 
         /// <summary> The ClientDiagnostics is used to provide tracing support for the client library. </summary>
@@ -37,35 +35,28 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary> Initializes a new instance of DevCenterClient. </summary>
-        /// <param name="tenantId"> The tenant to operate on. </param>
-        /// <param name="devCenter"> The DevCenter to operate on. </param>
+        /// <param name="endpoint"> The DevCenter-specific URI to operate on. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="tenantId"/>, <paramref name="devCenter"/> or <paramref name="credential"/> is null. </exception>
-        public DevCenterClient(string tenantId, string devCenter, TokenCredential credential) : this(tenantId, devCenter, credential, "devcenter.azure.com", new DevCenterClientOptions())
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="credential"/> is null. </exception>
+        public DevCenterClient(string endpoint, TokenCredential credential) : this(endpoint, credential, new DevCenterClientOptions())
         {
         }
 
         /// <summary> Initializes a new instance of DevCenterClient. </summary>
-        /// <param name="tenantId"> The tenant to operate on. </param>
-        /// <param name="devCenter"> The DevCenter to operate on. </param>
+        /// <param name="endpoint"> The DevCenter-specific URI to operate on. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
-        /// <param name="devCenterDnsSuffix"> The DNS suffix used as the base for all devcenter requests. </param>
         /// <param name="options"> The options for configuring the client. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="tenantId"/>, <paramref name="devCenter"/>, <paramref name="credential"/> or <paramref name="devCenterDnsSuffix"/> is null. </exception>
-        public DevCenterClient(string tenantId, string devCenter, TokenCredential credential, string devCenterDnsSuffix, DevCenterClientOptions options)
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="credential"/> is null. </exception>
+        public DevCenterClient(string endpoint, TokenCredential credential, DevCenterClientOptions options)
         {
-            Argument.AssertNotNull(tenantId, nameof(tenantId));
-            Argument.AssertNotNull(devCenter, nameof(devCenter));
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNull(credential, nameof(credential));
-            Argument.AssertNotNull(devCenterDnsSuffix, nameof(devCenterDnsSuffix));
             options ??= new DevCenterClientOptions();
 
             ClientDiagnostics = new ClientDiagnostics(options, true);
             _tokenCredential = credential;
             _pipeline = HttpPipelineBuilder.Build(options, Array.Empty<HttpPipelinePolicy>(), new HttpPipelinePolicy[] { new BearerTokenAuthenticationPolicy(_tokenCredential, AuthorizationScopes) }, new ResponseClassifier());
-            _tenantId = tenantId;
-            _devCenter = devCenter;
-            _devCenterDnsSuffix = devCenterDnsSuffix;
+            _endpoint = endpoint;
             _apiVersion = options.Version;
         }
 
@@ -221,12 +212,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects", false);
             uri.AppendQuery("api-version", _apiVersion, true);
             if (filter != null)
@@ -248,12 +234,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(projectName, true);
             uri.AppendQuery("api-version", _apiVersion, true);
@@ -268,12 +249,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/devboxes", false);
             uri.AppendQuery("api-version", _apiVersion, true);
             if (filter != null)
@@ -295,12 +271,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
             uri.AppendPath("/devboxes", false);
@@ -324,12 +295,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -342,12 +308,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -360,12 +321,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClient.cs
@@ -20,7 +20,7 @@ namespace Azure.Developer.DevCenter
         private static readonly string[] AuthorizationScopes = new string[] { "https://devcenter.azure.com/.default" };
         private readonly TokenCredential _tokenCredential;
         private readonly HttpPipeline _pipeline;
-        private readonly string _endpoint;
+        private readonly Uri _endpoint;
         private readonly string _apiVersion;
 
         /// <summary> The ClientDiagnostics is used to provide tracing support for the client library. </summary>
@@ -38,7 +38,7 @@ namespace Azure.Developer.DevCenter
         /// <param name="endpoint"> The DevCenter-specific URI to operate on. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="credential"/> is null. </exception>
-        public DevCenterClient(string endpoint, TokenCredential credential) : this(endpoint, credential, new DevCenterClientOptions())
+        public DevCenterClient(Uri endpoint, TokenCredential credential) : this(endpoint, credential, new DevCenterClientOptions())
         {
         }
 
@@ -47,7 +47,7 @@ namespace Azure.Developer.DevCenter
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
         /// <param name="options"> The options for configuring the client. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="credential"/> is null. </exception>
-        public DevCenterClient(string endpoint, TokenCredential credential, DevCenterClientOptions options)
+        public DevCenterClient(Uri endpoint, TokenCredential credential, DevCenterClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNull(credential, nameof(credential));
@@ -212,7 +212,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects", false);
             uri.AppendQuery("api-version", _apiVersion, true);
             if (filter != null)
@@ -234,7 +234,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(projectName, true);
             uri.AppendQuery("api-version", _apiVersion, true);
@@ -249,7 +249,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/devboxes", false);
             uri.AppendQuery("api-version", _apiVersion, true);
             if (filter != null)
@@ -271,7 +271,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
             uri.AppendPath("/devboxes", false);
@@ -295,7 +295,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -308,7 +308,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -321,7 +321,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClientOptions.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/DevCenterClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Developer.DevCenter
     /// <summary> Client options for DevCenter library clients. </summary>
     public partial class DevCenterClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_Preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2022_11_11_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
-            /// <summary> Service version "2022-03-01-preview". </summary>
-            V2022_03_01_Preview = 1,
+            /// <summary> Service version "2022-11-11-preview". </summary>
+            V2022_11_11_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Developer.DevCenter
         {
             Version = version switch
             {
-                ServiceVersion.V2022_03_01_Preview => "2022-03-01-preview",
+                ServiceVersion.V2022_11_11_Preview => "2022-11-11-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevBoxesClient.xml
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevBoxesClient.xml
@@ -6,7 +6,7 @@
 This sample shows how to call GetPoolAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetPoolAsync("<poolName>");
 
@@ -17,6 +17,7 @@ Console.WriteLine(result.GetProperty("osType").ToString());
 Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
 Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
 Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
+Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
 Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
 Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
@@ -41,6 +42,7 @@ Schema for <c>Pool</c>:
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
     memoryGB: number, # Optional. The amount of memory available for the Dev Box.
   }, # Optional. Hardware settings for the Dev Boxes created in this pool
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   storageProfile: {
     osDisk: {
       diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
@@ -64,7 +66,7 @@ Schema for <c>Pool</c>:
 This sample shows how to call GetPool with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetPool("<poolName>");
 
@@ -75,6 +77,7 @@ Console.WriteLine(result.GetProperty("osType").ToString());
 Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
 Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
 Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
+Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
 Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
 Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
@@ -99,6 +102,7 @@ Schema for <c>Pool</c>:
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
     memoryGB: number, # Optional. The amount of memory available for the Dev Box.
   }, # Optional. Hardware settings for the Dev Boxes created in this pool
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   storageProfile: {
     osDisk: {
       diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
@@ -122,7 +126,7 @@ Schema for <c>Pool</c>:
 This sample shows how to call GetScheduleByPoolAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetScheduleByPoolAsync("<poolName>", "<scheduleName>");
 
@@ -156,7 +160,7 @@ Schema for <c>Schedule</c>:
 This sample shows how to call GetScheduleByPool with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetScheduleByPool("<poolName>", "<scheduleName>");
 
@@ -190,7 +194,7 @@ Schema for <c>Schedule</c>:
 This sample shows how to call GetDevBoxByUserAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetDevBoxByUserAsync("<devBoxName>");
 
@@ -200,7 +204,7 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call GetDevBoxByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetDevBoxByUserAsync("<devBoxName>", <me>);
 
@@ -208,6 +212,7 @@ JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("projectName").ToString());
 Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("actionState").ToString());
 Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -240,6 +245,7 @@ Schema for <c>DevBox</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -250,7 +256,7 @@ Schema for <c>DevBox</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -280,7 +286,7 @@ Schema for <c>DevBox</c>:
 This sample shows how to call GetDevBoxByUser with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetDevBoxByUser("<devBoxName>");
 
@@ -290,7 +296,7 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call GetDevBoxByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetDevBoxByUser("<devBoxName>", <me>);
 
@@ -298,6 +304,7 @@ JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("projectName").ToString());
 Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("actionState").ToString());
 Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -330,6 +337,7 @@ Schema for <c>DevBox</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -340,7 +348,7 @@ Schema for <c>DevBox</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -370,7 +378,7 @@ Schema for <c>DevBox</c>:
 This sample shows how to call GetRemoteConnectionAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetRemoteConnectionAsync("<devBoxName>");
 
@@ -380,7 +388,7 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetRemoteConnectionAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetRemoteConnectionAsync("<devBoxName>", <me>);
 
@@ -408,7 +416,7 @@ Schema for <c>RemoteConnection</c>:
 This sample shows how to call GetRemoteConnection with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetRemoteConnection("<devBoxName>");
 
@@ -418,7 +426,7 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetRemoteConnection with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetRemoteConnection("<devBoxName>", <me>);
 
@@ -441,12 +449,236 @@ Schema for <c>RemoteConnection</c>:
 
 </remarks>
     </member>
+    <member name="GetUpcomingActionAsync(String,String,String,RequestContext)">
+<example>
+This sample shows how to call GetUpcomingActionAsync with required parameters and parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = await client.GetUpcomingActionAsync("<devBoxName>", "<upcomingActionId>");
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call GetUpcomingActionAsync with all parameters, and how to parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = await client.GetUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", <me>);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("actionType").ToString());
+Console.WriteLine(result.GetProperty("reason").ToString());
+Console.WriteLine(result.GetProperty("scheduledTime").ToString());
+Console.WriteLine(result.GetProperty("originalScheduledTime").ToString());
+Console.WriteLine(result.GetProperty("sourceId").ToString());
+]]></code>
+</example>
+<remarks>
+Below is the JSON schema for the response payload.
+
+Response Body:
+
+Schema for <c>UpcomingAction</c>:
+<code>{
+  id: string, # Optional. Uniquely identifies the action.
+  actionType: &quot;Stop&quot;, # Optional. The action that will be taken.
+  reason: &quot;Schedule&quot;, # Optional. The reason for this action.
+  scheduledTime: string (ISO 8601 Format), # Optional. The target time the action will be triggered (UTC).
+  originalScheduledTime: string (ISO 8601 Format), # Optional. The original scheduled time for the action (UTC).
+  sourceId: string, # Optional. The id of the resource which triggered this action
+}
+</code>
+
+</remarks>
+    </member>
+    <member name="GetUpcomingAction(String,String,String,RequestContext)">
+<example>
+This sample shows how to call GetUpcomingAction with required parameters and parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = client.GetUpcomingAction("<devBoxName>", "<upcomingActionId>");
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call GetUpcomingAction with all parameters, and how to parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = client.GetUpcomingAction("<devBoxName>", "<upcomingActionId>", <me>);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("actionType").ToString());
+Console.WriteLine(result.GetProperty("reason").ToString());
+Console.WriteLine(result.GetProperty("scheduledTime").ToString());
+Console.WriteLine(result.GetProperty("originalScheduledTime").ToString());
+Console.WriteLine(result.GetProperty("sourceId").ToString());
+]]></code>
+</example>
+<remarks>
+Below is the JSON schema for the response payload.
+
+Response Body:
+
+Schema for <c>UpcomingAction</c>:
+<code>{
+  id: string, # Optional. Uniquely identifies the action.
+  actionType: &quot;Stop&quot;, # Optional. The action that will be taken.
+  reason: &quot;Schedule&quot;, # Optional. The reason for this action.
+  scheduledTime: string (ISO 8601 Format), # Optional. The target time the action will be triggered (UTC).
+  originalScheduledTime: string (ISO 8601 Format), # Optional. The original scheduled time for the action (UTC).
+  sourceId: string, # Optional. The id of the resource which triggered this action
+}
+</code>
+
+</remarks>
+    </member>
+    <member name="SkipUpcomingActionAsync(String,String,String,RequestContext)">
+<example>
+This sample shows how to call SkipUpcomingActionAsync with required parameters.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = await client.SkipUpcomingActionAsync("<devBoxName>", "<upcomingActionId>");
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call SkipUpcomingActionAsync with all parameters.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = await client.SkipUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", <me>);
+Console.WriteLine(response.Status);
+]]></code>
+</example>
+    </member>
+    <member name="SkipUpcomingAction(String,String,String,RequestContext)">
+<example>
+This sample shows how to call SkipUpcomingAction with required parameters.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = client.SkipUpcomingAction("<devBoxName>", "<upcomingActionId>");
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call SkipUpcomingAction with all parameters.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = client.SkipUpcomingAction("<devBoxName>", "<upcomingActionId>", <me>);
+Console.WriteLine(response.Status);
+]]></code>
+</example>
+    </member>
+    <member name="DelayUpcomingActionAsync(String,String,DateTimeOffset,String,RequestContext)">
+<example>
+This sample shows how to call DelayUpcomingActionAsync with required parameters and parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = await client.DelayUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call DelayUpcomingActionAsync with all parameters, and how to parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = await client.DelayUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow, <me>);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("actionType").ToString());
+Console.WriteLine(result.GetProperty("reason").ToString());
+Console.WriteLine(result.GetProperty("scheduledTime").ToString());
+Console.WriteLine(result.GetProperty("originalScheduledTime").ToString());
+Console.WriteLine(result.GetProperty("sourceId").ToString());
+]]></code>
+</example>
+<remarks>
+Below is the JSON schema for the response payload.
+
+Response Body:
+
+Schema for <c>UpcomingAction</c>:
+<code>{
+  id: string, # Optional. Uniquely identifies the action.
+  actionType: &quot;Stop&quot;, # Optional. The action that will be taken.
+  reason: &quot;Schedule&quot;, # Optional. The reason for this action.
+  scheduledTime: string (ISO 8601 Format), # Optional. The target time the action will be triggered (UTC).
+  originalScheduledTime: string (ISO 8601 Format), # Optional. The original scheduled time for the action (UTC).
+  sourceId: string, # Optional. The id of the resource which triggered this action
+}
+</code>
+
+</remarks>
+    </member>
+    <member name="DelayUpcomingAction(String,String,DateTimeOffset,String,RequestContext)">
+<example>
+This sample shows how to call DelayUpcomingAction with required parameters and parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = client.DelayUpcomingAction("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.ToString());
+]]></code>
+This sample shows how to call DelayUpcomingAction with all parameters, and how to parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+Response response = client.DelayUpcomingAction("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow, <me>);
+
+JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
+Console.WriteLine(result.GetProperty("id").ToString());
+Console.WriteLine(result.GetProperty("actionType").ToString());
+Console.WriteLine(result.GetProperty("reason").ToString());
+Console.WriteLine(result.GetProperty("scheduledTime").ToString());
+Console.WriteLine(result.GetProperty("originalScheduledTime").ToString());
+Console.WriteLine(result.GetProperty("sourceId").ToString());
+]]></code>
+</example>
+<remarks>
+Below is the JSON schema for the response payload.
+
+Response Body:
+
+Schema for <c>UpcomingAction</c>:
+<code>{
+  id: string, # Optional. Uniquely identifies the action.
+  actionType: &quot;Stop&quot;, # Optional. The action that will be taken.
+  reason: &quot;Schedule&quot;, # Optional. The reason for this action.
+  scheduledTime: string (ISO 8601 Format), # Optional. The target time the action will be triggered (UTC).
+  originalScheduledTime: string (ISO 8601 Format), # Optional. The original scheduled time for the action (UTC).
+  sourceId: string, # Optional. The id of the resource which triggered this action
+}
+</code>
+
+</remarks>
+    </member>
     <member name="GetPoolsAsync(Int32,String,RequestContext)">
 <example>
 This sample shows how to call GetPoolsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetPoolsAsync())
 {
@@ -457,7 +689,7 @@ await foreach (var data in client.GetPoolsAsync())
 This sample shows how to call GetPoolsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetPoolsAsync(1234, "<filter>"))
 {
@@ -468,6 +700,7 @@ await foreach (var data in client.GetPoolsAsync(1234, "<filter>"))
     Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
     Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
     Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
     Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
@@ -493,6 +726,7 @@ Schema for <c>PoolListResultValue</c>:
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
     memoryGB: number, # Optional. The amount of memory available for the Dev Box.
   }, # Optional. Hardware settings for the Dev Boxes created in this pool
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   storageProfile: {
     osDisk: {
       diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
@@ -516,7 +750,7 @@ Schema for <c>PoolListResultValue</c>:
 This sample shows how to call GetPools and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetPools())
 {
@@ -527,7 +761,7 @@ foreach (var data in client.GetPools())
 This sample shows how to call GetPools with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetPools(1234, "<filter>"))
 {
@@ -538,6 +772,7 @@ foreach (var data in client.GetPools(1234, "<filter>"))
     Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
     Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
     Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
     Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
@@ -563,6 +798,7 @@ Schema for <c>PoolListResultValue</c>:
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
     memoryGB: number, # Optional. The amount of memory available for the Dev Box.
   }, # Optional. Hardware settings for the Dev Boxes created in this pool
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   storageProfile: {
     osDisk: {
       diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
@@ -586,7 +822,7 @@ Schema for <c>PoolListResultValue</c>:
 This sample shows how to call GetSchedulesByPoolAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetSchedulesByPoolAsync("<poolName>"))
 {
@@ -597,7 +833,7 @@ await foreach (var data in client.GetSchedulesByPoolAsync("<poolName>"))
 This sample shows how to call GetSchedulesByPoolAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetSchedulesByPoolAsync("<poolName>", 1234, "<filter>"))
 {
@@ -632,7 +868,7 @@ Schema for <c>ScheduleListResultValue</c>:
 This sample shows how to call GetSchedulesByPool with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetSchedulesByPool("<poolName>"))
 {
@@ -643,7 +879,7 @@ foreach (var data in client.GetSchedulesByPool("<poolName>"))
 This sample shows how to call GetSchedulesByPool with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetSchedulesByPool("<poolName>", 1234, "<filter>"))
 {
@@ -678,7 +914,7 @@ Schema for <c>ScheduleListResultValue</c>:
 This sample shows how to call GetDevBoxesByUserAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetDevBoxesByUserAsync())
 {
@@ -689,7 +925,7 @@ await foreach (var data in client.GetDevBoxesByUserAsync())
 This sample shows how to call GetDevBoxesByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetDevBoxesByUserAsync(<me>, "<filter>", 1234))
 {
@@ -697,6 +933,7 @@ await foreach (var data in client.GetDevBoxesByUserAsync(<me>, "<filter>", 1234)
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("projectName").ToString());
     Console.WriteLine(result.GetProperty("poolName").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("actionState").ToString());
     Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -730,6 +967,7 @@ Schema for <c>DevBoxListResultValue</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -740,7 +978,7 @@ Schema for <c>DevBoxListResultValue</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -770,7 +1008,7 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetDevBoxesByUser and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetDevBoxesByUser())
 {
@@ -781,7 +1019,7 @@ foreach (var data in client.GetDevBoxesByUser())
 This sample shows how to call GetDevBoxesByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetDevBoxesByUser(<me>, "<filter>", 1234))
 {
@@ -789,6 +1027,7 @@ foreach (var data in client.GetDevBoxesByUser(<me>, "<filter>", 1234))
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("projectName").ToString());
     Console.WriteLine(result.GetProperty("poolName").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("actionState").ToString());
     Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -822,6 +1061,7 @@ Schema for <c>DevBoxListResultValue</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -832,7 +1072,7 @@ Schema for <c>DevBoxListResultValue</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -857,12 +1097,108 @@ Schema for <c>DevBoxListResultValue</c>:
 
 </remarks>
     </member>
+    <member name="GetUpcomingActionsAsync(String,String,RequestContext)">
+<example>
+This sample shows how to call GetUpcomingActionsAsync with required parameters and parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+await foreach (var data in client.GetUpcomingActionsAsync("<devBoxName>"))
+{
+    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
+    Console.WriteLine(result.ToString());
+}
+]]></code>
+This sample shows how to call GetUpcomingActionsAsync with all parameters, and how to parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+await foreach (var data in client.GetUpcomingActionsAsync("<devBoxName>", <me>))
+{
+    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
+    Console.WriteLine(result.GetProperty("id").ToString());
+    Console.WriteLine(result.GetProperty("actionType").ToString());
+    Console.WriteLine(result.GetProperty("reason").ToString());
+    Console.WriteLine(result.GetProperty("scheduledTime").ToString());
+    Console.WriteLine(result.GetProperty("originalScheduledTime").ToString());
+    Console.WriteLine(result.GetProperty("sourceId").ToString());
+}
+]]></code>
+</example>
+<remarks>
+Below is the JSON schema for one item in the pageable response.
+
+Response Body:
+
+Schema for <c>UpcomingActionsListResultValue</c>:
+<code>{
+  id: string, # Optional. Uniquely identifies the action.
+  actionType: &quot;Stop&quot;, # Optional. The action that will be taken.
+  reason: &quot;Schedule&quot;, # Optional. The reason for this action.
+  scheduledTime: string (ISO 8601 Format), # Optional. The target time the action will be triggered (UTC).
+  originalScheduledTime: string (ISO 8601 Format), # Optional. The original scheduled time for the action (UTC).
+  sourceId: string, # Optional. The id of the resource which triggered this action
+}
+</code>
+
+</remarks>
+    </member>
+    <member name="GetUpcomingActions(String,String,RequestContext)">
+<example>
+This sample shows how to call GetUpcomingActions with required parameters and parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+foreach (var data in client.GetUpcomingActions("<devBoxName>"))
+{
+    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
+    Console.WriteLine(result.ToString());
+}
+]]></code>
+This sample shows how to call GetUpcomingActions with all parameters, and how to parse the result.
+<code><![CDATA[
+var credential = new DefaultAzureCredential();
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+
+foreach (var data in client.GetUpcomingActions("<devBoxName>", <me>))
+{
+    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
+    Console.WriteLine(result.GetProperty("id").ToString());
+    Console.WriteLine(result.GetProperty("actionType").ToString());
+    Console.WriteLine(result.GetProperty("reason").ToString());
+    Console.WriteLine(result.GetProperty("scheduledTime").ToString());
+    Console.WriteLine(result.GetProperty("originalScheduledTime").ToString());
+    Console.WriteLine(result.GetProperty("sourceId").ToString());
+}
+]]></code>
+</example>
+<remarks>
+Below is the JSON schema for one item in the pageable response.
+
+Response Body:
+
+Schema for <c>UpcomingActionsListResultValue</c>:
+<code>{
+  id: string, # Optional. Uniquely identifies the action.
+  actionType: &quot;Stop&quot;, # Optional. The action that will be taken.
+  reason: &quot;Schedule&quot;, # Optional. The reason for this action.
+  scheduledTime: string (ISO 8601 Format), # Optional. The target time the action will be triggered (UTC).
+  originalScheduledTime: string (ISO 8601 Format), # Optional. The original scheduled time for the action (UTC).
+  sourceId: string, # Optional. The id of the resource which triggered this action
+}
+</code>
+
+</remarks>
+    </member>
     <member name="CreateDevBoxAsync(WaitUntil,String,RequestContent,String,RequestContext)">
 <example>
 This sample shows how to call CreateDevBoxAsync with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -877,7 +1213,7 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call CreateDevBoxAsync with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -891,6 +1227,7 @@ JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("projectName").ToString());
 Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("actionState").ToString());
 Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -923,6 +1260,7 @@ Schema for <c>DevBox</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -933,7 +1271,7 @@ Schema for <c>DevBox</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -963,6 +1301,7 @@ Schema for <c>DevBox</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -973,7 +1312,7 @@ Schema for <c>DevBox</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -1003,7 +1342,7 @@ Schema for <c>DevBox</c>:
 This sample shows how to call CreateDevBox with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -1018,7 +1357,7 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call CreateDevBox with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -1032,6 +1371,7 @@ JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("projectName").ToString());
 Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("actionState").ToString());
 Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -1064,6 +1404,7 @@ Schema for <c>DevBox</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -1074,7 +1415,7 @@ Schema for <c>DevBox</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -1104,6 +1445,7 @@ Schema for <c>DevBox</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -1114,7 +1456,7 @@ Schema for <c>DevBox</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -1141,555 +1483,135 @@ Schema for <c>DevBox</c>:
     </member>
     <member name="DeleteDevBoxAsync(WaitUntil,String,String,RequestContext)">
 <example>
-This sample shows how to call DeleteDevBoxAsync with required parameters and parse the result.
+This sample shows how to call DeleteDevBoxAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = await client.DeleteDevBoxAsync(WaitUntil.Completed, "<devBoxName>");
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
-This sample shows how to call DeleteDevBoxAsync with all parameters, and how to parse the result.
+This sample shows how to call DeleteDevBoxAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = await client.DeleteDevBoxAsync(WaitUntil.Completed, "<devBoxName>", <me>);
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("projectName").ToString());
-Console.WriteLine(result.GetProperty("poolName").ToString());
-Console.WriteLine(result.GetProperty("provisioningState").ToString());
-Console.WriteLine(result.GetProperty("actionState").ToString());
-Console.WriteLine(result.GetProperty("powerState").ToString());
-Console.WriteLine(result.GetProperty("uniqueId").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("code").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("message").ToString());
-Console.WriteLine(result.GetProperty("location").ToString());
-Console.WriteLine(result.GetProperty("osType").ToString());
-Console.WriteLine(result.GetProperty("user").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
-Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("operatingSystem").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("osBuildNumber").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("publishedDate").ToString());
-Console.WriteLine(result.GetProperty("createdTime").ToString());
-Console.WriteLine(result.GetProperty("localAdministrator").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
 </example>
-<remarks>
-Below is the JSON schema for the response payload.
-
-Response Body:
-
-Schema for <c>DevBox</c>:
-<code>{
-  name: string, # Optional. Display name for the Dev Box
-  projectName: string, # Optional. Name of the project this Dev Box belongs to
-  poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
-  provisioningState: string, # Optional. The current provisioning state of the Dev Box.
-  actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
-  powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
-  uniqueId: string, # Optional. A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).
-  errorDetails: {
-    code: string, # Optional. The error code.
-    message: string, # Optional. The error message.
-  }, # Optional. Provisioning or action error details. Populated only for error states.
-  location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
-  osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
-  hardwareProfile: {
-    skuName: string, # Optional. The name of the SKU
-    vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
-    memoryGB: number, # Optional. The amount of memory available for the Dev Box.
-  }, # Optional. Information about the Dev Box&apos;s hardware resources
-  storageProfile: {
-    osDisk: {
-      diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
-    }, # Optional. Settings for the operating system disk.
-  }, # Optional. Storage settings for this Dev Box
-  imageReference: {
-    name: string, # Optional. The name of the image used.
-    version: string, # Optional. The version of the image.
-    operatingSystem: string, # Optional. The operating system of the image.
-    osBuildNumber: string, # Optional. The operating system build number of the image.
-    publishedDate: string (ISO 8601 Format), # Optional. The datetime that the backing image version was published.
-  }, # Optional. Information about the image used for this Dev Box
-  createdTime: string (ISO 8601 Format), # Optional. Creation time of this Dev Box
-  localAdministrator: &quot;Enabled&quot; | &quot;Disabled&quot;, # Optional. Indicates whether the owner of the Dev Box is a local administrator.
-}
-</code>
-
-</remarks>
     </member>
     <member name="DeleteDevBox(WaitUntil,String,String,RequestContext)">
 <example>
-This sample shows how to call DeleteDevBox with required parameters and parse the result.
+This sample shows how to call DeleteDevBox with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = client.DeleteDevBox(WaitUntil.Completed, "<devBoxName>");
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
-This sample shows how to call DeleteDevBox with all parameters, and how to parse the result.
+This sample shows how to call DeleteDevBox with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = client.DeleteDevBox(WaitUntil.Completed, "<devBoxName>", <me>);
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("projectName").ToString());
-Console.WriteLine(result.GetProperty("poolName").ToString());
-Console.WriteLine(result.GetProperty("provisioningState").ToString());
-Console.WriteLine(result.GetProperty("actionState").ToString());
-Console.WriteLine(result.GetProperty("powerState").ToString());
-Console.WriteLine(result.GetProperty("uniqueId").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("code").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("message").ToString());
-Console.WriteLine(result.GetProperty("location").ToString());
-Console.WriteLine(result.GetProperty("osType").ToString());
-Console.WriteLine(result.GetProperty("user").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
-Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("operatingSystem").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("osBuildNumber").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("publishedDate").ToString());
-Console.WriteLine(result.GetProperty("createdTime").ToString());
-Console.WriteLine(result.GetProperty("localAdministrator").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
 </example>
-<remarks>
-Below is the JSON schema for the response payload.
-
-Response Body:
-
-Schema for <c>DevBox</c>:
-<code>{
-  name: string, # Optional. Display name for the Dev Box
-  projectName: string, # Optional. Name of the project this Dev Box belongs to
-  poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
-  provisioningState: string, # Optional. The current provisioning state of the Dev Box.
-  actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
-  powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
-  uniqueId: string, # Optional. A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).
-  errorDetails: {
-    code: string, # Optional. The error code.
-    message: string, # Optional. The error message.
-  }, # Optional. Provisioning or action error details. Populated only for error states.
-  location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
-  osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
-  hardwareProfile: {
-    skuName: string, # Optional. The name of the SKU
-    vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
-    memoryGB: number, # Optional. The amount of memory available for the Dev Box.
-  }, # Optional. Information about the Dev Box&apos;s hardware resources
-  storageProfile: {
-    osDisk: {
-      diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
-    }, # Optional. Settings for the operating system disk.
-  }, # Optional. Storage settings for this Dev Box
-  imageReference: {
-    name: string, # Optional. The name of the image used.
-    version: string, # Optional. The version of the image.
-    operatingSystem: string, # Optional. The operating system of the image.
-    osBuildNumber: string, # Optional. The operating system build number of the image.
-    publishedDate: string (ISO 8601 Format), # Optional. The datetime that the backing image version was published.
-  }, # Optional. Information about the image used for this Dev Box
-  createdTime: string (ISO 8601 Format), # Optional. Creation time of this Dev Box
-  localAdministrator: &quot;Enabled&quot; | &quot;Disabled&quot;, # Optional. Indicates whether the owner of the Dev Box is a local administrator.
-}
-</code>
-
-</remarks>
     </member>
     <member name="StartDevBoxAsync(WaitUntil,String,String,RequestContext)">
 <example>
-This sample shows how to call StartDevBoxAsync with required parameters and parse the result.
+This sample shows how to call StartDevBoxAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = await client.StartDevBoxAsync(WaitUntil.Completed, "<devBoxName>");
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
-This sample shows how to call StartDevBoxAsync with all parameters, and how to parse the result.
+This sample shows how to call StartDevBoxAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = await client.StartDevBoxAsync(WaitUntil.Completed, "<devBoxName>", <me>);
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("projectName").ToString());
-Console.WriteLine(result.GetProperty("poolName").ToString());
-Console.WriteLine(result.GetProperty("provisioningState").ToString());
-Console.WriteLine(result.GetProperty("actionState").ToString());
-Console.WriteLine(result.GetProperty("powerState").ToString());
-Console.WriteLine(result.GetProperty("uniqueId").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("code").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("message").ToString());
-Console.WriteLine(result.GetProperty("location").ToString());
-Console.WriteLine(result.GetProperty("osType").ToString());
-Console.WriteLine(result.GetProperty("user").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
-Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("operatingSystem").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("osBuildNumber").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("publishedDate").ToString());
-Console.WriteLine(result.GetProperty("createdTime").ToString());
-Console.WriteLine(result.GetProperty("localAdministrator").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
 </example>
-<remarks>
-Below is the JSON schema for the response payload.
-
-Response Body:
-
-Schema for <c>DevBox</c>:
-<code>{
-  name: string, # Optional. Display name for the Dev Box
-  projectName: string, # Optional. Name of the project this Dev Box belongs to
-  poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
-  provisioningState: string, # Optional. The current provisioning state of the Dev Box.
-  actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
-  powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
-  uniqueId: string, # Optional. A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).
-  errorDetails: {
-    code: string, # Optional. The error code.
-    message: string, # Optional. The error message.
-  }, # Optional. Provisioning or action error details. Populated only for error states.
-  location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
-  osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
-  hardwareProfile: {
-    skuName: string, # Optional. The name of the SKU
-    vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
-    memoryGB: number, # Optional. The amount of memory available for the Dev Box.
-  }, # Optional. Information about the Dev Box&apos;s hardware resources
-  storageProfile: {
-    osDisk: {
-      diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
-    }, # Optional. Settings for the operating system disk.
-  }, # Optional. Storage settings for this Dev Box
-  imageReference: {
-    name: string, # Optional. The name of the image used.
-    version: string, # Optional. The version of the image.
-    operatingSystem: string, # Optional. The operating system of the image.
-    osBuildNumber: string, # Optional. The operating system build number of the image.
-    publishedDate: string (ISO 8601 Format), # Optional. The datetime that the backing image version was published.
-  }, # Optional. Information about the image used for this Dev Box
-  createdTime: string (ISO 8601 Format), # Optional. Creation time of this Dev Box
-  localAdministrator: &quot;Enabled&quot; | &quot;Disabled&quot;, # Optional. Indicates whether the owner of the Dev Box is a local administrator.
-}
-</code>
-
-</remarks>
     </member>
     <member name="StartDevBox(WaitUntil,String,String,RequestContext)">
 <example>
-This sample shows how to call StartDevBox with required parameters and parse the result.
+This sample shows how to call StartDevBox with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = client.StartDevBox(WaitUntil.Completed, "<devBoxName>");
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
-This sample shows how to call StartDevBox with all parameters, and how to parse the result.
+This sample shows how to call StartDevBox with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = client.StartDevBox(WaitUntil.Completed, "<devBoxName>", <me>);
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("projectName").ToString());
-Console.WriteLine(result.GetProperty("poolName").ToString());
-Console.WriteLine(result.GetProperty("provisioningState").ToString());
-Console.WriteLine(result.GetProperty("actionState").ToString());
-Console.WriteLine(result.GetProperty("powerState").ToString());
-Console.WriteLine(result.GetProperty("uniqueId").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("code").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("message").ToString());
-Console.WriteLine(result.GetProperty("location").ToString());
-Console.WriteLine(result.GetProperty("osType").ToString());
-Console.WriteLine(result.GetProperty("user").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
-Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("operatingSystem").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("osBuildNumber").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("publishedDate").ToString());
-Console.WriteLine(result.GetProperty("createdTime").ToString());
-Console.WriteLine(result.GetProperty("localAdministrator").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
 </example>
-<remarks>
-Below is the JSON schema for the response payload.
-
-Response Body:
-
-Schema for <c>DevBox</c>:
-<code>{
-  name: string, # Optional. Display name for the Dev Box
-  projectName: string, # Optional. Name of the project this Dev Box belongs to
-  poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
-  provisioningState: string, # Optional. The current provisioning state of the Dev Box.
-  actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
-  powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
-  uniqueId: string, # Optional. A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).
-  errorDetails: {
-    code: string, # Optional. The error code.
-    message: string, # Optional. The error message.
-  }, # Optional. Provisioning or action error details. Populated only for error states.
-  location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
-  osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
-  hardwareProfile: {
-    skuName: string, # Optional. The name of the SKU
-    vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
-    memoryGB: number, # Optional. The amount of memory available for the Dev Box.
-  }, # Optional. Information about the Dev Box&apos;s hardware resources
-  storageProfile: {
-    osDisk: {
-      diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
-    }, # Optional. Settings for the operating system disk.
-  }, # Optional. Storage settings for this Dev Box
-  imageReference: {
-    name: string, # Optional. The name of the image used.
-    version: string, # Optional. The version of the image.
-    operatingSystem: string, # Optional. The operating system of the image.
-    osBuildNumber: string, # Optional. The operating system build number of the image.
-    publishedDate: string (ISO 8601 Format), # Optional. The datetime that the backing image version was published.
-  }, # Optional. Information about the image used for this Dev Box
-  createdTime: string (ISO 8601 Format), # Optional. Creation time of this Dev Box
-  localAdministrator: &quot;Enabled&quot; | &quot;Disabled&quot;, # Optional. Indicates whether the owner of the Dev Box is a local administrator.
-}
-</code>
-
-</remarks>
     </member>
-    <member name="StopDevBoxAsync(WaitUntil,String,String,RequestContext)">
+    <member name="StopDevBoxAsync(WaitUntil,String,String,Boolean,RequestContext)">
 <example>
-This sample shows how to call StopDevBoxAsync with required parameters and parse the result.
+This sample shows how to call StopDevBoxAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = await client.StopDevBoxAsync(WaitUntil.Completed, "<devBoxName>");
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
-This sample shows how to call StopDevBoxAsync with all parameters, and how to parse the result.
+This sample shows how to call StopDevBoxAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
-var operation = await client.StopDevBoxAsync(WaitUntil.Completed, "<devBoxName>", <me>);
+var operation = await client.StopDevBoxAsync(WaitUntil.Completed, "<devBoxName>", <me>, true);
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("projectName").ToString());
-Console.WriteLine(result.GetProperty("poolName").ToString());
-Console.WriteLine(result.GetProperty("provisioningState").ToString());
-Console.WriteLine(result.GetProperty("actionState").ToString());
-Console.WriteLine(result.GetProperty("powerState").ToString());
-Console.WriteLine(result.GetProperty("uniqueId").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("code").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("message").ToString());
-Console.WriteLine(result.GetProperty("location").ToString());
-Console.WriteLine(result.GetProperty("osType").ToString());
-Console.WriteLine(result.GetProperty("user").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
-Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("operatingSystem").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("osBuildNumber").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("publishedDate").ToString());
-Console.WriteLine(result.GetProperty("createdTime").ToString());
-Console.WriteLine(result.GetProperty("localAdministrator").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
 </example>
-<remarks>
-Below is the JSON schema for the response payload.
-
-Response Body:
-
-Schema for <c>DevBox</c>:
-<code>{
-  name: string, # Optional. Display name for the Dev Box
-  projectName: string, # Optional. Name of the project this Dev Box belongs to
-  poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
-  provisioningState: string, # Optional. The current provisioning state of the Dev Box.
-  actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
-  powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
-  uniqueId: string, # Optional. A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).
-  errorDetails: {
-    code: string, # Optional. The error code.
-    message: string, # Optional. The error message.
-  }, # Optional. Provisioning or action error details. Populated only for error states.
-  location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
-  osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
-  hardwareProfile: {
-    skuName: string, # Optional. The name of the SKU
-    vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
-    memoryGB: number, # Optional. The amount of memory available for the Dev Box.
-  }, # Optional. Information about the Dev Box&apos;s hardware resources
-  storageProfile: {
-    osDisk: {
-      diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
-    }, # Optional. Settings for the operating system disk.
-  }, # Optional. Storage settings for this Dev Box
-  imageReference: {
-    name: string, # Optional. The name of the image used.
-    version: string, # Optional. The version of the image.
-    operatingSystem: string, # Optional. The operating system of the image.
-    osBuildNumber: string, # Optional. The operating system build number of the image.
-    publishedDate: string (ISO 8601 Format), # Optional. The datetime that the backing image version was published.
-  }, # Optional. Information about the image used for this Dev Box
-  createdTime: string (ISO 8601 Format), # Optional. Creation time of this Dev Box
-  localAdministrator: &quot;Enabled&quot; | &quot;Disabled&quot;, # Optional. Indicates whether the owner of the Dev Box is a local administrator.
-}
-</code>
-
-</remarks>
     </member>
-    <member name="StopDevBox(WaitUntil,String,String,RequestContext)">
+    <member name="StopDevBox(WaitUntil,String,String,Boolean,RequestContext)">
 <example>
-This sample shows how to call StopDevBox with required parameters and parse the result.
+This sample shows how to call StopDevBox with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = client.StopDevBox(WaitUntil.Completed, "<devBoxName>");
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("poolName").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
-This sample shows how to call StopDevBox with all parameters, and how to parse the result.
+This sample shows how to call StopDevBox with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
 
-var operation = client.StopDevBox(WaitUntil.Completed, "<devBoxName>", <me>);
+var operation = client.StopDevBox(WaitUntil.Completed, "<devBoxName>", <me>, true);
 
-BinaryData data = operation.Value;
-JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-Console.WriteLine(result.GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("projectName").ToString());
-Console.WriteLine(result.GetProperty("poolName").ToString());
-Console.WriteLine(result.GetProperty("provisioningState").ToString());
-Console.WriteLine(result.GetProperty("actionState").ToString());
-Console.WriteLine(result.GetProperty("powerState").ToString());
-Console.WriteLine(result.GetProperty("uniqueId").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("code").ToString());
-Console.WriteLine(result.GetProperty("errorDetails").GetProperty("message").ToString());
-Console.WriteLine(result.GetProperty("location").ToString());
-Console.WriteLine(result.GetProperty("osType").ToString());
-Console.WriteLine(result.GetProperty("user").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("skuName").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("vCPUs").ToString());
-Console.WriteLine(result.GetProperty("hardwareProfile").GetProperty("memoryGB").ToString());
-Console.WriteLine(result.GetProperty("storageProfile").GetProperty("osDisk").GetProperty("diskSizeGB").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("name").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("version").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("operatingSystem").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("osBuildNumber").ToString());
-Console.WriteLine(result.GetProperty("imageReference").GetProperty("publishedDate").ToString());
-Console.WriteLine(result.GetProperty("createdTime").ToString());
-Console.WriteLine(result.GetProperty("localAdministrator").ToString());
+Console.WriteLine(operation.GetRawResponse().Status)
 ]]></code>
 </example>
-<remarks>
-Below is the JSON schema for the response payload.
-
-Response Body:
-
-Schema for <c>DevBox</c>:
-<code>{
-  name: string, # Optional. Display name for the Dev Box
-  projectName: string, # Optional. Name of the project this Dev Box belongs to
-  poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
-  provisioningState: string, # Optional. The current provisioning state of the Dev Box.
-  actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
-  powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
-  uniqueId: string, # Optional. A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).
-  errorDetails: {
-    code: string, # Optional. The error code.
-    message: string, # Optional. The error message.
-  }, # Optional. Provisioning or action error details. Populated only for error states.
-  location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
-  osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
-  hardwareProfile: {
-    skuName: string, # Optional. The name of the SKU
-    vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
-    memoryGB: number, # Optional. The amount of memory available for the Dev Box.
-  }, # Optional. Information about the Dev Box&apos;s hardware resources
-  storageProfile: {
-    osDisk: {
-      diskSizeGB: number, # Optional. The size of the OS Disk in gigabytes.
-    }, # Optional. Settings for the operating system disk.
-  }, # Optional. Storage settings for this Dev Box
-  imageReference: {
-    name: string, # Optional. The name of the image used.
-    version: string, # Optional. The version of the image.
-    operatingSystem: string, # Optional. The operating system of the image.
-    osBuildNumber: string, # Optional. The operating system build number of the image.
-    publishedDate: string (ISO 8601 Format), # Optional. The datetime that the backing image version was published.
-  }, # Optional. Information about the image used for this Dev Box
-  createdTime: string (ISO 8601 Format), # Optional. Creation time of this Dev Box
-  localAdministrator: &quot;Enabled&quot; | &quot;Disabled&quot;, # Optional. Indicates whether the owner of the Dev Box is a local administrator.
-}
-</code>
-
-</remarks>
     </member>
   </members>
 </doc>

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevBoxesClient.xml
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevBoxesClient.xml
@@ -6,7 +6,8 @@
 This sample shows how to call GetPoolAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetPoolAsync("<poolName>");
 
@@ -66,7 +67,8 @@ Schema for <c>Pool</c>:
 This sample shows how to call GetPool with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetPool("<poolName>");
 
@@ -126,7 +128,8 @@ Schema for <c>Pool</c>:
 This sample shows how to call GetScheduleByPoolAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetScheduleByPoolAsync("<poolName>", "<scheduleName>");
 
@@ -160,7 +163,8 @@ Schema for <c>Schedule</c>:
 This sample shows how to call GetScheduleByPool with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetScheduleByPool("<poolName>", "<scheduleName>");
 
@@ -194,7 +198,8 @@ Schema for <c>Schedule</c>:
 This sample shows how to call GetDevBoxByUserAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetDevBoxByUserAsync("<devBoxName>");
 
@@ -204,7 +209,8 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call GetDevBoxByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetDevBoxByUserAsync("<devBoxName>", <me>);
 
@@ -286,7 +292,8 @@ Schema for <c>DevBox</c>:
 This sample shows how to call GetDevBoxByUser with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetDevBoxByUser("<devBoxName>");
 
@@ -296,7 +303,8 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call GetDevBoxByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetDevBoxByUser("<devBoxName>", <me>);
 
@@ -378,7 +386,8 @@ Schema for <c>DevBox</c>:
 This sample shows how to call GetRemoteConnectionAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetRemoteConnectionAsync("<devBoxName>");
 
@@ -388,7 +397,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetRemoteConnectionAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetRemoteConnectionAsync("<devBoxName>", <me>);
 
@@ -416,7 +426,8 @@ Schema for <c>RemoteConnection</c>:
 This sample shows how to call GetRemoteConnection with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetRemoteConnection("<devBoxName>");
 
@@ -426,7 +437,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetRemoteConnection with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetRemoteConnection("<devBoxName>", <me>);
 
@@ -454,7 +466,8 @@ Schema for <c>RemoteConnection</c>:
 This sample shows how to call GetUpcomingActionAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetUpcomingActionAsync("<devBoxName>", "<upcomingActionId>");
 
@@ -464,7 +477,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetUpcomingActionAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", <me>);
 
@@ -500,7 +514,8 @@ Schema for <c>UpcomingAction</c>:
 This sample shows how to call GetUpcomingAction with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetUpcomingAction("<devBoxName>", "<upcomingActionId>");
 
@@ -510,7 +525,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetUpcomingAction with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetUpcomingAction("<devBoxName>", "<upcomingActionId>", <me>);
 
@@ -546,7 +562,8 @@ Schema for <c>UpcomingAction</c>:
 This sample shows how to call SkipUpcomingActionAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.SkipUpcomingActionAsync("<devBoxName>", "<upcomingActionId>");
 Console.WriteLine(response.Status);
@@ -554,7 +571,8 @@ Console.WriteLine(response.Status);
 This sample shows how to call SkipUpcomingActionAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.SkipUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", <me>);
 Console.WriteLine(response.Status);
@@ -566,7 +584,8 @@ Console.WriteLine(response.Status);
 This sample shows how to call SkipUpcomingAction with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.SkipUpcomingAction("<devBoxName>", "<upcomingActionId>");
 Console.WriteLine(response.Status);
@@ -574,7 +593,8 @@ Console.WriteLine(response.Status);
 This sample shows how to call SkipUpcomingAction with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.SkipUpcomingAction("<devBoxName>", "<upcomingActionId>", <me>);
 Console.WriteLine(response.Status);
@@ -586,7 +606,8 @@ Console.WriteLine(response.Status);
 This sample shows how to call DelayUpcomingActionAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.DelayUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow);
 
@@ -596,7 +617,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call DelayUpcomingActionAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = await client.DelayUpcomingActionAsync("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow, <me>);
 
@@ -632,7 +654,8 @@ Schema for <c>UpcomingAction</c>:
 This sample shows how to call DelayUpcomingAction with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.DelayUpcomingAction("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow);
 
@@ -642,7 +665,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call DelayUpcomingAction with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 Response response = client.DelayUpcomingAction("<devBoxName>", "<upcomingActionId>", DateTimeOffset.UtcNow, <me>);
 
@@ -678,7 +702,8 @@ Schema for <c>UpcomingAction</c>:
 This sample shows how to call GetPoolsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetPoolsAsync())
 {
@@ -689,7 +714,8 @@ await foreach (var data in client.GetPoolsAsync())
 This sample shows how to call GetPoolsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetPoolsAsync(1234, "<filter>"))
 {
@@ -750,7 +776,8 @@ Schema for <c>PoolListResultValue</c>:
 This sample shows how to call GetPools and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetPools())
 {
@@ -761,7 +788,8 @@ foreach (var data in client.GetPools())
 This sample shows how to call GetPools with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetPools(1234, "<filter>"))
 {
@@ -822,7 +850,8 @@ Schema for <c>PoolListResultValue</c>:
 This sample shows how to call GetSchedulesByPoolAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetSchedulesByPoolAsync("<poolName>"))
 {
@@ -833,7 +862,8 @@ await foreach (var data in client.GetSchedulesByPoolAsync("<poolName>"))
 This sample shows how to call GetSchedulesByPoolAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetSchedulesByPoolAsync("<poolName>", 1234, "<filter>"))
 {
@@ -868,7 +898,8 @@ Schema for <c>ScheduleListResultValue</c>:
 This sample shows how to call GetSchedulesByPool with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetSchedulesByPool("<poolName>"))
 {
@@ -879,7 +910,8 @@ foreach (var data in client.GetSchedulesByPool("<poolName>"))
 This sample shows how to call GetSchedulesByPool with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetSchedulesByPool("<poolName>", 1234, "<filter>"))
 {
@@ -914,7 +946,8 @@ Schema for <c>ScheduleListResultValue</c>:
 This sample shows how to call GetDevBoxesByUserAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetDevBoxesByUserAsync())
 {
@@ -925,7 +958,8 @@ await foreach (var data in client.GetDevBoxesByUserAsync())
 This sample shows how to call GetDevBoxesByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetDevBoxesByUserAsync(<me>, "<filter>", 1234))
 {
@@ -1008,7 +1042,8 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetDevBoxesByUser and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetDevBoxesByUser())
 {
@@ -1019,7 +1054,8 @@ foreach (var data in client.GetDevBoxesByUser())
 This sample shows how to call GetDevBoxesByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetDevBoxesByUser(<me>, "<filter>", 1234))
 {
@@ -1102,7 +1138,8 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetUpcomingActionsAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetUpcomingActionsAsync("<devBoxName>"))
 {
@@ -1113,7 +1150,8 @@ await foreach (var data in client.GetUpcomingActionsAsync("<devBoxName>"))
 This sample shows how to call GetUpcomingActionsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetUpcomingActionsAsync("<devBoxName>", <me>))
 {
@@ -1150,7 +1188,8 @@ Schema for <c>UpcomingActionsListResultValue</c>:
 This sample shows how to call GetUpcomingActions with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetUpcomingActions("<devBoxName>"))
 {
@@ -1161,7 +1200,8 @@ foreach (var data in client.GetUpcomingActions("<devBoxName>"))
 This sample shows how to call GetUpcomingActions with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetUpcomingActions("<devBoxName>", <me>))
 {
@@ -1198,7 +1238,8 @@ Schema for <c>UpcomingActionsListResultValue</c>:
 This sample shows how to call CreateDevBoxAsync with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -1213,7 +1254,8 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call CreateDevBoxAsync with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -1342,7 +1384,8 @@ Schema for <c>DevBox</c>:
 This sample shows how to call CreateDevBox with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -1357,7 +1400,8 @@ Console.WriteLine(result.GetProperty("poolName").ToString());
 This sample shows how to call CreateDevBox with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var data = new {
     poolName = "<poolName>",
@@ -1486,7 +1530,8 @@ Schema for <c>DevBox</c>:
 This sample shows how to call DeleteDevBoxAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = await client.DeleteDevBoxAsync(WaitUntil.Completed, "<devBoxName>");
 
@@ -1495,7 +1540,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteDevBoxAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = await client.DeleteDevBoxAsync(WaitUntil.Completed, "<devBoxName>", <me>);
 
@@ -1508,7 +1554,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteDevBox with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = client.DeleteDevBox(WaitUntil.Completed, "<devBoxName>");
 
@@ -1517,7 +1564,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteDevBox with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = client.DeleteDevBox(WaitUntil.Completed, "<devBoxName>", <me>);
 
@@ -1530,7 +1578,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StartDevBoxAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = await client.StartDevBoxAsync(WaitUntil.Completed, "<devBoxName>");
 
@@ -1539,7 +1588,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StartDevBoxAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = await client.StartDevBoxAsync(WaitUntil.Completed, "<devBoxName>", <me>);
 
@@ -1552,7 +1602,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StartDevBox with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = client.StartDevBox(WaitUntil.Completed, "<devBoxName>");
 
@@ -1561,7 +1612,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StartDevBox with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = client.StartDevBox(WaitUntil.Completed, "<devBoxName>", <me>);
 
@@ -1574,7 +1626,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StopDevBoxAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = await client.StopDevBoxAsync(WaitUntil.Completed, "<devBoxName>");
 
@@ -1583,7 +1636,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StopDevBoxAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = await client.StopDevBoxAsync(WaitUntil.Completed, "<devBoxName>", <me>, true);
 
@@ -1596,7 +1650,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StopDevBox with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = client.StopDevBox(WaitUntil.Completed, "<devBoxName>");
 
@@ -1605,7 +1660,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call StopDevBox with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevBoxesClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevBoxesClient(endpoint, "<projectName>", credential);
 
 var operation = client.StopDevBox(WaitUntil.Completed, "<devBoxName>", <me>, true);
 

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevCenterClient.xml
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevCenterClient.xml
@@ -6,7 +6,7 @@
 This sample shows how to call GetProjectAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 Response response = await client.GetProjectAsync("<projectName>");
 
@@ -34,7 +34,7 @@ Schema for <c>Project</c>:
 This sample shows how to call GetProject with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 Response response = client.GetProject("<projectName>");
 
@@ -62,7 +62,7 @@ Schema for <c>Project</c>:
 This sample shows how to call GetProjectsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 await foreach (var data in client.GetProjectsAsync())
 {
@@ -73,7 +73,7 @@ await foreach (var data in client.GetProjectsAsync())
 This sample shows how to call GetProjectsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 await foreach (var data in client.GetProjectsAsync("<filter>", 1234))
 {
@@ -102,7 +102,7 @@ Schema for <c>ProjectListResultValue</c>:
 This sample shows how to call GetProjects and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 foreach (var data in client.GetProjects())
 {
@@ -113,7 +113,7 @@ foreach (var data in client.GetProjects())
 This sample shows how to call GetProjects with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 foreach (var data in client.GetProjects("<filter>", 1234))
 {
@@ -142,7 +142,7 @@ Schema for <c>ProjectListResultValue</c>:
 This sample shows how to call GetAllDevBoxesAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 await foreach (var data in client.GetAllDevBoxesAsync())
 {
@@ -153,7 +153,7 @@ await foreach (var data in client.GetAllDevBoxesAsync())
 This sample shows how to call GetAllDevBoxesAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 await foreach (var data in client.GetAllDevBoxesAsync("<filter>", 1234))
 {
@@ -161,6 +161,7 @@ await foreach (var data in client.GetAllDevBoxesAsync("<filter>", 1234))
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("projectName").ToString());
     Console.WriteLine(result.GetProperty("poolName").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("actionState").ToString());
     Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -194,6 +195,7 @@ Schema for <c>DevBoxListResultValue</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -204,7 +206,7 @@ Schema for <c>DevBoxListResultValue</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -234,7 +236,7 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetAllDevBoxes and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 foreach (var data in client.GetAllDevBoxes())
 {
@@ -245,7 +247,7 @@ foreach (var data in client.GetAllDevBoxes())
 This sample shows how to call GetAllDevBoxes with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 foreach (var data in client.GetAllDevBoxes("<filter>", 1234))
 {
@@ -253,6 +255,7 @@ foreach (var data in client.GetAllDevBoxes("<filter>", 1234))
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("projectName").ToString());
     Console.WriteLine(result.GetProperty("poolName").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("actionState").ToString());
     Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -286,6 +289,7 @@ Schema for <c>DevBoxListResultValue</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -296,7 +300,7 @@ Schema for <c>DevBoxListResultValue</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -326,7 +330,7 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetAllDevBoxesByUserAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 await foreach (var data in client.GetAllDevBoxesByUserAsync())
 {
@@ -337,7 +341,7 @@ await foreach (var data in client.GetAllDevBoxesByUserAsync())
 This sample shows how to call GetAllDevBoxesByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 await foreach (var data in client.GetAllDevBoxesByUserAsync(<me>, "<filter>", 1234))
 {
@@ -345,6 +349,7 @@ await foreach (var data in client.GetAllDevBoxesByUserAsync(<me>, "<filter>", 12
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("projectName").ToString());
     Console.WriteLine(result.GetProperty("poolName").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("actionState").ToString());
     Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -378,6 +383,7 @@ Schema for <c>DevBoxListResultValue</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -388,7 +394,7 @@ Schema for <c>DevBoxListResultValue</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.
@@ -418,7 +424,7 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetAllDevBoxesByUser and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 foreach (var data in client.GetAllDevBoxesByUser())
 {
@@ -429,7 +435,7 @@ foreach (var data in client.GetAllDevBoxesByUser())
 This sample shows how to call GetAllDevBoxesByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<tenantId>", "<devCenter>", credential);
+var client = new DevCenterClient("<https://my-service.azure.com>", credential);
 
 foreach (var data in client.GetAllDevBoxesByUser(<me>, "<filter>", 1234))
 {
@@ -437,6 +443,7 @@ foreach (var data in client.GetAllDevBoxesByUser(<me>, "<filter>", 1234))
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("projectName").ToString());
     Console.WriteLine(result.GetProperty("poolName").ToString());
+    Console.WriteLine(result.GetProperty("hibernateSupport").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("actionState").ToString());
     Console.WriteLine(result.GetProperty("powerState").ToString());
@@ -470,6 +477,7 @@ Schema for <c>DevBoxListResultValue</c>:
   name: string, # Optional. Display name for the Dev Box
   projectName: string, # Optional. Name of the project this Dev Box belongs to
   poolName: string, # Required. The name of the Dev Box pool this machine belongs to.
+  hibernateSupport: &quot;Disabled&quot; | &quot;Enabled&quot;, # Optional. Indicates whether hibernate is enabled/disabled or unknown.
   provisioningState: string, # Optional. The current provisioning state of the Dev Box.
   actionState: string, # Optional. The current action state of the Dev Box. This is state is based on previous action performed by user.
   powerState: &quot;Unknown&quot; | &quot;Deallocated&quot; | &quot;PoweredOff&quot; | &quot;Running&quot; | &quot;Hibernated&quot;, # Optional. The current power state of the Dev Box.
@@ -480,7 +488,7 @@ Schema for <c>DevBoxListResultValue</c>:
   }, # Optional. Provisioning or action error details. Populated only for error states.
   location: string, # Optional. Azure region where this Dev Box is located. This will be the same region as the Virtual Network it is attached to.
   osType: &quot;Windows&quot;, # Optional. The operating system type of this Dev Box.
-  user: string, # Optional. User identifier of the user this vm is assigned to.
+  user: string, # Optional. The AAD object id of the user this Dev Box is assigned to.
   hardwareProfile: {
     skuName: string, # Optional. The name of the SKU
     vCPUs: number, # Optional. The number of vCPUs available for the Dev Box.

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevCenterClient.xml
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/DevCenterClient.xml
@@ -6,7 +6,8 @@
 This sample shows how to call GetProjectAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 Response response = await client.GetProjectAsync("<projectName>");
 
@@ -34,7 +35,8 @@ Schema for <c>Project</c>:
 This sample shows how to call GetProject with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 Response response = client.GetProject("<projectName>");
 
@@ -62,7 +64,8 @@ Schema for <c>Project</c>:
 This sample shows how to call GetProjectsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 await foreach (var data in client.GetProjectsAsync())
 {
@@ -73,7 +76,8 @@ await foreach (var data in client.GetProjectsAsync())
 This sample shows how to call GetProjectsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 await foreach (var data in client.GetProjectsAsync("<filter>", 1234))
 {
@@ -102,7 +106,8 @@ Schema for <c>ProjectListResultValue</c>:
 This sample shows how to call GetProjects and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 foreach (var data in client.GetProjects())
 {
@@ -113,7 +118,8 @@ foreach (var data in client.GetProjects())
 This sample shows how to call GetProjects with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 foreach (var data in client.GetProjects("<filter>", 1234))
 {
@@ -142,7 +148,8 @@ Schema for <c>ProjectListResultValue</c>:
 This sample shows how to call GetAllDevBoxesAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 await foreach (var data in client.GetAllDevBoxesAsync())
 {
@@ -153,7 +160,8 @@ await foreach (var data in client.GetAllDevBoxesAsync())
 This sample shows how to call GetAllDevBoxesAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 await foreach (var data in client.GetAllDevBoxesAsync("<filter>", 1234))
 {
@@ -236,7 +244,8 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetAllDevBoxes and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 foreach (var data in client.GetAllDevBoxes())
 {
@@ -247,7 +256,8 @@ foreach (var data in client.GetAllDevBoxes())
 This sample shows how to call GetAllDevBoxes with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 foreach (var data in client.GetAllDevBoxes("<filter>", 1234))
 {
@@ -330,7 +340,8 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetAllDevBoxesByUserAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 await foreach (var data in client.GetAllDevBoxesByUserAsync())
 {
@@ -341,7 +352,8 @@ await foreach (var data in client.GetAllDevBoxesByUserAsync())
 This sample shows how to call GetAllDevBoxesByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 await foreach (var data in client.GetAllDevBoxesByUserAsync(<me>, "<filter>", 1234))
 {
@@ -424,7 +436,8 @@ Schema for <c>DevBoxListResultValue</c>:
 This sample shows how to call GetAllDevBoxesByUser and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 foreach (var data in client.GetAllDevBoxesByUser())
 {
@@ -435,7 +448,8 @@ foreach (var data in client.GetAllDevBoxesByUser())
 This sample shows how to call GetAllDevBoxesByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new DevCenterClient("<https://my-service.azure.com>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new DevCenterClient(endpoint, credential);
 
 foreach (var data in client.GetAllDevBoxesByUser(<me>, "<filter>", 1234))
 {

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/EnvironmentsClient.xml
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/EnvironmentsClient.xml
@@ -6,7 +6,7 @@
 This sample shows how to call GetEnvironmentByUserAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetEnvironmentByUserAsync("<environmentName>");
 
@@ -17,14 +17,14 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetEnvironmentByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetEnvironmentByUserAsync("<environmentName>", <me>);
 
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("environmentType").ToString());
-Console.WriteLine(result.GetProperty("owner").ToString());
+Console.WriteLine(result.GetProperty("user").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
 Console.WriteLine(result.GetProperty("description").ToString());
@@ -46,7 +46,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -65,7 +65,7 @@ Schema for <c>Environment</c>:
 This sample shows how to call GetEnvironmentByUser with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetEnvironmentByUser("<environmentName>");
 
@@ -76,14 +76,14 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetEnvironmentByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetEnvironmentByUser("<environmentName>", <me>);
 
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("environmentType").ToString());
-Console.WriteLine(result.GetProperty("owner").ToString());
+Console.WriteLine(result.GetProperty("user").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
 Console.WriteLine(result.GetProperty("description").ToString());
@@ -105,7 +105,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -124,7 +124,7 @@ Schema for <c>Environment</c>:
 This sample shows how to call UpdateEnvironmentAsync with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -139,11 +139,11 @@ Console.WriteLine(result.ToString());
 This sample shows how to call UpdateEnvironmentAsync with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
-    owner = "<owner>",
+    user = "<user>",
     description = "<description>",
     catalogName = "<catalogName>",
     catalogItemName = "<catalogItemName>",
@@ -165,7 +165,7 @@ Response response = await client.UpdateEnvironmentAsync("<environmentName>", Req
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("environmentType").ToString());
-Console.WriteLine(result.GetProperty("owner").ToString());
+Console.WriteLine(result.GetProperty("user").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
 Console.WriteLine(result.GetProperty("description").ToString());
@@ -187,7 +187,7 @@ Request Body:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -206,7 +206,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -225,7 +225,7 @@ Schema for <c>Environment</c>:
 This sample shows how to call UpdateEnvironment with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -240,11 +240,11 @@ Console.WriteLine(result.ToString());
 This sample shows how to call UpdateEnvironment with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
-    owner = "<owner>",
+    user = "<user>",
     description = "<description>",
     catalogName = "<catalogName>",
     catalogItemName = "<catalogItemName>",
@@ -266,7 +266,7 @@ Response response = client.UpdateEnvironment("<environmentName>", RequestContent
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("environmentType").ToString());
-Console.WriteLine(result.GetProperty("owner").ToString());
+Console.WriteLine(result.GetProperty("user").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
 Console.WriteLine(result.GetProperty("description").ToString());
@@ -288,7 +288,7 @@ Request Body:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -307,7 +307,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -326,7 +326,7 @@ Schema for <c>Environment</c>:
 This sample shows how to call GetCatalogItemAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetCatalogItemAsync("<catalogItemId>");
 
@@ -356,7 +356,7 @@ Schema for <c>CatalogItem</c>:
 This sample shows how to call GetCatalogItem with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetCatalogItem("<catalogItemId>");
 
@@ -386,7 +386,7 @@ Schema for <c>CatalogItem</c>:
 This sample shows how to call GetCatalogItemVersionAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = await client.GetCatalogItemVersionAsync("<catalogItemId>", "<version>");
 
@@ -479,7 +479,7 @@ Schema for <c>CatalogItemVersion</c>:
 This sample shows how to call GetCatalogItemVersion with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 Response response = client.GetCatalogItemVersion("<catalogItemId>", "<version>");
 
@@ -572,7 +572,7 @@ Schema for <c>CatalogItemVersion</c>:
 This sample shows how to call GetEnvironmentsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsAsync())
 {
@@ -584,14 +584,14 @@ await foreach (var data in client.GetEnvironmentsAsync())
 This sample shows how to call GetEnvironmentsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsAsync(1234))
 {
     JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("environmentType").ToString());
-    Console.WriteLine(result.GetProperty("owner").ToString());
+    Console.WriteLine(result.GetProperty("user").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
     Console.WriteLine(result.GetProperty("description").ToString());
@@ -614,7 +614,7 @@ Schema for <c>EnvironmentListResultValue</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -633,7 +633,7 @@ Schema for <c>EnvironmentListResultValue</c>:
 This sample shows how to call GetEnvironments and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetEnvironments())
 {
@@ -645,14 +645,14 @@ foreach (var data in client.GetEnvironments())
 This sample shows how to call GetEnvironments with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetEnvironments(1234))
 {
     JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("environmentType").ToString());
-    Console.WriteLine(result.GetProperty("owner").ToString());
+    Console.WriteLine(result.GetProperty("user").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
     Console.WriteLine(result.GetProperty("description").ToString());
@@ -675,7 +675,7 @@ Schema for <c>EnvironmentListResultValue</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -694,7 +694,7 @@ Schema for <c>EnvironmentListResultValue</c>:
 This sample shows how to call GetEnvironmentsByUserAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsByUserAsync())
 {
@@ -706,14 +706,14 @@ await foreach (var data in client.GetEnvironmentsByUserAsync())
 This sample shows how to call GetEnvironmentsByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsByUserAsync(<me>, 1234))
 {
     JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("environmentType").ToString());
-    Console.WriteLine(result.GetProperty("owner").ToString());
+    Console.WriteLine(result.GetProperty("user").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
     Console.WriteLine(result.GetProperty("description").ToString());
@@ -736,7 +736,7 @@ Schema for <c>EnvironmentListResultValue</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -755,7 +755,7 @@ Schema for <c>EnvironmentListResultValue</c>:
 This sample shows how to call GetEnvironmentsByUser and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentsByUser())
 {
@@ -767,14 +767,14 @@ foreach (var data in client.GetEnvironmentsByUser())
 This sample shows how to call GetEnvironmentsByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentsByUser(<me>, 1234))
 {
     JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
     Console.WriteLine(result.GetProperty("name").ToString());
     Console.WriteLine(result.GetProperty("environmentType").ToString());
-    Console.WriteLine(result.GetProperty("owner").ToString());
+    Console.WriteLine(result.GetProperty("user").ToString());
     Console.WriteLine(result.GetProperty("provisioningState").ToString());
     Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
     Console.WriteLine(result.GetProperty("description").ToString());
@@ -797,7 +797,7 @@ Schema for <c>EnvironmentListResultValue</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -811,212 +811,12 @@ Schema for <c>EnvironmentListResultValue</c>:
 
 </remarks>
     </member>
-    <member name="GetArtifactsByEnvironmentAsync(String,String,RequestContext)">
-<example>
-This sample shows how to call GetArtifactsByEnvironmentAsync with required parameters and parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-await foreach (var data in client.GetArtifactsByEnvironmentAsync("<environmentName>"))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.ToString());
-}
-]]></code>
-This sample shows how to call GetArtifactsByEnvironmentAsync with all parameters, and how to parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-await foreach (var data in client.GetArtifactsByEnvironmentAsync("<environmentName>", <me>))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.GetProperty("id").ToString());
-    Console.WriteLine(result.GetProperty("name").ToString());
-    Console.WriteLine(result.GetProperty("isDirectory").ToString());
-    Console.WriteLine(result.GetProperty("downloadUri").ToString());
-    Console.WriteLine(result.GetProperty("fileSize").ToString());
-    Console.WriteLine(result.GetProperty("createdTime").ToString());
-    Console.WriteLine(result.GetProperty("lastModifiedTime").ToString());
-}
-]]></code>
-</example>
-<remarks>
-Below is the JSON schema for one item in the pageable response.
-
-Response Body:
-
-Schema for <c>ArtifactListResultValue</c>:
-<code>{
-  id: string, # Optional. Artifact identifier
-  name: string, # Optional. Artifact name
-  isDirectory: boolean, # Optional. Whether artifact is a directory
-  downloadUri: Uri, # Optional. Uri where the file contents can be downloaded
-  fileSize: number, # Optional. Size of file in bytes, if the artifact is a file
-  createdTime: string (ISO 8601 Format), # Optional. Time the artifact was created
-  lastModifiedTime: string (ISO 8601 Format), # Optional. Time the artifact was last modified
-}
-</code>
-
-</remarks>
-    </member>
-    <member name="GetArtifactsByEnvironment(String,String,RequestContext)">
-<example>
-This sample shows how to call GetArtifactsByEnvironment with required parameters and parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-foreach (var data in client.GetArtifactsByEnvironment("<environmentName>"))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.ToString());
-}
-]]></code>
-This sample shows how to call GetArtifactsByEnvironment with all parameters, and how to parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-foreach (var data in client.GetArtifactsByEnvironment("<environmentName>", <me>))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.GetProperty("id").ToString());
-    Console.WriteLine(result.GetProperty("name").ToString());
-    Console.WriteLine(result.GetProperty("isDirectory").ToString());
-    Console.WriteLine(result.GetProperty("downloadUri").ToString());
-    Console.WriteLine(result.GetProperty("fileSize").ToString());
-    Console.WriteLine(result.GetProperty("createdTime").ToString());
-    Console.WriteLine(result.GetProperty("lastModifiedTime").ToString());
-}
-]]></code>
-</example>
-<remarks>
-Below is the JSON schema for one item in the pageable response.
-
-Response Body:
-
-Schema for <c>ArtifactListResultValue</c>:
-<code>{
-  id: string, # Optional. Artifact identifier
-  name: string, # Optional. Artifact name
-  isDirectory: boolean, # Optional. Whether artifact is a directory
-  downloadUri: Uri, # Optional. Uri where the file contents can be downloaded
-  fileSize: number, # Optional. Size of file in bytes, if the artifact is a file
-  createdTime: string (ISO 8601 Format), # Optional. Time the artifact was created
-  lastModifiedTime: string (ISO 8601 Format), # Optional. Time the artifact was last modified
-}
-</code>
-
-</remarks>
-    </member>
-    <member name="GetArtifactsByEnvironmentAndPathAsync(String,String,String,RequestContext)">
-<example>
-This sample shows how to call GetArtifactsByEnvironmentAndPathAsync with required parameters and parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-await foreach (var data in client.GetArtifactsByEnvironmentAndPathAsync("<environmentName>", "<artifactPath>"))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.ToString());
-}
-]]></code>
-This sample shows how to call GetArtifactsByEnvironmentAndPathAsync with all parameters, and how to parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-await foreach (var data in client.GetArtifactsByEnvironmentAndPathAsync("<environmentName>", "<artifactPath>", <me>))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.GetProperty("id").ToString());
-    Console.WriteLine(result.GetProperty("name").ToString());
-    Console.WriteLine(result.GetProperty("isDirectory").ToString());
-    Console.WriteLine(result.GetProperty("downloadUri").ToString());
-    Console.WriteLine(result.GetProperty("fileSize").ToString());
-    Console.WriteLine(result.GetProperty("createdTime").ToString());
-    Console.WriteLine(result.GetProperty("lastModifiedTime").ToString());
-}
-]]></code>
-</example>
-<remarks>
-Below is the JSON schema for one item in the pageable response.
-
-Response Body:
-
-Schema for <c>ArtifactListResultValue</c>:
-<code>{
-  id: string, # Optional. Artifact identifier
-  name: string, # Optional. Artifact name
-  isDirectory: boolean, # Optional. Whether artifact is a directory
-  downloadUri: Uri, # Optional. Uri where the file contents can be downloaded
-  fileSize: number, # Optional. Size of file in bytes, if the artifact is a file
-  createdTime: string (ISO 8601 Format), # Optional. Time the artifact was created
-  lastModifiedTime: string (ISO 8601 Format), # Optional. Time the artifact was last modified
-}
-</code>
-
-</remarks>
-    </member>
-    <member name="GetArtifactsByEnvironmentAndPath(String,String,String,RequestContext)">
-<example>
-This sample shows how to call GetArtifactsByEnvironmentAndPath with required parameters and parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-foreach (var data in client.GetArtifactsByEnvironmentAndPath("<environmentName>", "<artifactPath>"))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.ToString());
-}
-]]></code>
-This sample shows how to call GetArtifactsByEnvironmentAndPath with all parameters, and how to parse the result.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-foreach (var data in client.GetArtifactsByEnvironmentAndPath("<environmentName>", "<artifactPath>", <me>))
-{
-    JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-    Console.WriteLine(result.GetProperty("id").ToString());
-    Console.WriteLine(result.GetProperty("name").ToString());
-    Console.WriteLine(result.GetProperty("isDirectory").ToString());
-    Console.WriteLine(result.GetProperty("downloadUri").ToString());
-    Console.WriteLine(result.GetProperty("fileSize").ToString());
-    Console.WriteLine(result.GetProperty("createdTime").ToString());
-    Console.WriteLine(result.GetProperty("lastModifiedTime").ToString());
-}
-]]></code>
-</example>
-<remarks>
-Below is the JSON schema for one item in the pageable response.
-
-Response Body:
-
-Schema for <c>ArtifactListResultValue</c>:
-<code>{
-  id: string, # Optional. Artifact identifier
-  name: string, # Optional. Artifact name
-  isDirectory: boolean, # Optional. Whether artifact is a directory
-  downloadUri: Uri, # Optional. Uri where the file contents can be downloaded
-  fileSize: number, # Optional. Size of file in bytes, if the artifact is a file
-  createdTime: string (ISO 8601 Format), # Optional. Time the artifact was created
-  lastModifiedTime: string (ISO 8601 Format), # Optional. Time the artifact was last modified
-}
-</code>
-
-</remarks>
-    </member>
     <member name="GetCatalogItemsAsync(Int32,RequestContext)">
 <example>
 This sample shows how to call GetCatalogItemsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemsAsync())
 {
@@ -1027,7 +827,7 @@ await foreach (var data in client.GetCatalogItemsAsync())
 This sample shows how to call GetCatalogItemsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemsAsync(1234))
 {
@@ -1058,7 +858,7 @@ Schema for <c>CatalogItemListResultValue</c>:
 This sample shows how to call GetCatalogItems and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItems())
 {
@@ -1069,7 +869,7 @@ foreach (var data in client.GetCatalogItems())
 This sample shows how to call GetCatalogItems with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItems(1234))
 {
@@ -1100,7 +900,7 @@ Schema for <c>CatalogItemListResultValue</c>:
 This sample shows how to call GetCatalogItemVersionsAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemVersionsAsync("<catalogItemId>"))
 {
@@ -1111,7 +911,7 @@ await foreach (var data in client.GetCatalogItemVersionsAsync("<catalogItemId>")
 This sample shows how to call GetCatalogItemVersionsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemVersionsAsync("<catalogItemId>", 1234))
 {
@@ -1205,7 +1005,7 @@ Schema for <c>CatalogItemVersionListResultValue</c>:
 This sample shows how to call GetCatalogItemVersions with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItemVersions("<catalogItemId>"))
 {
@@ -1216,7 +1016,7 @@ foreach (var data in client.GetCatalogItemVersions("<catalogItemId>"))
 This sample shows how to call GetCatalogItemVersions with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItemVersions("<catalogItemId>", 1234))
 {
@@ -1310,7 +1110,7 @@ Schema for <c>CatalogItemVersionListResultValue</c>:
 This sample shows how to call GetEnvironmentTypesAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentTypesAsync())
 {
@@ -1321,7 +1121,7 @@ await foreach (var data in client.GetEnvironmentTypesAsync())
 This sample shows how to call GetEnvironmentTypesAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentTypesAsync(1234))
 {
@@ -1352,7 +1152,7 @@ Schema for <c>EnvironmentTypeListResultValue</c>:
 This sample shows how to call GetEnvironmentTypes and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentTypes())
 {
@@ -1363,7 +1163,7 @@ foreach (var data in client.GetEnvironmentTypes())
 This sample shows how to call GetEnvironmentTypes with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentTypes(1234))
 {
@@ -1394,7 +1194,7 @@ Schema for <c>EnvironmentTypeListResultValue</c>:
 This sample shows how to call CreateOrUpdateEnvironmentAsync with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -1410,11 +1210,11 @@ Console.WriteLine(result.ToString());
 This sample shows how to call CreateOrUpdateEnvironmentAsync with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
-    owner = "<owner>",
+    user = "<user>",
     description = "<description>",
     catalogName = "<catalogName>",
     catalogItemName = "<catalogItemName>",
@@ -1437,7 +1237,7 @@ BinaryData data = operation.Value;
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("environmentType").ToString());
-Console.WriteLine(result.GetProperty("owner").ToString());
+Console.WriteLine(result.GetProperty("user").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
 Console.WriteLine(result.GetProperty("description").ToString());
@@ -1459,7 +1259,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -1477,7 +1277,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -1496,7 +1296,7 @@ Schema for <c>Environment</c>:
 This sample shows how to call CreateOrUpdateEnvironment with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -1512,11 +1312,11 @@ Console.WriteLine(result.ToString());
 This sample shows how to call CreateOrUpdateEnvironment with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
-    owner = "<owner>",
+    user = "<user>",
     description = "<description>",
     catalogName = "<catalogName>",
     catalogItemName = "<catalogItemName>",
@@ -1539,7 +1339,7 @@ BinaryData data = operation.Value;
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
 Console.WriteLine(result.GetProperty("environmentType").ToString());
-Console.WriteLine(result.GetProperty("owner").ToString());
+Console.WriteLine(result.GetProperty("user").ToString());
 Console.WriteLine(result.GetProperty("provisioningState").ToString());
 Console.WriteLine(result.GetProperty("resourceGroupId").ToString());
 Console.WriteLine(result.GetProperty("description").ToString());
@@ -1561,7 +1361,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -1579,7 +1379,7 @@ Schema for <c>Environment</c>:
 <code>{
   name: string, # Optional. Environment name.
   environmentType: string, # Required. Environment type.
-  owner: string, # Optional. Identifier of the owner of this Environment.
+  user: string, # Optional. The AAD object id of the owner of this Environment.
   provisioningState: string, # Optional. The provisioning state of the environment.
   resourceGroupId: string, # Optional. The identifier of the resource group containing the environment&apos;s resources.
   description: string, # Optional. Description of the Environment.
@@ -1598,7 +1398,7 @@ Schema for <c>Environment</c>:
 This sample shows how to call DeleteEnvironmentAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = await client.DeleteEnvironmentAsync(WaitUntil.Completed, "<environmentName>");
 
@@ -1607,7 +1407,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteEnvironmentAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = await client.DeleteEnvironmentAsync(WaitUntil.Completed, "<environmentName>", <me>);
 
@@ -1620,7 +1420,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteEnvironment with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = client.DeleteEnvironment(WaitUntil.Completed, "<environmentName>");
 
@@ -1629,7 +1429,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteEnvironment with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var operation = client.DeleteEnvironment(WaitUntil.Completed, "<environmentName>", <me>);
 
@@ -1642,7 +1442,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeployEnvironmentActionAsync with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1655,7 +1455,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeployEnvironmentActionAsync with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1686,7 +1486,7 @@ Schema for <c>ActionRequest</c>:
 This sample shows how to call DeployEnvironmentAction with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1699,7 +1499,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeployEnvironmentAction with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1725,100 +1525,12 @@ Schema for <c>ActionRequest</c>:
 
 </remarks>
     </member>
-    <member name="DeleteEnvironmentActionAsync(WaitUntil,String,RequestContent,String,RequestContext)">
-<example>
-This sample shows how to call DeleteEnvironmentActionAsync with required parameters and request content.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-var data = new {
-    actionId = "<actionId>",
-};
-
-var operation = await client.DeleteEnvironmentActionAsync(WaitUntil.Completed, "<environmentName>", RequestContent.Create(data));
-
-Console.WriteLine(operation.GetRawResponse().Status)
-]]></code>
-This sample shows how to call DeleteEnvironmentActionAsync with all parameters and request content.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-var data = new {
-    actionId = "<actionId>",
-    parameters = new {},
-};
-
-var operation = await client.DeleteEnvironmentActionAsync(WaitUntil.Completed, "<environmentName>", RequestContent.Create(data), <me>);
-
-Console.WriteLine(operation.GetRawResponse().Status)
-]]></code>
-</example>
-<remarks>
-Below is the JSON schema for the request payload.
-
-Request Body:
-
-Schema for <c>ActionRequest</c>:
-<code>{
-  actionId: string, # Required. The Catalog Item action id to execute
-  parameters: AnyObject, # Optional. Parameters object for the Action
-}
-</code>
-
-</remarks>
-    </member>
-    <member name="DeleteEnvironmentAction(WaitUntil,String,RequestContent,String,RequestContext)">
-<example>
-This sample shows how to call DeleteEnvironmentAction with required parameters and request content.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-var data = new {
-    actionId = "<actionId>",
-};
-
-var operation = client.DeleteEnvironmentAction(WaitUntil.Completed, "<environmentName>", RequestContent.Create(data));
-
-Console.WriteLine(operation.GetRawResponse().Status)
-]]></code>
-This sample shows how to call DeleteEnvironmentAction with all parameters and request content.
-<code><![CDATA[
-var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
-
-var data = new {
-    actionId = "<actionId>",
-    parameters = new {},
-};
-
-var operation = client.DeleteEnvironmentAction(WaitUntil.Completed, "<environmentName>", RequestContent.Create(data), <me>);
-
-Console.WriteLine(operation.GetRawResponse().Status)
-]]></code>
-</example>
-<remarks>
-Below is the JSON schema for the request payload.
-
-Request Body:
-
-Schema for <c>ActionRequest</c>:
-<code>{
-  actionId: string, # Required. The Catalog Item action id to execute
-  parameters: AnyObject, # Optional. Parameters object for the Action
-}
-</code>
-
-</remarks>
-    </member>
     <member name="CustomEnvironmentActionAsync(WaitUntil,String,RequestContent,String,RequestContext)">
 <example>
 This sample shows how to call CustomEnvironmentActionAsync with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1831,7 +1543,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call CustomEnvironmentActionAsync with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1862,7 +1574,7 @@ Schema for <c>ActionRequest</c>:
 This sample shows how to call CustomEnvironmentAction with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1875,7 +1587,7 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call CustomEnvironmentAction with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<tenantId>", "<devCenter>", "<projectName>", credential);
+var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/EnvironmentsClient.xml
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/Docs/EnvironmentsClient.xml
@@ -6,7 +6,8 @@
 This sample shows how to call GetEnvironmentByUserAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetEnvironmentByUserAsync("<environmentName>");
 
@@ -17,7 +18,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetEnvironmentByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetEnvironmentByUserAsync("<environmentName>", <me>);
 
@@ -65,7 +67,8 @@ Schema for <c>Environment</c>:
 This sample shows how to call GetEnvironmentByUser with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetEnvironmentByUser("<environmentName>");
 
@@ -76,7 +79,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call GetEnvironmentByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetEnvironmentByUser("<environmentName>", <me>);
 
@@ -124,7 +128,8 @@ Schema for <c>Environment</c>:
 This sample shows how to call UpdateEnvironmentAsync with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -139,7 +144,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call UpdateEnvironmentAsync with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -225,7 +231,8 @@ Schema for <c>Environment</c>:
 This sample shows how to call UpdateEnvironment with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -240,7 +247,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call UpdateEnvironment with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -326,7 +334,8 @@ Schema for <c>Environment</c>:
 This sample shows how to call GetCatalogItemAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetCatalogItemAsync("<catalogItemId>");
 
@@ -356,7 +365,8 @@ Schema for <c>CatalogItem</c>:
 This sample shows how to call GetCatalogItem with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetCatalogItem("<catalogItemId>");
 
@@ -386,7 +396,8 @@ Schema for <c>CatalogItem</c>:
 This sample shows how to call GetCatalogItemVersionAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = await client.GetCatalogItemVersionAsync("<catalogItemId>", "<version>");
 
@@ -479,7 +490,8 @@ Schema for <c>CatalogItemVersion</c>:
 This sample shows how to call GetCatalogItemVersion with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 Response response = client.GetCatalogItemVersion("<catalogItemId>", "<version>");
 
@@ -572,7 +584,8 @@ Schema for <c>CatalogItemVersion</c>:
 This sample shows how to call GetEnvironmentsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsAsync())
 {
@@ -584,7 +597,8 @@ await foreach (var data in client.GetEnvironmentsAsync())
 This sample shows how to call GetEnvironmentsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsAsync(1234))
 {
@@ -633,7 +647,8 @@ Schema for <c>EnvironmentListResultValue</c>:
 This sample shows how to call GetEnvironments and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetEnvironments())
 {
@@ -645,7 +660,8 @@ foreach (var data in client.GetEnvironments())
 This sample shows how to call GetEnvironments with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetEnvironments(1234))
 {
@@ -694,7 +710,8 @@ Schema for <c>EnvironmentListResultValue</c>:
 This sample shows how to call GetEnvironmentsByUserAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsByUserAsync())
 {
@@ -706,7 +723,8 @@ await foreach (var data in client.GetEnvironmentsByUserAsync())
 This sample shows how to call GetEnvironmentsByUserAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentsByUserAsync(<me>, 1234))
 {
@@ -755,7 +773,8 @@ Schema for <c>EnvironmentListResultValue</c>:
 This sample shows how to call GetEnvironmentsByUser and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentsByUser())
 {
@@ -767,7 +786,8 @@ foreach (var data in client.GetEnvironmentsByUser())
 This sample shows how to call GetEnvironmentsByUser with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentsByUser(<me>, 1234))
 {
@@ -816,7 +836,8 @@ Schema for <c>EnvironmentListResultValue</c>:
 This sample shows how to call GetCatalogItemsAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemsAsync())
 {
@@ -827,7 +848,8 @@ await foreach (var data in client.GetCatalogItemsAsync())
 This sample shows how to call GetCatalogItemsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemsAsync(1234))
 {
@@ -858,7 +880,8 @@ Schema for <c>CatalogItemListResultValue</c>:
 This sample shows how to call GetCatalogItems and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItems())
 {
@@ -869,7 +892,8 @@ foreach (var data in client.GetCatalogItems())
 This sample shows how to call GetCatalogItems with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItems(1234))
 {
@@ -900,7 +924,8 @@ Schema for <c>CatalogItemListResultValue</c>:
 This sample shows how to call GetCatalogItemVersionsAsync with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemVersionsAsync("<catalogItemId>"))
 {
@@ -911,7 +936,8 @@ await foreach (var data in client.GetCatalogItemVersionsAsync("<catalogItemId>")
 This sample shows how to call GetCatalogItemVersionsAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetCatalogItemVersionsAsync("<catalogItemId>", 1234))
 {
@@ -1005,7 +1031,8 @@ Schema for <c>CatalogItemVersionListResultValue</c>:
 This sample shows how to call GetCatalogItemVersions with required parameters and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItemVersions("<catalogItemId>"))
 {
@@ -1016,7 +1043,8 @@ foreach (var data in client.GetCatalogItemVersions("<catalogItemId>"))
 This sample shows how to call GetCatalogItemVersions with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetCatalogItemVersions("<catalogItemId>", 1234))
 {
@@ -1110,7 +1138,8 @@ Schema for <c>CatalogItemVersionListResultValue</c>:
 This sample shows how to call GetEnvironmentTypesAsync and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentTypesAsync())
 {
@@ -1121,7 +1150,8 @@ await foreach (var data in client.GetEnvironmentTypesAsync())
 This sample shows how to call GetEnvironmentTypesAsync with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 await foreach (var data in client.GetEnvironmentTypesAsync(1234))
 {
@@ -1152,7 +1182,8 @@ Schema for <c>EnvironmentTypeListResultValue</c>:
 This sample shows how to call GetEnvironmentTypes and parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentTypes())
 {
@@ -1163,7 +1194,8 @@ foreach (var data in client.GetEnvironmentTypes())
 This sample shows how to call GetEnvironmentTypes with all parameters, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 foreach (var data in client.GetEnvironmentTypes(1234))
 {
@@ -1194,7 +1226,8 @@ Schema for <c>EnvironmentTypeListResultValue</c>:
 This sample shows how to call CreateOrUpdateEnvironmentAsync with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -1210,7 +1243,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call CreateOrUpdateEnvironmentAsync with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -1296,7 +1330,8 @@ Schema for <c>Environment</c>:
 This sample shows how to call CreateOrUpdateEnvironment with required parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -1312,7 +1347,8 @@ Console.WriteLine(result.ToString());
 This sample shows how to call CreateOrUpdateEnvironment with all parameters and request content, and how to parse the result.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     environmentType = "<environmentType>",
@@ -1398,7 +1434,8 @@ Schema for <c>Environment</c>:
 This sample shows how to call DeleteEnvironmentAsync with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var operation = await client.DeleteEnvironmentAsync(WaitUntil.Completed, "<environmentName>");
 
@@ -1407,7 +1444,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteEnvironmentAsync with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var operation = await client.DeleteEnvironmentAsync(WaitUntil.Completed, "<environmentName>", <me>);
 
@@ -1420,7 +1458,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteEnvironment with required parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var operation = client.DeleteEnvironment(WaitUntil.Completed, "<environmentName>");
 
@@ -1429,7 +1468,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeleteEnvironment with all parameters.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var operation = client.DeleteEnvironment(WaitUntil.Completed, "<environmentName>", <me>);
 
@@ -1442,7 +1482,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeployEnvironmentActionAsync with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1455,7 +1496,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeployEnvironmentActionAsync with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1486,7 +1528,8 @@ Schema for <c>ActionRequest</c>:
 This sample shows how to call DeployEnvironmentAction with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1499,7 +1542,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call DeployEnvironmentAction with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1530,7 +1574,8 @@ Schema for <c>ActionRequest</c>:
 This sample shows how to call CustomEnvironmentActionAsync with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1543,7 +1588,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call CustomEnvironmentActionAsync with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1574,7 +1620,8 @@ Schema for <c>ActionRequest</c>:
 This sample shows how to call CustomEnvironmentAction with required parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",
@@ -1587,7 +1634,8 @@ Console.WriteLine(operation.GetRawResponse().Status)
 This sample shows how to call CustomEnvironmentAction with all parameters and request content.
 <code><![CDATA[
 var credential = new DefaultAzureCredential();
-var client = new EnvironmentsClient("<https://my-service.azure.com>", "<projectName>", credential);
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new EnvironmentsClient(endpoint, "<projectName>", credential);
 
 var data = new {
     actionId = "<actionId>",

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/EnvironmentsClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/EnvironmentsClient.cs
@@ -20,7 +20,7 @@ namespace Azure.Developer.DevCenter
         private static readonly string[] AuthorizationScopes = new string[] { "https://devcenter.azure.com/.default" };
         private readonly TokenCredential _tokenCredential;
         private readonly HttpPipeline _pipeline;
-        private readonly string _endpoint;
+        private readonly Uri _endpoint;
         private readonly string _projectName;
         private readonly string _apiVersion;
 
@@ -41,7 +41,7 @@ namespace Azure.Developer.DevCenter
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public EnvironmentsClient(string endpoint, string projectName, TokenCredential credential) : this(endpoint, projectName, credential, new DevCenterClientOptions())
+        public EnvironmentsClient(Uri endpoint, string projectName, TokenCredential credential) : this(endpoint, projectName, credential, new DevCenterClientOptions())
         {
         }
 
@@ -52,7 +52,7 @@ namespace Azure.Developer.DevCenter
         /// <param name="options"> The options for configuring the client. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public EnvironmentsClient(string endpoint, string projectName, TokenCredential credential, DevCenterClientOptions options)
+        public EnvironmentsClient(Uri endpoint, string projectName, TokenCredential credential, DevCenterClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNullOrEmpty(projectName, nameof(projectName));
@@ -691,7 +691,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/environments", false);
@@ -711,7 +711,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -733,7 +733,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -752,7 +752,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -773,7 +773,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Patch;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -794,7 +794,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -813,7 +813,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -835,7 +835,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -857,7 +857,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems", false);
@@ -877,7 +877,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems/", false);
@@ -894,7 +894,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems/", false);
@@ -916,7 +916,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems/", false);
@@ -935,7 +935,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/environmentTypes", false);
@@ -955,7 +955,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -968,7 +968,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -981,7 +981,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -994,7 +994,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1007,7 +1007,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(_endpoint, false);
+            uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/EnvironmentsClient.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/Generated/EnvironmentsClient.cs
@@ -20,10 +20,8 @@ namespace Azure.Developer.DevCenter
         private static readonly string[] AuthorizationScopes = new string[] { "https://devcenter.azure.com/.default" };
         private readonly TokenCredential _tokenCredential;
         private readonly HttpPipeline _pipeline;
-        private readonly string _tenantId;
-        private readonly string _devCenter;
+        private readonly string _endpoint;
         private readonly string _projectName;
-        private readonly string _devCenterDnsSuffix;
         private readonly string _apiVersion;
 
         /// <summary> The ClientDiagnostics is used to provide tracing support for the client library. </summary>
@@ -38,41 +36,34 @@ namespace Azure.Developer.DevCenter
         }
 
         /// <summary> Initializes a new instance of EnvironmentsClient. </summary>
-        /// <param name="tenantId"> The tenant to operate on. </param>
-        /// <param name="devCenter"> The DevCenter to operate on. </param>
+        /// <param name="endpoint"> The DevCenter-specific URI to operate on. </param>
         /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="tenantId"/>, <paramref name="devCenter"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public EnvironmentsClient(string tenantId, string devCenter, string projectName, TokenCredential credential) : this(tenantId, devCenter, projectName, credential, "devcenter.azure.com", new DevCenterClientOptions())
+        public EnvironmentsClient(string endpoint, string projectName, TokenCredential credential) : this(endpoint, projectName, credential, new DevCenterClientOptions())
         {
         }
 
         /// <summary> Initializes a new instance of EnvironmentsClient. </summary>
-        /// <param name="tenantId"> The tenant to operate on. </param>
-        /// <param name="devCenter"> The DevCenter to operate on. </param>
+        /// <param name="endpoint"> The DevCenter-specific URI to operate on. </param>
         /// <param name="projectName"> The DevCenter Project upon which to execute operations. </param>
         /// <param name="credential"> A credential used to authenticate to an Azure Service. </param>
-        /// <param name="devCenterDnsSuffix"> The DNS suffix used as the base for all devcenter requests. </param>
         /// <param name="options"> The options for configuring the client. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="tenantId"/>, <paramref name="devCenter"/>, <paramref name="projectName"/>, <paramref name="credential"/> or <paramref name="devCenterDnsSuffix"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/>, <paramref name="projectName"/> or <paramref name="credential"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="projectName"/> is an empty string, and was expected to be non-empty. </exception>
-        public EnvironmentsClient(string tenantId, string devCenter, string projectName, TokenCredential credential, string devCenterDnsSuffix, DevCenterClientOptions options)
+        public EnvironmentsClient(string endpoint, string projectName, TokenCredential credential, DevCenterClientOptions options)
         {
-            Argument.AssertNotNull(tenantId, nameof(tenantId));
-            Argument.AssertNotNull(devCenter, nameof(devCenter));
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNullOrEmpty(projectName, nameof(projectName));
             Argument.AssertNotNull(credential, nameof(credential));
-            Argument.AssertNotNull(devCenterDnsSuffix, nameof(devCenterDnsSuffix));
             options ??= new DevCenterClientOptions();
 
             ClientDiagnostics = new ClientDiagnostics(options, true);
             _tokenCredential = credential;
             _pipeline = HttpPipelineBuilder.Build(options, Array.Empty<HttpPipelinePolicy>(), new HttpPipelinePolicy[] { new BearerTokenAuthenticationPolicy(_tokenCredential, AuthorizationScopes) }, new ResponseClassifier());
-            _tenantId = tenantId;
-            _devCenter = devCenter;
+            _endpoint = endpoint;
             _projectName = projectName;
-            _devCenterDnsSuffix = devCenterDnsSuffix;
             _apiVersion = options.Version;
         }
 
@@ -362,86 +353,6 @@ namespace Azure.Developer.DevCenter
             return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "EnvironmentsClient.GetEnvironmentsByUser", "value", "nextLink", context);
         }
 
-        /// <summary> Lists the artifacts for an environment. </summary>
-        /// <param name="environmentName"> The name of the environment. </param>
-        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
-        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="environmentName"/> or <paramref name="userId"/> is null. </exception>
-        /// <exception cref="ArgumentException"> <paramref name="environmentName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="AsyncPageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        /// <include file="Docs/EnvironmentsClient.xml" path="doc/members/member[@name='GetArtifactsByEnvironmentAsync(String,String,RequestContext)']/*" />
-        public virtual AsyncPageable<BinaryData> GetArtifactsByEnvironmentAsync(string environmentName, string userId = "me", RequestContext context = null)
-        {
-            Argument.AssertNotNullOrEmpty(environmentName, nameof(environmentName));
-            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
-
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetArtifactsByEnvironmentRequest(environmentName, userId, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetArtifactsByEnvironmentNextPageRequest(nextLink, environmentName, userId, context);
-            return PageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "EnvironmentsClient.GetArtifactsByEnvironment", "value", "nextLink", context);
-        }
-
-        /// <summary> Lists the artifacts for an environment. </summary>
-        /// <param name="environmentName"> The name of the environment. </param>
-        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
-        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="environmentName"/> or <paramref name="userId"/> is null. </exception>
-        /// <exception cref="ArgumentException"> <paramref name="environmentName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Pageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        /// <include file="Docs/EnvironmentsClient.xml" path="doc/members/member[@name='GetArtifactsByEnvironment(String,String,RequestContext)']/*" />
-        public virtual Pageable<BinaryData> GetArtifactsByEnvironment(string environmentName, string userId = "me", RequestContext context = null)
-        {
-            Argument.AssertNotNullOrEmpty(environmentName, nameof(environmentName));
-            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
-
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetArtifactsByEnvironmentRequest(environmentName, userId, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetArtifactsByEnvironmentNextPageRequest(nextLink, environmentName, userId, context);
-            return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "EnvironmentsClient.GetArtifactsByEnvironment", "value", "nextLink", context);
-        }
-
-        /// <summary> Lists the artifacts for an environment at a specified path, or returns the file at the path. </summary>
-        /// <param name="environmentName"> The name of the environment. </param>
-        /// <param name="artifactPath"> The path of the artifact. </param>
-        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
-        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="environmentName"/>, <paramref name="artifactPath"/> or <paramref name="userId"/> is null. </exception>
-        /// <exception cref="ArgumentException"> <paramref name="environmentName"/>, <paramref name="artifactPath"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="AsyncPageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        /// <include file="Docs/EnvironmentsClient.xml" path="doc/members/member[@name='GetArtifactsByEnvironmentAndPathAsync(String,String,String,RequestContext)']/*" />
-        public virtual AsyncPageable<BinaryData> GetArtifactsByEnvironmentAndPathAsync(string environmentName, string artifactPath, string userId = "me", RequestContext context = null)
-        {
-            Argument.AssertNotNullOrEmpty(environmentName, nameof(environmentName));
-            Argument.AssertNotNullOrEmpty(artifactPath, nameof(artifactPath));
-            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
-
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetArtifactsByEnvironmentAndPathRequest(environmentName, artifactPath, userId, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetArtifactsByEnvironmentAndPathNextPageRequest(nextLink, environmentName, artifactPath, userId, context);
-            return PageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "EnvironmentsClient.GetArtifactsByEnvironmentAndPath", "value", "nextLink", context);
-        }
-
-        /// <summary> Lists the artifacts for an environment at a specified path, or returns the file at the path. </summary>
-        /// <param name="environmentName"> The name of the environment. </param>
-        /// <param name="artifactPath"> The path of the artifact. </param>
-        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
-        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="environmentName"/>, <paramref name="artifactPath"/> or <paramref name="userId"/> is null. </exception>
-        /// <exception cref="ArgumentException"> <paramref name="environmentName"/>, <paramref name="artifactPath"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Pageable{T}"/> from the service containing a list of <see cref="BinaryData"/> objects. Details of the body schema for each item in the collection are in the Remarks section below. </returns>
-        /// <include file="Docs/EnvironmentsClient.xml" path="doc/members/member[@name='GetArtifactsByEnvironmentAndPath(String,String,String,RequestContext)']/*" />
-        public virtual Pageable<BinaryData> GetArtifactsByEnvironmentAndPath(string environmentName, string artifactPath, string userId = "me", RequestContext context = null)
-        {
-            Argument.AssertNotNullOrEmpty(environmentName, nameof(environmentName));
-            Argument.AssertNotNullOrEmpty(artifactPath, nameof(artifactPath));
-            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
-
-            HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetArtifactsByEnvironmentAndPathRequest(environmentName, artifactPath, userId, context);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetArtifactsByEnvironmentAndPathNextPageRequest(nextLink, environmentName, artifactPath, userId, context);
-            return PageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => BinaryData.FromString(e.GetRawText()), ClientDiagnostics, _pipeline, "EnvironmentsClient.GetArtifactsByEnvironmentAndPath", "value", "nextLink", context);
-        }
-
         /// <summary> Lists latest version of all catalog items available for a project. </summary>
         /// <param name="maxCount"> The maximum number of resources to return from the operation. Example: &apos;top=10&apos;. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
@@ -592,7 +503,7 @@ namespace Azure.Developer.DevCenter
             }
         }
 
-        /// <summary> Deletes an environment and all it&apos;s associated resources. </summary>
+        /// <summary> Deletes an environment and all its associated resources. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="environmentName"> The name of the environment. </param>
         /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
@@ -612,7 +523,7 @@ namespace Azure.Developer.DevCenter
             try
             {
                 using HttpMessage message = CreateDeleteEnvironmentRequest(environmentName, userId, context);
-                return await ProtocolOperationHelpers.ProcessMessageWithoutResponseValueAsync(_pipeline, message, ClientDiagnostics, "EnvironmentsClient.DeleteEnvironment", OperationFinalStateVia.OriginalUri, context, waitUntil).ConfigureAwait(false);
+                return await ProtocolOperationHelpers.ProcessMessageWithoutResponseValueAsync(_pipeline, message, ClientDiagnostics, "EnvironmentsClient.DeleteEnvironment", OperationFinalStateVia.Location, context, waitUntil).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -621,7 +532,7 @@ namespace Azure.Developer.DevCenter
             }
         }
 
-        /// <summary> Deletes an environment and all it&apos;s associated resources. </summary>
+        /// <summary> Deletes an environment and all its associated resources. </summary>
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="environmentName"> The name of the environment. </param>
         /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
@@ -641,7 +552,7 @@ namespace Azure.Developer.DevCenter
             try
             {
                 using HttpMessage message = CreateDeleteEnvironmentRequest(environmentName, userId, context);
-                return ProtocolOperationHelpers.ProcessMessageWithoutResponseValue(_pipeline, message, ClientDiagnostics, "EnvironmentsClient.DeleteEnvironment", OperationFinalStateVia.OriginalUri, context, waitUntil);
+                return ProtocolOperationHelpers.ProcessMessageWithoutResponseValue(_pipeline, message, ClientDiagnostics, "EnvironmentsClient.DeleteEnvironment", OperationFinalStateVia.Location, context, waitUntil);
             }
             catch (Exception e)
             {
@@ -704,68 +615,6 @@ namespace Azure.Developer.DevCenter
             {
                 using HttpMessage message = CreateDeployEnvironmentActionRequest(environmentName, content, userId, context);
                 return ProtocolOperationHelpers.ProcessMessageWithoutResponseValue(_pipeline, message, ClientDiagnostics, "EnvironmentsClient.DeployEnvironmentAction", OperationFinalStateVia.OriginalUri, context, waitUntil);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        /// <summary> Executes a delete action. </summary>
-        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
-        /// <param name="environmentName"> The name of the environment. </param>
-        /// <param name="content"> The content to send as the body of the request. Details of the request body schema are in the Remarks section below. </param>
-        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
-        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="environmentName"/>, <paramref name="content"/> or <paramref name="userId"/> is null. </exception>
-        /// <exception cref="ArgumentException"> <paramref name="environmentName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
-        /// <include file="Docs/EnvironmentsClient.xml" path="doc/members/member[@name='DeleteEnvironmentActionAsync(WaitUntil,String,RequestContent,String,RequestContext)']/*" />
-        public virtual async Task<Operation> DeleteEnvironmentActionAsync(WaitUntil waitUntil, string environmentName, RequestContent content, string userId = "me", RequestContext context = null)
-        {
-            Argument.AssertNotNullOrEmpty(environmentName, nameof(environmentName));
-            Argument.AssertNotNull(content, nameof(content));
-            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
-
-            using var scope = ClientDiagnostics.CreateScope("EnvironmentsClient.DeleteEnvironmentAction");
-            scope.Start();
-            try
-            {
-                using HttpMessage message = CreateDeleteEnvironmentActionRequest(environmentName, content, userId, context);
-                return await ProtocolOperationHelpers.ProcessMessageWithoutResponseValueAsync(_pipeline, message, ClientDiagnostics, "EnvironmentsClient.DeleteEnvironmentAction", OperationFinalStateVia.OriginalUri, context, waitUntil).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        /// <summary> Executes a delete action. </summary>
-        /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
-        /// <param name="environmentName"> The name of the environment. </param>
-        /// <param name="content"> The content to send as the body of the request. Details of the request body schema are in the Remarks section below. </param>
-        /// <param name="userId"> The AAD object id of the user. If value is &apos;me&apos;, the identity is taken from the authentication context. </param>
-        /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="environmentName"/>, <paramref name="content"/> or <paramref name="userId"/> is null. </exception>
-        /// <exception cref="ArgumentException"> <paramref name="environmentName"/> or <paramref name="userId"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
-        /// <returns> The <see cref="Operation"/> representing an asynchronous operation on the service. </returns>
-        /// <include file="Docs/EnvironmentsClient.xml" path="doc/members/member[@name='DeleteEnvironmentAction(WaitUntil,String,RequestContent,String,RequestContext)']/*" />
-        public virtual Operation DeleteEnvironmentAction(WaitUntil waitUntil, string environmentName, RequestContent content, string userId = "me", RequestContext context = null)
-        {
-            Argument.AssertNotNullOrEmpty(environmentName, nameof(environmentName));
-            Argument.AssertNotNull(content, nameof(content));
-            Argument.AssertNotNullOrEmpty(userId, nameof(userId));
-
-            using var scope = ClientDiagnostics.CreateScope("EnvironmentsClient.DeleteEnvironmentAction");
-            scope.Start();
-            try
-            {
-                using HttpMessage message = CreateDeleteEnvironmentActionRequest(environmentName, content, userId, context);
-                return ProtocolOperationHelpers.ProcessMessageWithoutResponseValue(_pipeline, message, ClientDiagnostics, "EnvironmentsClient.DeleteEnvironmentAction", OperationFinalStateVia.OriginalUri, context, waitUntil);
             }
             catch (Exception e)
             {
@@ -842,12 +691,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/environments", false);
@@ -867,12 +711,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -894,12 +733,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -918,12 +752,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -944,12 +773,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Patch;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -970,12 +794,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -994,12 +813,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1015,45 +829,13 @@ namespace Azure.Developer.DevCenter
             return message;
         }
 
-        internal HttpMessage CreateDeleteEnvironmentActionRequest(string environmentName, RequestContent content, string userId, RequestContext context)
-        {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200202);
-            var request = message.Request;
-            request.Method = RequestMethod.Post;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
-            uri.AppendPath("/projects/", false);
-            uri.AppendPath(_projectName, true);
-            uri.AppendPath("/users/", false);
-            uri.AppendPath(userId, true);
-            uri.AppendPath("/environments/", false);
-            uri.AppendPath(environmentName, true);
-            uri.AppendPath(":delete", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("Content-Type", "application/json");
-            request.Content = content;
-            return message;
-        }
-
         internal HttpMessage CreateCustomEnvironmentActionRequest(string environmentName, RequestContent content, string userId, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200202);
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/users/", false);
@@ -1069,69 +851,13 @@ namespace Azure.Developer.DevCenter
             return message;
         }
 
-        internal HttpMessage CreateGetArtifactsByEnvironmentRequest(string environmentName, string userId, RequestContext context)
-        {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
-            var request = message.Request;
-            request.Method = RequestMethod.Get;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
-            uri.AppendPath("/projects/", false);
-            uri.AppendPath(_projectName, true);
-            uri.AppendPath("/users/", false);
-            uri.AppendPath(userId, true);
-            uri.AppendPath("/environments/", false);
-            uri.AppendPath(environmentName, true);
-            uri.AppendPath("/artifacts", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/json");
-            return message;
-        }
-
-        internal HttpMessage CreateGetArtifactsByEnvironmentAndPathRequest(string environmentName, string artifactPath, string userId, RequestContext context)
-        {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
-            var request = message.Request;
-            request.Method = RequestMethod.Get;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
-            uri.AppendPath("/projects/", false);
-            uri.AppendPath(_projectName, true);
-            uri.AppendPath("/users/", false);
-            uri.AppendPath(userId, true);
-            uri.AppendPath("/environments/", false);
-            uri.AppendPath(environmentName, true);
-            uri.AppendPath("/artifacts/", false);
-            uri.AppendPath(artifactPath, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/json");
-            return message;
-        }
-
         internal HttpMessage CreateGetCatalogItemsRequest(int? maxCount, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems", false);
@@ -1151,12 +877,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems/", false);
@@ -1173,12 +894,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems/", false);
@@ -1200,12 +916,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/catalogItems/", false);
@@ -1224,12 +935,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/projects/", false);
             uri.AppendPath(_projectName, true);
             uri.AppendPath("/environmentTypes", false);
@@ -1249,12 +955,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1267,48 +968,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
-            uri.AppendRawNextLink(nextLink, false);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/json");
-            return message;
-        }
-
-        internal HttpMessage CreateGetArtifactsByEnvironmentNextPageRequest(string nextLink, string environmentName, string userId, RequestContext context)
-        {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
-            var request = message.Request;
-            request.Method = RequestMethod.Get;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
-            uri.AppendRawNextLink(nextLink, false);
-            request.Uri = uri;
-            request.Headers.Add("Accept", "application/json");
-            return message;
-        }
-
-        internal HttpMessage CreateGetArtifactsByEnvironmentAndPathNextPageRequest(string nextLink, string environmentName, string artifactPath, string userId, RequestContext context)
-        {
-            var message = _pipeline.CreateMessage(context, ResponseClassifier200);
-            var request = message.Request;
-            request.Method = RequestMethod.Get;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1321,12 +981,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1339,12 +994,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -1357,12 +1007,7 @@ namespace Azure.Developer.DevCenter
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw("https://", false);
-            uri.AppendRaw(_tenantId, false);
-            uri.AppendRaw("-", false);
-            uri.AppendRaw(_devCenter, false);
-            uri.AppendRaw(".", false);
-            uri.AppendRaw(_devCenterDnsSuffix, false);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/autorest.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/autorest.md
@@ -7,9 +7,9 @@ Run `dotnet build /t:GenerateCode` to generate code.
 
 ``` yaml
 input-file:
-  - https://github.com/Azure/azure-rest-api-specs/blob/75a8d8dcc9f6d0ec626bdeb32f5154f20c8c61cd/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2022-03-01-preview/devcenter.json
-  - https://github.com/Azure/azure-rest-api-specs/blob/75a8d8dcc9f6d0ec626bdeb32f5154f20c8c61cd/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2022-03-01-preview/devbox.json
-  - https://github.com/Azure/azure-rest-api-specs/blob/75a8d8dcc9f6d0ec626bdeb32f5154f20c8c61cd/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2022-03-01-preview/environments.json
+  - https://github.com/Azure/azure-rest-api-specs/blob/af3f7994582c0cbd61a48b636907ad2ac95d332c/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2022-11-11-preview/devcenter.json
+  - https://github.com/Azure/azure-rest-api-specs/blob/af3f7994582c0cbd61a48b636907ad2ac95d332c/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2022-11-11-preview/devbox.json
+  - https://github.com/Azure/azure-rest-api-specs/blob/af3f7994582c0cbd61a48b636907ad2ac95d332c/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2022-11-11-preview/environments.json
 
 namespace: Azure.Developer.DevCenter
 security: AADToken

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/autorest.md
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/autorest.md
@@ -14,4 +14,11 @@ input-file:
 namespace: Azure.Developer.DevCenter
 security: AADToken
 security-scopes: https://devcenter.azure.com/.default
+
+directive:
+  # Ensure we use Uri rather than string in .NET
+  - from: swagger-document
+    where: "$.parameters.EndpointParameter"
+    transform: >-
+      $["format"] = "url";
 ```

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxCreateTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevBoxCreateTests.cs
@@ -19,13 +19,11 @@ namespace Azure.Developer.DevCenter.Tests
         {
         }
 
-        private DevBoxesClient GetDevBoxesClient(string dnsSuffix = "devcenter.azure.com") =>
+        private DevBoxesClient GetDevBoxesClient() =>
             InstrumentClient(new DevBoxesClient(
-                TestEnvironment.TenantId,
-                TestEnvironment.DevCenterName,
+                TestEnvironment.Endpoint,
                 TestEnvironment.ProjectName,
                 TestEnvironment.Credential,
-                dnsSuffix,
                 InstrumentClientOptions(new DevCenterClientOptions())));
 
         [RecordedTest]

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTestEnvironment.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTestEnvironment.cs
@@ -20,7 +20,7 @@ namespace Azure.Developer.DevCenter.Tests
         private string _scope => GetRecordedVariable("DEFAULT_DEVCENTER_SCOPE");
         private string _testUserSecret => GetRecordedVariable("DEFAULT_TEST_USER_SECRET", options => options.IsSecret());
         private string _testUserName => GetRecordedVariable("DEFAULT_TEST_USER_NAME");
-        public Uri Endpoint => new(GetRecordedVariable("DEVCENTER_ENDPOINT"));
+        public Uri Endpoint => new(GetRecordedVariable("DEFAULT_DEVCENTER_ENDPOINT"));
         public string ProjectName => GetRecordedVariable("DEFAULT_PROJECT_NAME");
         public string PoolName => GetRecordedVariable("DEFAULT_POOL_NAME");
         public string CatalogName => GetRecordedVariable("DEFAULT_CATALOG_NAME");

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTestEnvironment.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTestEnvironment.cs
@@ -20,7 +20,7 @@ namespace Azure.Developer.DevCenter.Tests
         private string _scope => GetRecordedVariable("DEFAULT_DEVCENTER_SCOPE");
         private string _testUserSecret => GetRecordedVariable("DEFAULT_TEST_USER_SECRET", options => options.IsSecret());
         private string _testUserName => GetRecordedVariable("DEFAULT_TEST_USER_NAME");
-        public string Endpoint => GetRecordedVariable("DEVCENTER_ENDPOINT");
+        public Uri Endpoint => new(GetRecordedVariable("DEVCENTER_ENDPOINT"));
         public string ProjectName => GetRecordedVariable("DEFAULT_PROJECT_NAME");
         public string PoolName => GetRecordedVariable("DEFAULT_POOL_NAME");
         public string CatalogName => GetRecordedVariable("DEFAULT_CATALOG_NAME");

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTestEnvironment.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/DevCenterClientTestEnvironment.cs
@@ -20,7 +20,7 @@ namespace Azure.Developer.DevCenter.Tests
         private string _scope => GetRecordedVariable("DEFAULT_DEVCENTER_SCOPE");
         private string _testUserSecret => GetRecordedVariable("DEFAULT_TEST_USER_SECRET", options => options.IsSecret());
         private string _testUserName => GetRecordedVariable("DEFAULT_TEST_USER_NAME");
-        public string DevCenterName => GetRecordedVariable("DEFAULT_DEVCENTER_NAME");
+        public string Endpoint => GetRecordedVariable("DEVCENTER_ENDPOINT");
         public string ProjectName => GetRecordedVariable("DEFAULT_PROJECT_NAME");
         public string PoolName => GetRecordedVariable("DEFAULT_POOL_NAME");
         public string CatalogName => GetRecordedVariable("DEFAULT_CATALOG_NAME");

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/EnvironmentCreateTests.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/EnvironmentCreateTests.cs
@@ -19,13 +19,11 @@ namespace Azure.Developer.DevCenter.Tests
         {
         }
 
-        private EnvironmentsClient GetEnvironmentsClient(string dnsSuffix = "devcenter.azure.com") =>
+        private EnvironmentsClient GetEnvironmentsClient() =>
             InstrumentClient(new EnvironmentsClient(
-                TestEnvironment.TenantId,
-                TestEnvironment.DevCenterName,
+                TestEnvironment.Endpoint,
                 TestEnvironment.ProjectName,
                 TestEnvironment.Credential,
-                dnsSuffix,
                 InstrumentClientOptions(new DevCenterClientOptions())));
 
         [RecordedTest]

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteDevBoxAsync.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteDevBoxAsync.cs
@@ -13,7 +13,7 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 {
     public partial class DevCenterSamples: SamplesBase<DevCenterClientTestEnvironment>
     {
-        public async Task CreateDeleteDevBoxAsync(string endpoint)
+        public async Task CreateDeleteDevBoxAsync(Uri endpoint)
         {
             // Create and delete a user devbox
             #region Snippet:Azure_DevCenter_GetProjects_Scenario

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteDevBoxAsync.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteDevBoxAsync.cs
@@ -13,12 +13,12 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 {
     public partial class DevCenterSamples: SamplesBase<DevCenterClientTestEnvironment>
     {
-        public async Task CreateDeleteDevBoxAsync(string tenantId, string devCenterName)
+        public async Task CreateDeleteDevBoxAsync(string endpoint)
         {
             // Create and delete a user devbox
             #region Snippet:Azure_DevCenter_GetProjects_Scenario
             var credential = new DefaultAzureCredential();
-            var devCenterClient = new DevCenterClient(tenantId, devCenterName, credential);
+            var devCenterClient = new DevCenterClient(endpoint, credential);
             string targetProjectName = null;
             await foreach (BinaryData data in devCenterClient.GetProjectsAsync(filter: null, maxCount: 1))
             {
@@ -29,12 +29,12 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 
             if (targetProjectName is null)
             {
-                throw new InvalidOperationException($"No valid project resources found in DevCenter {devCenterName}/tenant {tenantId}.");
+                throw new InvalidOperationException($"No valid project resources found in DevCenter {endpoint}.");
             }
 
             // Grab a pool
             #region Snippet:Azure_DevCenter_GetPools_Scenario
-            var devBoxesClient = new DevBoxesClient(tenantId, devCenterName, targetProjectName, credential);
+            var devBoxesClient = new DevBoxesClient(endpoint, targetProjectName, credential);
             string targetPoolName = null;
             await foreach (BinaryData data in devBoxesClient.GetPoolsAsync(filter: null, maxCount: 1))
             {
@@ -45,7 +45,7 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 
             if (targetPoolName is null)
             {
-                throw new InvalidOperationException($"No valid pool resources found in Project {targetProjectName}/DevCenter {devCenterName}/tenant {tenantId}.");
+                throw new InvalidOperationException($"No valid pool resources found in Project {targetProjectName}/DevCenter {endpoint}.");
             }
 
             // Provision your dev box in the selected pool

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteEnvironmentAsync.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteEnvironmentAsync.cs
@@ -14,11 +14,11 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 {
     public partial class DevCenterSamples: SamplesBase<DevCenterClientTestEnvironment>
     {
-        public async Task CreateDeleteEnvironmentAsync(string tenantId, string devCenterName)
+        public async Task CreateDeleteEnvironmentAsync(string endpoint)
         {
             // Create and delete a user environment
             var credential = new DefaultAzureCredential();
-            var devCenterClient = new DevCenterClient(tenantId, devCenterName, credential);
+            var devCenterClient = new DevCenterClient(endpoint, credential);
             string projectName = null;
             await foreach (BinaryData data in devCenterClient.GetProjectsAsync(filter: null, maxCount: 1))
             {
@@ -28,11 +28,11 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 
             if (projectName is null)
             {
-                throw new InvalidOperationException($"No valid project resources found in DevCenter {devCenterName}/tenant {tenantId}.");
+                throw new InvalidOperationException($"No valid project resources found in DevCenter {endpoint}.");
             }
 
             #region Snippet:Azure_DevCenter_GetCatalogItems_Scenario
-            var environmentsClient = new EnvironmentsClient(tenantId, devCenterName, projectName, credential);
+            var environmentsClient = new EnvironmentsClient(endpoint, projectName, credential);
             string catalogItemName = null;
             await foreach (BinaryData data in environmentsClient.GetCatalogItemsAsync(maxCount: 1))
             {
@@ -43,7 +43,7 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 
             if (catalogItemName is null)
             {
-                throw new InvalidOperationException($"No valid catalog item resources found in Project {projectName}/DevCenter {devCenterName}/tenant {tenantId}.");
+                throw new InvalidOperationException($"No valid catalog item resources found in Project {projectName}/DevCenter {endpoint}.");
             }
 
             #region Snippet:Azure_DevCenter_GetEnvironmentTypes_Scenario
@@ -57,7 +57,7 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 
             if (environmentTypeName is null)
             {
-                throw new InvalidOperationException($"No valid catalog item resources found in Project {projectName}/DevCenter {devCenterName}/tenant {tenantId}.");
+                throw new InvalidOperationException($"No valid catalog item resources found in Project {projectName}/DevCenter {endpoint}.");
             }
 
             #region Snippet:Azure_DevCenter_CreateEnvironment_Scenario
@@ -73,15 +73,6 @@ namespace Azure.Developer.DevCenter.Tests.Samples
             JsonElement environment = JsonDocument.Parse(environmentData.ToStream()).RootElement;
             Console.WriteLine($"Completed provisioning for environment with status {environment.GetProperty("provisioningState")}.");
             #endregion
-
-            // Fetch and output the deployment artifacts
-            await foreach (BinaryData data in environmentsClient.GetArtifactsByEnvironmentAsync(projectName, "DevEnvironment"))
-            {
-                JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
-                Console.WriteLine(result.GetProperty("name").ToString());
-                Console.WriteLine(result.GetProperty("isDirectory").ToString());
-                Console.WriteLine(result.GetProperty("downloadUri").ToString());
-            }
 
             // Delete the environment when finished
             #region Snippet:Azure_DevCenter_DeleteEnvironment_Scenario

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteEnvironmentAsync.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/Samples/Sample_CreateDeleteEnvironmentAsync.cs
@@ -14,7 +14,7 @@ namespace Azure.Developer.DevCenter.Tests.Samples
 {
     public partial class DevCenterSamples: SamplesBase<DevCenterClientTestEnvironment>
     {
-        public async Task CreateDeleteEnvironmentAsync(string endpoint)
+        public async Task CreateDeleteEnvironmentAsync(Uri endpoint)
         {
             // Create and delete a user environment
             var credential = new DefaultAzureCredential();

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceeds.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceeds.json
@@ -1,46 +1,44 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-11-11-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "31",
+        "Content-Length": "37",
         "Content-Type": "application/json",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-99f53fde2ef57548-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "3337c094a1c543a02e6081230f7dfa99",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-d5d1559e5b615150-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b72631f0657183f780991aac8badcd5b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "poolName": "sdk-default-pool"
+        "poolName": "sdk-pool-bxwfu4kgo6dz6"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "1180",
+        "Content-Length": "885",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:54:57 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "Date": "Fri, 27 Jan 2023 18:43:42 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "b72631f0657183f780991aac8badcd5b",
+        "x-ms-correlation-request-id": "9fa3f75e-53cb-4464-bf73-9d3d74180bfa",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:55:16.8512678Z"
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:44:41.3350030Z"
       },
       "ResponseBody": {
         "name": "MyDevBox",
-        "projectName": "sdk-default-project",
-        "poolName": "sdk-default-pool",
-        "provisioningState": "ProvisionedWithWarning",
+        "projectName": "sdk-project-hdhjgzht7tgyq",
+        "poolName": "sdk-pool-bxwfu4kgo6dz6",
+        "hibernateSupport": "Disabled",
+        "provisioningState": "Creating",
         "actionState": "Unknown",
-        "powerState": "Running",
-        "uniqueId": "762e31d4-7909-4bd6-8c33-2c2fafd81894",
-        "errorDetails": {
-          "code": "DevBoxProvisioningFailed",
-          "message": "The dev box provisioning failed with error code \u0027applyConfigFailed\u0027 and message \u0027One or more configurations did not apply successfully\u0027. The error appears to have been transient and the operation can be retried later."
-        },
+        "uniqueId": "61313d72-520a-433f-b027-0436f98f8b4b",
         "location": "eastus",
         "osType": "Windows",
         "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
@@ -61,109 +59,1337 @@
           "osBuildNumber": "win11-21h2-ent-cpc-m365",
           "publishedDate": "2021-10-04T00:00:00\u002B00:00"
         },
-        "createdTime": "2022-09-28T17:21:25.4687051\u002B00:00",
+        "createdTime": "2023-01-27T18:43:41.5008208\u002B00:00",
         "localAdministrator": "Enabled"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-261336a12cc0094b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "08564406a403d90d96ee636d0d7da8c2",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-84cc77a8a1f49840-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f727551a6831530a7a9dac0f9e226acd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "232",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:54:57 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "Date": "Fri, 27 Jan 2023 18:43:42 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "f727551a6831530a7a9dac0f9e226acd",
+        "x-ms-correlation-request-id": "d337c67c-00ac-443c-8d9c-72aef6f008bc",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:55:57.2809299Z"
+        "X-Rate-Limit-Reset": "2023-01-27T18:44:42.5897579Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
-        "name": "774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "NotStarted",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-15ba44c4c9ed266c-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af024cd7cba38bc29465b552ccfa658f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:44:12 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "af024cd7cba38bc29465b552ccfa658f",
+        "x-ms-correlation-request-id": "ace58afe-dada-462c-b1c4-93d436c307b7",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:45:12.8275257Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
         "status": "Running",
-        "startTime": "2022-09-28T22:54:56.3449136\u002B00:00"
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-2de27cb7edd77a42-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "1fd73e07e4d1e9974a1aaffe7b7106c2",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-2cbc0f9ef1d9f5eb-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c78651609cac87fd27d23cd3b9e7e55e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "275",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:27 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "Date": "Fri, 27 Jan 2023 18:44:43 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "c78651609cac87fd27d23cd3b9e7e55e",
+        "x-ms-correlation-request-id": "6485eeaf-9483-4003-b67c-cc701614e9b5",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:27.5166117Z"
+        "X-Rate-Limit-Reset": "2023-01-27T18:45:43.0106613Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
-        "name": "774a2cd2-24d5-4b19-a8ac-ef73602717ad",
-        "status": "Succeeded",
-        "startTime": "2022-09-28T22:54:56.3449136\u002B00:00",
-        "endTime": "2022-09-28T22:55:01.3121983\u002B00:00"
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-4206cbaf497e674e-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "fabff8d2b3d1f08fb25e9cd73d3235b0",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-de33d0b25b2ca80f-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3ed44c2f1dab4fb8929c63cbb3b7867f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "1180",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:27 GMT",
+        "Date": "Fri, 27 Jan 2023 18:45:13 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "3ed44c2f1dab4fb8929c63cbb3b7867f",
+        "x-ms-correlation-request-id": "ae4d7528-d83d-4563-9315-d843bf80b71c",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:46:13.1632105Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-b1ea90b243ab65c2-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4caf1d37a29b3b214f7a88d08eeed1ac",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:45:43 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "4caf1d37a29b3b214f7a88d08eeed1ac",
+        "x-ms-correlation-request-id": "247eeeae-92b5-4bb6-9301-2c7fa071eff5",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:46:43.4120842Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-8bc56e7939b622fb-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "80235780272643e4993734103831d46f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:46:14 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "80235780272643e4993734103831d46f",
+        "x-ms-correlation-request-id": "17e1f0b1-61fa-4093-806a-e9b394ccb795",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:47:13.6821569Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-305e023205cc49f4-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9c9cbd4b98388cc22a99ef3094e7c0a3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:46:44 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "9c9cbd4b98388cc22a99ef3094e7c0a3",
+        "x-ms-correlation-request-id": "c8bc4254-8a42-4895-8f14-fa0db4fda84c",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:47:44.1314489Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-749e02ccdd206add-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5c4bb6ca06941059386bb3646e11021d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:47:14 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5c4bb6ca06941059386bb3646e11021d",
+        "x-ms-correlation-request-id": "faae39f1-2274-427c-9ff2-d474eff523c8",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:48:14.3421613Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-15a8bca43638371a-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d08419a53552e7749497568d37b3aeb1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:47:44 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "d08419a53552e7749497568d37b3aeb1",
+        "x-ms-correlation-request-id": "90e4d435-4912-4829-9bf5-c7612e106400",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:48:44.5580101Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-6d6ff07b2ef30beb-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8245917678e645db648b63cce55e1e18",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:48:14 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "8245917678e645db648b63cce55e1e18",
+        "x-ms-correlation-request-id": "75c86928-36e4-4f8c-8c99-7d8d5a8584e4",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:49:14.7711544Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-12b907f314a5f3af-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7b8bd296ef6394504263c7fcb0ccd885",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:48:45 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "7b8bd296ef6394504263c7fcb0ccd885",
+        "x-ms-correlation-request-id": "3bd08ed9-a04c-43ae-b00f-92909ce13422",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:49:44.9823760Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-3b5f1a89de20f80a-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dced01bd80cb2d363d3f6cc7d2a80236",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:49:15 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "dced01bd80cb2d363d3f6cc7d2a80236",
+        "x-ms-correlation-request-id": "0052cb70-ebbb-42b2-a2d1-a3be02141f30",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:50:15.2128560Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-ecc624e0ec48f047-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "65f63d783227874e40b14082b0de9597",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:49:45 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "65f63d783227874e40b14082b0de9597",
+        "x-ms-correlation-request-id": "4a1a6245-0a44-4341-9639-a865e268c29e",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:50:45.4755700Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-9e37e8e2a69f3c4a-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e40fddb34170164c9b5e3e248289c199",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:50:15 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "e40fddb34170164c9b5e3e248289c199",
+        "x-ms-correlation-request-id": "63f8e49b-6036-4876-a158-9cf2eab343ad",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:51:15.7946733Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-4cadcd44dfbea7da-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7283906172d58a5eb3669c1a40b47c5f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:50:46 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "7283906172d58a5eb3669c1a40b47c5f",
+        "x-ms-correlation-request-id": "9c4e4508-2270-42cf-8e9c-4aa83b24c2da",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:51:45.9774104Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-ed7537f64108a7f7-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f513d4a91e9837c5f0e0cac9f42a04b6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:51:16 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "f513d4a91e9837c5f0e0cac9f42a04b6",
+        "x-ms-correlation-request-id": "cbeb2833-75a6-4246-be3f-8ddee7e6a367",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:52:16.1755362Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-55a0c39b777dde28-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1f20a6ef225a40c27f84310aa432d6e6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:51:46 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "1f20a6ef225a40c27f84310aa432d6e6",
+        "x-ms-correlation-request-id": "23aa5c82-6ddc-4afe-b065-64073ba1e645",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:52:46.4046077Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-cc6158070ac5302e-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ae7adee1cc764301cb4c82f5a8949688",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:52:16 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "ae7adee1cc764301cb4c82f5a8949688",
+        "x-ms-correlation-request-id": "d8ac6a9f-8df7-4da8-a577-2292dd7b2c72",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:53:16.6171272Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-e59ba41ea571a2e8-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "992be6625c93860412d37614edbb92be",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:52:46 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "992be6625c93860412d37614edbb92be",
+        "x-ms-correlation-request-id": "af4d5935-bdc8-4cc1-8c25-9a421939d738",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:53:46.7927368Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-dbf5c2bcc87928e2-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "15e7e30a56af2240a5dd540ea0cd98ea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:53:17 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "15e7e30a56af2240a5dd540ea0cd98ea",
+        "x-ms-correlation-request-id": "145c9e2f-df3c-4063-8147-cda2ced1db18",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:54:16.9809931Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-c5197be4d2c4a458-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bea7a8ee3c068553d9f39ba256ed560f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:53:47 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "bea7a8ee3c068553d9f39ba256ed560f",
+        "x-ms-correlation-request-id": "ad1a303b-4180-4bb7-b8f5-dfb575bef0de",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:54:47.1957527Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-d9580e407288a04d-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c4ebc3b980ad0cd9a508f4b507f6e645",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:54:17 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "c4ebc3b980ad0cd9a508f4b507f6e645",
+        "x-ms-correlation-request-id": "6edac456-0644-4bad-ad55-c2a9d5f5c647",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:55:17.4554668Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-d493e8b14935253e-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "44258b3bd413cdb790613bbbba9dccb8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:54:47 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "44258b3bd413cdb790613bbbba9dccb8",
+        "x-ms-correlation-request-id": "6a6d80e0-45e0-4cf9-852f-cd587b34888f",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:55:47.6834866Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-755b9e1d3ed6a27f-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dc544587d3e16d3dcf9b18fe479d7ee3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:55:18 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "dc544587d3e16d3dcf9b18fe479d7ee3",
+        "x-ms-correlation-request-id": "bc7ebad9-2e2f-4cf2-81b7-eca43b3b4bfb",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:56:17.9287084Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-6c8f978de1e99f36-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ca67560d11c7e5fb0b1d344b441d5107",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:55:48 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "ca67560d11c7e5fb0b1d344b441d5107",
+        "x-ms-correlation-request-id": "5874abd4-a331-48aa-927d-7aa465ae99b0",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:17.5947455Z"
+        "X-Rate-Limit-Reset": "2023-01-27T18:56:29.3124674Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-8d2d3f98de5ce702-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c12e3c3c09a267634eb77578bbb986f2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:56:18 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "c12e3c3c09a267634eb77578bbb986f2",
+        "x-ms-correlation-request-id": "921d066c-3e3f-4b42-8930-4e095fb56592",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "297",
+        "X-Rate-Limit-Reset": "2023-01-27T18:56:53.5197687Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-8f967f3923df9e40-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "64ae58e3013675f04a6fd1c49ff129b1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:56:48 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "64ae58e3013675f04a6fd1c49ff129b1",
+        "x-ms-correlation-request-id": "f8350ad3-d6d3-4cac-bc53-d4249afe730e",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "297",
+        "X-Rate-Limit-Reset": "2023-01-27T18:57:32.9908642Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-b93f23fc0c1895ff-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0ac11049bc6f0440f2ff7b0f9b832952",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:57:18 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "0ac11049bc6f0440f2ff7b0f9b832952",
+        "x-ms-correlation-request-id": "ea6ddbcd-504a-421e-b1f2-285d141ec312",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:58:18.7350065Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-13ab95d68578feb6-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ec674196ed6f3ad14cb87732389ec75c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:57:49 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "ec674196ed6f3ad14cb87732389ec75c",
+        "x-ms-correlation-request-id": "2ed5ff59-269d-4eef-a9fc-bebc772ff34d",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:58:48.9506077Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-0d4967c8f7013701-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aa2ec48e7bf7278317a9713786e0dac7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:58:19 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "aa2ec48e7bf7278317a9713786e0dac7",
+        "x-ms-correlation-request-id": "d15651f0-a8d5-468a-8425-d2cdc1ccd4f9",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:59:19.1570959Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-447a5921070ef7b3-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5e2d7e463c8a5c423f87beb6440ecc54",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:58:49 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5e2d7e463c8a5c423f87beb6440ecc54",
+        "x-ms-correlation-request-id": "31b3204c-411e-4e93-a4e9-1e9b6689a97e",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T18:59:49.4006455Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-95b5f314379f7613-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d7811e377e541a5abd40d4c57c9ab46b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:59:19 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "d7811e377e541a5abd40d4c57c9ab46b",
+        "x-ms-correlation-request-id": "e5b14711-6819-4006-a075-c0b3f1c0342a",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T18:59:59.2547840Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-7d4d213dab06be8d-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b9ecb0de697051d281d26b70bdcde209",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 18:59:49 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "b9ecb0de697051d281d26b70bdcde209",
+        "x-ms-correlation-request-id": "ff32a387-fbe6-4b88-a835-a7681c5ffbee",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:00:49.7347837Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-4f7f7e02bafba1f7-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "67ff1cdd035fc7722412a049687ddfa5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:00:20 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "67ff1cdd035fc7722412a049687ddfa5",
+        "x-ms-correlation-request-id": "87149d71-92eb-454e-8f14-581c9e38bb48",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:01:19.9774262Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-fa4318009ead567a-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "94d752d21221cee34c2f558213e95df0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:00:50 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "94d752d21221cee34c2f558213e95df0",
+        "x-ms-correlation-request-id": "8cf08a4e-e5c6-4fd7-ac92-6d2c6f79337d",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:01:50.2702213Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-fafe4c8367b53a87-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5fe7cb5e4d9adb0b3e24945ec889e904",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:01:20 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5fe7cb5e4d9adb0b3e24945ec889e904",
+        "x-ms-correlation-request-id": "8a9ed377-c554-41e8-b6c7-a4699e3ad694",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:01:59.2577792Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-fd2f902fb04d64bf-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6a9dc5f24ef5cbe839301b30adf0b43a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:01:50 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "6a9dc5f24ef5cbe839301b30adf0b43a",
+        "x-ms-correlation-request-id": "6a4bce8f-748a-4845-9780-f2a2d021a032",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:02:29.3664965Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Running",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-b1c65bdcbc02e686-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9cebb0b57f95850a47fc55fc7d8505c2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "281",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:02:21 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "9cebb0b57f95850a47fc55fc7d8505c2",
+        "x-ms-correlation-request-id": "bd6c5431-98f1-4316-86d6-c7c1b1a06766",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "297",
+        "X-Rate-Limit-Reset": "2023-01-27T19:02:59.2538310Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "name": "df61150f-d72e-4ee7-8639-a2497f6c1efb",
+        "status": "Succeeded",
+        "startTime": "2023-01-27T18:43:41.5180523\u002B00:00",
+        "endTime": "2023-01-27T19:02:17.2385734\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a1ed5809e937ddac766b5c83547c643-7c240bb15d1c1c18-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d8f5045f24b0ffae31c266a32db2d4d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "935",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:02:21 GMT",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "4d8f5045f24b0ffae31c266a32db2d4d",
+        "x-ms-correlation-request-id": "811ec23f-386a-4310-a315-90246463d494",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:03:15.6833075Z"
       },
       "ResponseBody": {
         "name": "MyDevBox",
-        "projectName": "sdk-default-project",
-        "poolName": "sdk-default-pool",
-        "provisioningState": "ProvisionedWithWarning",
+        "projectName": "sdk-project-hdhjgzht7tgyq",
+        "poolName": "sdk-pool-bxwfu4kgo6dz6",
+        "hibernateSupport": "Disabled",
+        "provisioningState": "Succeeded",
         "actionState": "Unknown",
         "powerState": "Running",
-        "uniqueId": "762e31d4-7909-4bd6-8c33-2c2fafd81894",
-        "errorDetails": {
-          "code": "DevBoxProvisioningFailed",
-          "message": "The dev box provisioning failed with error code \u0027applyConfigFailed\u0027 and message \u0027One or more configurations did not apply successfully\u0027. The error appears to have been transient and the operation can be retried later."
-        },
+        "uniqueId": "61313d72-520a-433f-b027-0436f98f8b4b",
+        "errorDetails": {},
         "location": "eastus",
         "osType": "Windows",
         "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
@@ -184,19 +1410,19 @@
           "osBuildNumber": "win11-21h2-ent-cpc-m365",
           "publishedDate": "2021-10-04T00:00:00\u002B00:00"
         },
-        "createdTime": "2022-09-28T17:21:25.4687051\u002B00:00",
+        "createdTime": "2023-01-27T18:43:41.5008208\u002B00:00",
         "localAdministrator": "Enabled"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox/remoteConnection?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox/remoteConnection?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6b660b3a3a0e334eb298051f88ff1caf-448f863140cfe64f-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d11bbeb8daa621c7ac6dbee8f40e5d25",
+        "traceparent": "00-af8c71a54360bef5fc9a63e1084191e7-9d6e11fe0ef23ce6-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "18a859704c9d726eba1823f9f8eb4db3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -205,54 +1431,56 @@
         "Connection": "keep-alive",
         "Content-Length": "332",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:28 GMT",
+        "Date": "Fri, 27 Jan 2023 19:02:22 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "18a859704c9d726eba1823f9f8eb4db3",
+        "x-ms-correlation-request-id": "bbd89d31-6fe8-4da9-a1d0-1f30e2494384",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "296",
-        "X-Rate-Limit-Reset": "2022-09-28T22:55:57.2809299Z"
+        "X-Rate-Limit-Remaining": "297",
+        "X-Rate-Limit-Reset": "2023-01-27T19:02:29.3664965Z"
       },
       "ResponseBody": {
-        "webUrl": "https://deschutes-ppe.microsoft.com/webclient/0b1a81f2-91d9-431e-bb60-64e55d5b100b",
-        "rdpConnectionUrl": "ms-avd:connect?env=avdarm\u0026resourceid=613b6330-51cd-4f01-8ace-08da93231eca\u0026username=sdk_integration_test_1@fidalgoppe010.onmicrosoft.com\u0026version=0\u0026workspaceId=fa7f99ce-701c-49ca-a110-743c04978305\u0026preview=yes"
+        "webUrl": "https://deschutes-ppe.microsoft.com/webclient/69005fa3-25e7-4b9a-bd74-57548ac5b7bf",
+        "rdpConnectionUrl": "ms-avd:connect?env=avdarm\u0026resourceid=8ee26a2c-c118-443a-933d-08dafbbbf752\u0026username=sdk_integration_test_1@fidalgoppe010.onmicrosoft.com\u0026version=0\u0026workspaceId=8b6d1c8b-92cd-4eb6-a4ec-928f04941b52\u0026preview=yes"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-11-11-preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-78b55545c714d144-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "149aa1e7adbe54f0aee76c7347bfab17",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-4b4323a63e4d4edc-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5ceb582a6761c2eeb5dbb97959a0536c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "1166",
+        "Content-Length": "934",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:29 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:02:22 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5ceb582a6761c2eeb5dbb97959a0536c",
+        "x-ms-correlation-request-id": "11b253fc-0dc3-4af6-bd7f-ec7afd22f750",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:27.5166117Z"
+        "X-Rate-Limit-Remaining": "296",
+        "X-Rate-Limit-Reset": "2023-01-27T19:02:59.2538310Z"
       },
       "ResponseBody": {
         "name": "MyDevBox",
-        "projectName": "sdk-default-project",
-        "poolName": "sdk-default-pool",
+        "projectName": "sdk-project-hdhjgzht7tgyq",
+        "poolName": "sdk-pool-bxwfu4kgo6dz6",
+        "hibernateSupport": "Disabled",
         "provisioningState": "Deleting",
         "actionState": "Unknown",
         "powerState": "Running",
-        "uniqueId": "762e31d4-7909-4bd6-8c33-2c2fafd81894",
-        "errorDetails": {
-          "code": "DevBoxProvisioningFailed",
-          "message": "The dev box provisioning failed with error code \u0027applyConfigFailed\u0027 and message \u0027One or more configurations did not apply successfully\u0027. The error appears to have been transient and the operation can be retried later."
-        },
+        "uniqueId": "61313d72-520a-433f-b027-0436f98f8b4b",
+        "errorDetails": {},
         "location": "eastus",
         "osType": "Windows",
         "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
@@ -273,630 +1501,362 @@
           "osBuildNumber": "win11-21h2-ent-cpc-m365",
           "publishedDate": "2021-10-04T00:00:00\u002B00:00"
         },
-        "createdTime": "2022-09-28T17:21:25.4687051\u002B00:00",
+        "createdTime": "2023-01-27T18:43:41.5008208\u002B00:00",
         "localAdministrator": "Enabled"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-e33dc90b874b4141-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "bd45fee43455f81c309d4e63f4a7fba3",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-7016fbd7e0e9e5b5-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "248c08ceeddcf824e21c9233cf0117f7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "226",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:29 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:02:22 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "248c08ceeddcf824e21c9233cf0117f7",
+        "x-ms-correlation-request-id": "2c5fe4f2-d7e1-4de7-a384-bd8aeca41caa",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:17.5947455Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:03:15.6833075Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "NotStarted",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-3d8f3a5f5f4f3140-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "9cef770020970bf2cdc723bf6d54d9ed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:59 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:27.5166117Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-3b312dd2f682ad40-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f503a6c2a0c9b3d084a2e4215f8d5f07",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-a6aac0df110b774b-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d93f72cfd1ef08ec6be563c292f5191a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:56:30 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:02:52 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "d93f72cfd1ef08ec6be563c292f5191a",
+        "x-ms-correlation-request-id": "1d73c5e1-1364-4610-91fe-6aa4f00fffe7",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:57:30.0126656Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:03:52.7846260Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-6079c9e242740444-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d073c9eb0ecfc37f0c3aef8e115c8adc",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-a41623054be635cc-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f02ab6c4295f3dd633f27a45d5bbf3b3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:57:00 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:03:22 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "f02ab6c4295f3dd633f27a45d5bbf3b3",
+        "x-ms-correlation-request-id": "cc1c03c1-9bd9-4271-87eb-e9fe2b2ce4e7",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T22:57:18.5072613Z"
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:04:22.9252282Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-1c6392711c7b0c4b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "4da160c306a35fdaa63c18f43cd1ac40",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-0cfc53f5e5fb6342-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e6aac2c47961fd7c1b83b9f7896265ec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:57:30 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:03:53 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "e6aac2c47961fd7c1b83b9f7896265ec",
+        "x-ms-correlation-request-id": "b75dfb66-e7ad-42da-8844-51c10b787207",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:04:53.0623998Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "status": "Running",
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-9cac53a46b78e5e1-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "186e770226d7a6989b01a6fd56a733af",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:04:23 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "186e770226d7a6989b01a6fd56a733af",
+        "x-ms-correlation-request-id": "692ebdff-dbec-4f23-98f2-939fa9ffac3d",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:05:23.2893435Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "status": "Running",
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-8634c7ece1a62b31-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d0fdb0f2324a4bb83a2dd4db70dfb3d0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:04:53 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "d0fdb0f2324a4bb83a2dd4db70dfb3d0",
+        "x-ms-correlation-request-id": "9bcdfd69-9b9b-48b0-ab56-d0474fdc149c",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:58:19.3048726Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:05:29.2251085Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-a877a3abd7bef240-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "a4d41b6709e1b31d2640e88eb042a127",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-d69ab92971acf865-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d428d8cda4c9ddc29044b60d27fa774",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:58:00 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:05:24 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:58:51.4329983Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-bc2fd54129cce043-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "fe5d071811ebe564ee132992f68b863b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:58:30 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5d428d8cda4c9ddc29044b60d27fa774",
+        "x-ms-correlation-request-id": "66bd1f48-4991-4125-895e-ef0e4da67600",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:59:30.8705828Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:06:24.0594107Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-ed5783d32386084b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f626af8ee588bafa43ed26621d4cae64",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-7ab63b64785b8ba3-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d90409509564d0a1bf23deaa51bd36bc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:59:01 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:05:54 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "d90409509564d0a1bf23deaa51bd36bc",
+        "x-ms-correlation-request-id": "f30eb956-852b-42b9-ad42-34c2b3f521c6",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:00:01.0061970Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:06:54.3219758Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-b581f005c64c034d-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "35dcf09bad735555b7eeb6cddf8abd9b",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-4501a3e73b77d99a-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c870d54dd6641763d360a646e75878bb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:59:31 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:06:24 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:00:31.1405993Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-d4c1dd2d0328584c-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "0100adb9ab1b329f0ca3bafdeb01c8a1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:00:01 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:01:01.3803144Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-4c4a7d4669bd924b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "06f7c46551aee0c75ad03e992f2ddbb9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:00:32 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:01:32.1938808Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-2d8989a24515af48-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "6fa98b30ad4cf04950a928d0f3576ab6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:01:02 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:02:02.4931725Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-3fb10a2895896c4e-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "1a681426b69368ece51fa74a6c0502df",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:01:32 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "c870d54dd6641763d360a646e75878bb",
+        "x-ms-correlation-request-id": "e1fcd4d8-153c-4cf9-828a-a675a20e8d57",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T23:02:24.1239269Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:06:29.2409461Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-f32bb2896cfee943-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "60cd01c75858b8557b06b50429f7ed02",
+        "traceparent": "00-0b009335158c8e3dd0778d155d0b4aec-6194550f9232bd80-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "668b6085dadaf76cec729d28fc314c6c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:02:02 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:06:54 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "668b6085dadaf76cec729d28fc314c6c",
+        "x-ms-correlation-request-id": "4a03c839-2694-4a51-b561-90fddfe40558",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:03:02.8343044Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:07:54.6993981Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-fa739126e7c9da40-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "1b738866c0c579259e408a2c05fe844b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:02:33 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:03:32.9666837Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-18a47d331a8df846-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f10848a70a8ace5dbeb09e8c01e73fee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:03:03 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:04:03.2383329Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-ab886a22e0e85c42-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "e3e4a432e791071adb53c117ce29b27c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:03:33 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:04:33.4567810Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-56a681884a158142-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "e05d6a82fbee5b782aa55c15219978b6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:04:03 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:05:03.6606263Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-cb8e96a4f412f040-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "61f99c01a019bfb92e0116374846ff95",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "275",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:04:33 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:05:33.8177154Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
+        "name": "3c5b6a1d-e4a8-4158-85fa-6d1a38842dbf",
         "status": "Succeeded",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00",
-        "endTime": "2022-09-28T23:04:04.4337491\u002B00:00"
+        "startTime": "2023-01-27T19:02:22.455714\u002B00:00",
+        "endTime": "2023-01-27T19:06:24.7667598\u002B00:00"
       }
     }
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
     "CLIENT_ID": "82759f53-fe56-4a00-a282-dc1990e29267",
-    "DEFAULT_DEVCENTER_NAME": "sdk-default-devcenter-n",
     "DEFAULT_DEVCENTER_SCOPE": "https://devcenter.azure.com/.default",
-    "DEFAULT_POOL_NAME": "sdk-default-pool",
-    "DEFAULT_PROJECT_NAME": "sdk-default-project",
-    "DEFAULT_TEST_USER_SECRET": "Sanitized",
+    "DEFAULT_POOL_NAME": "sdk-pool-bxwfu4kgo6dz6",
+    "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
     "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
-    "RandomSeed": "1078026214",
+    "DEFAULT_TEST_USER_SECRET": "Sanitized",
+    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "RandomSeed": "2099054292",
     "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
     "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"
   }

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceeds.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceeds.json
@@ -1855,7 +1855,7 @@
     "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
     "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
     "DEFAULT_TEST_USER_SECRET": "Sanitized",
-    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "DEFAULT_DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
     "RandomSeed": "2099054292",
     "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
     "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceedsAsync.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceedsAsync.json
@@ -1,46 +1,44 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-11-11-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "31",
+        "Content-Length": "37",
         "Content-Type": "application/json",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-99f53fde2ef57548-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "3337c094a1c543a02e6081230f7dfa99",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-75b00606f45d5b10-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "781c0e688b7d0f80b6ec85853887a1f9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "poolName": "sdk-default-pool"
+        "poolName": "sdk-pool-bxwfu4kgo6dz6"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "1180",
+        "Content-Length": "885",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:54:57 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "Date": "Fri, 27 Jan 2023 19:06:56 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "781c0e688b7d0f80b6ec85853887a1f9",
+        "x-ms-correlation-request-id": "b4984481-b8ba-4b5d-896b-b488a8800659",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:55:16.8512678Z"
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:07:55.9888618Z"
       },
       "ResponseBody": {
         "name": "MyDevBox",
-        "projectName": "sdk-default-project",
-        "poolName": "sdk-default-pool",
-        "provisioningState": "ProvisionedWithWarning",
+        "projectName": "sdk-project-hdhjgzht7tgyq",
+        "poolName": "sdk-pool-bxwfu4kgo6dz6",
+        "hibernateSupport": "Disabled",
+        "provisioningState": "Creating",
         "actionState": "Unknown",
-        "powerState": "Running",
-        "uniqueId": "762e31d4-7909-4bd6-8c33-2c2fafd81894",
-        "errorDetails": {
-          "code": "DevBoxProvisioningFailed",
-          "message": "The dev box provisioning failed with error code \u0027applyConfigFailed\u0027 and message \u0027One or more configurations did not apply successfully\u0027. The error appears to have been transient and the operation can be retried later."
-        },
+        "uniqueId": "59ee8e80-bed1-47f2-bf80-707a6929a56d",
         "location": "eastus",
         "osType": "Windows",
         "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
@@ -61,109 +59,1269 @@
           "osBuildNumber": "win11-21h2-ent-cpc-m365",
           "publishedDate": "2021-10-04T00:00:00\u002B00:00"
         },
-        "createdTime": "2022-09-28T17:21:25.4687051\u002B00:00",
+        "createdTime": "2023-01-27T19:06:56.1361901\u002B00:00",
         "localAdministrator": "Enabled"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-261336a12cc0094b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "08564406a403d90d96ee636d0d7da8c2",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-e34868c35ad8d7e9-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ed25cc75db57b690a7fd93654920155d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:54:57 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "Date": "Fri, 27 Jan 2023 19:06:56 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "ed25cc75db57b690a7fd93654920155d",
+        "x-ms-correlation-request-id": "fa9ed2b0-468d-423a-ad6d-9471ff7f329b",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:55:57.2809299Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:07:29.2614456Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
-        "name": "774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
         "status": "Running",
-        "startTime": "2022-09-28T22:54:56.3449136\u002B00:00"
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-2de27cb7edd77a42-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "1fd73e07e4d1e9974a1aaffe7b7106c2",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-382e9c8420da72e4-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f7b0893849e691a6994c0fb814a8c2b9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "275",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:27 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
+        "Date": "Fri, 27 Jan 2023 19:07:26 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "f7b0893849e691a6994c0fb814a8c2b9",
+        "x-ms-correlation-request-id": "7a7279e2-7720-45be-be21-552901eb5ba7",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:27.5166117Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:07:54.6993981Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/774a2cd2-24d5-4b19-a8ac-ef73602717ad",
-        "name": "774a2cd2-24d5-4b19-a8ac-ef73602717ad",
-        "status": "Succeeded",
-        "startTime": "2022-09-28T22:54:56.3449136\u002B00:00",
-        "endTime": "2022-09-28T22:55:01.3121983\u002B00:00"
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c9045e64776e5d4da0d2060078e83b39-4206cbaf497e674e-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "fabff8d2b3d1f08fb25e9cd73d3235b0",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-e38e391f9043709a-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8d76ed48b228cb37d66d17ff81bc696",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "1180",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:27 GMT",
+        "Date": "Fri, 27 Jan 2023 19:07:56 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "a8d76ed48b228cb37d66d17ff81bc696",
+        "x-ms-correlation-request-id": "504bd6b2-164d-4a94-a173-ae9d76aabfbb",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:08:56.7264819Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-089e7c82f6cc08ac-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af4d27d7a9d72b132593540bccd7a2ff",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:08:27 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "af4d27d7a9d72b132593540bccd7a2ff",
+        "x-ms-correlation-request-id": "e6f4a54e-df54-4298-89a8-914520b73430",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:09:26.8615889Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-e8764ec236ba4479-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "da91d93a6c48ad3ad6247a807827997e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:08:57 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "da91d93a6c48ad3ad6247a807827997e",
+        "x-ms-correlation-request-id": "ae733a0a-93c8-4d00-8312-ab7b19c434ed",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:17.5947455Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:08:59.3699658Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-38f01b0015464ee7-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ece17885135b2ae25bab828f37a7c0a6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:09:27 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "ece17885135b2ae25bab828f37a7c0a6",
+        "x-ms-correlation-request-id": "f88b809a-1df0-43c2-beb7-847e229e4eef",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:10:03.0185997Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-1c03c84e318db9b0-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1e45d1c4ec896a4deca0d8b22f93b3fe",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:09:57 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "1e45d1c4ec896a4deca0d8b22f93b3fe",
+        "x-ms-correlation-request-id": "66a5618e-80fb-4581-85d4-e1224bbbe05c",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:10:34.6918028Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-ae2720b9077fe6e4-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5385d5fab5f526a4f7667f9deaab752e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:10:27 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5385d5fab5f526a4f7667f9deaab752e",
+        "x-ms-correlation-request-id": "2394dd3a-ce8c-4f3f-8fed-d235077325f4",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:11:27.6957744Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-866f253137c47a1a-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a6bbd3637ae199f42b77ffba3b2ffbc7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:10:57 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "a6bbd3637ae199f42b77ffba3b2ffbc7",
+        "x-ms-correlation-request-id": "09d065ac-0f50-4639-bcca-d96cdb6d4faf",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:11:45.7772406Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-f764cde23d87b13e-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "619583f86d220eb02d1e27236cb07f41",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:11:28 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "619583f86d220eb02d1e27236cb07f41",
+        "x-ms-correlation-request-id": "31e0b0c1-3fbd-47a3-825b-c7f847887919",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:12:28.0539955Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-642707c883bfd3d6-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5b4faa2a0dd77f1ce1eb287eb5e9ebc8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:11:58 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5b4faa2a0dd77f1ce1eb287eb5e9ebc8",
+        "x-ms-correlation-request-id": "fd8655b7-59c6-486f-b04d-7487bfd946c2",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:12:58.2576481Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-ff2fe55795e35949-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "66a5b76b1416f60c23ad78c353d02d7a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:12:28 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "66a5b76b1416f60c23ad78c353d02d7a",
+        "x-ms-correlation-request-id": "acae473a-d50a-4251-b50f-7ea85e23fa94",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:13:28.4696978Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-04d6df0354e7f2c6-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9090bef89fdfeaf06615803644315844",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:12:58 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "9090bef89fdfeaf06615803644315844",
+        "x-ms-correlation-request-id": "59ab8fc3-09bb-4b17-bda8-452784b2bff7",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:13:58.6055234Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-a5538f04b67de9d6-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b5b85e32180b152b9d59372994592c10",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:13:29 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "b5b85e32180b152b9d59372994592c10",
+        "x-ms-correlation-request-id": "601966f8-d6b5-4f12-89b0-9ee189e3724b",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:14:28.8651779Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-410f1658347ec5d3-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f786adbe5a58cce8c6ba000093d5b1f2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:13:59 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "f786adbe5a58cce8c6ba000093d5b1f2",
+        "x-ms-correlation-request-id": "c5079698-af81-4985-8653-13d86675e5d3",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:14:59.0745422Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-deace02ec37e4ee4-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f49034547718df6f937af28667c6560d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:14:29 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "f49034547718df6f937af28667c6560d",
+        "x-ms-correlation-request-id": "e1b85fbc-77b5-4496-adcd-9eaee342e3e2",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:15:29.3029593Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-7d294d5891edd439-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "977870e961abd7eb75ecee51182a81c8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:14:59 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "977870e961abd7eb75ecee51182a81c8",
+        "x-ms-correlation-request-id": "d3d76a9b-9359-40f7-8760-9921157e0d06",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:15:59.4558420Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-a457896ccc460b89-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "60d545a737c847f73da664dd68616400",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:15:29 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "60d545a737c847f73da664dd68616400",
+        "x-ms-correlation-request-id": "86a45540-e374-40e3-9946-3c5397a9eaad",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:16:29.6201279Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-f74ad22fc0a391d6-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2317f263195df34648b87e2c881ec668",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:16:00 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "2317f263195df34648b87e2c881ec668",
+        "x-ms-correlation-request-id": "0e74e57d-b2e9-4f5f-9a1b-0c133ed3aa63",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:16:59.9436640Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-6abff32d245080f2-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "21df2af8f5f1b14478315a04fc0d6f13",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:16:30 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "21df2af8f5f1b14478315a04fc0d6f13",
+        "x-ms-correlation-request-id": "06134902-4e58-498b-88bf-ded6e5c7cc36",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:17:03.0024432Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-273bfa2e7ce59f00-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "25edee875e138d6affe11810b8cbbe1f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:17:00 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "25edee875e138d6affe11810b8cbbe1f",
+        "x-ms-correlation-request-id": "24e61560-4435-4fe1-978e-a79b21f4b4a5",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:18:00.3701184Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-e29836cffccf184d-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3de4fce043826e0ead65ab2cbf41f63a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:17:30 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "3de4fce043826e0ead65ab2cbf41f63a",
+        "x-ms-correlation-request-id": "0a60b767-683e-4928-b570-19c648637198",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:18:15.8200751Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-ae07956def34370b-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9aa46a48a0319a54bf512210dd34f8ad",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:18:00 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "9aa46a48a0319a54bf512210dd34f8ad",
+        "x-ms-correlation-request-id": "f36be6ea-67ef-45a2-bd84-7cdd508dcc56",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:18:29.2860293Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-a06e566610b78bc7-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "00243a7232284491df7f78adb23ecdbd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:18:31 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "00243a7232284491df7f78adb23ecdbd",
+        "x-ms-correlation-request-id": "5e35d576-0441-4dbe-a92c-1b8dc4b90a02",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:19:30.9956190Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-0a9dd83f261b802d-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4dc7ddea24263feea74a7e3121fe9078",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:19:01 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "4dc7ddea24263feea74a7e3121fe9078",
+        "x-ms-correlation-request-id": "a79efdc3-deff-4b3f-b0e3-43a5fb3baa7a",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:20:01.2190355Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-728c49c6d487da56-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "84b9fd6df61c1611d960bab128a7e881",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:19:31 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "84b9fd6df61c1611d960bab128a7e881",
+        "x-ms-correlation-request-id": "b88f0e67-5d35-4e2e-9558-b67884c0ad16",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:20:31.3709547Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-a904e962356eb6c2-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "00256483aa6d4e874ce559deb45f23e0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:20:01 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "00256483aa6d4e874ce559deb45f23e0",
+        "x-ms-correlation-request-id": "3d334d63-8582-460c-9a81-8d36aa9165f8",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:21:01.5808398Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-8f362aa794d0b8d1-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b540ffef4884f4a0ccb074c5693c1600",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:20:31 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "b540ffef4884f4a0ccb074c5693c1600",
+        "x-ms-correlation-request-id": "ec91f4a4-3cca-449e-9f10-e89e5c18deae",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:21:31.8260143Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-9dc5762a9f5b87df-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bcadfd6290d9c20b766a38379c326279",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:21:02 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "bcadfd6290d9c20b766a38379c326279",
+        "x-ms-correlation-request-id": "0f026723-6ad2-439b-aa19-f116db82cdd0",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:22:02.0268899Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-c1bbe93048ce4ecc-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "29c2d93d33663afcc33134bc36c1e410",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:21:32 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "29c2d93d33663afcc33134bc36c1e410",
+        "x-ms-correlation-request-id": "27800634-12db-4f6a-8a48-d57f6fe1f423",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:22:32.1886471Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-0a1ef20bb2d23602-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b77c59ce66b25e07f37e3e1910695799",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:22:02 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "b77c59ce66b25e07f37e3e1910695799",
+        "x-ms-correlation-request-id": "998428ec-6fc3-4eee-922d-66638029e3d3",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "297",
+        "X-Rate-Limit-Reset": "2023-01-27T19:22:33.0860721Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-944937a37446248d-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9088fa4eed792f990172f8a85c4e8cb5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:22:32 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "9088fa4eed792f990172f8a85c4e8cb5",
+        "x-ms-correlation-request-id": "27676796-a616-4e51-9115-ab2b06ce4804",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:23:03.0051383Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-d596b929db3ebfa4-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "43682786abb5d6c7d16335e8f4e2295a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:23:02 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "43682786abb5d6c7d16335e8f4e2295a",
+        "x-ms-correlation-request-id": "899b0911-b266-481d-baa0-f39d68e3abf4",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:24:02.8402090Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-5e0915c6ac812404-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3b6e9ad95439e196c04db63f6d5f02a5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:23:33 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "3b6e9ad95439e196c04db63f6d5f02a5",
+        "x-ms-correlation-request-id": "f3a99f83-918f-44a3-a6f5-b7c55051b963",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:24:33.0112303Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-69318d3b9be854b3-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e99389f11400a3e333b1be16b7b03a1e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:24:03 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "e99389f11400a3e333b1be16b7b03a1e",
+        "x-ms-correlation-request-id": "f522edc7-0725-4da5-8b98-fecaff853939",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:25:03.0038452Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Running",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-004f8823dd3c3f05-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1ce9e4950e0317b91868268f5876972",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "281",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:24:33 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "c1ce9e4950e0317b91868268f5876972",
+        "x-ms-correlation-request-id": "e64581cb-55d7-4614-ae90-ed8067280dea",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:25:33.4493307Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "name": "1ac12fee-a2ff-4b0b-8b11-be8d1aa6928e",
+        "status": "Succeeded",
+        "startTime": "2023-01-27T19:06:56.1539574\u002B00:00",
+        "endTime": "2023-01-27T19:24:21.5425048\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a926394bd8bb99ff366338a7f17bc36-54fea796fb5a0d8c-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6bf69061404ec459b7ca08879580290f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "935",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:24:33 GMT",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "6bf69061404ec459b7ca08879580290f",
+        "x-ms-correlation-request-id": "976b5c25-5e36-42ce-94df-8cbbbb90498f",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:25:33.7411928Z"
       },
       "ResponseBody": {
         "name": "MyDevBox",
-        "projectName": "sdk-default-project",
-        "poolName": "sdk-default-pool",
-        "provisioningState": "ProvisionedWithWarning",
+        "projectName": "sdk-project-hdhjgzht7tgyq",
+        "poolName": "sdk-pool-bxwfu4kgo6dz6",
+        "hibernateSupport": "Disabled",
+        "provisioningState": "Succeeded",
         "actionState": "Unknown",
         "powerState": "Running",
-        "uniqueId": "762e31d4-7909-4bd6-8c33-2c2fafd81894",
-        "errorDetails": {
-          "code": "DevBoxProvisioningFailed",
-          "message": "The dev box provisioning failed with error code \u0027applyConfigFailed\u0027 and message \u0027One or more configurations did not apply successfully\u0027. The error appears to have been transient and the operation can be retried later."
-        },
+        "uniqueId": "59ee8e80-bed1-47f2-bf80-707a6929a56d",
+        "errorDetails": {},
         "location": "eastus",
         "osType": "Windows",
         "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
@@ -184,19 +1342,19 @@
           "osBuildNumber": "win11-21h2-ent-cpc-m365",
           "publishedDate": "2021-10-04T00:00:00\u002B00:00"
         },
-        "createdTime": "2022-09-28T17:21:25.4687051\u002B00:00",
+        "createdTime": "2023-01-27T19:06:56.1361901\u002B00:00",
         "localAdministrator": "Enabled"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox/remoteConnection?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox/remoteConnection?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6b660b3a3a0e334eb298051f88ff1caf-448f863140cfe64f-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d11bbeb8daa621c7ac6dbee8f40e5d25",
+        "traceparent": "00-8a9ff2094d56d95f55ce1d15574ed988-56399d47221933c1-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cff697134190a1c40d62577a917baeab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -205,54 +1363,56 @@
         "Connection": "keep-alive",
         "Content-Length": "332",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:28 GMT",
+        "Date": "Fri, 27 Jan 2023 19:24:34 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "cff697134190a1c40d62577a917baeab",
+        "x-ms-correlation-request-id": "23135880-22c6-4b51-bf30-83f9b6310ef5",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "296",
-        "X-Rate-Limit-Reset": "2022-09-28T22:55:57.2809299Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:25:03.0038452Z"
       },
       "ResponseBody": {
-        "webUrl": "https://deschutes-ppe.microsoft.com/webclient/0b1a81f2-91d9-431e-bb60-64e55d5b100b",
-        "rdpConnectionUrl": "ms-avd:connect?env=avdarm\u0026resourceid=613b6330-51cd-4f01-8ace-08da93231eca\u0026username=sdk_integration_test_1@fidalgoppe010.onmicrosoft.com\u0026version=0\u0026workspaceId=fa7f99ce-701c-49ca-a110-743c04978305\u0026preview=yes"
+        "webUrl": "https://deschutes-ppe.microsoft.com/webclient/1ba98ebb-5027-4c27-a128-bbd955547eb2",
+        "rdpConnectionUrl": "ms-avd:connect?env=avdarm\u0026resourceid=8ee26a2c-c118-443a-933d-08dafbbbf752\u0026username=sdk_integration_test_1@fidalgoppe010.onmicrosoft.com\u0026version=0\u0026workspaceId=8b6d1c8b-92cd-4eb6-a4ec-928f04941b52\u0026preview=yes"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/df428e89-1bc2-4e72-b736-032c31a6cd97/devboxes/MyDevBox?api-version=2022-11-11-preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-78b55545c714d144-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "149aa1e7adbe54f0aee76c7347bfab17",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-654d51473ac8e97b-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "27b54c48ceba08d0440a0a1547f49b11",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "1166",
+        "Content-Length": "934",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:29 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:24:34 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "27b54c48ceba08d0440a0a1547f49b11",
+        "x-ms-correlation-request-id": "7615fd48-4d1e-4f3c-8576-89fec729c591",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:27.5166117Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:25:33.4493307Z"
       },
       "ResponseBody": {
         "name": "MyDevBox",
-        "projectName": "sdk-default-project",
-        "poolName": "sdk-default-pool",
+        "projectName": "sdk-project-hdhjgzht7tgyq",
+        "poolName": "sdk-pool-bxwfu4kgo6dz6",
+        "hibernateSupport": "Disabled",
         "provisioningState": "Deleting",
         "actionState": "Unknown",
         "powerState": "Running",
-        "uniqueId": "762e31d4-7909-4bd6-8c33-2c2fafd81894",
-        "errorDetails": {
-          "code": "DevBoxProvisioningFailed",
-          "message": "The dev box provisioning failed with error code \u0027applyConfigFailed\u0027 and message \u0027One or more configurations did not apply successfully\u0027. The error appears to have been transient and the operation can be retried later."
-        },
+        "uniqueId": "59ee8e80-bed1-47f2-bf80-707a6929a56d",
+        "errorDetails": {},
         "location": "eastus",
         "osType": "Windows",
         "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
@@ -273,630 +1433,600 @@
           "osBuildNumber": "win11-21h2-ent-cpc-m365",
           "publishedDate": "2021-10-04T00:00:00\u002B00:00"
         },
-        "createdTime": "2022-09-28T17:21:25.4687051\u002B00:00",
+        "createdTime": "2023-01-27T19:06:56.1361901\u002B00:00",
         "localAdministrator": "Enabled"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-e33dc90b874b4141-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "bd45fee43455f81c309d4e63f4a7fba3",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-aa380e3266be30a8-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5e55735c999120e1cb555eebe9df323c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "226",
+        "Content-Length": "231",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:29 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:24:34 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "5e55735c999120e1cb555eebe9df323c",
+        "x-ms-correlation-request-id": "4a7c1fed-3b78-40f2-bca6-ced4ea04da48",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:17.5947455Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:25:33.7411928Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "NotStarted",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-3d8f3a5f5f4f3140-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "9cef770020970bf2cdc723bf6d54d9ed",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-cc0d727238683d32-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "493f5c1c02ca4455c6ee8a8636ae5919",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:55:59 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:25:05 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T22:56:27.5166117Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-3b312dd2f682ad40-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f503a6c2a0c9b3d084a2e4215f8d5f07",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:56:30 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "493f5c1c02ca4455c6ee8a8636ae5919",
+        "x-ms-correlation-request-id": "273de177-18ae-4df2-830a-fe27e327c3b0",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:57:30.0126656Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:26:04.8681091Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-6079c9e242740444-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "d073c9eb0ecfc37f0c3aef8e115c8adc",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-2f15ba0f270b9398-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1e1d46c65025ae1a6b955b6470e41f64",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:57:00 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:25:35 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "1e1d46c65025ae1a6b955b6470e41f64",
+        "x-ms-correlation-request-id": "ef1d5409-f698-4c69-a626-6f2727f13c39",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T22:57:18.5072613Z"
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:26:35.0743080Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-1c6392711c7b0c4b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "4da160c306a35fdaa63c18f43cd1ac40",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-090f56d4a6a4031e-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "eaf8cdd752b45a461e1097a30e5ae91d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:57:30 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:26:05 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "eaf8cdd752b45a461e1097a30e5ae91d",
+        "x-ms-correlation-request-id": "70f5ab8f-6a91-477f-8c39-3bca46b13ce9",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:27:05.3879335Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-d00b448b49055c7d-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a32544fb14c2cc164290dd35a7f0d3e1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:26:35 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "a32544fb14c2cc164290dd35a7f0d3e1",
+        "x-ms-correlation-request-id": "1460039b-a0b4-4bd3-b2dd-49a5bde7e700",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:27:35.5751425Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-aec861f04ab26c72-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "68af26ce6eb57364ffc30014b8769f11",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:27:05 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "68af26ce6eb57364ffc30014b8769f11",
+        "x-ms-correlation-request-id": "b8cb22db-666b-4c61-b93e-63a3b856acbc",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:28:05.7300251Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-f15030a52cbfc191-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2c693eab7cbfc3a2b72ca8237510b22d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:27:36 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "2c693eab7cbfc3a2b72ca8237510b22d",
+        "x-ms-correlation-request-id": "daf5ab6f-ff5d-4531-9e0e-b92cacab80a2",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:28:35.9340693Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-d4a3b0cb7159b1a0-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e8d4b53d80aa8c67dfb1a3fe130114cb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "close",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:28:06 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "e8d4b53d80aa8c67dfb1a3fe130114cb",
+        "x-ms-correlation-request-id": "2416363e-b9d7-4800-8693-093b2dd84475",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:29:06.3240317Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-63c233229251fca8-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6889ccf0a787522283ecb189c641feee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:28:36 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "6889ccf0a787522283ecb189c641feee",
+        "x-ms-correlation-request-id": "2e8c4d34-788a-4696-8526-6082bbab7f9d",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:58:19.3048726Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:29:29.3238557Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-a877a3abd7bef240-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "a4d41b6709e1b31d2640e88eb042a127",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-949ba65df759a416-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "02d7d210b7a22b66d6dd4c0dd8a3afb6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:58:00 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:29:07 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "02d7d210b7a22b66d6dd4c0dd8a3afb6",
+        "x-ms-correlation-request-id": "94f50ee6-ade6-40a7-a07f-994191a26218",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:30:07.0275253Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-5743757c934c3a83-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a832dc174a8796a6928164beceddc59e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:29:37 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "a832dc174a8796a6928164beceddc59e",
+        "x-ms-correlation-request-id": "568578c6-b793-4c59-85e4-30a8d2fbb9a2",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-09-28T22:58:51.4329983Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:30:07.0275253Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-bc2fd54129cce043-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "fe5d071811ebe564ee132992f68b863b",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-580d6ca8ae1cb625-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "40eeb4b3112a3929665e92a95a157ae0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:58:30 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:30:07 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "40eeb4b3112a3929665e92a95a157ae0",
+        "x-ms-correlation-request-id": "adb0e71e-c70a-4a05-ae94-f831663776e5",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:30:45.7309779Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-5375e60f5b11296c-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea71fb3c550ec6672c406f2152a75cf8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:30:37 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "ea71fb3c550ec6672c406f2152a75cf8",
+        "x-ms-correlation-request-id": "d8f0b8d7-efdf-42ca-883b-ba8eb3653c35",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T22:59:30.8705828Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:31:37.6598154Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-ed5783d32386084b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f626af8ee588bafa43ed26621d4cae64",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-c1ba7dd5f3dfc8a4-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2359ad176eb4068bb3f94229b8fc3b7d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:59:01 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:31:08 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "2359ad176eb4068bb3f94229b8fc3b7d",
+        "x-ms-correlation-request-id": "cf872492-83d4-48f2-86f5-80f606edcb9e",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:00:01.0061970Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:32:07.9081311Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-b581f005c64c034d-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "35dcf09bad735555b7eeb6cddf8abd9b",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-dd55b21cd2d886a4-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d3818407da6c5d8f4d2814e9a107e7be",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "228",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 22:59:31 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:31:38 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "d3818407da6c5d8f4d2814e9a107e7be",
+        "x-ms-correlation-request-id": "e4a6bedc-f867-4e1c-b928-ec95478b0049",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:31:59.2791871Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "status": "Running",
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-f59badb7f667c5da-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ad92990156bbce2b6f6b3715123e0e30",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "228",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:32:08 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "ad92990156bbce2b6f6b3715123e0e30",
+        "x-ms-correlation-request-id": "fa93bc78-e826-4edd-ab18-0981e73bfb89",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:00:31.1405993Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:33:08.4571145Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-d4c1dd2d0328584c-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "0100adb9ab1b329f0ca3bafdeb01c8a1",
+        "traceparent": "00-ee1ddbc00c8d3d5cbacf09d7745436d7-796dfd3d02e81e1e-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cd1af20589263c8c1dfbd68c5aa264ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:00:01 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "Date": "Fri, 27 Jan 2023 19:32:38 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "cd1af20589263c8c1dfbd68c5aa264ab",
+        "x-ms-correlation-request-id": "d1c0f7d7-e408-48b7-b92b-d6544fa82eda",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:01:01.3803144Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:33:38.6347198Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-4c4a7d4669bd924b-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "06f7c46551aee0c75ad03e992f2ddbb9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:00:32 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:01:32.1938808Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-2d8989a24515af48-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "6fa98b30ad4cf04950a928d0f3576ab6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:01:02 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:02:02.4931725Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-3fb10a2895896c4e-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "1a681426b69368ece51fa74a6c0502df",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:01:32 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-09-28T23:02:24.1239269Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-f32bb2896cfee943-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "60cd01c75858b8557b06b50429f7ed02",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:02:02 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:03:02.8343044Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-fa739126e7c9da40-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "1b738866c0c579259e408a2c05fe844b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:02:33 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:03:32.9666837Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-18a47d331a8df846-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "f10848a70a8ace5dbeb09e8c01e73fee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:03:03 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:04:03.2383329Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-ab886a22e0e85c42-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "e3e4a432e791071adb53c117ce29b27c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:03:33 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:04:33.4567810Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-56a681884a158142-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "e05d6a82fbee5b782aa55c15219978b6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:04:03 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:05:03.6606263Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "status": "Running",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c7a1d3f88035424abf11996c21649f2a-cb8e96a4f412f040-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET Core 3.1.29; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "61f99c01a019bfb92e0116374846ff95",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "275",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Sep 2022 23:04:33 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-devcenter-n.devcenter.azure.com/projects/sdk-default-project/operationstatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-09-28T23:05:33.8177154Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/781241e1-095e-480f-ac1e-0d89fe5855ab",
-        "name": "781241e1-095e-480f-ac1e-0d89fe5855ab",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/c7ea13c4-587b-442f-aa17-88bac951cf67",
+        "name": "c7ea13c4-587b-442f-aa17-88bac951cf67",
         "status": "Succeeded",
-        "startTime": "2022-09-28T22:55:29.0911599\u002B00:00",
-        "endTime": "2022-09-28T23:04:04.4337491\u002B00:00"
+        "startTime": "2023-01-27T19:24:34.593332\u002B00:00",
+        "endTime": "2023-01-27T19:32:37.0278708\u002B00:00"
       }
     }
   ],
   "Variables": {
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
     "CLIENT_ID": "82759f53-fe56-4a00-a282-dc1990e29267",
-    "DEFAULT_DEVCENTER_NAME": "sdk-default-devcenter-n",
     "DEFAULT_DEVCENTER_SCOPE": "https://devcenter.azure.com/.default",
-    "DEFAULT_POOL_NAME": "sdk-default-pool",
-    "DEFAULT_PROJECT_NAME": "sdk-default-project",
-    "DEFAULT_TEST_USER_SECRET": "Sanitized",
+    "DEFAULT_POOL_NAME": "sdk-pool-bxwfu4kgo6dz6",
+    "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
     "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
-    "RandomSeed": "1078026214",
+    "DEFAULT_TEST_USER_SECRET": "Sanitized",
+    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "RandomSeed": "939434413",
     "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
     "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"
   }

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceedsAsync.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/DevBoxCreateTests/DevBoxCreationSucceedsAsync.json
@@ -2025,7 +2025,7 @@
     "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
     "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
     "DEFAULT_TEST_USER_SECRET": "Sanitized",
-    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "DEFAULT_DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
     "RandomSeed": "939434413",
     "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
     "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceeds.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceeds.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/catalogItems?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/catalogItems?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-6d8a9f7cfdca2cadc7ed8566bffbc0db-a810e3207826fafa-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "011140bde4703cb54c0a75f266676f2d",
+        "traceparent": "00-fd8c46f22a74c199fbd4fb0c56260923-e4cd6b0ac310f7d7-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5fd9c3034701deb132e6ed02bb8f0403",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -17,18 +17,18 @@
         "Connection": "keep-alive",
         "Content-Length": "197",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:20:34 GMT",
+        "Date": "Fri, 27 Jan 2023 19:32:39 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "011140bde4703cb54c0a75f266676f2d",
-        "x-ms-correlation-request-id": "d80b5185-e509-44d6-8fa8-75074cedf5ac",
+        "x-ms-client-request-id": "5fd9c3034701deb132e6ed02bb8f0403",
+        "x-ms-correlation-request-id": "dcec0887-c4fc-49ec-a7a6-a3dcdb41a516",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:21:34.2006555Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:33:39.6014990Z"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd:sdk-default-dc-euap7:sdk-default-catalog:empty",
+            "id": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd:sdk-dc-na4b3zkj5hmeo:sdk-default-catalog:empty",
             "name": "Empty",
             "catalogName": "sdk-default-catalog"
           }
@@ -36,42 +36,42 @@
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/users/me/environments/DevTestEnv?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/me/environments/DevTestEnv?api-version=2022-11-11-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "112",
+        "Content-Length": "118",
         "Content-Type": "application/json",
-        "traceparent": "00-56bcd5f3b709eb23807f84809744831f-c12fff9527d9d570-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "efecf48cd3e627e5d475cf768682caf4",
+        "traceparent": "00-f5830445ea0d2271e91a173479e3de34-0fcf49acc2448e2f-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8f391d29ab49f05c4966cb6065a72c7a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "catalogItemName": "Empty",
         "catalogName": "sdk-default-catalog",
-        "environmentType": "sdk-default-environment-type"
+        "environmentType": "sdk-environment-type-5x47m3lk7iv3i"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "273",
+        "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:20:35 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
+        "Date": "Fri, 27 Jan 2023 19:32:40 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "efecf48cd3e627e5d475cf768682caf4",
-        "x-ms-correlation-request-id": "9e810474-cca9-4989-ae2c-4a113d9b32c9",
+        "x-ms-client-request-id": "8f391d29ab49f05c4966cb6065a72c7a",
+        "x-ms-correlation-request-id": "0ecd0919-dc0f-4eee-9935-1b83489bc5eb",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-10-06T19:21:31.1337375Z"
+        "X-Rate-Limit-Remaining": "297",
+        "X-Rate-Limit-Reset": "2023-01-27T19:33:08.4571145Z"
       },
       "ResponseBody": {
         "name": "devtestenv",
-        "environmentType": "sdk-default-environment-type",
-        "owner": "df428e89-1bc2-4e72-b736-032c31a6cd97",
+        "environmentType": "sdk-environment-type-5x47m3lk7iv3i",
+        "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
         "provisioningState": "Creating",
         "catalogName": "sdk-default-catalog",
         "catalogItemName": "Empty",
@@ -80,172 +80,138 @@
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-56bcd5f3b709eb23807f84809744831f-7a49368040257fc7-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "88a9b0a8d10ba9cba1bd81f1bc6103a9",
+        "traceparent": "00-f5830445ea0d2271e91a173479e3de34-dfeafd8c2c395196-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8e2dc6f7da4aac78d084243727b7112c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "226",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:20:35 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
+        "Date": "Fri, 27 Jan 2023 19:32:41 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "88a9b0a8d10ba9cba1bd81f1bc6103a9",
-        "x-ms-correlation-request-id": "cc83af67-15d5-4c5e-82f3-8161b7dec027",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:21:35.4276344Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
-        "name": "2edaf908-46d4-4c1f-8399-4d74de607448",
-        "status": "NotStarted",
-        "startTime": "2022-10-06T19:20:35.2983682\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-56bcd5f3b709eb23807f84809744831f-13b3547b437fc525-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "280f2b0d808ceac65ae92cfa143fb5ca",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:21:06 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "280f2b0d808ceac65ae92cfa143fb5ca",
-        "x-ms-correlation-request-id": "24de79fd-0eb7-4780-81d5-6770ac591f1a",
+        "x-ms-client-request-id": "8e2dc6f7da4aac78d084243727b7112c",
+        "x-ms-correlation-request-id": "e07a9ff2-e018-4f99-b75f-00be15525c33",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-10-06T19:21:34.2006555Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:33:38.6347198Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
-        "name": "2edaf908-46d4-4c1f-8399-4d74de607448",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
+        "name": "ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
         "status": "Running",
-        "startTime": "2022-10-06T19:20:35.2983682\u002B00:00"
+        "startTime": "2023-01-27T19:32:39.9603379\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-56bcd5f3b709eb23807f84809744831f-384260d009f13281-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "b54a8140e7bdba2229434d2952f46b73",
+        "traceparent": "00-f5830445ea0d2271e91a173479e3de34-dd9235e6b72d1c3b-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a2c285e7c6a1585467e9159a7b51798a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:21:36 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
+        "Date": "Fri, 27 Jan 2023 19:33:11 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "b54a8140e7bdba2229434d2952f46b73",
-        "x-ms-correlation-request-id": "7900826a-80ba-4919-9925-2261955975a6",
+        "x-ms-client-request-id": "a2c285e7c6a1585467e9159a7b51798a",
+        "x-ms-correlation-request-id": "7fe20091-ac4a-4066-a32a-870381a00944",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:22:36.0474075Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:33:39.6014990Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
-        "name": "2edaf908-46d4-4c1f-8399-4d74de607448",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
+        "name": "ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
         "status": "Running",
-        "startTime": "2022-10-06T19:20:35.2983682\u002B00:00"
+        "startTime": "2023-01-27T19:32:39.9603379\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-56bcd5f3b709eb23807f84809744831f-68fa706a3a9d1213-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "5b692572a1732767e9bf2d21a5d09462",
+        "traceparent": "00-f5830445ea0d2271e91a173479e3de34-6c29952cf31bc7bd-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f40a73b975614fb8a58cbfc58624c892",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "274",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:22:06 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
+        "Date": "Fri, 27 Jan 2023 19:33:41 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "5b692572a1732767e9bf2d21a5d09462",
-        "x-ms-correlation-request-id": "f7547d9f-8a04-4c36-994d-86ad891b3081",
+        "x-ms-client-request-id": "f40a73b975614fb8a58cbfc58624c892",
+        "x-ms-correlation-request-id": "35a7d014-1a95-4670-a55e-681fd70d438a",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:23:06.2859124Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:34:29.2987146Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/2edaf908-46d4-4c1f-8399-4d74de607448",
-        "name": "2edaf908-46d4-4c1f-8399-4d74de607448",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
+        "name": "ac227221-47f9-40d8-af8c-5a9f46f0b2ab",
         "status": "Succeeded",
-        "startTime": "2022-10-06T19:20:35.2983682\u002B00:00",
-        "endTime": "2022-10-06T19:22:01.035976\u002B00:00"
+        "startTime": "2023-01-27T19:32:39.9603379\u002B00:00",
+        "endTime": "2023-01-27T19:33:18.461508\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/users/me/environments/DevTestEnv?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/me/environments/DevTestEnv?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-56bcd5f3b709eb23807f84809744831f-c330abb5e12f43b0-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "3ab1b6074d1626eb0854ff49329d9766",
+        "traceparent": "00-f5830445ea0d2271e91a173479e3de34-c24d43aadaff64ef-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "df789f5589e430d872d52761c4dd307e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "398",
+        "Content-Length": "407",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:22:06 GMT",
+        "Date": "Fri, 27 Jan 2023 19:33:41 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "3ab1b6074d1626eb0854ff49329d9766",
-        "x-ms-correlation-request-id": "a63d65e4-d426-4502-a5a1-cb14437dbc13",
+        "x-ms-client-request-id": "df789f5589e430d872d52761c4dd307e",
+        "x-ms-correlation-request-id": "edf7577c-5247-4c18-8060-39f0a6ee08ae",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:23:06.4839664Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:34:41.4614327Z"
       },
       "ResponseBody": {
         "name": "devtestenv",
-        "environmentType": "sdk-default-environment-type",
-        "owner": "df428e89-1bc2-4e72-b736-032c31a6cd97",
+        "environmentType": "sdk-environment-type-5x47m3lk7iv3i",
+        "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
         "provisioningState": "Succeeded",
-        "resourceGroupId": "/subscriptions/62e47139-66d0-4b0b-a000-1e8a412890c1/resourceGroups/sdk-default-project-devtestenv-8",
+        "resourceGroupId": "/subscriptions/62e47139-66d0-4b0b-a000-1e8a412890c1/resourceGroups/sdk-project-hdhjgzht7tgyq-devtestenv",
         "catalogName": "sdk-default-catalog",
         "catalogItemName": "Empty",
         "scheduledTasks": {},
@@ -253,14 +219,14 @@
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/users/me/environments/DevTestEnv?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/me/environments/DevTestEnv?api-version=2022-11-11-preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0366ac2ca206fbba33e17d498fb05f50-285512b282f46e32-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "ef88b97d5ad69f571923ccfeba011559",
+        "traceparent": "00-74c28342e8ffce1a505d2de7fa4bcd05-f0f61a3a34558179-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b47e9a0a1cad71cacd73fd15078fd142",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -268,131 +234,131 @@
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Thu, 06 Oct 2022 19:22:06 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05",
+        "Date": "Fri, 27 Jan 2023 19:33:41 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "ef88b97d5ad69f571923ccfeba011559",
-        "x-ms-correlation-request-id": "379fa4f1-96ff-4ea0-bc31-e312331712d3",
+        "x-ms-client-request-id": "b47e9a0a1cad71cacd73fd15078fd142",
+        "x-ms-correlation-request-id": "b13c0036-5867-44e6-a235-9fe125063d5d",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-10-06T19:22:36.0474075Z"
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:34:41.6199566Z"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "9b22ebaf3043245c3942521ea21ef54c",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dc4583209ad830a59ad9828c4e568ac8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "226",
+        "Content-Length": "232",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:22:07 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05",
+        "Date": "Fri, 27 Jan 2023 19:33:41 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "9b22ebaf3043245c3942521ea21ef54c",
-        "x-ms-correlation-request-id": "930f0a7f-05a4-41cd-998b-ece4490000a3",
+        "x-ms-client-request-id": "dc4583209ad830a59ad9828c4e568ac8",
+        "x-ms-correlation-request-id": "227edad8-4611-4088-8f94-257e2b975573",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-10-06T19:23:06.2859124Z"
+        "X-Rate-Limit-Remaining": "297",
+        "X-Rate-Limit-Reset": "2023-01-27T19:34:29.2987146Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/4669ee53-9385-4dae-a192-d14d7f655b05",
-        "name": "4669ee53-9385-4dae-a192-d14d7f655b05",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/28563ae8-e833-4108-9153-e564f774e998",
+        "name": "28563ae8-e833-4108-9153-e564f774e998",
         "status": "NotStarted",
-        "startTime": "2022-10-06T19:22:06.8679114\u002B00:00"
+        "startTime": "2023-01-27T19:33:41.7344697\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "eba4c628a447ac8c5f1221f381ed6c07",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ecba405b14a638e4d40611718bc329e3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:22:37 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05",
+        "Date": "Fri, 27 Jan 2023 19:34:12 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "eba4c628a447ac8c5f1221f381ed6c07",
-        "x-ms-correlation-request-id": "4c1951ef-3360-4963-a7e3-e3bc5852debf",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "296",
-        "X-Rate-Limit-Reset": "2022-10-06T19:23:06.4839664Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/4669ee53-9385-4dae-a192-d14d7f655b05",
-        "name": "4669ee53-9385-4dae-a192-d14d7f655b05",
-        "status": "Running",
-        "startTime": "2022-10-06T19:22:06.8679114\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "479aa53ffb7b4c235d64b5930838fcfa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "275",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:23:07 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/4669ee53-9385-4dae-a192-d14d7f655b05",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "479aa53ffb7b4c235d64b5930838fcfa",
-        "x-ms-correlation-request-id": "1615bf45-bc4f-474e-a500-5e7deb2c966e",
+        "x-ms-client-request-id": "ecba405b14a638e4d40611718bc329e3",
+        "x-ms-correlation-request-id": "83760398-778a-4e6d-a8e2-c0383d05bf99",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-10-06T19:23:46.9559022Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:34:41.4614327Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/4669ee53-9385-4dae-a192-d14d7f655b05",
-        "name": "4669ee53-9385-4dae-a192-d14d7f655b05",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/28563ae8-e833-4108-9153-e564f774e998",
+        "name": "28563ae8-e833-4108-9153-e564f774e998",
+        "status": "Running",
+        "startTime": "2023-01-27T19:33:41.7344697\u002B00:00"
+      }
+    },
+    {
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998?api-version=2022-11-11-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4141e40454976fa6f44d1ad4993e2377",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 27 Jan 2023 19:34:42 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/28563ae8-e833-4108-9153-e564f774e998",
+        "Retry-After": "30",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "x-ms-client-request-id": "4141e40454976fa6f44d1ad4993e2377",
+        "x-ms-correlation-request-id": "a752cd67-00b7-4272-81f3-86e2a3cf4c55",
+        "X-Rate-Limit-Limit": "1m",
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:35:42.2282079Z"
+      },
+      "ResponseBody": {
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/28563ae8-e833-4108-9153-e564f774e998",
+        "name": "28563ae8-e833-4108-9153-e564f774e998",
         "status": "Succeeded",
-        "startTime": "2022-10-06T19:22:06.8679114\u002B00:00",
-        "endTime": "2022-10-06T19:22:48.7052949\u002B00:00"
+        "startTime": "2023-01-27T19:33:41.7344697\u002B00:00",
+        "endTime": "2023-01-27T19:34:29.279032\u002B00:00"
       }
     }
   ],
-    "Variables": {
-        "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
-        "CLIENT_ID": "82759f53-fe56-4a00-a282-dc1990e29267",
-        "DEFAULT_CATALOG_NAME": "sdk-default-catalog",
-        "DEFAULT_DEVCENTER_NAME": "sdk-default-dc-euap7",
-        "DEFAULT_DEVCENTER_SCOPE": "https://devcenter.azure.com/.default",
-        "DEFAULT_ENVIRONMENT_TYPE_NAME": "sdk-default-environment-type",
-        "DEFAULT_PROJECT_NAME": "sdk-default-project",
-        "DEFAULT_TEST_USER_SECRET": "Sanitized",
-        "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
-        "RandomSeed": "190431703",
-        "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
-        "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"
-    }
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "CLIENT_ID": "82759f53-fe56-4a00-a282-dc1990e29267",
+    "DEFAULT_CATALOG_NAME": "sdk-default-catalog",
+    "DEFAULT_DEVCENTER_SCOPE": "https://devcenter.azure.com/.default",
+    "DEFAULT_ENVIRONMENT_TYPE_NAME": "sdk-environment-type-5x47m3lk7iv3i",
+    "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
+    "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
+    "DEFAULT_TEST_USER_SECRET": "Sanitized",
+    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "RandomSeed": "230440922",
+    "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
+    "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"
+  }
 }

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceeds.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceeds.json
@@ -356,7 +356,7 @@
     "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
     "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
     "DEFAULT_TEST_USER_SECRET": "Sanitized",
-    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "DEFAULT_DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
     "RandomSeed": "230440922",
     "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
     "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceedsAsync.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceedsAsync.json
@@ -322,7 +322,7 @@
     "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
     "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
     "DEFAULT_TEST_USER_SECRET": "Sanitized",
-    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "DEFAULT_DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
     "RandomSeed": "110972054",
     "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
     "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"

--- a/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceedsAsync.json
+++ b/sdk/devcenter/Azure.Developer.DevCenter/tests/SessionRecords/EnvironmentCreateTests/EnvironmentCreationSucceedsAsync.json
@@ -1,14 +1,13 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/catalogItems?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/catalogItems?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-20416d0a65c23b9bd32ba30d9563f7c1-59a7de09beaedd83-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "b86139f5376f4b7aee94124e116d129c",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c9b5c19e067b3ffa50415f23c77f599e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -17,18 +16,18 @@
         "Connection": "keep-alive",
         "Content-Length": "197",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:23:08 GMT",
+        "Date": "Fri, 27 Jan 2023 19:34:43 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "b86139f5376f4b7aee94124e116d129c",
-        "x-ms-correlation-request-id": "c2d93c53-80d8-466b-b6d9-d5a5df02161b",
+        "x-ms-client-request-id": "c9b5c19e067b3ffa50415f23c77f599e",
+        "x-ms-correlation-request-id": "c0b7d536-77ed-4ee6-8e7b-b71b6495fb36",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:24:08.2295302Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:35:43.1994105Z"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd:sdk-default-dc-euap7:sdk-default-catalog:empty",
+            "id": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd:sdk-dc-na4b3zkj5hmeo:sdk-default-catalog:empty",
             "name": "Empty",
             "catalogName": "sdk-default-catalog"
           }
@@ -36,42 +35,42 @@
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/users/me/environments/DevTestEnv?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/me/environments/DevTestEnv?api-version=2022-11-11-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "112",
+        "Content-Length": "118",
         "Content-Type": "application/json",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-28d2f1b74e277297-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "b460b6308a39054857dd05e8930c0bd5",
+        "traceparent": "00-1910e20ec807d17f70324f08108c374d-4fb2d7b289bb409e-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7ab583e712748fc7a6f8c0466fe5e1fb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "catalogItemName": "Empty",
         "catalogName": "sdk-default-catalog",
-        "environmentType": "sdk-default-environment-type"
+        "environmentType": "sdk-environment-type-5x47m3lk7iv3i"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "273",
+        "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:23:08 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
+        "Date": "Fri, 27 Jan 2023 19:34:43 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "b460b6308a39054857dd05e8930c0bd5",
-        "x-ms-correlation-request-id": "e3915ed4-488a-4fbc-a321-e0e4f074e71b",
+        "x-ms-client-request-id": "7ab583e712748fc7a6f8c0466fe5e1fb",
+        "x-ms-correlation-request-id": "f6a8b5ad-f0c6-4ae1-aa93-ccff444956c0",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:24:08.4814867Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:35:43.3690919Z"
       },
       "ResponseBody": {
         "name": "devtestenv",
-        "environmentType": "sdk-default-environment-type",
-        "owner": "df428e89-1bc2-4e72-b736-032c31a6cd97",
+        "environmentType": "sdk-environment-type-5x47m3lk7iv3i",
+        "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
         "provisioningState": "Creating",
         "catalogName": "sdk-default-catalog",
         "catalogItemName": "Empty",
@@ -80,240 +79,138 @@
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-6d0386f1586b27ce-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "582798b21a78a183bbc7a63e7b61c67b",
+        "traceparent": "00-1910e20ec807d17f70324f08108c374d-acbd57ac175aa217-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bec6e7e0ba74bd6876f0325c6a7f8fd5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "226",
+        "Content-Length": "232",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:23:09 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
+        "Date": "Fri, 27 Jan 2023 19:34:43 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "582798b21a78a183bbc7a63e7b61c67b",
-        "x-ms-correlation-request-id": "de702cc4-65c3-4ba9-9d50-0b911546ee04",
+        "x-ms-client-request-id": "bec6e7e0ba74bd6876f0325c6a7f8fd5",
+        "x-ms-correlation-request-id": "0f35cb00-af10-44eb-bc2d-0c40e9cbd308",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-10-06T19:23:46.9559022Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:35:42.2282079Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "name": "3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
+        "name": "e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
         "status": "NotStarted",
-        "startTime": "2022-10-06T19:23:08.7525554\u002B00:00"
+        "startTime": "2023-01-27T19:34:43.5846488\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-b149b7e3d0679107-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "c67f019d22626bf3f05c61913291b8e1",
+        "traceparent": "00-1910e20ec807d17f70324f08108c374d-fd7efa59f48de45f-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "65916cfea7ce8cbdfa25238245b4d06b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "229",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:23:39 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
+        "Date": "Fri, 27 Jan 2023 19:35:14 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "c67f019d22626bf3f05c61913291b8e1",
-        "x-ms-correlation-request-id": "eee1ff85-e080-4ea8-9cea-a674f8308ea0",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-10-06T19:24:08.2295302Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "name": "3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "status": "Running",
-        "startTime": "2022-10-06T19:23:08.7525554\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-5898484656d3e11a-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "789c3d89b946152433bef972e40a89f6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:24:09 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "789c3d89b946152433bef972e40a89f6",
-        "x-ms-correlation-request-id": "4793c768-5508-450b-8df4-f1de5b1a8e23",
+        "x-ms-client-request-id": "65916cfea7ce8cbdfa25238245b4d06b",
+        "x-ms-correlation-request-id": "54810eac-2d88-4f5e-949b-a40d37ffb871",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-10-06T19:25:01.1435925Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:35:43.3690919Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "name": "3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
+        "name": "e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
         "status": "Running",
-        "startTime": "2022-10-06T19:23:08.7525554\u002B00:00"
+        "startTime": "2023-01-27T19:34:43.5846488\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-f3027058819ef3cf-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "914b8917458d8f73a5bc681bb8f16e29",
+        "traceparent": "00-1910e20ec807d17f70324f08108c374d-97c31bca3fc43621-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e04263609bb82d291bf70483df6a2526",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "223",
+        "Content-Length": "281",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:24:39 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
+        "Date": "Fri, 27 Jan 2023 19:35:44 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "914b8917458d8f73a5bc681bb8f16e29",
-        "x-ms-correlation-request-id": "ebc6ef3a-a673-4fe2-9f1e-895e1f6d1278",
+        "x-ms-client-request-id": "e04263609bb82d291bf70483df6a2526",
+        "x-ms-correlation-request-id": "cccccf75-33b8-400d-9e98-d906bfd793e8",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:25:39.4485611Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:36:44.0712930Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "name": "3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "status": "Running",
-        "startTime": "2022-10-06T19:23:08.7525554\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-29e2c0395cff08f3-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "3eb5c40f4dc4e335dc6993a3298086e5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:25:09 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "3eb5c40f4dc4e335dc6993a3298086e5",
-        "x-ms-correlation-request-id": "46d9a3f6-4e01-43aa-9c7f-e0bbc61d5e88",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-10-06T19:25:12.4473676Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "name": "3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "status": "Running",
-        "startTime": "2022-10-06T19:23:08.7525554\u002B00:00"
-      }
-    },
-    {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?api-version=2022-03-01-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-891459258ff7a47f-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "a97a6bd226454454c90dd38a50085c41",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Connection": "keep-alive",
-        "Content-Length": "275",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:25:40 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "Retry-After": "30",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "a97a6bd226454454c90dd38a50085c41",
-        "x-ms-correlation-request-id": "c05be7e5-5902-49e5-89d9-430c8b7fd9a1",
-        "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-10-06T19:26:18.9398484Z"
-      },
-      "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
-        "name": "3563a100-bcbf-4d4d-95d4-2e38ef1fdd74",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
+        "name": "e2e41a37-a943-44c7-bb25-08ad64bf2ddf",
         "status": "Succeeded",
-        "startTime": "2022-10-06T19:23:08.7525554\u002B00:00",
-        "endTime": "2022-10-06T19:25:23.7432002\u002B00:00"
+        "startTime": "2023-01-27T19:34:43.5846488\u002B00:00",
+        "endTime": "2023-01-27T19:35:41.0574818\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/users/me/environments/DevTestEnv?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/me/environments/DevTestEnv?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2c2ae08b3f2ca9238a24c1e24fb3aa49-7f8054617424ffd6-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "1f62cf4f4b55ca315367b523b1d06524",
+        "traceparent": "00-1910e20ec807d17f70324f08108c374d-c916b8f28056aa78-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0247ea687b53392d2a39c44e96e578c2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "398",
+        "Content-Length": "407",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:25:40 GMT",
+        "Date": "Fri, 27 Jan 2023 19:35:44 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "1f62cf4f4b55ca315367b523b1d06524",
-        "x-ms-correlation-request-id": "6967212e-fa24-4461-b5d7-8bec8d30fe1d",
+        "x-ms-client-request-id": "0247ea687b53392d2a39c44e96e578c2",
+        "x-ms-correlation-request-id": "dca9c760-19bd-4fe3-b945-86e6f840156f",
         "X-Rate-Limit-Limit": "1m",
         "X-Rate-Limit-Remaining": "299",
-        "X-Rate-Limit-Reset": "2022-10-06T19:26:40.2252956Z"
+        "X-Rate-Limit-Reset": "2023-01-27T19:36:44.2092791Z"
       },
       "ResponseBody": {
         "name": "devtestenv",
-        "environmentType": "sdk-default-environment-type",
-        "owner": "df428e89-1bc2-4e72-b736-032c31a6cd97",
+        "environmentType": "sdk-environment-type-5x47m3lk7iv3i",
+        "user": "df428e89-1bc2-4e72-b736-032c31a6cd97",
         "provisioningState": "Succeeded",
-        "resourceGroupId": "/subscriptions/62e47139-66d0-4b0b-a000-1e8a412890c1/resourceGroups/sdk-default-project-devtestenv-8",
+        "resourceGroupId": "/subscriptions/62e47139-66d0-4b0b-a000-1e8a412890c1/resourceGroups/sdk-project-hdhjgzht7tgyq-devtestenv",
         "catalogName": "sdk-default-catalog",
         "catalogItemName": "Empty",
         "scheduledTasks": {},
@@ -321,14 +218,14 @@
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/users/me/environments/DevTestEnv?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/users/me/environments/DevTestEnv?api-version=2022-11-11-preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f7d6730dae89220876d9c338f28b7056-f283fb325ca25660-00",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "4d498335c577e9e3707074b77aab92d4",
+        "traceparent": "00-e79bccfa9c3fa93489c6c0a88dde1ebd-d111f9221be85139-00",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "06fcc720af3d631d43644ad7a339ad90",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -336,98 +233,98 @@
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Thu, 06 Oct 2022 19:25:40 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f",
+        "Date": "Fri, 27 Jan 2023 19:35:44 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "4d498335c577e9e3707074b77aab92d4",
-        "x-ms-correlation-request-id": "fd6f6441-8240-484c-9164-b32f08c0328e",
+        "x-ms-client-request-id": "06fcc720af3d631d43644ad7a339ad90",
+        "x-ms-correlation-request-id": "28d98425-a32e-4a8e-90b3-ca3609735108",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "298",
-        "X-Rate-Limit-Reset": "2022-10-06T19:26:31.1401673Z"
+        "X-Rate-Limit-Remaining": "299",
+        "X-Rate-Limit-Reset": "2023-01-27T19:36:44.3264997Z"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "5a53510d661e878f39b055dd703092f9",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5a1afd00cd6ce4173608b57ed7da9735",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "226",
+        "Content-Length": "232",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:25:40 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f",
+        "Date": "Fri, 27 Jan 2023 19:35:44 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "5a53510d661e878f39b055dd703092f9",
-        "x-ms-correlation-request-id": "4def8125-a32c-4958-8ec2-cf6999d2381d",
+        "x-ms-client-request-id": "5a1afd00cd6ce4173608b57ed7da9735",
+        "x-ms-correlation-request-id": "4695b76c-6cba-4cd0-9aeb-ed6f1fd418a1",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-10-06T19:26:18.9398484Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:36:44.0712930Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f",
-        "name": "2ebe359b-0c2e-4915-9d2a-d030719c5b4f",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b",
+        "name": "2e1feb49-2326-4e80-969f-a5e7eb09e57b",
         "status": "NotStarted",
-        "startTime": "2022-10-06T19:25:40.6902147\u002B00:00"
+        "startTime": "2023-01-27T19:35:44.3987137\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f?api-version=2022-03-01-preview",
+      "RequestUri": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b?api-version=2022-11-11-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20220925.1 (.NET 6.0.9; Microsoft Windows 10.0.22000)",
-        "x-ms-client-request-id": "cd54aea70fbe8ac9eb79afe4d67a4fa8",
+        "User-Agent": "azsdk-net-Developer.DevCenter/1.0.0-alpha.20230127.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1863417e1e6db9e9cde4bfef315696f0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
-        "Content-Length": "275",
+        "Content-Length": "281",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 06 Oct 2022 19:26:11 GMT",
-        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f?monitor=true",
-        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-default-dc-euap7.devcenter.azure.com/projects/sdk-default-project/operationstatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f",
+        "Date": "Fri, 27 Jan 2023 19:36:14 GMT",
+        "Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b?monitor=true",
+        "Operation-Location": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com/projects/sdk-project-hdhjgzht7tgyq/operationstatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b",
         "Retry-After": "30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "x-ms-client-request-id": "cd54aea70fbe8ac9eb79afe4d67a4fa8",
-        "x-ms-correlation-request-id": "38168f01-41d4-43d5-bd8b-75faf97da4f3",
+        "x-ms-client-request-id": "1863417e1e6db9e9cde4bfef315696f0",
+        "x-ms-correlation-request-id": "a042b0d4-1bfa-4901-a3fc-925c921a12ad",
         "X-Rate-Limit-Limit": "1m",
-        "X-Rate-Limit-Remaining": "297",
-        "X-Rate-Limit-Reset": "2022-10-06T19:26:31.1401673Z"
+        "X-Rate-Limit-Remaining": "298",
+        "X-Rate-Limit-Reset": "2023-01-27T19:36:44.3264997Z"
       },
       "ResponseBody": {
-        "id": "/projects/sdk-default-project/operationStatuses/2ebe359b-0c2e-4915-9d2a-d030719c5b4f",
-        "name": "2ebe359b-0c2e-4915-9d2a-d030719c5b4f",
+        "id": "/projects/sdk-project-hdhjgzht7tgyq/operationStatuses/2e1feb49-2326-4e80-969f-a5e7eb09e57b",
+        "name": "2e1feb49-2326-4e80-969f-a5e7eb09e57b",
         "status": "Succeeded",
-        "startTime": "2022-10-06T19:25:40.6902147\u002B00:00",
-        "endTime": "2022-10-06T19:26:10.9334903\u002B00:00"
+        "startTime": "2023-01-27T19:35:44.3987137\u002B00:00",
+        "endTime": "2023-01-27T19:36:00.7136333\u002B00:00"
       }
     }
   ],
-    "Variables": {
-        "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
-        "CLIENT_ID": "82759f53-fe56-4a00-a282-dc1990e29267",
-        "DEFAULT_CATALOG_NAME": "sdk-default-catalog",
-        "DEFAULT_DEVCENTER_NAME": "sdk-default-dc-euap7",
-        "DEFAULT_DEVCENTER_SCOPE": "https://devcenter.azure.com/.default",
-        "DEFAULT_ENVIRONMENT_TYPE_NAME": "sdk-default-environment-type",
-        "DEFAULT_PROJECT_NAME": "sdk-default-project",
-        "DEFAULT_TEST_USER_SECRET": "Sanitized",
-        "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
-        "RandomSeed": "1634549996",
-        "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
-        "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"
-    }
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "CLIENT_ID": "82759f53-fe56-4a00-a282-dc1990e29267",
+    "DEFAULT_CATALOG_NAME": "sdk-default-catalog",
+    "DEFAULT_DEVCENTER_SCOPE": "https://devcenter.azure.com/.default",
+    "DEFAULT_ENVIRONMENT_TYPE_NAME": "sdk-environment-type-5x47m3lk7iv3i",
+    "DEFAULT_PROJECT_NAME": "sdk-project-hdhjgzht7tgyq",
+    "DEFAULT_TEST_USER_NAME": "sdk_integration_test_1@fidalgoppe010.onmicrosoft.com",
+    "DEFAULT_TEST_USER_SECRET": "Sanitized",
+    "DEVCENTER_ENDPOINT": "https://8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd-sdk-dc-na4b3zkj5hmeo.eastus.devcenter.azure.com",
+    "RandomSeed": "110972054",
+    "STATIC_TEST_USER_ID": "df428e89-1bc2-4e72-b736-032c31a6cd97",
+    "TENANT_ID": "8ab2df1c-ed88-4946-a8a9-e1bbb3e4d1fd"
+  }
 }

--- a/sdk/devcenter/test-resources.bicep
+++ b/sdk/devcenter/test-resources.bicep
@@ -8,21 +8,21 @@ param testUserName string
 param projectAdminRoleDefinitionId string
 param deploymentEnvironmentsRoleDefinitionId string
 
-var defaultDevCenterName = 'sdk-dc-${uniqueString('devcenter', baseName, resourceGroup().name)}'
+var defaultDevCenterName = 'sdk-dc-${uniqueString('devcenter', '2022-11-11-preview', baseName, resourceGroup().name)}'
 
-var defaultProjectName = 'sdk-default-project'
-var defaultPoolName = 'sdk-default-pool'
-var defaultNetworkConnectionName = 'sdk-networkconnection-${uniqueString('networkConnection', baseName, resourceGroup().name)}'
-var defaultNetworkConnection2Name = 'sdk-networkconnection2-${uniqueString('networkConnection', baseName, resourceGroup().name)}'
-var defaultMarketplaceDefinition = 'sdk-default-devboxdefinition'
+var defaultProjectName = 'sdk-project-${uniqueString('project', '2022-09-01-preview', baseName, resourceGroup().name)}'
+var defaultPoolName = 'sdk-pool-${uniqueString('pool', '2022-09-01-preview', baseName, resourceGroup().name)}'
+var defaultNetworkConnectionName = 'sdk-networkconnection-${uniqueString('networkConnection', '2022-09-01-preview', baseName, resourceGroup().name)}'
+var defaultNetworkConnection2Name = 'sdk-networkconnection2-${uniqueString('networkConnection', '2022-09-01-preview', baseName, resourceGroup().name)}'
+var defaultMarketplaceDefinition = 'sdk-devboxdefinition-${uniqueString('devboxdefinition', '2022-09-01-preview', baseName, resourceGroup().name)}'
 var defaultCatalogName = 'sdk-default-catalog'
-var defaultEnvironmentTypeName = 'sdk-default-environment-type'
+var defaultEnvironmentTypeName = 'sdk-environment-type-${uniqueString('environment-type', '2022-11-11-preview', baseName, resourceGroup().name)}'
 var devBoxSkuName = 'general_a_8c32gb_v1'
 var devBoxStorage = 'ssd_1024gb'
 var marketplaceImageName = 'MicrosoftWindowsDesktop_windows-ent-cpc_win11-21h2-ent-cpc-m365'
 var gitUri = 'https://github.com/Azure/fidalgoIntegrationTests.git'
 
-resource devcenter 'Microsoft.DevCenter/devcenters@2022-09-01-preview' = {
+resource devcenter 'Microsoft.DevCenter/devcenters@2022-11-11-preview' = {
   name: defaultDevCenterName
   location: resourceLocation
   identity: {
@@ -175,13 +175,13 @@ resource catalog 'Microsoft.DevCenter/devcenters/catalogs@2022-09-01-preview' = 
   }
 }
 
-resource environmentType 'Microsoft.DevCenter/devcenters/environmentTypes@2022-09-01-preview' = {
+resource environmentType 'Microsoft.DevCenter/devcenters/environmentTypes@2022-11-11-preview' = {
   name: '${devcenter.name}/${defaultEnvironmentTypeName}'
   properties: {
   }
 }
 
-resource projectEnvironmentType 'Microsoft.DevCenter/projects/environmentTypes@2022-09-01-preview' = {
+resource projectEnvironmentType 'Microsoft.DevCenter/projects/environmentTypes@2022-11-11-preview' = {
   name: '${project.name}/${defaultEnvironmentTypeName}'
   identity: {
     type: 'UserAssigned'
@@ -196,20 +196,20 @@ resource projectEnvironmentType 'Microsoft.DevCenter/projects/environmentTypes@2
 }
 
 resource environmentRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
-  name: guid(resourceGroup().id, projectAdminRoleDefinitionId, testUserOid)
+  name: guid(resourceGroup().id, project.name, deploymentEnvironmentsRoleDefinitionId, testUserOid)
   scope: project
   properties: {
-    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', projectAdminRoleDefinitionId)
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', deploymentEnvironmentsRoleDefinitionId)
     principalId: testUserOid
     principalType: 'User'
   }
 }
 
 resource devBoxRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
-  name: guid(resourceGroup().id, deploymentEnvironmentsRoleDefinitionId, testUserOid)
+  name: guid(resourceGroup().id, project.name, projectAdminRoleDefinitionId, testUserOid)
   scope: project
   properties: {
-    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', deploymentEnvironmentsRoleDefinitionId)
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', projectAdminRoleDefinitionId)
     principalId: testUserOid
     principalType: 'User'
 }
@@ -227,5 +227,6 @@ output DEFAULT_POOL_NAME string = defaultPoolName
 output DEFAULT_ENVIRONMENT_TYPE_NAME string = defaultEnvironmentTypeName
 output DEFAULT_CATALOG_NAME string = defaultCatalogName
 output DEVCENTER_TENANT_ID string = subscription().tenantId
+output DEVCENTER_ENDPOINT string = devcenter.properties.devCenterUri
 output STATIC_TEST_USER_ID string = testUserOid
 output DEFAULT_TEST_USER_NAME string = testUserName


### PR DESCRIPTION
This pull request includes changes to the Azure.Developer.DevCenter SDK that constitue version 1.0.0-beta.2. This SDK version is built around version **2022-11-11-preview** of our Data Plane API. The most notable change from 1.0.0-beta.1 is the use of an endpoint URI to construct clients, rather than tenant ID + dev center name, which was the architecture board's largest point of feedback for us in our initial review.