### PR TITLE
[Smoke Tests] Ignore Known Incompatible Packages

### DIFF
--- a/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
+++ b/common/SmokeTests/SmokeTest/Update-Dependencies.ps1
@@ -12,7 +12,7 @@ param(
 # packages do not target netstandard2.0, and the package source is unable to
 # filter upstream to restrict to the appropriate packages for the running target.
 
-$packageExcludeSet = [System.Collections.Generic.HashSet[string]]@(
+$packageExcludeSet = @(
     "Microsoft.Azure.WebPubSub.AspNetCore"
 )
 
@@ -76,7 +76,7 @@ Log-Info "Querying package information."
 $referenceUpdateCount = 0
 
 Get-SmokeTestPkgProperties -ArtifactsPath $ArtifactsPath
-| Where-Object { -not $packageExcludeSet.Contains($_.Name) }
+| Where-Object { $packageExcludeSet -notcontains $_.Name }
 | Foreach-Object { $referenceUpdateCount += AddPackageReference $csproj $referenceNode $_ }
 
 # Save the project and report the outcome.  If no refrences were added, consider this


### PR DESCRIPTION
# Summary

The focus of these changes is to define a set that contains the list of packages which should not be included as references to the smoke tests. This is necessary because some compatibility packages do not target `netstandard2.0`, and the package source is unable to filter upstream to restrict to the appropriate packages for the running target.

# References and Related

- [Example pipeline failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2165670&view=logs&j=3a441aab-9de4-504b-b9a2-4be57a5928c9&t=e498f9c1-7696-590c-95d2-e75523098f78)