### PR TITLE
[Vision.ContentModerator] Fix build error from unused usings

### DIFF
--- a/sdk/cognitiveservices/Vision.ContentModerator/tests/ImageModerator.cs
+++ b/sdk/cognitiveservices/Vision.ContentModerator/tests/ImageModerator.cs
@@ -3,21 +3,16 @@ using Microsoft.Azure.CognitiveServices.ContentModerator;
 using Microsoft.Azure.CognitiveServices.ContentModerator.Models;
 using System.Collections.Generic;
 using System.Net;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System.Linq;
 using ContentModeratorTests.Helpers;
 using System.IO;
-using d = System.Drawing;
-using ContentModeratorTests.Data;
-using System.Reflection;
 using Xunit;
 using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using Microsoft.Azure.Test.HttpRecorder;
 
 namespace ContentModeratorTests
 {
-        public class ImageModerator : TestBase
+    public class ImageModerator : TestBase
     {
 
         ContentModeratorClient client = null;


### PR DESCRIPTION
This PR fixes the below [build error](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2147396&view=logs&j=27c03001-287e-5ae8-d960-3c850f33bc87&t=2b24ddae-0af2-54d4-5a50-19e46b8ceb5c&l=112):
`[error]sdk\cognitiveservices\Vision.ContentModerator\tests\ImageModerator.cs(11,7): Error CS8981: The type name 'd' only contains lower-cased ascii characters. Such names may become reserved for the language.`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
