### PR TITLE
Updated ChangeLog for stable SDK release 

### DIFF
--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/CHANGELOG.md
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2023-02-13)
 
 ### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+Added support for Immutable vaults.
 
 ### Other Changes
+Changed API verison to 2023-01-01.
 
 ## 1.0.0-beta.1 (2022-09-25)
 

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/README.md
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/README.md
@@ -17,7 +17,7 @@ This library follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Microsoft Azure Recovery Services management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```dotnetcli
-dotnet add package Azure.ResourceManager.RecoveryServices --prerelease
+dotnet add package Azure.ResourceManager.RecoveryServices
 ```
 
 ### Prerequisites

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/api/Azure.ResourceManager.RecoveryServices.netstandard2.0.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/api/Azure.ResourceManager.RecoveryServices.netstandard2.0.cs
@@ -187,7 +187,7 @@ namespace Azure.ResourceManager.RecoveryServices.Models
     public partial class CapabilitiesResult : Azure.ResourceManager.RecoveryServices.Models.ResourceCapabilitiesBase
     {
         public CapabilitiesResult(string resourceCapabilitiesBaseType) : base (default(string)) { }
-        public System.Collections.Generic.IList<Azure.ResourceManager.RecoveryServices.Models.DnsZoneResponse> CapabilitiesResponseDnsZones { get { throw null; } }
+        public System.Collections.Generic.IList<Azure.ResourceManager.RecoveryServices.Models.DnsZoneResult> CapabilitiesResponseDnsZones { get { throw null; } }
     }
     public partial class CertificateContent
     {
@@ -236,9 +236,9 @@ namespace Azure.ResourceManager.RecoveryServices.Models
         public DnsZone() { }
         public Azure.ResourceManager.RecoveryServices.Models.VaultSubResourceType? SubResource { get { throw null; } set { } }
     }
-    public partial class DnsZoneResponse : Azure.ResourceManager.RecoveryServices.Models.DnsZone
+    public partial class DnsZoneResult : Azure.ResourceManager.RecoveryServices.Models.DnsZone
     {
-        public DnsZoneResponse() { }
+        public DnsZoneResult() { }
         public System.Collections.Generic.IList<string> RequiredZoneNames { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/api/Azure.ResourceManager.RecoveryServices.netstandard2.0.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/api/Azure.ResourceManager.RecoveryServices.netstandard2.0.cs
@@ -2,10 +2,10 @@ namespace Azure.ResourceManager.RecoveryServices
 {
     public static partial class RecoveryServicesExtensions
     {
-        public static Azure.Response<Azure.ResourceManager.RecoveryServices.Models.CapabilitiesResponse> CapabilitiesRecoveryService(this Azure.ResourceManager.Resources.SubscriptionResource subscriptionResource, Azure.Core.AzureLocation location, Azure.ResourceManager.RecoveryServices.Models.ResourceCapabilities input, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.RecoveryServices.Models.CapabilitiesResponse>> CapabilitiesRecoveryServiceAsync(this Azure.ResourceManager.Resources.SubscriptionResource subscriptionResource, Azure.Core.AzureLocation location, Azure.ResourceManager.RecoveryServices.Models.ResourceCapabilities input, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static Azure.Response<Azure.ResourceManager.RecoveryServices.Models.CheckNameAvailabilityResult> CheckNameAvailabilityRecoveryService(this Azure.ResourceManager.Resources.ResourceGroupResource resourceGroupResource, Azure.Core.AzureLocation location, Azure.ResourceManager.RecoveryServices.Models.CheckNameAvailabilityContent content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.RecoveryServices.Models.CheckNameAvailabilityResult>> CheckNameAvailabilityRecoveryServiceAsync(this Azure.ResourceManager.Resources.ResourceGroupResource resourceGroupResource, Azure.Core.AzureLocation location, Azure.ResourceManager.RecoveryServices.Models.CheckNameAvailabilityContent content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static Azure.Response<Azure.ResourceManager.RecoveryServices.Models.CapabilitiesResult> GetCapabilitiesRecoveryService(this Azure.ResourceManager.Resources.SubscriptionResource subscriptionResource, Azure.Core.AzureLocation location, Azure.ResourceManager.RecoveryServices.Models.ResourceCapabilities input, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.RecoveryServices.Models.CapabilitiesResult>> GetCapabilitiesRecoveryServiceAsync(this Azure.ResourceManager.Resources.SubscriptionResource subscriptionResource, Azure.Core.AzureLocation location, Azure.ResourceManager.RecoveryServices.Models.ResourceCapabilities input, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static Azure.ResourceManager.RecoveryServices.RecoveryServicesPrivateLinkResource GetRecoveryServicesPrivateLinkResource(this Azure.ResourceManager.ArmClient client, Azure.Core.ResourceIdentifier id) { throw null; }
         public static Azure.Response<Azure.ResourceManager.RecoveryServices.VaultResource> GetVault(this Azure.ResourceManager.Resources.ResourceGroupResource resourceGroupResource, string vaultName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.Task<Azure.Response<Azure.ResourceManager.RecoveryServices.VaultResource>> GetVaultAsync(this Azure.ResourceManager.Resources.ResourceGroupResource resourceGroupResource, string vaultName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -184,9 +184,9 @@ namespace Azure.ResourceManager.RecoveryServices.Models
         public static bool operator !=(Azure.ResourceManager.RecoveryServices.Models.BackupStorageVersion left, Azure.ResourceManager.RecoveryServices.Models.BackupStorageVersion right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class CapabilitiesResponse : Azure.ResourceManager.RecoveryServices.Models.ResourceCapabilitiesBase
+    public partial class CapabilitiesResult : Azure.ResourceManager.RecoveryServices.Models.ResourceCapabilitiesBase
     {
-        public CapabilitiesResponse(string resourceCapabilitiesBaseType) : base (default(string)) { }
+        public CapabilitiesResult(string resourceCapabilitiesBaseType) : base (default(string)) { }
         public System.Collections.Generic.IList<Azure.ResourceManager.RecoveryServices.Models.DnsZoneResponse> CapabilitiesResponseDnsZones { get { throw null; } }
     }
     public partial class CertificateContent

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/samples/Generated/Samples/Sample_SubscriptionResourceExtensions.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/samples/Generated/Samples/Sample_SubscriptionResourceExtensions.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.RecoveryServices.Samples
         // Capabilities for Microsoft.RecoveryServices/Vaults
         [NUnit.Framework.Test]
         [NUnit.Framework.Ignore("Only verifying that the sample builds")]
-        public async Task CapabilitiesRecoveryService_CapabilitiesForMicrosoftRecoveryServicesVaults()
+        public async Task GetCapabilitiesRecoveryService_CapabilitiesForMicrosoftRecoveryServicesVaults()
         {
             // Generated from example definition: specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/stable/2023-01-01/examples/Capabilities.json
             // this example is just showing the usage of "RecoveryServices_Capabilities" operation, for the dependent resources, they will have to be created separately.
@@ -52,7 +52,7 @@ SubResource = VaultSubResourceType.AzureSiteRecovery,
 }
 },
             };
-            CapabilitiesResponse result = await subscriptionResource.CapabilitiesRecoveryServiceAsync(location, input);
+            CapabilitiesResult result = await subscriptionResource.GetCapabilitiesRecoveryServiceAsync(location, input);
 
             Console.WriteLine($"Succeeded: {result}");
         }

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Azure.ResourceManager.RecoveryServices.csproj
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Azure.ResourceManager.RecoveryServices.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta.2</Version>
+    <Version>1.0.0</Version>
     <PackageId>Azure.ResourceManager.RecoveryServices</PackageId>
     <Description>Microsoft Azure Resource Manager client SDK for Azure resource provider Microsoft.RecoveryServices.</Description>
     <PackageTags>azure;management;arm;resource manager;recoveryservices</PackageTags>

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Extensions/RecoveryServicesExtensions.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Extensions/RecoveryServicesExtensions.cs
@@ -46,11 +46,11 @@ namespace Azure.ResourceManager.RecoveryServices
         /// <param name="input"> Contains information about Resource type and properties to get capabilities. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public static async Task<Response<CapabilitiesResponse>> CapabilitiesRecoveryServiceAsync(this SubscriptionResource subscriptionResource, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
+        public static async Task<Response<CapabilitiesResult>> GetCapabilitiesRecoveryServiceAsync(this SubscriptionResource subscriptionResource, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(input, nameof(input));
 
-            return await GetExtensionClient(subscriptionResource).CapabilitiesRecoveryServiceAsync(location, input, cancellationToken).ConfigureAwait(false);
+            return await GetExtensionClient(subscriptionResource).GetCapabilitiesRecoveryServiceAsync(location, input, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -71,11 +71,11 @@ namespace Azure.ResourceManager.RecoveryServices
         /// <param name="input"> Contains information about Resource type and properties to get capabilities. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public static Response<CapabilitiesResponse> CapabilitiesRecoveryService(this SubscriptionResource subscriptionResource, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
+        public static Response<CapabilitiesResult> GetCapabilitiesRecoveryService(this SubscriptionResource subscriptionResource, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(input, nameof(input));
 
-            return GetExtensionClient(subscriptionResource).CapabilitiesRecoveryService(location, input, cancellationToken);
+            return GetExtensionClient(subscriptionResource).GetCapabilitiesRecoveryService(location, input, cancellationToken);
         }
 
         /// <summary>

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Extensions/SubscriptionResourceExtensionClient.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Extensions/SubscriptionResourceExtensionClient.cs
@@ -63,9 +63,9 @@ namespace Azure.ResourceManager.RecoveryServices
         /// <param name="location"> Location of the resource. </param>
         /// <param name="input"> Contains information about Resource type and properties to get capabilities. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response<CapabilitiesResponse>> CapabilitiesRecoveryServiceAsync(AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<CapabilitiesResult>> GetCapabilitiesRecoveryServiceAsync(AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
         {
-            using var scope = RecoveryServicesClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.CapabilitiesRecoveryService");
+            using var scope = RecoveryServicesClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.GetCapabilitiesRecoveryService");
             scope.Start();
             try
             {
@@ -95,9 +95,9 @@ namespace Azure.ResourceManager.RecoveryServices
         /// <param name="location"> Location of the resource. </param>
         /// <param name="input"> Contains information about Resource type and properties to get capabilities. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<CapabilitiesResponse> CapabilitiesRecoveryService(AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
+        public virtual Response<CapabilitiesResult> GetCapabilitiesRecoveryService(AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
         {
-            using var scope = RecoveryServicesClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.CapabilitiesRecoveryService");
+            using var scope = RecoveryServicesClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.GetCapabilitiesRecoveryService");
             scope.Start();
             try
             {

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResponseProperties.Serialization.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResponseProperties.Serialization.cs
@@ -31,7 +31,7 @@ namespace Azure.ResourceManager.RecoveryServices.Models
 
         internal static CapabilitiesResponseProperties DeserializeCapabilitiesResponseProperties(JsonElement element)
         {
-            Optional<IList<DnsZoneResponse>> dnsZones = default;
+            Optional<IList<DnsZoneResult>> dnsZones = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("dnsZones"))
@@ -41,10 +41,10 @@ namespace Azure.ResourceManager.RecoveryServices.Models
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    List<DnsZoneResponse> array = new List<DnsZoneResponse>();
+                    List<DnsZoneResult> array = new List<DnsZoneResult>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DnsZoneResponse.DeserializeDnsZoneResponse(item));
+                        array.Add(DnsZoneResult.DeserializeDnsZoneResult(item));
                     }
                     dnsZones = array;
                     continue;

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResponseProperties.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResponseProperties.cs
@@ -16,17 +16,17 @@ namespace Azure.ResourceManager.RecoveryServices.Models
         /// <summary> Initializes a new instance of CapabilitiesResponseProperties. </summary>
         public CapabilitiesResponseProperties()
         {
-            DnsZones = new ChangeTrackingList<DnsZoneResponse>();
+            DnsZones = new ChangeTrackingList<DnsZoneResult>();
         }
 
         /// <summary> Initializes a new instance of CapabilitiesResponseProperties. </summary>
         /// <param name="dnsZones"></param>
-        internal CapabilitiesResponseProperties(IList<DnsZoneResponse> dnsZones)
+        internal CapabilitiesResponseProperties(IList<DnsZoneResult> dnsZones)
         {
             DnsZones = dnsZones;
         }
 
         /// <summary> Gets the dns zones. </summary>
-        public IList<DnsZoneResponse> DnsZones { get; }
+        public IList<DnsZoneResult> DnsZones { get; }
     }
 }

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResult.Serialization.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResult.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.RecoveryServices.Models
 {
-    public partial class CapabilitiesResponse : IUtf8JsonSerializable
+    public partial class CapabilitiesResult : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.RecoveryServices.Models
             writer.WriteEndObject();
         }
 
-        internal static CapabilitiesResponse DeserializeCapabilitiesResponse(JsonElement element)
+        internal static CapabilitiesResult DeserializeCapabilitiesResult(JsonElement element)
         {
             Optional<CapabilitiesResponseProperties> properties = default;
             string type = default;
@@ -47,7 +47,7 @@ namespace Azure.ResourceManager.RecoveryServices.Models
                     continue;
                 }
             }
-            return new CapabilitiesResponse(type, properties.Value);
+            return new CapabilitiesResult(type, properties.Value);
         }
     }
 }

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResult.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResult.cs
@@ -12,21 +12,21 @@ using Azure.Core;
 namespace Azure.ResourceManager.RecoveryServices.Models
 {
     /// <summary> Capabilities response for Microsoft.RecoveryServices. </summary>
-    public partial class CapabilitiesResponse : ResourceCapabilitiesBase
+    public partial class CapabilitiesResult : ResourceCapabilitiesBase
     {
-        /// <summary> Initializes a new instance of CapabilitiesResponse. </summary>
+        /// <summary> Initializes a new instance of CapabilitiesResult. </summary>
         /// <param name="resourceCapabilitiesBaseType"> Describes the Resource type: Microsoft.RecoveryServices/Vaults. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceCapabilitiesBaseType"/> is null. </exception>
-        public CapabilitiesResponse(string resourceCapabilitiesBaseType) : base(resourceCapabilitiesBaseType)
+        public CapabilitiesResult(string resourceCapabilitiesBaseType) : base(resourceCapabilitiesBaseType)
         {
             Argument.AssertNotNull(resourceCapabilitiesBaseType, nameof(resourceCapabilitiesBaseType));
         }
 
-        /// <summary> Initializes a new instance of CapabilitiesResponse. </summary>
+        /// <summary> Initializes a new instance of CapabilitiesResult. </summary>
         /// <param name="resourceCapabilitiesBaseType"> Describes the Resource type: Microsoft.RecoveryServices/Vaults. </param>
         /// <param name="properties"> Capabilities properties in response. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceCapabilitiesBaseType"/> is null. </exception>
-        internal CapabilitiesResponse(string resourceCapabilitiesBaseType, CapabilitiesResponseProperties properties) : base(resourceCapabilitiesBaseType)
+        internal CapabilitiesResult(string resourceCapabilitiesBaseType, CapabilitiesResponseProperties properties) : base(resourceCapabilitiesBaseType)
         {
             Argument.AssertNotNull(resourceCapabilitiesBaseType, nameof(resourceCapabilitiesBaseType));
 

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResult.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/CapabilitiesResult.cs
@@ -36,7 +36,7 @@ namespace Azure.ResourceManager.RecoveryServices.Models
         /// <summary> Capabilities properties in response. </summary>
         internal CapabilitiesResponseProperties Properties { get; set; }
         /// <summary> Gets the capabilities response dns zones. </summary>
-        public IList<DnsZoneResponse> CapabilitiesResponseDnsZones
+        public IList<DnsZoneResult> CapabilitiesResponseDnsZones
         {
             get
             {

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/DnsZoneResult.Serialization.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/DnsZoneResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.RecoveryServices.Models
 {
-    public partial class DnsZoneResponse : IUtf8JsonSerializable
+    public partial class DnsZoneResult : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.RecoveryServices.Models
             writer.WriteEndObject();
         }
 
-        internal static DnsZoneResponse DeserializeDnsZoneResponse(JsonElement element)
+        internal static DnsZoneResult DeserializeDnsZoneResult(JsonElement element)
         {
             Optional<IList<string>> requiredZoneNames = default;
             Optional<VaultSubResourceType> subResource = default;
@@ -66,7 +66,7 @@ namespace Azure.ResourceManager.RecoveryServices.Models
                     continue;
                 }
             }
-            return new DnsZoneResponse(Optional.ToNullable(subResource), Optional.ToList(requiredZoneNames));
+            return new DnsZoneResult(Optional.ToNullable(subResource), Optional.ToList(requiredZoneNames));
         }
     }
 }

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/DnsZoneResult.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/Models/DnsZoneResult.cs
@@ -11,18 +11,18 @@ using Azure.Core;
 namespace Azure.ResourceManager.RecoveryServices.Models
 {
     /// <summary> DNSZone information for Microsoft.RecoveryServices. </summary>
-    public partial class DnsZoneResponse : DnsZone
+    public partial class DnsZoneResult : DnsZone
     {
-        /// <summary> Initializes a new instance of DnsZoneResponse. </summary>
-        public DnsZoneResponse()
+        /// <summary> Initializes a new instance of DnsZoneResult. </summary>
+        public DnsZoneResult()
         {
             RequiredZoneNames = new ChangeTrackingList<string>();
         }
 
-        /// <summary> Initializes a new instance of DnsZoneResponse. </summary>
+        /// <summary> Initializes a new instance of DnsZoneResult. </summary>
         /// <param name="subResource"> Subresource type for vault AzureBackup, AzureBackup_secondary or AzureSiteRecovery. </param>
         /// <param name="requiredZoneNames"> The private link resource Private link DNS zone names. </param>
-        internal DnsZoneResponse(VaultSubResourceType? subResource, IList<string> requiredZoneNames) : base(subResource)
+        internal DnsZoneResult(VaultSubResourceType? subResource, IList<string> requiredZoneNames) : base(subResource)
         {
             RequiredZoneNames = requiredZoneNames;
         }

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/RestOperations/RecoveryServicesRestOperations.cs
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/Generated/RestOperations/RecoveryServicesRestOperations.cs
@@ -160,7 +160,7 @@ namespace Azure.ResourceManager.RecoveryServices
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/> or <paramref name="input"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="subscriptionId"/> is an empty string, and was expected to be non-empty. </exception>
-        public async Task<Response<CapabilitiesResponse>> CapabilitiesAsync(string subscriptionId, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
+        public async Task<Response<CapabilitiesResult>> CapabilitiesAsync(string subscriptionId, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(subscriptionId, nameof(subscriptionId));
             Argument.AssertNotNull(input, nameof(input));
@@ -171,9 +171,9 @@ namespace Azure.ResourceManager.RecoveryServices
             {
                 case 200:
                     {
-                        CapabilitiesResponse value = default;
+                        CapabilitiesResult value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        value = CapabilitiesResponse.DeserializeCapabilitiesResponse(document.RootElement);
+                        value = CapabilitiesResult.DeserializeCapabilitiesResult(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -188,7 +188,7 @@ namespace Azure.ResourceManager.RecoveryServices
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/> or <paramref name="input"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="subscriptionId"/> is an empty string, and was expected to be non-empty. </exception>
-        public Response<CapabilitiesResponse> Capabilities(string subscriptionId, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
+        public Response<CapabilitiesResult> Capabilities(string subscriptionId, AzureLocation location, ResourceCapabilities input, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(subscriptionId, nameof(subscriptionId));
             Argument.AssertNotNull(input, nameof(input));
@@ -199,9 +199,9 @@ namespace Azure.ResourceManager.RecoveryServices
             {
                 case 200:
                     {
-                        CapabilitiesResponse value = default;
+                        CapabilitiesResult value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        value = CapabilitiesResponse.DeserializeCapabilitiesResponse(document.RootElement);
+                        value = CapabilitiesResult.DeserializeCapabilitiesResult(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/autorest.md
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/autorest.md
@@ -46,6 +46,13 @@ rename-rules:
   URI: Uri
   Etag: ETag|etag
 
+override-operation-name:
+  RecoveryServices_Capabilities: GetCapabilitiesRecoveryService
+
+rename-mapping:
+  DnsZoneResponse: DnsZoneResult
+  CapabilitiesResponse: CapabilitiesResult
+
 directive:
   - remove-operation: GetOperationStatus
   - remove-operation: GetOperationResult

--- a/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/autorest.md
+++ b/sdk/recoveryservices/Azure.ResourceManager.RecoveryServices/src/autorest.md
@@ -50,7 +50,7 @@ override-operation-name:
   RecoveryServices_Capabilities: GetCapabilitiesRecoveryService
 
 rename-mapping:
-  DnsZoneResponse: DnsZoneResult
+  DNSZoneResponse: DnsZoneResult
   CapabilitiesResponse: CapabilitiesResult
 
 directive:


### PR DESCRIPTION
Updated ChangeLog for stable SDK release 
Renamed OprationId from RecoveryServices_Capabilities to GetCapabilitiesRecoveryService
Renamed CapabilitiesResponse to CapabilitiesResult
Added rename mapping for DnsZoneResponse to DnsZoneResult

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
