### PR TITLE
Add custom BatchExportProcessor to support standard metrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterTraceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterTraceExtensions.cs
@@ -5,7 +5,7 @@
 
 using System;
 using Azure.Core;
-using OpenTelemetry;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using OpenTelemetry.Trace;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
@@ -36,7 +36,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             // Statsbeat.InitializeAttachStatsbeat(options.ConnectionString);
 
             // TODO: Pick Simple vs Batching based on AzureMonitorExporterOptions
-            return builder.AddProcessor(new BatchActivityExportProcessor(new AzureMonitorTraceExporter(options, credential)));
+            return builder.AddProcessor(new AzureMonitorBatchActivityExportProcessor(new AzureMonitorTraceExporter(options, credential)));
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorBatchActivityExportProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorBatchActivityExportProcessor.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    internal class AzureMonitorBatchActivityExportProcessor : BatchExportProcessor<Activity>
+    {
+        public AzureMonitorBatchActivityExportProcessor(BaseExporter<Activity> exporter) : base(exporter)
+        {
+        }
+
+        /// <inheritdoc />
+        public override void OnEnd(Activity data)
+        {
+            // All activities will be passed on to exporter to extract standard metrics
+            // activities with Recorded = false will be sampled out on exporter side.
+            OnExport(data);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorBatchActivityExportProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorBatchActivityExportProcessor.cs
@@ -12,7 +12,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         {
         }
 
-        /// <inheritdoc />
         public override void OnEnd(Activity data)
         {
             // All activities will be passed on to exporter to extract standard metrics


### PR DESCRIPTION
Updating trace exporter to use the custom BatchExportProcessor to let all activities pass on to exporter. This will enable accurate standard metric collection on the exporter side. Activities with `Recorded=false` will be filtered out on the exporter side to prevent sampledOut activities to get transmitted to backend.

Custom ApplicationInsights sampler will also be [updated](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/933) to return `RecordOnly` SamplingResult instead of `Drop` when the samplers decision is to drop the telemetry. This will allow activities to be enriched by instrumentation libraries (This is needed for setting dimensions on standard metrics) and also allow correct traceflags(`traceparent` header) to be transmitted to downstream services.