### PR TITLE
Renaming participantsRawId for MediaStreaming

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/MediaStreaming/MediaStreamingAudioDataInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/MediaStreaming/MediaStreamingAudioDataInternal.cs
@@ -26,7 +26,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// Participant ID.
         /// </summary>
-        [JsonPropertyName("participantRawId")]
+        [JsonPropertyName("participantRawID")]
         public string ParticipantRawId { get; set; }
         /// <summary>
         /// Indicates if the received audio buffer contains only silence.

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/MediaStreaming/CallAutomationStreamingParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/MediaStreaming/CallAutomationStreamingParserTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
                 + "\"audioData\": {"
                 + "\"data\": \"AQIDBAU=\","      // [1, 2, 3, 4, 5]
                 + "\"timestamp\": \"2022-08-23T11:48:05Z\","
-                + "\"participantRawId\": \"participantId\","
+                + "\"participantRawID\": \"participantId\","
                 + "\"silent\": false"
                 + "}"
                 + "}";
@@ -53,7 +53,7 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             jsonData["audioData"] = new JObject();
             jsonData["audioData"]["data"] = "AQIDBAU=";
             jsonData["audioData"]["timestamp"] = "2022-08-23T11:48:05Z";
-            jsonData["audioData"]["participantRawId"] = "participantId";
+            jsonData["audioData"]["participantRawID"] = "participantId";
             jsonData["audioData"]["silent"] = false;
 
             var binaryData = BinaryData.FromString(jsonData.ToString());
@@ -70,7 +70,7 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             jsonData["audioData"] = new JObject();
             jsonData["audioData"]["data"] = "AQIDBAU=";
             jsonData["audioData"]["timestamp"] = "2022-08-23T11:48:05Z";
-            jsonData["audioData"]["participantRawId"] = "participantId";
+            jsonData["audioData"]["participantRawID"] = "participantId";
             jsonData["audioData"]["silent"] = false;
 
             byte[] receivedBytes = System.Text.Encoding.UTF8.GetBytes(jsonData.ToString());


### PR DESCRIPTION
Matching the right name from backend.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
