### PR TITLE
[AzureMonitorExporter] update Otel packages

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -116,7 +116,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="[1.4.0-rc.2]"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry" Version="[1.4.0-rc.3]"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
     <PackageReference Update="OpenTelemetry.Extensions.PersistentStorage" Version="1.0.0-beta.1" Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 
@@ -255,11 +255,11 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0-rc.2" />
+    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0-rc.3" />
     <PackageReference Update="OpenTelemetry.Extensions.AzureMonitor" Version="1.0.0-beta.2" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.2" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.11" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.11" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.3" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.12" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.12" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -15,7 +15,7 @@ Exceptions reported via ActivityEvents will continue to be exported to Exception
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([]())
+  ([#33859](https://github.com/Azure/azure-sdk-for-net/pull/33859))
   - OpenTelemetry 1.4.0-rc.3
 
 ## 1.0.0-beta.6 (2023-01-10)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -15,8 +15,8 @@ Exceptions reported via ActivityEvents will continue to be exported to Exception
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([#33471](https://github.com/Azure/azure-sdk-for-net/pull/33471))
-  - OpenTelemetry 1.4.0-rc.2
+  ([]())
+  - OpenTelemetry 1.4.0-rc.3
 
 ## 1.0.0-beta.6 (2023-01-10)
 


### PR DESCRIPTION
1.4.0-rc3 was released yesterday.
I'm updating our dependencies.


## Changes
- update packages to 1.4.0-rc.3 (https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.3)


# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
