### PR TITLE
Update ACR changelog for 1.1.0-beta.6 release

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/CHANGELOG.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Release History
 
-## 1.1.0-beta.6 (Unreleased)
-
+## 1.1.0-beta.6 (2023-02-07)
 ### Features Added
+
+- Added method `DownloadBlobTo()` to `ContainerRegistryBlobClient`.  This method downloads a blob to a provided Stream, using multiple requests if the blob size exceeds the maximum chunk size.
+- Added an optional `ManifestMediaType` parameter to `UploadManifest()` to enable uploading image manifests of any type.
+- Added `MediaType` property to `DownloadManifestResult` to enable checking the media type prior to deserializing returned manifest.
 
 ### Breaking Changes
 
-### Bugs Fixed
-
-### Other Changes
+- Changed signatures of `DownloadManifest()` and `UploadManifest()` methods on `ContainerRegistryBlobClient`.
+- Removed `DownloadManifestOptions` and `UploadManifestOptions` types.
+- Removed `ArtifactManifest` type.
+- Removed `Manifest` and `ManifestStream` properties from `DownloadManifestResult`.
 
 ## 1.1.0-beta.5 (2023-01-10)
 


### PR DESCRIPTION
Update the Azure.Containers.ContainerRegistry changelog for the 1.1.0-beta.6 release.