### PR TITLE
use `GenerateTests` instead of `GenerateTest` in autorest

### DIFF
--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -90,7 +90,7 @@ try {
 
         Write-Host "Re-generating tests"
         Invoke-Block {
-            & dotnet msbuild $PSScriptRoot/../service.proj /restore /t:GenerateTest /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory
+            & dotnet msbuild $PSScriptRoot/../service.proj /restore /t:GenerateTests /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory
         }
     }
 
@@ -180,7 +180,7 @@ try {
     run 'eng\scripts\Update-Snippets.ps1' if you modified sample snippets or other *.md files (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#updating-sample-snippets), `
     run 'eng\scripts\Export-API.ps1' if you changed public APIs (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#public-api-additions). `
     run 'dotnet build /t:GenerateCode' to update the generated code.`
-    run 'dotnet build /t:GenerateTest' to update the generated test code.`
+    run 'dotnet build /t:GenerateTests' to update the generated test code.`
     `
 To reproduce this error locally, run 'eng\scripts\CodeChecks.ps1 -ServiceDirectory $ServiceDirectory'."
         }

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -90,7 +90,7 @@ try {
 
         Write-Host "Re-generating tests"
         Invoke-Block {
-            & dotnet msbuild $PSScriptRoot/../service.proj /restore /t:GenerateTests /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory
+            & dotnet msbuild $PSScriptRoot/../service.proj /restore /t:GenerateTest /p:SDKType=$SDKType /p:ServiceDirectory=$ServiceDirectory
         }
     }
 

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -52,9 +52,9 @@
              SkipNonexistentTargets="true" />
   </Target>
 
-  <Target Name="GenerateTest">
+  <Target Name="GenerateTests">
     <MSBuild Projects="@(ProjectReference)"
-             Targets="GenerateTest"
+             Targets="GenerateTests"
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="false"
              SkipNonexistentTargets="true" />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -52,7 +52,7 @@
              SkipNonexistentTargets="true" />
   </Target>
 
-  <Target Name="GenerateTests">
+  <Target Name="GenerateTest">
     <MSBuild Projects="@(ProjectReference)"
              Targets="GenerateTest"
              BuildInParallel="$(BuildInParallel)"


### PR DESCRIPTION
We currently have target `GenerateTests` in service.proj which leverage `GenerateTest` in Autorest.csharp.
And we got some feedbacks saying that inconsistent names make some confusion.

Since we also have target `GenerateCode` in service.proj which leverage `GenerateCode` in Autorest.csharp, I think we can also use singular name for test generation?