### PR TITLE
AVS ScriptExecutionData.ScriptCmdletId not a ResourceIdentifier

### DIFF
--- a/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
+++ b/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.2.0-beta.1 (Unreleased)
 
+### Breaking Changes
+
+Polishing since last public beta release:
+- Corrected the format of `ScriptExecutionData.ScriptCmdletId` property. It is not a `ResourceIdentifier`.
+
 ### Features Added
 
 ### Breaking Changes

--- a/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
+++ b/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Breaking Changes
 
-Polishing since last public beta release:
 - Corrected the format of `ScriptExecutionData.ScriptCmdletId` property. It is not a `ResourceIdentifier`.
 
 ### Features Added

--- a/sdk/avs/Azure.ResourceManager.Avs/src/Generated/Models/ScriptExecutionData.Serialization.cs
+++ b/sdk/avs/Azure.ResourceManager.Avs/src/Generated/Models/ScriptExecutionData.Serialization.cs
@@ -90,7 +90,7 @@ namespace Azure.ResourceManager.Avs
             string name = default;
             ResourceType type = default;
             Optional<SystemData> systemData = default;
-            Optional<ResourceIdentifier> scriptCmdletId = default;
+            Optional<string> scriptCmdletId = default;
             Optional<IList<ScriptExecutionParameterDetails>> parameters = default;
             Optional<IList<ScriptExecutionParameterDetails>> hiddenParameters = default;
             Optional<string> failureReason = default;
@@ -143,12 +143,7 @@ namespace Azure.ResourceManager.Avs
                     {
                         if (property0.NameEquals("scriptCmdletId"))
                         {
-                            if (property0.Value.ValueKind == JsonValueKind.Null)
-                            {
-                                property0.ThrowNonNullablePropertyIsNull();
-                                continue;
-                            }
-                            scriptCmdletId = new ResourceIdentifier(property0.Value.GetString());
+                            scriptCmdletId = property0.Value.GetString();
                             continue;
                         }
                         if (property0.NameEquals("parameters"))

--- a/sdk/avs/Azure.ResourceManager.Avs/src/Generated/ScriptExecutionData.cs
+++ b/sdk/avs/Azure.ResourceManager.Avs/src/Generated/ScriptExecutionData.cs
@@ -55,7 +55,7 @@ namespace Azure.ResourceManager.Avs
         /// <param name="information"> Standard information out stream from the powershell execution. </param>
         /// <param name="warnings"> Standard warning out stream from the powershell execution. </param>
         /// <param name="errors"> Standard error output stream from the powershell execution. </param>
-        internal ScriptExecutionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, ResourceIdentifier scriptCmdletId, IList<ScriptExecutionParameterDetails> parameters, IList<ScriptExecutionParameterDetails> hiddenParameters, string failureReason, string timeout, string retention, DateTimeOffset? submittedOn, DateTimeOffset? startedOn, DateTimeOffset? finishedOn, ScriptExecutionProvisioningState? provisioningState, IList<string> output, BinaryData namedOutputs, IReadOnlyList<string> information, IReadOnlyList<string> warnings, IReadOnlyList<string> errors) : base(id, name, resourceType, systemData)
+        internal ScriptExecutionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string scriptCmdletId, IList<ScriptExecutionParameterDetails> parameters, IList<ScriptExecutionParameterDetails> hiddenParameters, string failureReason, string timeout, string retention, DateTimeOffset? submittedOn, DateTimeOffset? startedOn, DateTimeOffset? finishedOn, ScriptExecutionProvisioningState? provisioningState, IList<string> output, BinaryData namedOutputs, IReadOnlyList<string> information, IReadOnlyList<string> warnings, IReadOnlyList<string> errors) : base(id, name, resourceType, systemData)
         {
             ScriptCmdletId = scriptCmdletId;
             Parameters = parameters;
@@ -75,7 +75,7 @@ namespace Azure.ResourceManager.Avs
         }
 
         /// <summary> A reference to the script cmdlet resource if user is running a AVS script. </summary>
-        public ResourceIdentifier ScriptCmdletId { get; set; }
+        public string ScriptCmdletId { get; set; }
         /// <summary>
         /// Parameters the script will accept
         /// Please note <see cref="ScriptExecutionParameterDetails"/> is the base class. According to the scenario, a derived class of the base class might need to be assigned here, or this property needs to be casted to one of the possible derived classes.

--- a/sdk/avs/Azure.ResourceManager.Avs/src/autorest.md
+++ b/sdk/avs/Azure.ResourceManager.Avs/src/autorest.md
@@ -7,7 +7,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 azure-arm: true
 csharp: true
 library-name: Avs
-namespace: Azure.ResourceManager.Avs2
+namespace: Azure.ResourceManager.Avs
 require: https://github.com/Azure/azure-rest-api-specs/blob/2ecbe51762643c7f6b6c6d8dd604dd934a1cc808/specification/vmware/resource-manager/readme.md
 output-folder: $(this-folder)/Generated
 clear-output-folder: true

--- a/sdk/avs/Azure.ResourceManager.Avs/src/autorest.md
+++ b/sdk/avs/Azure.ResourceManager.Avs/src/autorest.md
@@ -7,7 +7,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 azure-arm: true
 csharp: true
 library-name: Avs
-namespace: Azure.ResourceManager.Avs
+namespace: Azure.ResourceManager.Avs2
 require: https://github.com/Azure/azure-rest-api-specs/blob/2ecbe51762643c7f6b6c6d8dd604dd934a1cc808/specification/vmware/resource-manager/readme.md
 output-folder: $(this-folder)/Generated
 clear-output-folder: true
@@ -72,7 +72,6 @@ rename-mapping:
   PSCredentialExecutionParameter: PSCredentialExecutionParameterDetails
   ScriptSecureStringExecutionParameter: ScriptSecureStringExecutionParameterDetails
   ScriptStringExecutionParameter: ScriptStringExecutionParameterDetails
-  ScriptExecution.properties.scriptCmdletId: -|arm-id
   VirtualMachine: AvsPrivateCloudClusterVirtualMachine
   WorkloadNetworkDnsService.properties.dnsServiceIp: -|ip-address
   DnsServiceLogLevelEnum: DnsServiceLogLevel


### PR DESCRIPTION
This is to address this [internal IcM](https://portal.microsofticm.com/imp/v3/incidents/details/365736253/home).