### PR TITLE
Fix for regression where PublicAccessType returning null instead of PublicAccessType.None

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added support for service version 2021-12-02.
 - Added support for Blob Cold Tier.
 - Fixed bug where BlobErrorCode.IncrementalCopyOfEarlierVersionSnapshotNotAllowed was spelled incorrectly.
+- Fixed bug / regression where BlobContainerClient.GetProperties would return null instead of PublicAccessType.None for the BlobContainerProperties.PublicAccess
 
 ## 12.14.1 (2022-10-20)
 - Fixed bug were BlobBaseClient constructor taking a URI and BlobClientOptions would ignore BlobClientOptions.TrimBlobNameSlashes.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobExtensions.cs
@@ -1312,7 +1312,7 @@ namespace Azure.Storage.Blobs
                 LeaseStatus = response.Headers.LeaseStatus,
                 LeaseState = response.Headers.LeaseState,
                 LeaseDuration = response.Headers.LeaseDuration ?? LeaseDurationType.Infinite,
-                PublicAccess = response.Headers.BlobPublicAccess,
+                PublicAccess = response.Headers.BlobPublicAccess ?? PublicAccessType.None,
                 HasImmutabilityPolicy = response.Headers.HasImmutabilityPolicy,
                 HasLegalHold = response.Headers.HasLegalHold,
                 DefaultEncryptionScope = response.Headers.DefaultEncryptionScope,

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -554,6 +554,24 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        public async Task CreateAsync_PublicAccess_None()
+        {
+            // Arrange
+            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
+
+            // Act
+            await container.CreateAsync(publicAccessType: PublicAccessType.None);
+
+            // Assert
+            Response<BlobContainerProperties> response = await container.GetPropertiesAsync();
+            Assert.AreEqual(PublicAccessType.None, response.Value.PublicAccess);
+
+            // Cleanup
+            await container.DeleteIfExistsAsync();
+        }
+
+        [RecordedTest]
         public async Task CreateAsync_Error()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateAsync_PublicAccess_None.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateAsync_PublicAccess_None.json
@@ -1,0 +1,105 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-e022fc48-7222-6ea3-77ed-bbf972fa293f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "traceparent": "00-546ec73ab50fc74b89edff19db490d56-8eadced1eb365b4c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.15.0-alpha.20230127.1 (.NET Framework 4.8.9105.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "39cc4c6e-cf65-a9db-8e17-36f4695298b4",
+        "x-ms-date": "Fri, 27 Jan 2023 22:13:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "ETag": "\u00220x8DB00B3BAAC5ACC\u0022",
+        "Last-Modified": "Fri, 27 Jan 2023 22:13:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "39cc4c6e-cf65-a9db-8e17-36f4695298b4",
+        "x-ms-request-id": "48a8872a-801e-000e-149c-325c51000000",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-e022fc48-7222-6ea3-77ed-bbf972fa293f?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6c1ff3d2bb0d1447a1940dcfc2128b05-e2330ddc2cd62245-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.15.0-alpha.20230127.1 (.NET Framework 4.8.9105.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "268bf341-f02e-fdd9-6d5b-2145b3abc737",
+        "x-ms-date": "Fri, 27 Jan 2023 22:13:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "ETag": "\u00220x8DB00B3BAAC5ACC\u0022",
+        "Last-Modified": "Fri, 27 Jan 2023 22:13:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "268bf341-f02e-fdd9-6d5b-2145b3abc737",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-immutable-storage-with-versioning-enabled": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "48a88767-801e-000e-4e9c-325c51000000",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-e022fc48-7222-6ea3-77ed-bbf972fa293f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b4f1526ffe1cce4bb585be42ff0dfe4d-c22181c6837eea46-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.15.0-alpha.20230127.1 (.NET Framework 4.8.9105.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "76b2b20c-71c7-d786-896b-5f71fb84aab1",
+        "x-ms-date": "Fri, 27 Jan 2023 22:13:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76b2b20c-71c7-d786-896b-5f71fb84aab1",
+        "x-ms-request-id": "48a887b3-801e-000e-179c-325c51000000",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1724088161",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateAsync_PublicAccess_NoneAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateAsync_PublicAccess_NoneAsync.json
@@ -1,0 +1,104 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-659d602a-0c0a-9ffa-e326-90edbd4ac702?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-316f40b0a688e54381ccae167251ec0a-709eeae96490084a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.15.0-alpha.20230127.1 (.NET Framework 4.8.9105.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "e8bd38fb-f1f4-7619-b4b6-2b8189a7cce0",
+        "x-ms-date": "Fri, 27 Jan 2023 22:13:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "ETag": "\u00220x8DB00B3BAE2CC0E\u0022",
+        "Last-Modified": "Fri, 27 Jan 2023 22:13:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e8bd38fb-f1f4-7619-b4b6-2b8189a7cce0",
+        "x-ms-request-id": "48a88824-801e-000e-7d9c-325c51000000",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-659d602a-0c0a-9ffa-e326-90edbd4ac702?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-18833ba7bc49b742b8cea6e3043ccd0e-457f947dcb6ce84f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.15.0-alpha.20230127.1 (.NET Framework 4.8.9105.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "84f1b0ee-df8c-fe0d-bd8e-6ecf72a9e727",
+        "x-ms-date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "ETag": "\u00220x8DB00B3BAE2CC0E\u0022",
+        "Last-Modified": "Fri, 27 Jan 2023 22:13:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "84f1b0ee-df8c-fe0d-bd8e-6ecf72a9e727",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-immutable-storage-with-versioning-enabled": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "48a88859-801e-000e-309c-325c51000000",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-659d602a-0c0a-9ffa-e326-90edbd4ac702?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-318d500f30f49942993e72eea35afc72-de8bd2c9d2cf6447-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.15.0-alpha.20230127.1 (.NET Framework 4.8.9105.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "d892943a-48b5-ca54-9a2f-c8751a411a8d",
+        "x-ms-date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-12-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 27 Jan 2023 22:13:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d892943a-48b5-ca54-9a2f-c8751a411a8d",
+        "x-ms-request-id": "48a88894-801e-000e-6b9c-325c51000000",
+        "x-ms-version": "2021-12-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1576741160",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}


### PR DESCRIPTION
Fixed regression where BlobContainerClient.GetProperties would return null instead of PublicAccessType.None for the BlobContainerProperties.PublicAccess

Resolves https://github.com/Azure/azure-sdk-for-net/issues/27242
