### PR TITLE
Reacting to a missing participant Id

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/MediaStreaming/MediaStreamingAudioData.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/MediaStreaming/MediaStreamingAudioData.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Azure.Communication.CallAutomation
 {
@@ -16,7 +14,10 @@ namespace Azure.Communication.CallAutomation
         {
             Data = data;
             Timestamp = timestamp;
-            Participant = new CommunicationUserIdentifier(participantId);
+            if (participantId != null)
+            {
+                Participant = new CommunicationUserIdentifier(participantId);
+            }
             IsSilent = silent;
         }
 

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/MediaStreaming/CallAutomationStreamingParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/MediaStreaming/CallAutomationStreamingParserTests.cs
@@ -46,6 +46,21 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
         }
 
         [Test]
+        public void ParseAudio_NoParticipantIdSilent_Test()
+        {
+            string audioJson = "{"
+                + "\"kind\": \"AudioData\","
+                + "\"audioData\": {"
+                + "\"data\": \"AQIDBAU=\","      // [1, 2, 3, 4, 5]
+                + "\"timestamp\": \"2022-08-23T11:48:05Z\""
+                + "}"
+                + "}";
+
+            MediaStreamingAudioData streamingAudio = (MediaStreamingAudioData)MediaStreamingPackageParser.Parse(audioJson);
+            ValidateAudioDataNoParticipant(streamingAudio);
+        }
+
+        [Test]
         public void ParseBinaryData()
         {
             JObject jsonData = new JObject();
@@ -97,6 +112,14 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             Assert.AreEqual(2022, streamingAudio.Timestamp.Year);
             Assert.IsTrue(streamingAudio.Participant is CommunicationIdentifier);
             Assert.AreEqual("participantId", streamingAudio.Participant.RawId);
+            Assert.IsFalse(streamingAudio.IsSilent);
+        }
+        private static void ValidateAudioDataNoParticipant(MediaStreamingAudioData streamingAudio)
+        {
+            Assert.IsNotNull(streamingAudio);
+            Assert.AreEqual("AQIDBAU=", streamingAudio.Data);
+            Assert.AreEqual(2022, streamingAudio.Timestamp.Year);
+            Assert.IsNull(streamingAudio.Participant);
             Assert.IsFalse(streamingAudio.IsSilent);
         }
     }


### PR DESCRIPTION
Fixing the case when participantId is not being provided for Media Streaming packets.
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
