### PR TITLE
Storage `PartitionedUploader` supports `BinaryData`

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -3163,7 +3163,7 @@ namespace Azure.Storage.Blobs.Specialized
                         operationName,
                         async,
                         cancellationToken).ConfigureAwait(false),
-                SingleUploadContent = async (content, args, progressHandler, validationOptions, operationName, async, cancellationToken)
+                SingleUploadBinaryData = async (content, args, progressHandler, validationOptions, operationName, async, cancellationToken)
                     => await client.UploadInternal(
                         content.ToStream(),
                         args?.HttpHeaders,
@@ -3199,7 +3199,7 @@ namespace Azure.Storage.Blobs.Specialized
                             async,
                             cancellationToken).ConfigureAwait(false);
                 },
-                UploadPartitionContent = async (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                UploadPartitionBinaryData = async (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     =>
                 {
                     // Stage Block only accepts LeaseId.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -3148,7 +3148,7 @@ namespace Azure.Storage.Blobs.Specialized
         {
             return new PartitionedUploader<BlobUploadOptions, BlobContentInfo>.Behaviors
             {
-                SingleUpload = async (stream, args, progressHandler, validationOptions, operationName, async, cancellationToken)
+                SingleUploadStreaming = async (stream, args, progressHandler, validationOptions, operationName, async, cancellationToken)
                     => await client.UploadInternal(
                         stream,
                         args?.HttpHeaders,
@@ -3163,7 +3163,7 @@ namespace Azure.Storage.Blobs.Specialized
                         operationName,
                         async,
                         cancellationToken).ConfigureAwait(false),
-                UploadPartition = async (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                UploadPartitionStreaming = async (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     =>
                 {
                     // Stage Block only accepts LeaseId.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -3163,6 +3163,21 @@ namespace Azure.Storage.Blobs.Specialized
                         operationName,
                         async,
                         cancellationToken).ConfigureAwait(false),
+                SingleUploadContent = async (content, args, progressHandler, validationOptions, operationName, async, cancellationToken)
+                    => await client.UploadInternal(
+                        content.ToStream(),
+                        args?.HttpHeaders,
+                        args?.Metadata,
+                        args?.Tags,
+                        args?.Conditions,
+                        args?.AccessTier,
+                        args?.ImmutabilityPolicy,
+                        args?.LegalHold,
+                        progressHandler,
+                        validationOptions,
+                        operationName,
+                        async,
+                        cancellationToken).ConfigureAwait(false),
                 UploadPartitionStreaming = async (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     =>
                 {
@@ -3178,6 +3193,27 @@ namespace Azure.Storage.Blobs.Specialized
                     await client.StageBlockInternal(
                             Shared.StorageExtensions.GenerateBlockId(offset),
                             stream,
+                            validationOptions,
+                            conditions,
+                            progressHandler,
+                            async,
+                            cancellationToken).ConfigureAwait(false);
+                },
+                UploadPartitionContent = async (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                    =>
+                {
+                    // Stage Block only accepts LeaseId.
+                    BlobRequestConditions conditions = null;
+                    if (args?.Conditions != null)
+                    {
+                        conditions = new BlobRequestConditions
+                        {
+                            LeaseId = args.Conditions.LeaseId
+                        };
+                    }
+                    await client.StageBlockInternal(
+                            Shared.StorageExtensions.GenerateBlockId(offset),
+                            content.ToStream(),
                             validationOptions,
                             conditions,
                             progressHandler,

--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage
             string operationName,
             bool async,
             CancellationToken cancellationToken);
-        public delegate Task<Response<TCompleteUploadReturn>> SingleUploadContentInternal(
+        public delegate Task<Response<TCompleteUploadReturn>> SingleUploadBinaryDataInternal(
             BinaryData content,
             TServiceSpecificData args,
             IProgress<long> progressHandler,
@@ -145,7 +145,7 @@ namespace Azure.Storage
             UploadTransferValidationOptions transferValidation,
             bool async,
             CancellationToken cancellationToken);
-        public delegate Task UploadPartitionContentInternal(
+        public delegate Task UploadPartitionBinaryDataInternal(
             BinaryData content,
             long offset,
             TServiceSpecificData args,
@@ -163,9 +163,9 @@ namespace Azure.Storage
         {
             public InitializeDestinationInternal InitializeDestination { get; set; }
             public SingleUploadStreamingInternal SingleUploadStreaming { get; set; }
-            public SingleUploadContentInternal SingleUploadContent { get; set; }
+            public SingleUploadBinaryDataInternal SingleUploadBinaryData { get; set; }
             public UploadPartitionStreamingInternal UploadPartitionStreaming { get; set; }
-            public UploadPartitionContentInternal UploadPartitionContent { get; set; }
+            public UploadPartitionBinaryDataInternal UploadPartitionBinaryData { get; set; }
             public CommitPartitionedUploadInternal CommitPartitionedUpload { get; set; }
             public CreateScope Scope { get; set; }
         }
@@ -176,9 +176,9 @@ namespace Azure.Storage
 
         private readonly InitializeDestinationInternal _initializeDestinationInternal;
         private readonly SingleUploadStreamingInternal _singleUploadStreamingInternal;
-        private readonly SingleUploadContentInternal _singleUploadContentInternal;
+        private readonly SingleUploadBinaryDataInternal _singleUploadBinaryDataInternal;
         private readonly UploadPartitionStreamingInternal _uploadPartitionStreamingInternal;
-        private readonly UploadPartitionContentInternal _uploadPartitionContentInternal;
+        private readonly UploadPartitionBinaryDataInternal _uploadPartitionBinaryDataInternal;
         private readonly CommitPartitionedUploadInternal _commitPartitionedUploadInternal;
         private readonly CreateScope _createScope;
 
@@ -225,12 +225,12 @@ namespace Azure.Storage
             _initializeDestinationInternal = behaviors.InitializeDestination ?? InitializeNoOp;
             _singleUploadStreamingInternal = Argument.CheckNotNull(
                 behaviors.SingleUploadStreaming, nameof(behaviors.SingleUploadStreaming));
-            _singleUploadContentInternal = Argument.CheckNotNull(
-                behaviors.SingleUploadContent, nameof(behaviors.SingleUploadContent));
+            _singleUploadBinaryDataInternal = Argument.CheckNotNull(
+                behaviors.SingleUploadBinaryData, nameof(behaviors.SingleUploadBinaryData));
             _uploadPartitionStreamingInternal = Argument.CheckNotNull(
                 behaviors.UploadPartitionStreaming, nameof(behaviors.UploadPartitionStreaming));
-            _uploadPartitionContentInternal = Argument.CheckNotNull(
-                behaviors.UploadPartitionContent, nameof(behaviors.UploadPartitionContent));
+            _uploadPartitionBinaryDataInternal = Argument.CheckNotNull(
+                behaviors.UploadPartitionBinaryData, nameof(behaviors.UploadPartitionBinaryData));
             _commitPartitionedUploadInternal = Argument.CheckNotNull(
                 behaviors.CommitPartitionedUpload, nameof(behaviors.CommitPartitionedUpload));
             _createScope = Argument.CheckNotNull(
@@ -293,7 +293,7 @@ namespace Azure.Storage
 
             if (length < _singleUploadThreshold)
             {
-                return await _singleUploadContentInternal(
+                return await _singleUploadBinaryDataInternal(
                     content,
                     args,
                     progressHandler,
@@ -706,7 +706,7 @@ namespace Azure.Storage
             bool async,
             CancellationToken cancellationToken)
         {
-            await _uploadPartitionContentInternal(
+            await _uploadPartitionBinaryDataInternal(
                 content,
                 offset,
                 args,

--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -57,9 +57,9 @@ namespace Azure.Storage.Tests
             return mock;
         }
 
-        private Mock<PartitionedUploader<object, object>.SingleUploadContentInternal> GetMockSingleUploadContentInternal(int expectedSize)
+        private Mock<PartitionedUploader<object, object>.SingleUploadBinaryDataInternal> GetMockSingleUploadContentInternal(int expectedSize)
         {
-            var mock = new Mock<PartitionedUploader<object, object>.SingleUploadContentInternal>(MockBehavior.Strict);
+            var mock = new Mock<PartitionedUploader<object, object>.SingleUploadBinaryDataInternal>(MockBehavior.Strict);
             mock.Setup(del => del(It.IsNotNull<BinaryData>(), s_objectArgs, It.IsAny<IProgress<long>>(), It.IsAny<UploadTransferValidationOptions>(), s_operationName, IsAsync, s_cancellation))
                 .Returns<BinaryData, object, IProgress<long>, UploadTransferValidationOptions, string, bool, CancellationToken>((content, obj, progress, validationOptions, operation, async, cancellation) =>
                 {
@@ -96,9 +96,9 @@ namespace Azure.Storage.Tests
             return mock;
         }
 
-        private Mock<PartitionedUploader<object, object>.UploadPartitionContentInternal> GetMockUploadPartitionContentInternal(int maxSize)
+        private Mock<PartitionedUploader<object, object>.UploadPartitionBinaryDataInternal> GetMockUploadPartitionContentInternal(int maxSize)
         {
-            var mock = new Mock<PartitionedUploader<object, object>.UploadPartitionContentInternal>(MockBehavior.Strict);
+            var mock = new Mock<PartitionedUploader<object, object>.UploadPartitionBinaryDataInternal>(MockBehavior.Strict);
             mock.Setup(del => del(It.IsNotNull<BinaryData>(), It.IsAny<long>(), s_objectArgs, It.IsAny<IProgress<long>>(), It.IsAny<UploadTransferValidationOptions>(), IsAsync, s_cancellation))
                 .Returns<BinaryData, long, object, IProgress<long>, UploadTransferValidationOptions, bool, CancellationToken>((content, offset, obj, progress, validationOptions, async, cancellation) =>
                 {
@@ -151,9 +151,9 @@ namespace Azure.Storage.Tests
                     Scope = createScope.Object,
                     InitializeDestination = initializeDestination.Object,
                     SingleUploadStreaming = singleUploadStreaming.Object,
-                    SingleUploadContent = singleUploadContent.Object,
+                    SingleUploadBinaryData = singleUploadContent.Object,
                     UploadPartitionStreaming = uploadPartitionStreaming.Object,
-                    UploadPartitionContent = uploadPartitionContent.Object,
+                    UploadPartitionBinaryData = uploadPartitionContent.Object,
                     CommitPartitionedUpload = commitPartitions.Object
                 },
                 new StorageTransferOptions()
@@ -207,9 +207,9 @@ namespace Azure.Storage.Tests
                     Scope = createScope.Object,
                     InitializeDestination = initializeDestination.Object,
                     SingleUploadStreaming = singleUploadStreaming.Object,
-                    SingleUploadContent = singleUploadContent.Object,
+                    SingleUploadBinaryData = singleUploadContent.Object,
                     UploadPartitionStreaming = uploadPartitionStreaming.Object,
-                    UploadPartitionContent = uploadPartitionContent.Object,
+                    UploadPartitionBinaryData = uploadPartitionContent.Object,
                     CommitPartitionedUpload = commitPartitions.Object
                 },
                 new StorageTransferOptions()

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -40,9 +40,9 @@ namespace Azure.Storage.Tests
             return mock;
         }
 
-        private Mock<PartitionedUploader<object, object>.SingleUploadInternal> GetMockSingleUploadInternal(int expectedSize)
+        private Mock<PartitionedUploader<object, object>.SingleUploadStreamingInternal> GetMockSingleUploadInternal(int expectedSize)
         {
-            var mock = new Mock<PartitionedUploader<object, object>.SingleUploadInternal>(MockBehavior.Strict);
+            var mock = new Mock<PartitionedUploader<object, object>.SingleUploadStreamingInternal>(MockBehavior.Strict);
             mock.Setup(del => del(It.IsNotNull<Stream>(), s_objectArgs, It.IsAny<IProgress<long>>(), It.IsAny<UploadTransferValidationOptions>(), s_operationName, IsAsync, s_cancellation))
                 .Returns<Stream, object, IProgress<long>, UploadTransferValidationOptions, string, bool, CancellationToken>((stream, obj, progress, validationOptions, operation, async, cancellation) =>
                 {
@@ -66,9 +66,9 @@ namespace Azure.Storage.Tests
             return mock;
         }
 
-        private Mock<PartitionedUploader<object, object>.UploadPartitionInternal> GetMockUploadPartitionInternal(int maxSize)
+        private Mock<PartitionedUploader<object, object>.UploadPartitionStreamingInternal> GetMockUploadPartitionInternal(int maxSize)
         {
-            var mock = new Mock<PartitionedUploader<object, object>.UploadPartitionInternal>(MockBehavior.Strict);
+            var mock = new Mock<PartitionedUploader<object, object>.UploadPartitionStreamingInternal>(MockBehavior.Strict);
             mock.Setup(del => del(It.IsNotNull<Stream>(), It.IsAny<long>(), s_objectArgs, It.IsAny<IProgress<long>>(), It.IsAny<UploadTransferValidationOptions>(), IsAsync, s_cancellation))
                 .Returns<Stream, long, object, IProgress<long>, UploadTransferValidationOptions, bool, CancellationToken>((stream, offset, obj, progress, validationOptions, async, cancellation) =>
                 {
@@ -122,8 +122,8 @@ namespace Azure.Storage.Tests
                 {
                     Scope = createScope.Object,
                     InitializeDestination = initializeDestination.Object,
-                    SingleUpload = singleUpload.Object,
-                    UploadPartition = uploadPartition.Object,
+                    SingleUploadStreaming = singleUpload.Object,
+                    UploadPartitionStreaming = uploadPartition.Object,
                     CommitPartitionedUpload = commitPartitions.Object
                 },
                 new StorageTransferOptions()
@@ -174,8 +174,8 @@ namespace Azure.Storage.Tests
                 {
                     Scope = createScope.Object,
                     InitializeDestination = initializeDestination.Object,
-                    SingleUpload = singleUpload.Object,
-                    UploadPartition = uploadPartition.Object,
+                    SingleUploadStreaming = singleUpload.Object,
+                    UploadPartitionStreaming = uploadPartition.Object,
                     CommitPartitionedUpload = commitPartitions.Object
                 },
                 new StorageTransferOptions()

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -5252,7 +5252,7 @@ namespace Azure.Storage.Files.DataLake
                         cancellationToken)
                         .ConfigureAwait(false);
                 },
-                SingleUploadContent = async (content, args, progressHandler, validationOptions, operationName, async, cancellationToken) =>
+                SingleUploadBinaryData = async (content, args, progressHandler, validationOptions, operationName, async, cancellationToken) =>
                 {
                     // After the File is Create, Lease ID is the only valid request parameter.
                     if (args?.Conditions != null)
@@ -5301,7 +5301,7 @@ namespace Azure.Storage.Files.DataLake
                         flush: null,
                         async,
                         cancellationToken).ConfigureAwait(false),
-                UploadPartitionContent = async (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                UploadPartitionBinaryData = async (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     => await client.AppendInternal(
                         content.ToStream(),
                         offset,

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -5216,7 +5216,7 @@ namespace Azure.Storage.Files.DataLake
                         conditions: args.Conditions,
                         async: async,
                         cancellationToken: cancellationToken).ConfigureAwait(false),
-                SingleUpload = async (stream, args, progressHandler, validationOptions, operationName, async, cancellationToken) =>
+                SingleUploadStreaming = async (stream, args, progressHandler, validationOptions, operationName, async, cancellationToken) =>
                 {
                     // After the File is Create, Lease ID is the only valid request parameter.
                     if (args?.Conditions != null)
@@ -5252,7 +5252,7 @@ namespace Azure.Storage.Files.DataLake
                         cancellationToken)
                         .ConfigureAwait(false);
                 },
-                UploadPartition = async (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                UploadPartitionStreaming = async (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     => await client.AppendInternal(
                         stream,
                         offset,

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -5252,9 +5252,58 @@ namespace Azure.Storage.Files.DataLake
                         cancellationToken)
                         .ConfigureAwait(false);
                 },
+                SingleUploadContent = async (content, args, progressHandler, validationOptions, operationName, async, cancellationToken) =>
+                {
+                    // After the File is Create, Lease ID is the only valid request parameter.
+                    if (args?.Conditions != null)
+                        args.Conditions = new DataLakeRequestConditions { LeaseId = args.Conditions.LeaseId };
+
+                    long newPosition = content.ToMemory().Length;
+
+                    // Append data
+                    await client.AppendInternal(
+                        content.ToStream(),
+                        offset: 0,
+                        validationOptions,
+                        args?.Conditions?.LeaseId,
+                        leaseAction: null,
+                        leaseDuration: null,
+                        proposedLeaseId: null,
+                        progressHandler,
+                        flush: null,
+                        async,
+                        cancellationToken).ConfigureAwait(false);
+
+                    // Flush data
+                    return await client.FlushInternal(
+                        position: newPosition,
+                        retainUncommittedData: default,
+                        close: args.Close,
+                        args.HttpHeaders,
+                        args.Conditions,
+                        leaseAction: null,
+                        leaseDuration: null,
+                        proposedLeaseId: null,
+                        async,
+                        cancellationToken)
+                        .ConfigureAwait(false);
+                },
                 UploadPartitionStreaming = async (stream, offset, args, progressHandler, validationOptions, async, cancellationToken)
                     => await client.AppendInternal(
                         stream,
+                        offset,
+                        validationOptions,
+                        args?.Conditions?.LeaseId,
+                        leaseAction: null,
+                        leaseDuration: null,
+                        proposedLeaseId: null,
+                        progressHandler,
+                        flush: null,
+                        async,
+                        cancellationToken).ConfigureAwait(false),
+                UploadPartitionContent = async (content, offset, args, progressHandler, validationOptions, async, cancellationToken)
+                    => await client.AppendInternal(
+                        content.ToStream(),
                         offset,
                         validationOptions,
                         args?.Conditions?.LeaseId,

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -5168,11 +5168,37 @@ namespace Azure.Storage.Files.Shares
                         cancellationToken)
                         .ConfigureAwait(false);
                 },
+                SingleUploadBinaryData = async (content, data, progressHandler, validationOptions, operationName, async, cancellationToken) =>
+                {
+                    return await client.UploadRangeInternal(
+                        new HttpRange(offset: 0, length: content.ToMemory().Length),
+                        content.ToStream(),
+                        validationOptions,
+                        progressHandler,
+                        data.Conditions,
+                        fileLastWrittenMode: null,
+                        async,
+                        cancellationToken)
+                        .ConfigureAwait(false);
+                },
                 UploadPartitionStreaming = async (stream, offset, data, progressHandler, validationOptions, async, cancellationToken) =>
                 {
                     data.LastUploadRangeResponse = await client.UploadRangeInternal(
                         new HttpRange(offset: offset, length: stream.Length),
                         stream,
+                        validationOptions,
+                        progressHandler,
+                        data.Conditions,
+                        fileLastWrittenMode: null,
+                        async,
+                        cancellationToken)
+                        .ConfigureAwait(false);
+                },
+                UploadPartitionBinaryData = async (content, offset, data, progressHandler, validationOptions, async, cancellationToken) =>
+                {
+                    data.LastUploadRangeResponse = await client.UploadRangeInternal(
+                        new HttpRange(offset: offset, length: content.ToMemory().Length),
+                        content.ToStream(),
                         validationOptions,
                         progressHandler,
                         data.Conditions,

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -5155,7 +5155,7 @@ namespace Azure.Storage.Files.Shares
         internal static PartitionedUploader<ShareFileUploadData, ShareFileUploadInfo>.Behaviors GetPartitionedUploaderBehaviors(ShareFileClient client)
             => new PartitionedUploader<ShareFileUploadData, ShareFileUploadInfo>.Behaviors
             {
-                SingleUpload = async (stream, data, progressHandler, validationOptions, operationName, async, cancellationToken) =>
+                SingleUploadStreaming = async (stream, data, progressHandler, validationOptions, operationName, async, cancellationToken) =>
                 {
                     return await client.UploadRangeInternal(
                         new HttpRange(offset: 0, length: stream.Length),
@@ -5168,7 +5168,7 @@ namespace Azure.Storage.Files.Shares
                         cancellationToken)
                         .ConfigureAwait(false);
                 },
-                UploadPartition = async (stream, offset, data, progressHandler, validationOptions, async, cancellationToken) =>
+                UploadPartitionStreaming = async (stream, offset, data, progressHandler, validationOptions, async, cancellationToken) =>
                 {
                     data.LastUploadRangeResponse = await client.UploadRangeInternal(
                         new HttpRange(offset: offset, length: stream.Length),


### PR DESCRIPTION
Client APIs that upload via `PartitionedUploader` accept either `Stream` or `BinaryData` as input. But the uploader itself only accepted streams, wrapping the `BinaryData` in one under the hood. This leads to a lot of extra buffering and copying on data that is already referenceable in memory.

This abstracts the main logic of PartitionedUploader to handle content without knowing the type. Public APIs on the type now accept either Stream or BinaryData, injecting the appropriate data partitioning and upload behaviors into the main logic.