### PR TITLE
[FormRecognizer] Removed unused snippets

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/SampleSnippets.cs
@@ -32,19 +32,6 @@ namespace Azure.AI.FormRecognizer.Samples
         }
 
         [RecordedTest]
-        public void CreateFormRecognizerClientTokenCredential()
-        {
-            #region Snippet:CreateFormRecognizerClientTokenCredential
-#if SNIPPET
-            string endpoint = "<endpoint>";
-#else
-            string endpoint = TestEnvironment.Endpoint;
-#endif
-            var client = new FormRecognizerClient(new Uri(endpoint), new DefaultAzureCredential());
-            #endregion
-        }
-
-        [RecordedTest]
         public void CreateFormTrainingClient()
         {
             #region Snippet:CreateFormTrainingClient
@@ -57,27 +44,6 @@ namespace Azure.AI.FormRecognizer.Samples
 #endif
             var credential = new AzureKeyCredential(apiKey);
             var client = new FormTrainingClient(new Uri(endpoint), credential);
-            #endregion
-        }
-
-        [RecordedTest]
-        public async Task BadRequestSnippet()
-        {
-            string endpoint = TestEnvironment.Endpoint;
-            string apiKey = TestEnvironment.ApiKey;
-
-            var credential = new AzureKeyCredential(apiKey);
-            var client = new FormRecognizerClient(new Uri(endpoint), credential);
-
-            #region Snippet:FormRecognizerBadRequest
-            try
-            {
-                RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
-            }
-            catch (RequestFailedException e)
-            {
-                Console.WriteLine(e.ToString());
-            }
             #endregion
         }
 


### PR DESCRIPTION
Removing unused snippets we still had around. They were originally used in the README to illustrate the behavior of the old `FormRecognizerClient`. Once we migrated to the `DocumentAnalysisClient` we stopped using them.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/29102.