### PR TITLE
Set parent Id when starting ActivitySource

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -359,7 +359,7 @@ namespace Azure.Core.Pipeline
             {
                 if (_currentActivity != null)
                 {
-                    throw new InvalidOperationException("Traceparent can not be set after the activity is started");
+                    throw new InvalidOperationException("Traceparent can not be set after the activity is started.");
                 }
                 _traceparent = traceparent;
             }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -357,8 +357,11 @@ namespace Azure.Core.Pipeline
 
             public void SetTraceparent(string traceparent)
             {
+                if (_currentActivity != null)
+                {
+                    throw new InvalidOperationException("Traceparent can not be set after the activity is started");
+                }
                 _traceparent = traceparent;
-                _currentActivity?.SetParentId(traceparent);
             }
 
             public void Dispose()

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -384,7 +384,7 @@ namespace Azure.Core.Tests
                 true,
                 false);
 
-            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
             scope.SetTraceparent(parentId);
             scope.Start();
             scope.Dispose();
@@ -408,7 +408,7 @@ namespace Azure.Core.Tests
                 true,
                 false);
 
-            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
             scope.Start();
             scope.SetTraceparent(parentId);
             scope.Dispose();

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -396,7 +397,7 @@ namespace Azure.Core.Tests
 
         [Test]
         [NonParallelizable]
-        public void ParentIdCanBeSetOnStartedScopeActivitySource()
+        public void ParentIdCannotBeSetOnStartedScopeActivitySource()
         {
             using var _ = SetAppConfigSwitch();
             string parentId = "00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00";
@@ -408,14 +409,9 @@ namespace Azure.Core.Tests
                 true,
                 false);
 
-            DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
+            using DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
             scope.Start();
-            scope.SetTraceparent(parentId);
-            scope.Dispose();
-
-            Assert.AreEqual(1, activityListener.Activities.Count);
-            var activity = activityListener.Activities.Dequeue();
-            Assert.AreEqual(parentId, activity.ParentId);
+            Assert.Throws<InvalidOperationException>(() => scope.SetTraceparent(parentId));
         }
     }
 #endif

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -369,6 +369,54 @@ namespace Azure.Core.Tests
 
             Assert.AreEqual(0, activityListener.Activities.Single().Links.Count());
         }
+
+        [Test]
+        [NonParallelizable]
+        public void ParentIdCanBeSetActivitySource()
+        {
+            using var _ = SetAppConfigSwitch();
+            string parentId = "00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00";
+            using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
+
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory(
+                "Azure.Clients.ClientName",
+                "Microsoft.Azure.Core.Cool.Tests",
+                true,
+                false);
+
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
+            scope.SetTraceparent(parentId);
+            scope.Start();
+            scope.Dispose();
+
+            Assert.AreEqual(1, activityListener.Activities.Count);
+            var activity = activityListener.Activities.Dequeue();
+            Assert.AreEqual(parentId, activity.ParentId);
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ParentIdCanBeSetOnStartedScopeActivitySource()
+        {
+            using var _ = SetAppConfigSwitch();
+            string parentId = "00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00";
+            using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
+
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory(
+                "Azure.Clients.ClientName",
+                "Microsoft.Azure.Core.Cool.Tests",
+                true,
+                false);
+
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
+            scope.Start();
+            scope.SetTraceparent(parentId);
+            scope.Dispose();
+
+            Assert.AreEqual(1, activityListener.Activities.Count);
+            var activity = activityListener.Activities.Dequeue();
+            Assert.AreEqual(parentId, activity.ParentId);
+        }
     }
 #endif
 }

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -110,7 +110,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ParentIdCanBeSetOnStartedScope()
+        public void ParentIdCannotBeSetOnStartedScope()
         {
             string parentId = "parentId";
             using var testListener = new TestDiagnosticListener("Azure.Clients");
@@ -123,9 +123,7 @@ namespace Azure.Core.Tests
 
             using DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
             scope.Start();
-            scope.SetTraceparent(parentId);
-
-            Assert.AreEqual(parentId, Activity.Current.ParentId);
+            Assert.Throws<InvalidOperationException>(() => scope.SetTraceparent(parentId));
         }
 
         [Test]


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/33338

Will add Service Bus E2E tests in a separate PR.