### PR TITLE
[Event Hubs Bindings] Bindings Configuration Precedence Fix

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             if (!string.IsNullOrWhiteSpace(connection))
             {
                 var info = ResolveConnectionInformation(connection);
+                eventHubName = NormalizeEventHubName(info.ConnectionString, eventHubName);
+
                 var eventHubProducerClientOptions = new EventHubProducerClientOptions
                 {
                     RetryOptions = _options.ClientRetryOptions,
@@ -67,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 }
                 else
                 {
-                    eventHubConnection = new EventHubConnection(NormalizeConnectionString(info.ConnectionString, eventHubName), eventHubProducerClientOptions.ConnectionOptions);
+                    eventHubConnection = new EventHubConnection(info.ConnectionString, eventHubName, eventHubProducerClientOptions.ConnectionOptions);
                 }
 
                 return _producerCache.GetOrAdd(GenerateCacheKey(eventHubConnection), key =>
@@ -92,6 +94,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             if (!string.IsNullOrEmpty(connection))
             {
                 var info = ResolveConnectionInformation(connection);
+                eventHubName = NormalizeEventHubName(info.ConnectionString, eventHubName);
+
                 var maxEventBatchSize = singleDispatch ? 1 : _options.MaxEventBatchSize;
                 if (info.FullyQualifiedEndpoint != null &&
                     info.TokenCredential != null)
@@ -106,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 }
 
                 return new EventProcessorHost(consumerGroup: consumerGroup,
-                    connectionString: NormalizeConnectionString(info.ConnectionString, eventHubName),
+                    connectionString: info.ConnectionString,
                     eventHubName: eventHubName,
                     options: _options.EventProcessorOptions,
                     eventBatchMaximumCount: maxEventBatchSize,
@@ -126,6 +130,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             if (!string.IsNullOrEmpty(connection))
             {
                 var info = ResolveConnectionInformation(connection);
+                eventHubName = NormalizeEventHubName(info.ConnectionString, eventHubName);
+
                 var eventHubConsumerClientOptions = new EventHubConsumerClientOptions
                 {
                     RetryOptions = _options.ClientRetryOptions,
@@ -141,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 }
                 else
                 {
-                    eventHubConnection = new EventHubConnection(NormalizeConnectionString(info.ConnectionString, eventHubName), eventHubConsumerClientOptions.ConnectionOptions);
+                    eventHubConnection = new EventHubConnection(info.ConnectionString, eventHubName, eventHubConsumerClientOptions.ConnectionOptions);
                 }
 
                 return _consumerCache.GetOrAdd(GenerateCacheKey(eventHubConnection, consumerGroup), key =>
@@ -161,16 +167,24 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             return client.GetBlobContainerClient(_options.CheckpointContainer);
         }
 
-        internal static string NormalizeConnectionString(string originalConnectionString, string eventHubName)
+        internal static string NormalizeEventHubName(string connectionString, string configuredEventHubName)
         {
-            var connectionString = ConnectionString.Parse(originalConnectionString);
+            // If an Event Hub was specified as the entity path for the connection string, it
+            // should take precedence over the configuration-specified value.
 
-            if (!connectionString.ContainsSegmentKey("EntityPath"))
+            if (string.IsNullOrEmpty(connectionString))
             {
-                connectionString.Add("EntityPath", eventHubName);
+                return configuredEventHubName;
             }
 
-            return connectionString.ToString();
+            var connectionStringProperties = EventHubsConnectionStringProperties.Parse(connectionString);
+
+            if (!string.IsNullOrEmpty(connectionStringProperties.EventHubName))
+            {
+                return connectionStringProperties.EventHubName;
+            }
+
+            return configuredEventHubName;
         }
 
         private EventHubsConnectionInformation ResolveConnectionInformation(string connection)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubApplicationInsightsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubApplicationInsightsTests.cs
@@ -259,7 +259,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             Assert.True(request.Properties.ContainsKey(LogConstants.FunctionExecutionTimeKey));
             Assert.True(double.TryParse(request.Properties[LogConstants.FunctionExecutionTimeKey], out double functionDuration));
-            Assert.True(request.Duration.TotalMilliseconds >= functionDuration);
+
+            // Allow a margin of error of ~125 milliseconds, as timing is not precise.
+            functionDuration -= 125;
+            Assert.GreaterOrEqual(request.Duration.TotalMilliseconds, functionDuration);
 
             Assert.AreEqual(LogCategories.Results, request.Properties[LogConstants.CategoryNameKey]);
             Assert.AreEqual((success ? LogLevel.Information : LogLevel.Error).ToString(), request.Properties[LogConstants.LogLevelKey]);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsClientFactoryTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsClientFactoryTests.cs
@@ -188,9 +188,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual("devstoreaccount1", client.AccountName);
         }
 
-        [TestCase("k1", ConnectionString)]
-        [TestCase("path2", ConnectionStringWithEventHub)]
-        public void RespectsConnectionOptionsForProducer(string expectedPathName, string connectionString)
+        [TestCase("k1", "k1", ConnectionString)]
+        [TestCase("path2", "k1", ConnectionStringWithEventHub)]
+        public void RespectsConnectionOptionsForProducer(string expectedPathName, string eventHubName, string connectionString)
         {
             var testEndpoint = new Uri("http://mycustomendpoint.com");
             EventHubOptions options = new EventHubOptions
@@ -202,10 +202,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 }
             };
 
-            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", connectionString));
+            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", connectionString), new KeyValuePair<string, string>("eventHubName", eventHubName));
             var factory = ConfigurationUtilities.CreateFactory(configuration, options);
 
-            var producer = factory.GetEventHubProducerClient(expectedPathName, "connection");
+            var producer = factory.GetEventHubProducerClient(eventHubName, "connection");
             EventHubConnection connection = (EventHubConnection)typeof(EventHubProducerClient).GetProperty("Connection", BindingFlags.NonPublic | BindingFlags.Instance)
                 .GetValue(producer);
             EventHubConnectionOptions connectionOptions = (EventHubConnectionOptions)typeof(EventHubConnection).GetProperty("Options", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(connection);
@@ -218,9 +218,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(expectedPathName, producer.EventHubName);
         }
 
-        [TestCase("k1", ConnectionString)]
-        [TestCase("path2", ConnectionStringWithEventHub)]
-        public void RespectsConnectionOptionsForConsumer(string expectedPathName, string connectionString)
+        [TestCase("k1", "k1", ConnectionString)]
+        [TestCase("path2", "k1", ConnectionStringWithEventHub)]
+        public void RespectsConnectionOptionsForConsumer(string expectedPathName, string eventHubName, string connectionString)
         {
             var testEndpoint = new Uri("http://mycustomendpoint.com");
             EventHubOptions options = new EventHubOptions
@@ -232,10 +232,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 }
             };
 
-            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", connectionString));
+            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", connectionString), new KeyValuePair<string, string>("eventHubName", eventHubName));
             var factory = ConfigurationUtilities.CreateFactory(configuration, options);
 
-            var consumer = factory.GetEventHubConsumerClient(expectedPathName, "connection", "consumer");
+            var consumer = factory.GetEventHubConsumerClient(eventHubName, "connection", "consumer");
             var consumerClient = (EventHubConsumerClient)typeof(EventHubConsumerClientImpl)
                 .GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance)
                 .GetValue(consumer);
@@ -260,9 +260,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.AreEqual(expectedPathName, consumer.EventHubName);
         }
 
-        [TestCase("k1", ConnectionString)]
-        [TestCase("path2", ConnectionStringWithEventHub)]
-        public void RespectsConnectionOptionsForProcessor(string expectedPathName, string connectionString)
+        [TestCase("k1", "k1", ConnectionString)]
+        [TestCase("path2", "k1", ConnectionStringWithEventHub)]
+        public void RespectsConnectionOptionsForProcessor(string expectedPathName, string eventHubName, string connectionString)
         {
             var testEndpoint = new Uri("http://mycustomendpoint.com");
             EventHubOptions options = new EventHubOptions
@@ -277,10 +277,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 MaxEventBatchSize = 20
             };
 
-            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", connectionString));
+            var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>("connection", connectionString), new KeyValuePair<string, string>("eventHubName", eventHubName));
             var factory = ConfigurationUtilities.CreateFactory(configuration, options);
 
-            var processor = factory.GetEventProcessorHost(expectedPathName, "connection", "consumer", false);
+            var processor = factory.GetEventProcessorHost(eventHubName, "connection", "consumer", false);
             EventProcessorOptions processorOptions = (EventProcessorOptions)typeof(EventProcessor<EventProcessorHostPartition>)
                 .GetProperty("Options", BindingFlags.NonPublic | BindingFlags.Instance)
                 .GetValue(processor);


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a bug in the client factory where behavior differed when creating clients when a connection string and an explicit Event Hub name were both configured.  Creation for the producer and consumer gave precedence to the connection string, as documented, allowing both to be specified without error.  The event processor gave precedence to the event hub value, causing inconsistent behavior and potential errors to surface when it disagreed with the connection string.

Also included is a tweak for test assertions to reduce flakiness observed during nightly runs.

# References and Resources

- [Azure Event Hubs trigger binding attributes](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs-trigger?tabs=in-process%2Cfunctionsv2%2Cextensionv5&pivots=programming-language-csharp#attributes)
- [IcM incident #361375349](https://portal.microsofticm.com/imp/v3/incidents/details/361375349/home) _(Microsoft internal)_
