### PR TITLE
[AzureMonitorExporter] cleanup nullable in Exporter classes and Transmitter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Threading;
 using Azure.Core;
@@ -18,10 +16,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
-        private readonly AzureMonitorPersistentStorage _persistentStorage;
-        private AzureMonitorResource _resource;
+        private readonly AzureMonitorPersistentStorage? _persistentStorage;
+        private AzureMonitorResource? _resource;
 
-        public AzureMonitorLogExporter(AzureMonitorExporterOptions options, TokenCredential credential = null) : this(new AzureMonitorTransmitter(options, credential))
+        public AzureMonitorLogExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(new AzureMonitorTransmitter(options, credential))
         {
         }
 
@@ -34,9 +32,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
+            else
+            {
+                _persistentStorage = null;
+            }
         }
 
-        internal AzureMonitorResource LogResource => _resource ??= ParentProvider.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? LogResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<LogRecord> batch)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -32,10 +32,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
-            else
-            {
-                _persistentStorage = null;
-            }
         }
 
         internal AzureMonitorResource? LogResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -32,10 +32,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
-            else
-            {
-                _persistentStorage = null;
-            }
         }
 
         internal AzureMonitorResource? MetricResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Threading;
 using Azure.Core;
@@ -18,10 +16,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
-        private readonly AzureMonitorPersistentStorage _persistentStorage;
-        private AzureMonitorResource _resource;
+        private readonly AzureMonitorPersistentStorage? _persistentStorage;
+        private AzureMonitorResource? _resource;
 
-        public AzureMonitorMetricExporter(AzureMonitorExporterOptions options, TokenCredential credential = null) : this(new AzureMonitorTransmitter(options, credential))
+        public AzureMonitorMetricExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(new AzureMonitorTransmitter(options, credential))
         {
         }
 
@@ -34,9 +32,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
+            else
+            {
+                _persistentStorage = null;
+            }
         }
 
-        internal AzureMonitorResource MetricResource => _resource ??= ParentProvider.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? MetricResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Metric> batch)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -32,10 +32,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
-            else
-            {
-                _persistentStorage = null;
-            }
         }
 
         internal AzureMonitorResource? TraceResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Diagnostics;
 using System.Threading;
@@ -18,10 +16,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
-        private readonly AzureMonitorPersistentStorage _persistentStorage;
-        private AzureMonitorResource _resource;
+        private readonly AzureMonitorPersistentStorage? _persistentStorage;
+        private AzureMonitorResource? _resource;
 
-        public AzureMonitorTraceExporter(AzureMonitorExporterOptions options, TokenCredential credential = null) : this(new AzureMonitorTransmitter(options, credential))
+        public AzureMonitorTraceExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(new AzureMonitorTransmitter(options, credential))
         {
         }
 
@@ -34,9 +32,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 _persistentStorage = new AzureMonitorPersistentStorage(transmitter);
             }
+            else
+            {
+                _persistentStorage = null;
+            }
         }
 
-        internal AzureMonitorResource TraceResource => _resource ??= ParentProvider.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? TraceResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Activity> batch)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -90,13 +90,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             SetResourceSdkVersionAndIkey(resource, instrumentationKey);
         }
 
-        public TelemetryItem(DateTime time, AzureMonitorResource resource, string instrumentationKey) : this("Metric", FormatUtcTimestamp(time))
+        public TelemetryItem(DateTime time, AzureMonitorResource? resource, string instrumentationKey) : this("Metric", FormatUtcTimestamp(time))
         {
             SetResourceSdkVersionAndIkey(resource, instrumentationKey);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetResourceSdkVersionAndIkey(AzureMonitorResource resource, string instrumentationKey)
+        private void SetResourceSdkVersionAndIkey(AzureMonitorResource? resource, string instrumentationKey)
         {
             InstrumentationKey = instrumentationKey;
             Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
@@ -21,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
         /// <exception cref="InvalidOperationException">
         /// Any exceptions that occur while parsing the connection string will be wrapped and re-thrown.
         /// </exception>
-        public static ConnectionVars GetValues(string connectionString)
+        public static ConnectionVars GetValues(string? connectionString)
         {
             try
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
@@ -14,7 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         private const int Version = 2;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorMetrics(Batch<Metric> batch, AzureMonitorResource resource, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorMetrics(Batch<Metric> batch, AzureMonitorResource? resource, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new();
             foreach (var metric in batch)


### PR DESCRIPTION
Towards #34013

## Changes
- remove `#nullable disable` in Exporter classes and resolve issues
- remove `#nullable disable` in Transmitter class and resolve issues


### Notes
The biggest change here is that the `AzureMonitorResource` in the `Exporter` could be null.
This is provided to the `TelemetryItem` constructor which is eventually used to set Tags.
The Tags were already checking for null so I think this change is safe.
https://github.com/Azure/azure-sdk-for-net/blob/b6eb01b26613b30808eddb5a26402613e03b714e/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs#L99-L102
