### PR TITLE
Test Key Vault Administration package serially

### DIFF
--- a/sdk/keyvault/service.projects
+++ b/sdk/keyvault/service.projects
@@ -2,5 +2,10 @@
   <ItemGroup>
     <!-- Remove deprecated track 1 packages from builds and live testing. -->
     <ProjectReference Remove="$(MSBuildThisFileDirectory)Microsoft.Azure.*\**\*.csproj" />
+
+    <!-- Make sure backup/restore tests in the Administration package do not run parallel with other tests. -->
+    <ProjectReference Update="$(MSBuildThisFileDirectory)Azure.Security.KeyVault.Administration\tests\Azure.Security.KeyVault.Administration.Tests.csproj">
+      <TestInParallel>false</TestInParallel>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NUnit cannot de-parallelize assemblies without using its proprietary
projects format, so take advantage of the traversal SDK's ability to
update ProjectReference metadata and set TestInParallel=false to always
run administration tests (specifically, backup/restore tests) serially.
