### PR TITLE
Fix issues when building Cognitive Language snippets

### DIFF
--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample10_ExportProject.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample10_ExportProject.cs
@@ -57,6 +57,9 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
 
             Assert.That(response.Status, Is.EqualTo(200));
             Assert.That(new Uri(resultUrl).Host, Is.EqualTo(client.Endpoint.Host));
+
+            // Prevent compiler errors when building with SNIPPET.
+            await Task.Yield();
         }
 
         [AsyncOnly]

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample2_Chat.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample2_Chat.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -15,15 +16,17 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
         public void Chat()
         {
             QuestionAnsweringClient client = Client;
-            KnowledgeBaseAnswer previousAnswer = QuestionAnsweringModelFactory.KnowledgeBaseAnswer(qnaId: 27);
+            AnswersResult answers = QuestionAnsweringModelFactory.AnswersResult(new[]
+            {
+                QuestionAnsweringModelFactory.KnowledgeBaseAnswer(qnaId: 27),
+            });
 
             #region Snippet:QuestionAnsweringClient_Chat
             string projectName = "{ProjectName}";
             string deploymentName = "{DeploymentName}";
-#if SNIPPET
             // Answers are ordered by their ConfidenceScore so assume the user choose the first answer below:
             KnowledgeBaseAnswer previousAnswer = answers.Answers.First();
-#else
+#if !SNIPPET
             projectName = TestEnvironment.ProjectName;
             deploymentName = TestEnvironment.DeploymentName;
 #endif
@@ -51,15 +54,17 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
         public async Task ChatAsync()
         {
             QuestionAnsweringClient client = Client;
-            KnowledgeBaseAnswer previousAnswer = QuestionAnsweringModelFactory.KnowledgeBaseAnswer(qnaId: 27);
+            AnswersResult answers = QuestionAnsweringModelFactory.AnswersResult(new[]
+            {
+                QuestionAnsweringModelFactory.KnowledgeBaseAnswer(qnaId: 27),
+            });
 
             #region Snippet:QuestionAnsweringClient_ChatAsync
             string projectName = "{ProjectName}";
             string deploymentName = "{DeploymentName}";
-#if SNIPPET
             // Answers are ordered by their ConfidenceScore so assume the user choose the first answer below:
             KnowledgeBaseAnswer previousAnswer = answers.Answers.First();
-#else
+#if !SNIPPET
             projectName = TestEnvironment.ProjectName;
             deploymentName = TestEnvironment.DeploymentName;
 #endif


### PR DESCRIPTION
Somehow some issues made it through the recent change I made to build
snippets by default. Clearly we weren't building snippets for CLU and
QA.
