### PR TITLE
Support ignoring API versions of more ResourceManager resources when used as test dependencies

### DIFF
--- a/common/ManagementTestShared/Redesign/ManagementRecordedTestBase.cs
+++ b/common/ManagementTestShared/Redesign/ManagementRecordedTestBase.cs
@@ -73,20 +73,30 @@ namespace Azure.ResourceManager.TestFramework
 
         private void IgnoreArmCoreDependencyVersions()
         {
+            // Ignore the api-version for resource group operations
             UriRegexSanitizers.Add(new UriRegexSanitizer(
                 @"/resourcegroups/[^/]+api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"
             });
+            // Ignore the api-version for LRO query status operation for resource group deletion
             UriRegexSanitizers.Add(new UriRegexSanitizer(
                 @"/subscriptions/[^/]+/operationresults/[^/]+api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"
             });
+            // Ignore the api-version for TagResource operation
             UriRegexSanitizers.Add(new UriRegexSanitizer(
                 @"/providers/Microsoft.Resources/tags/default\?api-version=(?<group>[a-z0-9-]+)", "**"
+            )
+            {
+                GroupForReplace = "group"
+            });
+            // Ignore the api-version for the operation to query resources provider
+            UriRegexSanitizers.Add(new UriRegexSanitizer(
+                @"/subscriptions/[^/]+/providers/Microsoft.Resources\?api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"

--- a/common/ManagementTestShared/Redesign/ManagementRecordedTestBase.cs
+++ b/common/ManagementTestShared/Redesign/ManagementRecordedTestBase.cs
@@ -73,30 +73,30 @@ namespace Azure.ResourceManager.TestFramework
 
         private void IgnoreArmCoreDependencyVersions()
         {
-            // Ignore the api-version for resource group operations
+            // Ignore the api-version of resource group operations
             UriRegexSanitizers.Add(new UriRegexSanitizer(
                 @"/resourcegroups/[^/]+api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"
             });
-            // Ignore the api-version for LRO query status operation for resource group deletion
+            // Ignore the api-version of LRO query status operation for resource group deletion
             UriRegexSanitizers.Add(new UriRegexSanitizer(
                 @"/subscriptions/[^/]+/operationresults/[^/]+api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"
             });
-            // Ignore the api-version for TagResource operation
+            // Ignore the api-version of TagResource operations
             UriRegexSanitizers.Add(new UriRegexSanitizer(
                 @"/providers/Microsoft.Resources/tags/default\?api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"
             });
-            // Ignore the api-version for the operation to query resources provider
+            // Ignore the api-version of the operation to query resource providers
             UriRegexSanitizers.Add(new UriRegexSanitizer(
-                @"/subscriptions/[^/]+/providers/Microsoft.Resources\?api-version=(?<group>[a-z0-9-]+)", "**"
+                @"/providers/([^/]+)api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/AppConfigurationClientBase.cs
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/AppConfigurationClientBase.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core;
 using Azure.Core.TestFramework;
+using Azure.Core.TestFramework.Models;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Network;
 using Azure.ResourceManager.TestFramework;
@@ -55,6 +56,16 @@ namespace Azure.ResourceManager.AppConfiguration.Tests
             {
                 Assert.Ignore();
             }
+        }
+
+        private void IgnoreApiVersionForResourceProviders()
+        {
+            UriRegexSanitizers.Add(new UriRegexSanitizer(
+                @"/subscriptions/[^/]+/providers/Microsoft.Resources\?api-version=(?<group>[a-z0-9-]+)", "**"
+            )
+            {
+                GroupForReplace = "group"
+            });
         }
     }
 }

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/AppConfigurationClientBase.cs
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/AppConfigurationClientBase.cs
@@ -3,7 +3,6 @@
 
 using Azure.Core;
 using Azure.Core.TestFramework;
-using Azure.Core.TestFramework.Models;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Network;
 using Azure.ResourceManager.TestFramework;
@@ -56,16 +55,6 @@ namespace Azure.ResourceManager.AppConfiguration.Tests
             {
                 Assert.Ignore();
             }
-        }
-
-        private void IgnoreApiVersionForResourceProviders()
-        {
-            UriRegexSanitizers.Add(new UriRegexSanitizer(
-                @"/subscriptions/[^/]+/providers/Microsoft.Resources\?api-version=(?<group>[a-z0-9-]+)", "**"
-            )
-            {
-                GroupForReplace = "group"
-            });
         }
     }
 }

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/SessionRecords/ConfigurationStoreOperationTests/GetAvailableLocationsTest.json
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/SessionRecords/ConfigurationStoreOperationTests/GetAvailableLocationsTest.json
@@ -260,7 +260,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.AppConfiguration?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.AppConfiguration?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/SessionRecords/ConfigurationStoreOperationTests/GetAvailableLocationsTestAsync.json
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/SessionRecords/ConfigurationStoreOperationTests/GetAvailableLocationsTestAsync.json
@@ -260,7 +260,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.AppConfiguration?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.AppConfiguration?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/azurestackhci/Azure.ResourceManager.Hci/tests/SessionRecords/HciClusterOperationTests/SetTags(null).json
+++ b/sdk/azurestackhci/Azure.ResourceManager.Hci/tests/SessionRecords/HciClusterOperationTests/SetTags(null).json
@@ -168,7 +168,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/azurestackhci/Azure.ResourceManager.Hci/tests/SessionRecords/HciClusterOperationTests/SetTags(null)Async.json
+++ b/sdk/azurestackhci/Azure.ResourceManager.Hci/tests/SessionRecords/HciClusterOperationTests/SetTags(null)Async.json
@@ -168,7 +168,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/cdn/Azure.ResourceManager.Cdn/tests/SessionRecords/CdnWebApplicationFirewallPolicyOperationsTests/Update(null).json
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/tests/SessionRecords/CdnWebApplicationFirewallPolicyOperationsTests/Update(null).json
@@ -167,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/cdn/Azure.ResourceManager.Cdn/tests/SessionRecords/CdnWebApplicationFirewallPolicyOperationsTests/Update(null)Async.json
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/tests/SessionRecords/CdnWebApplicationFirewallPolicyOperationsTests/Update(null)Async.json
@@ -167,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/AddTag(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/AddTag(null).json
@@ -518,7 +518,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/AddTag(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/AddTag(null)Async.json
@@ -553,7 +553,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/RemoveTag(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/RemoveTag(null).json
@@ -518,7 +518,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/RemoveTag(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/RemoveTag(null)Async.json
@@ -553,7 +553,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/SetTags(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/SetTags(null).json
@@ -518,7 +518,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/SetTags(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/CommunicationServiceTests/SetTags(null)Async.json
@@ -518,7 +518,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/AddTag(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/AddTag(null).json
@@ -656,7 +656,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/AddTag(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/AddTag(null)Async.json
@@ -656,7 +656,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/RemoveTag(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/RemoveTag(null).json
@@ -656,7 +656,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/RemoveTag(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/RemoveTag(null)Async.json
@@ -656,7 +656,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/SetTags(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/SetTags(null).json
@@ -656,7 +656,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/SetTags(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/DomainTests/SetTags(null)Async.json
@@ -656,7 +656,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/AddTag(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/AddTag(null).json
@@ -551,7 +551,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/AddTag(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/AddTag(null)Async.json
@@ -551,7 +551,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/RemoveTag(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/RemoveTag(null).json
@@ -551,7 +551,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/RemoveTag(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/RemoveTag(null)Async.json
@@ -551,7 +551,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/SetTags(null).json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/SetTags(null).json
@@ -551,7 +551,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/SetTags(null)Async.json
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/SessionRecords/EmailServiceTests/SetTags(null)Async.json
@@ -551,7 +551,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2020-06-01].json
@@ -161,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2020-06-01]Async.json
@@ -161,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2021-04-01].json
@@ -161,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2021-04-01]Async.json
@@ -161,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2022-08-01].json
@@ -161,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/AvailabilitySetOperationsTests/AvailableLocations[2022-08-01]Async.json
@@ -161,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryImageOperationsTests/SetTags(null).json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryImageOperationsTests/SetTags(null).json
@@ -406,7 +406,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryImageOperationsTests/SetTags(null)Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryImageOperationsTests/SetTags(null)Async.json
@@ -406,7 +406,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryOperationsTests/SetTags(null).json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryOperationsTests/SetTags(null).json
@@ -245,7 +245,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryOperationsTests/SetTags(null)Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/GalleryOperationsTests/SetTags(null)Async.json
@@ -245,7 +245,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/CreateOrUpdate()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Exists()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/Get()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAll()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineCollectionTests/GetAllInSubscription()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAndUserAssignedIdentity()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithSystemAssignedIdentity()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10902,7 +10902,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/CreateVmWithUserAssignedIdentity()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10971,7 +10971,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10971,7 +10971,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10975,7 +10975,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystemAndUser[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -11319,7 +11319,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToSystem[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10971,7 +10971,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10971,7 +10971,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10899,7 +10899,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromNoneToUser[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10937,7 +10937,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToNone[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUserAsync.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUserAsync.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10882,7 +10882,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10832,7 +10832,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -11022,7 +11022,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10912,7 +10912,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToSystemUser[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -11026,7 +11026,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10995,7 +10995,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10984,7 +10984,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10946,7 +10946,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10874,7 +10874,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemToUser[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10836,7 +10836,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNoneAsync.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNoneAsync.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10523,7 +10523,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10902,7 +10902,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToNone[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10865,7 +10865,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToSystem[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10902,7 +10902,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10523,7 +10523,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10902,7 +10902,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromSystemUserToUser[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10523,7 +10523,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromTwoUsersToOneUser[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNoneAsync.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNoneAsync.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10523,7 +10523,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToNone[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUserAsync.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUserAsync.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10523,7 +10523,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystemUser[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10865,7 +10865,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToSystem[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineManagedIdentityTests/UpdateVmIdentityFromUserToTwoUsers[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -10450,7 +10450,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/BootDiagnostic[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete().json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete().json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Delete()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Get()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff().json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff().json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/PowerOff()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update().json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update().json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineOperationsTests/Update()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdate()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/CreateOrUpdateWithExtensions()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Exists()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/Get()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAll()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription().json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription().json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetCollectionTests/GetAllInSubscription()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Delete()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Get()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/PowerOff()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2020-06-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2020-06-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2020-06-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2020-06-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2021-04-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2021-04-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2021-04-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2021-04-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2022-08-01].json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2022-08-01].json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2022-08-01]Async.json
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/SessionRecords/VirtualMachineScaleSetOperationsTests/Update()[2022-08-01]Async.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/dns/Azure.ResourceManager.Dns/tests/SessionRecords/DnsZoneTest/AddRemoveTag(null).json
+++ b/sdk/dns/Azure.ResourceManager.Dns/tests/SessionRecords/DnsZoneTest/AddRemoveTag(null).json
@@ -207,7 +207,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/dns/Azure.ResourceManager.Dns/tests/SessionRecords/DnsZoneTest/AddRemoveTag(null)Async.json
+++ b/sdk/dns/Azure.ResourceManager.Dns/tests/SessionRecords/DnsZoneTest/AddRemoveTag(null)Async.json
@@ -207,7 +207,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/EventGridTopicTests/AddRemoveTag(null).json
+++ b/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/EventGridTopicTests/AddRemoveTag(null).json
@@ -264,7 +264,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/EventGridTopicTests/AddRemoveTag(null)Async.json
+++ b/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/EventGridTopicTests/AddRemoveTag(null)Async.json
@@ -328,7 +328,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerNamespaceTests/AddRemoveTag(null).json
+++ b/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerNamespaceTests/AddRemoveTag(null).json
@@ -319,7 +319,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerNamespaceTests/AddRemoveTag(null)Async.json
+++ b/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerNamespaceTests/AddRemoveTag(null)Async.json
@@ -352,7 +352,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerRegistrationTests/AddRemoveTag(null).json
+++ b/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerRegistrationTests/AddRemoveTag(null).json
@@ -151,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerRegistrationTests/AddRemoveTag(null)Async.json
+++ b/sdk/eventgrid/Azure.ResourceManager.EventGrid/tests/SessionRecords/PartnerRegistrationTests/AddRemoveTag(null)Async.json
@@ -151,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null).json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null).json
@@ -746,7 +746,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null)Async.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventHubNamespaceTests/AddSetRemoveTag(null)Async.json
@@ -746,7 +746,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameter.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameter.json
@@ -744,7 +744,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameterAsync.json
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/SessionRecords/EventhubTests/CreateEventhubWithParameterAsync.json
@@ -744,7 +744,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/326100e2-f69d-4268-8503-075374f62b6e/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/SessionRecords/HDInsightClusterTests/AddTagTest.json
+++ b/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/SessionRecords/HDInsightClusterTests/AddTagTest.json
@@ -2113,7 +2113,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/SessionRecords/HDInsightClusterTests/AddTagTestAsync.json
+++ b/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/SessionRecords/HDInsightClusterTests/AddTagTestAsync.json
@@ -1985,7 +1985,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationAddTagsTest(null).json
+++ b/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationAddTagsTest(null).json
@@ -432,7 +432,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationAddTagsTest(null)Async.json
+++ b/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationAddTagsTest(null)Async.json
@@ -432,7 +432,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationRemoveTagsTest(null).json
+++ b/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationRemoveTagsTest(null).json
@@ -362,7 +362,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationRemoveTagsTest(null)Async.json
+++ b/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/SessionRecords/IotCentralAppOperationsTests/IotCentralApplicationRemoveTagsTest(null)Async.json
@@ -514,7 +514,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/Azure.ResourceManager.ManagedServiceIdentities.sln
+++ b/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/Azure.ResourceManager.ManagedServiceIdentities.sln
@@ -57,6 +57,18 @@ Global
 		{DF15D10D-3646-447E-B00B-49506D142322}.Release|x64.Build.0 = Release|Any CPU
 		{DF15D10D-3646-447E-B00B-49506D142322}.Release|x86.ActiveCfg = Release|Any CPU
 		{DF15D10D-3646-447E-B00B-49506D142322}.Release|x86.Build.0 = Release|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Debug|x64.Build.0 = Debug|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Debug|x86.Build.0 = Debug|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Release|x64.ActiveCfg = Release|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Release|x64.Build.0 = Release|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Release|x86.ActiveCfg = Release|Any CPU
+		{1BC5B446-6EDD-4990-B3A1-947EF7BC2E88}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/AddTag(null).json
+++ b/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/AddTag(null).json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/AddTag(null)Async.json
+++ b/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/AddTag(null)Async.json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/RemoveTag(null).json
+++ b/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/RemoveTag(null).json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/RemoveTag(null)Async.json
+++ b/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/RemoveTag(null)Async.json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/SetTags(null).json
+++ b/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/SetTags(null).json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/SetTags(null)Async.json
+++ b/sdk/managedserviceidentity/Azure.ResourceManager.ManagedServiceIdentities/tests/SessionRecords/UserAssignedIdentityOperationTests/SetTags(null)Async.json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/netapp/Azure.ResourceManager.NetApp/tests/SessionRecords/NetAppAccountTests/NetAppAccountGetOperations.json
+++ b/sdk/netapp/Azure.ResourceManager.NetApp/tests/SessionRecords/NetAppAccountTests/NetAppAccountGetOperations.json
@@ -46,7 +46,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/69a75bda-882e-44d5-8431-63421204132a/providers/Microsoft.NetApp?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/69a75bda-882e-44d5-8431-63421204132a/providers/Microsoft.NetApp?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/netapp/Azure.ResourceManager.NetApp/tests/SessionRecords/NetAppAccountTests/NetAppAccountGetOperationsAsync.json
+++ b/sdk/netapp/Azure.ResourceManager.NetApp/tests/SessionRecords/NetAppAccountTests/NetAppAccountGetOperationsAsync.json
@@ -46,7 +46,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/69a75bda-882e-44d5-8431-63421204132a/providers/Microsoft.NetApp?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/69a75bda-882e-44d5-8431-63421204132a/providers/Microsoft.NetApp?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/Azure.ResourceManager.Network.sln
+++ b/sdk/network/Azure.ResourceManager.Network/Azure.ResourceManager.Network.sln
@@ -70,6 +70,18 @@ Global
 		{CED8D4C3-6A28-46B8-975E-D1127A9051AF}.Release|x64.Build.0 = Release|Any CPU
 		{CED8D4C3-6A28-46B8-975E-D1127A9051AF}.Release|x86.ActiveCfg = Release|Any CPU
 		{CED8D4C3-6A28-46B8-975E-D1127A9051AF}.Release|x86.Build.0 = Release|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Debug|x64.Build.0 = Debug|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Debug|x86.Build.0 = Debug|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Release|Any CPU.Build.0 = Release|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Release|x64.ActiveCfg = Release|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Release|x64.Build.0 = Release|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Release|x86.ActiveCfg = Release|Any CPU
+		{049D538F-4379-460C-B178-1946BE1AD737}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationGatewayTests/AppGatewayBackendHealthCheckTest.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationGatewayTests/AppGatewayBackendHealthCheckTest.json
@@ -621,7 +621,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationGatewayTests/AppGatewayBackendHealthCheckTestAsync.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationGatewayTests/AppGatewayBackendHealthCheckTestAsync.json
@@ -621,7 +621,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationSecurityGroupTests/ApplicationSecurityGroupApiTest(null).json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationSecurityGroupTests/ApplicationSecurityGroupApiTest(null).json
@@ -467,7 +467,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationSecurityGroupTests/ApplicationSecurityGroupApiTest(null)Async.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/ApplicationSecurityGroupTests/ApplicationSecurityGroupApiTest(null)Async.json
@@ -504,7 +504,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/DdosProtectionPlanTests/DdosProtectionPlanApiTest(null).json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/DdosProtectionPlanTests/DdosProtectionPlanApiTest(null).json
@@ -469,7 +469,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/DdosProtectionPlanTests/DdosProtectionPlanApiTest(null)Async.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/DdosProtectionPlanTests/DdosProtectionPlanApiTest(null)Async.json
@@ -469,7 +469,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionOperationsApisTest.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionOperationsApisTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionOperationsApisTestAsync.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionOperationsApisTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionWithIpsecPoliciesTest.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionWithIpsecPoliciesTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionWithIpsecPoliciesTestAsync.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/GatewayOperationsTests/VirtualNetworkGatewayConnectionWithIpsecPoliciesTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateEndpointTests/PrivateEndpointTest.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateEndpointTests/PrivateEndpointTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateEndpointTests/PrivateEndpointTestAsync.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateEndpointTests/PrivateEndpointTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateLinkServicesTest/CheckPrivateLinkServiceVisibilityTest.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateLinkServicesTest/CheckPrivateLinkServiceVisibilityTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateLinkServicesTest/CheckPrivateLinkServiceVisibilityTestAsync.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PrivateLinkServicesTest/CheckPrivateLinkServiceVisibilityTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Network?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PublicIpPrefixTests/PublicIpPrefixApiTest(null).json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PublicIpPrefixTests/PublicIpPrefixApiTest(null).json
@@ -570,7 +570,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PublicIpPrefixTests/PublicIpPrefixApiTest(null)Async.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/PublicIpPrefixTests/PublicIpPrefixApiTest(null)Async.json
@@ -570,7 +570,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssNetworkInterfaceTests/VmssNetworkInterfaceApiTest.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssNetworkInterfaceTests/VmssNetworkInterfaceApiTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssNetworkInterfaceTests/VmssNetworkInterfaceApiTestAsync.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssNetworkInterfaceTests/VmssNetworkInterfaceApiTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssPublicIpAddressTests/VmssPublicIpAddressApiTest.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssPublicIpAddressTests/VmssPublicIpAddressApiTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssPublicIpAddressTests/VmssPublicIpAddressApiTestAsync.json
+++ b/sdk/network/Azure.ResourceManager.Network/tests/SessionRecords/VmssPublicIpAddressTests/VmssPublicIpAddressApiTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/c9cbd920-c00c-427c-852b-8aaf38badaeb/providers/Microsoft.Compute?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/nginx/Azure.ResourceManager.Nginx/tests/SessionRecords/NginxDeploymentResourceTests/AddTag().json
+++ b/sdk/nginx/Azure.ResourceManager.Nginx/tests/SessionRecords/NginxDeploymentResourceTests/AddTag().json
@@ -1673,7 +1673,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/e3853e83-0d02-4fb3-b88f-05b5fd21aee2/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/e3853e83-0d02-4fb3-b88f-05b5fd21aee2/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/nginx/Azure.ResourceManager.Nginx/tests/SessionRecords/NginxDeploymentResourceTests/AddTag()Async.json
+++ b/sdk/nginx/Azure.ResourceManager.Nginx/tests/SessionRecords/NginxDeploymentResourceTests/AddTag()Async.json
@@ -1745,7 +1745,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/e3853e83-0d02-4fb3-b88f-05b5fd21aee2/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/e3853e83-0d02-4fb3-b88f-05b5fd21aee2/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/AddRemoveTag(null).json
+++ b/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/AddRemoveTag(null).json
@@ -138,7 +138,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/e815e305-b43a-49c4-8b1a-4e61f1aec1e8/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/e815e305-b43a-49c4-8b1a-4e61f1aec1e8/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/AddRemoveTag(null)Async.json
+++ b/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/AddRemoveTag(null)Async.json
@@ -138,7 +138,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/e815e305-b43a-49c4-8b1a-4e61f1aec1e8/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/e815e305-b43a-49c4-8b1a-4e61f1aec1e8/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/ListAllPeeringServiceAvailableLocations.json
+++ b/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/ListAllPeeringServiceAvailableLocations.json
@@ -138,7 +138,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Peering?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Peering?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/ListAllPeeringServiceAvailableLocationsAsync.json
+++ b/sdk/peering/Azure.ResourceManager.Peering/tests/SessionRecords/PeeringServiceTests/ListAllPeeringServiceAvailableLocationsAsync.json
@@ -138,7 +138,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Peering?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Peering?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/privatedns/Azure.ResourceManager.PrivateDns/tests/SessionRecords/PrivateDnsTests/AddRemoveTag(null).json
+++ b/sdk/privatedns/Azure.ResourceManager.PrivateDns/tests/SessionRecords/PrivateDnsTests/AddRemoveTag(null).json
@@ -248,7 +248,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/privatedns/Azure.ResourceManager.PrivateDns/tests/SessionRecords/PrivateDnsTests/AddRemoveTag(null)Async.json
+++ b/sdk/privatedns/Azure.ResourceManager.PrivateDns/tests/SessionRecords/PrivateDnsTests/AddRemoveTag(null)Async.json
@@ -248,7 +248,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/CreateOrUpdate().json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/CreateOrUpdate().json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/CreateOrUpdate()Async.json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/CreateOrUpdate()Async.json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/Get().json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/Get().json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/Get()Async.json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/Get()Async.json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListByRg().json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListByRg().json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListByRg()Async.json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListByRg()Async.json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListBySub().json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListBySub().json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListBySub()Async.json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptCollectionTests/ListBySub()Async.json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptOperationsTests/Delete().json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptOperationsTests/Delete().json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptOperationsTests/Delete()Async.json
+++ b/sdk/resources/Azure.ResourceManager.Resources/tests/SessionRecords/DeploymentScriptOperationsTests/Delete()Async.json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/f3d94233-a9aa-4241-ac82-2dfb63ce637a/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/AddTagAsync.json
+++ b/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/AddTagAsync.json
@@ -5272,7 +5272,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/AddTagAsyncAsync.json
+++ b/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/AddTagAsyncAsync.json
@@ -1850,7 +1850,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/RemoveTagAsync.json
+++ b/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/RemoveTagAsync.json
@@ -6490,7 +6490,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/RemoveTagAsyncAsync.json
+++ b/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/RemoveTagAsyncAsync.json
@@ -2372,7 +2372,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/SetTagsAsync.json
+++ b/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/SetTagsAsync.json
@@ -1908,7 +1908,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/SetTagsAsyncAsync.json
+++ b/sdk/search/Azure.ResourceManager.Search/tests/SessionRecords/SearchServiceResourceTest/SetTagsAsyncAsync.json
@@ -1792,7 +1792,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/AutomationCollectionTests/AddRemoveTag(null).json
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/AutomationCollectionTests/AddRemoveTag(null).json
@@ -460,7 +460,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/AutomationCollectionTests/AddRemoveTag(null)Async.json
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/AutomationCollectionTests/AddRemoveTag(null)Async.json
@@ -460,7 +460,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/IotSecuritySolutionTests/AddRemoveTag(null).json
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/IotSecuritySolutionTests/AddRemoveTag(null).json
@@ -1360,7 +1360,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/IotSecuritySolutionTests/AddRemoveTag(null)Async.json
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SessionRecords/IotSecuritySolutionTests/AddRemoveTag(null)Async.json
@@ -1391,7 +1391,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/sqlmanagement/Azure.ResourceManager.Sql/tests/SessionRecords/SqlAgentConfigurationTests/SqlAgentConfigurationApiTests.json
+++ b/sdk/sqlmanagement/Azure.ResourceManager.Sql/tests/SessionRecords/SqlAgentConfigurationTests/SqlAgentConfigurationApiTests.json
@@ -31784,7 +31784,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Sql?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Sql?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/sqlmanagement/Azure.ResourceManager.Sql/tests/SessionRecords/SqlAgentConfigurationTests/SqlAgentConfigurationApiTestsAsync.json
+++ b/sdk/sqlmanagement/Azure.ResourceManager.Sql/tests/SessionRecords/SqlAgentConfigurationTests/SqlAgentConfigurationApiTestsAsync.json
@@ -22229,7 +22229,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Sql?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Sql?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmGroupTests/SetTags(null).json
+++ b/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmGroupTests/SetTags(null).json
@@ -242,7 +242,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmGroupTests/SetTags(null)Async.json
+++ b/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmGroupTests/SetTags(null)Async.json
@@ -242,7 +242,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmTests/SetTags(null).json
+++ b/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmTests/SetTags(null).json
@@ -692,7 +692,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmTests/SetTags(null)Async.json
+++ b/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/tests/SessionRecords/SqlVmTests/SetTags(null)Async.json
@@ -658,7 +658,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithSystemAndUserAssignedIdentity.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithSystemAndUserAssignedIdentity.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithSystemAndUserAssignedIdentityAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithSystemAndUserAssignedIdentityAsync.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithUserAssignedIdentity.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithUserAssignedIdentity.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithUserAssignedIdentityAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/CreateAccountWithUserAssignedIdentityAsync.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToSystemAndUser.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToSystemAndUser.json
@@ -291,7 +291,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToSystemAndUserAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToSystemAndUserAsync.json
@@ -291,7 +291,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToUser.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToUser.json
@@ -291,7 +291,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToUserAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromNoneToUserAsync.json
@@ -291,7 +291,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToSystemUser.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToSystemUser.json
@@ -299,7 +299,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToSystemUserAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToSystemUserAsync.json
@@ -299,7 +299,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToUser.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToUser.json
@@ -299,7 +299,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToUserAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemToUserAsync.json
@@ -299,7 +299,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToNone.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToNone.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToNoneAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToNoneAsync.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToSystem.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToSystem.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToSystemAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToSystemAsync.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToUser.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToUser.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToUserAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromSystemUserToUserAsync.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToNone.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToNone.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToNoneAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToNoneAsync.json
@@ -130,7 +130,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystem.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystem.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystemAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystemAsync.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystemUser.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystemUser.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystemUserAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountManagedIdentityTests/UpdateAccountIdentityFromUserToSystemUserAsync.json
@@ -128,7 +128,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/45b60d85-fd72-427a-a708-f994d26e593e/providers/Microsoft.ManagedIdentity?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/AddRemoveTag(null).json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/AddRemoveTag(null).json
@@ -306,7 +306,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/AddRemoveTag(null)Async.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/AddRemoveTag(null)Async.json
@@ -306,7 +306,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/ListStorageAccountAvailableLocations.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/ListStorageAccountAvailableLocations.json
@@ -293,7 +293,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/ListStorageAccountAvailableLocationsAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/ListStorageAccountAvailableLocationsAsync.json
@@ -293,7 +293,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountGetOperations.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountGetOperations.json
@@ -47,7 +47,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountGetOperationsAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountGetOperationsAsync.json
@@ -47,7 +47,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountOperations.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountOperations.json
@@ -47,7 +47,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountOperationsAsync.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/SessionRecords/StorageAccountTests/StorageAccountOperationsAsync.json
@@ -47,7 +47,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/providers/Microsoft.Storage?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperations.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperations.json
@@ -56,7 +56,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -629,7 +629,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=**",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperations.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperations.json
@@ -94,7 +94,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperationsAsync.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperationsAsync.json
@@ -56,7 +56,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -629,7 +629,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testEmptyTag?api-version=**",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperationsAsync.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagOperationsAsync.json
@@ -94,7 +94,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperations.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperations.json
@@ -94,7 +94,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -131,7 +131,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperations.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperations.json
@@ -56,7 +56,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperationsAsync.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperationsAsync.json
@@ -94,7 +94,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -131,7 +131,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag/tagValues/preTestValue?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperationsAsync.json
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SessionRecords/SubscriptionExtensionTests/PredefinedTagValueOperationsAsync.json
@@ -56,7 +56,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/db1ab6f0-4769-4b27-930e-01e2ef9c123c/tagNames/testTag?api-version=**",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SubscriptionManagementTestBase.cs
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SubscriptionManagementTestBase.cs
@@ -22,8 +22,9 @@ namespace Azure.ResourceManager.Subscription.Tests
         }
 
         protected SubscriptionManagementTestBase(bool isAsync)
-            : this(isAsync, default)
+            : base(isAsync)
         {
+            IgnoreApiVersionInTagOperations();
         }
 
         [SetUp]

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SubscriptionManagementTestBase.cs
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SubscriptionManagementTestBase.cs
@@ -43,8 +43,16 @@ namespace Azure.ResourceManager.Subscription.Tests
 
         private void IgnoreApiVersionInTagOperations()
         {
+            // Ignore the api-version of tagNames operations including list
             UriRegexSanitizers.Add(new UriRegexSanitizer(
-                @"/subscriptions/[^/]+/tagNames/[^/]+api-version=(?<group>[a-z0-9-]+)", "**"
+                @"/subscriptions/[^/]+/tagNames[/]?[^/]*api-version=(?<group>[a-z0-9-]+)", "**"
+            )
+            {
+                GroupForReplace = "group"
+            });
+            // Ignore the api-version of tagValues operations
+            UriRegexSanitizers.Add(new UriRegexSanitizer(
+                @"/subscriptions/[^/]+/tagNames/[^/]+/tagValues/[^/]+api-version=(?<group>[a-z0-9-]+)", "**"
             )
             {
                 GroupForReplace = "group"

--- a/sdk/subscription/Azure.ResourceManager.Subscription/tests/SubscriptionManagementTestBase.cs
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/tests/SubscriptionManagementTestBase.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core;
 using Azure.Core.TestFramework;
+using Azure.Core.TestFramework.Models;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.TestFramework;
 using NUnit.Framework;
@@ -17,10 +18,11 @@ namespace Azure.ResourceManager.Subscription.Tests
         protected SubscriptionManagementTestBase(bool isAsync, RecordedTestMode mode)
         : base(isAsync, mode)
         {
+            IgnoreApiVersionInTagOperations();
         }
 
         protected SubscriptionManagementTestBase(bool isAsync)
-            : base(isAsync)
+            : this(isAsync, default)
         {
         }
 
@@ -36,6 +38,16 @@ namespace Azure.ResourceManager.Subscription.Tests
             ResourceGroupData input = new ResourceGroupData(location);
             var lro = await subscription.GetResourceGroups().CreateOrUpdateAsync(WaitUntil.Completed, rgName, input);
             return lro.Value;
+        }
+
+        private void IgnoreApiVersionInTagOperations()
+        {
+            UriRegexSanitizers.Add(new UriRegexSanitizer(
+                @"/subscriptions/[^/]+/tagNames/[^/]+api-version=(?<group>[a-z0-9-]+)", "**"
+            )
+            {
+                GroupForReplace = "group"
+            });
         }
     }
 }

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/AddTagTest(null).json
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/AddTagTest(null).json
@@ -305,7 +305,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/AddTagTest(null)Async.json
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/AddTagTest(null)Async.json
@@ -305,7 +305,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/RemoveTagTest(null).json
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/RemoveTagTest(null).json
@@ -305,7 +305,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/RemoveTagTest(null)Async.json
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/RemoveTagTest(null)Async.json
@@ -305,7 +305,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/SetTagsTest(null).json
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/SetTagsTest(null).json
@@ -305,7 +305,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/SetTagsTest(null)Async.json
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/tests/SessionRecords/ProfileTests/SetTagsTest(null)Async.json
@@ -305,7 +305,7 @@
       }
     },
     {
-      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=2021-04-01",
+      "RequestUri": "https://management.azure.com/subscriptions/6bb9d374-1f0d-437e-8bbe-4bc892850065/providers/Microsoft.Resources?api-version=**",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",


### PR DESCRIPTION
Ignore the api-version of the operation to query resource providers in `ManagementRecordedTestBase`.
Ignore the api-version of the TagNames and TagValues operations in `SubscriptionManagementTestBase` as they are only used in the `Subscription` SDK.


# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
