### PR TITLE
make repeatabilityHeaders internal and generated automatically

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/README.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/README.md
@@ -113,41 +113,6 @@ Your app will receive mid-connection call back events via the callbackEndpoint y
         return Ok();
     }
 ```
-### Idempotent Requests
-An operation is idempotent if it can be performed multiple times and have the same result as a single execution.
-
-The following operations are idempotent:
-- `AnswerCall`
-- `RedirectCall`
-- `RejectCall`
-- `CreateCall`
-- `HangUp` when terminating the call for everyone, ie. `forEveryone` parameter is set to `true`.
-- `TransferCallToParticipant`
-- `AddParticipants`
-- `RemoveParticipants`
-- `StartRecording`
-
-By default, SDK generates a new `RepeatabilityHeaders` object every time the above operation is called. If you would
-like to provide your own `RepeatabilityHeaders` for your application (eg. for your own retry mechanism), you can do so by specifying
-the `RepeatabilityHeaders` in the operation's `Options` object. If this is not set by user, then the SDK will generate
-it. You can also disable this by setting `RepeatabilityHeaders` to NULL in the option.
-
-The parameters for the `RepeatabilityHeaders` class are `repeatabilityRequestId` and `repeatabilityFirstSent`. Two or
-more requests are considered the same request **if and only if** both repeatability parameters are the same.
-- `repeatabilityRequestId`: an opaque string representing a client-generated unique identifier for the request.
-It is a version 4 (random) UUID.
-- `repeatabilityFirstSent`: The value should be the date and time at which the request was **first** created.
-
-To set repeatability parameters, see below C# code snippet as an example:
-```C#
-var createCallOptions = new CreateCallOptions(callSource, new CommunicationIdentifier[] { target }, new Uri("https://exmaple.com/callback")) {
-    RepeatabilityHeaders = new RepeatabilityHeaders(Guid.NewGuid(), DateTimeOffset.UtcNow);
-};
-CreateCallResult response1 = await callAutomationClient.CreateCallAsync(createCallOptions).ConfigureAwait(false);
-await Task.Delay(5000);
-CreateCallResult response2 = await callAutomationClient.CreateCallAsync(createCallOptions).ConfigureAwait(false);
-// response1 and response2 will have the same CallConnectionId as they have the same reapeatability parameters which means that the CreateCall operation was only executed once.
-```
 
 ## Troubleshooting
 A `RequestFailedException` is thrown as a service response for any unsuccessful requests. The exception contains information about what response code was returned from the service.

--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -18,7 +18,6 @@ namespace Azure.Communication.CallAutomation
         public int? InvitationTimeoutInSeconds { get { throw null; } set { } }
         public string OperationContext { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> ParticipantsToAdd { get { throw null; } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } set { } }
         public Azure.Communication.PhoneNumberIdentifier SourceCallerId { get { throw null; } set { } }
         public string SourceDisplayName { get { throw null; } set { } }
@@ -50,7 +49,6 @@ namespace Azure.Communication.CallAutomation
         public System.Uri CallbackUri { get { throw null; } }
         public string IncomingCallContext { get { throw null; } }
         public Azure.Communication.CallAutomation.MediaStreamingOptions MediaStreamingOptions { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
     }
     public partial class AnswerCallResult : Azure.Communication.CallAutomation.ResultWithWaitForEventBase
     {
@@ -417,7 +415,6 @@ namespace Azure.Communication.CallAutomation
         public Azure.Communication.CallAutomation.CallSource CallSource { get { throw null; } }
         public Azure.Communication.CallAutomation.MediaStreamingOptions MediaStreamingOptions { get { throw null; } set { } }
         public string OperationContext { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
         public System.Collections.Generic.IReadOnlyList<Azure.Communication.CommunicationIdentifier> Targets { get { throw null; } }
     }
     public partial class CreateCallResult : Azure.Communication.CallAutomation.ResultWithWaitForEventBase
@@ -513,7 +510,6 @@ namespace Azure.Communication.CallAutomation
     {
         public HangUpOptions(bool forEveryone) { }
         public bool ForEveryone { get { throw null; } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MediaStreamingAudioChannel : System.IEquatable<Azure.Communication.CallAutomation.MediaStreamingAudioChannel>
@@ -619,7 +615,6 @@ namespace Azure.Communication.CallAutomation
     {
         public MuteParticipantsOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> targetParticipants) { }
         public string OperationContext { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> TargetParticipants { get { throw null; } }
     }
     public partial class MuteParticipantsResponse
@@ -855,7 +850,6 @@ namespace Azure.Communication.CallAutomation
     {
         public RedirectCallOptions(string incomingCallContext, Azure.Communication.CommunicationIdentifier target) { }
         public string IncomingCallContext { get { throw null; } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
         public Azure.Communication.CommunicationIdentifier Target { get { throw null; } }
     }
     public partial class RejectCallOptions
@@ -863,26 +857,17 @@ namespace Azure.Communication.CallAutomation
         public RejectCallOptions(string incomingCallContext) { }
         public Azure.Communication.CallAutomation.CallRejectReason CallRejectReason { get { throw null; } set { } }
         public string IncomingCallContext { get { throw null; } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
     }
     public partial class RemoveParticipantsOptions
     {
         public RemoveParticipantsOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> participantsToRemove) { }
         public string OperationContext { get { throw null; } set { } }
         public System.Collections.Generic.IReadOnlyList<Azure.Communication.CommunicationIdentifier> ParticipantsToRemove { get { throw null; } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
     }
     public partial class RemoveParticipantsResult
     {
         internal RemoveParticipantsResult() { }
         public string OperationContext { get { throw null; } }
-    }
-    public partial class RepeatabilityHeaders
-    {
-        public RepeatabilityHeaders() { }
-        public RepeatabilityHeaders(System.Guid repeatabilityRequestId, System.DateTimeOffset repeatabilityFirstSent) { }
-        public System.DateTimeOffset RepeatabilityFirstSent { get { throw null; } }
-        public System.Guid RepeatabilityRequestId { get { throw null; } }
     }
     public partial class ResultInformation
     {
@@ -923,7 +908,6 @@ namespace Azure.Communication.CallAutomation
         public Azure.Communication.CallAutomation.RecordingFormat RecordingFormat { get { throw null; } set { } }
         public System.Uri RecordingStateCallbackEndpoint { get { throw null; } set { } }
         public Azure.Communication.CallAutomation.RecordingStorageType? RecordingStorageType { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
     }
     public partial class TextSource : Azure.Communication.CallAutomation.PlaySource
     {
@@ -951,7 +935,6 @@ namespace Azure.Communication.CallAutomation
     {
         public TransferToParticipantOptions(Azure.Communication.CommunicationIdentifier targetParticipant) { }
         public string OperationContext { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
         public Azure.Communication.PhoneNumberIdentifier SourceCallerId { get { throw null; } set { } }
         public Azure.Communication.CommunicationIdentifier TargetParticipant { get { throw null; } }
         public string UserToUserInformation { get { throw null; } set { } }
@@ -960,7 +943,6 @@ namespace Azure.Communication.CallAutomation
     {
         public UnmuteParticipantsOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> targetParticipant) { }
         public string OperationContext { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.RepeatabilityHeaders RepeatabilityHeaders { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> TargetParticipants { get { throw null; } }
     }
     public partial class UnmuteParticipantsResponse

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallAutomationClient.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallAutomationClient.cs
@@ -140,12 +140,12 @@ namespace Azure.Communication.CallAutomation
                 if (options == null) throw new ArgumentNullException(nameof(options));
 
                 AnswerCallRequestInternal request = CreateAnswerCallRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var answerResponse = await AzureCommunicationServicesRestClient.AnswerCallAsync(request,
-                        options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                        options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
-                        cancellationToken)
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
+                    cancellationToken)
                     .ConfigureAwait(false);
 
                 var result = new AnswerCallResult(GetCallConnection(answerResponse.Value.CallConnectionId), new CallConnectionProperties(answerResponse.Value));
@@ -194,11 +194,11 @@ namespace Azure.Communication.CallAutomation
                 if (options == null) throw new ArgumentNullException(nameof(options));
 
                 AnswerCallRequestInternal request = CreateAnswerCallRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var answerResponse = AzureCommunicationServicesRestClient.AnswerCall(request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken);
 
                 var result = new AnswerCallResult(GetCallConnection(answerResponse.Value.CallConnectionId), new CallConnectionProperties(answerResponse.Value));
@@ -267,12 +267,12 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 RedirectCallRequestInternal request = new RedirectCallRequestInternal(options.IncomingCallContext, CommunicationIdentifierSerializer.Serialize(options.Target));
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 return await AzureCommunicationServicesRestClient.RedirectCallAsync(
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     ).ConfigureAwait(false);
             }
@@ -313,12 +313,12 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 RedirectCallRequestInternal request = new RedirectCallRequestInternal(options.IncomingCallContext, CommunicationIdentifierSerializer.Serialize(options.Target));
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 return AzureCommunicationServicesRestClient.RedirectCall(
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken);
             }
             catch (Exception ex)
@@ -357,12 +357,12 @@ namespace Azure.Communication.CallAutomation
 
                 RejectCallRequestInternal request = new RejectCallRequestInternal(options.IncomingCallContext);
                 request.CallRejectReason = options.CallRejectReason.ToString();
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 return await AzureCommunicationServicesRestClient.RejectCallAsync(
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     ).ConfigureAwait(false);
             }
@@ -402,12 +402,12 @@ namespace Azure.Communication.CallAutomation
 
                 RejectCallRequestInternal request = new RejectCallRequestInternal(options.IncomingCallContext);
                 request.CallRejectReason = options.CallRejectReason.ToString();
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 return AzureCommunicationServicesRestClient.RejectCall(
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     );
             }
@@ -438,12 +438,12 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 CreateCallRequestInternal request = CreateCallRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var createCallResponse = await AzureCommunicationServicesRestClient.CreateCallAsync(
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     ).ConfigureAwait(false);
 
@@ -482,12 +482,12 @@ namespace Azure.Communication.CallAutomation
                 if (options == null) throw new ArgumentNullException(nameof(options));
 
                 CreateCallRequestInternal request = CreateCallRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var createCallResponse = AzureCommunicationServicesRestClient.CreateCall(
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     );
 

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallConnection.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallConnection.cs
@@ -114,11 +114,11 @@ namespace Azure.Communication.CallAutomation
 
                 if (options.ForEveryone)
                 {
-                    options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                    var repeatabilityHeaders = new RepeatabilityHeaders();
                     return await RestClient.TerminateCallAsync(
                         CallConnectionId,
-                        options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                        options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                        repeatabilityHeaders.RepeatabilityRequestId,
+                        repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                         cancellationToken
                         ).ConfigureAwait(false);
                 }
@@ -165,11 +165,11 @@ namespace Azure.Communication.CallAutomation
 
                 if (options.ForEveryone)
                 {
-                    options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                    var repeatabilityHeaders = new RepeatabilityHeaders();
                     return RestClient.TerminateCall(
                         CallConnectionId,
-                        options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                        options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                        repeatabilityHeaders.RepeatabilityRequestId,
+                        repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                         cancellationToken
                         );
                 }
@@ -205,13 +205,13 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 TransferToParticipantRequestInternal request = CreateTransferToParticipantRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var response = await RestClient.TransferToParticipantAsync(
                     CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     ).ConfigureAwait(false);
 
@@ -244,13 +244,13 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 TransferToParticipantRequestInternal request = CreateTransferToParticipantRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var response = RestClient.TransferToParticipant(
                     CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     );
 
@@ -314,13 +314,13 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 AddParticipantsRequestInternal request = CreateAddParticipantRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var response = await RestClient.AddParticipantAsync(
                     callConnectionId: CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken: cancellationToken
                     ).ConfigureAwait(false);
 
@@ -353,13 +353,13 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 AddParticipantsRequestInternal request = CreateAddParticipantRequest(options);
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 var response = RestClient.AddParticipant(
                     callConnectionId: CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken: cancellationToken
                     );
 
@@ -553,7 +553,7 @@ namespace Azure.Communication.CallAutomation
                 Argument.AssertNotNullOrEmpty(options.ParticipantsToRemove, nameof(options.ParticipantsToRemove));
 
                 RemoveParticipantsRequestInternal request = new RemoveParticipantsRequestInternal(options.ParticipantsToRemove.Select(t => CommunicationIdentifierSerializer.Serialize(t)).ToList());
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
                 if (options.OperationContext != null && options.OperationContext.Length > CallAutomationConstants.InputValidation.StringMaxLength)
                 {
                     throw new ArgumentException(CallAutomationErrorMessages.OperationContextExceedsMaxLength);
@@ -566,8 +566,8 @@ namespace Azure.Communication.CallAutomation
                 return await RestClient.RemoveParticipantsAsync(
                     CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                     repeatabilityHeaders.RepeatabilityRequestId,
+                     repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken
                     ).ConfigureAwait(false);
             }
@@ -610,7 +610,7 @@ namespace Azure.Communication.CallAutomation
                     throw new ArgumentNullException(nameof(options));
 
                 RemoveParticipantsRequestInternal request = new RemoveParticipantsRequestInternal(options.ParticipantsToRemove.Select(t => CommunicationIdentifierSerializer.Serialize(t)).ToList());
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 if (options.OperationContext != null && options.OperationContext.Length > CallAutomationConstants.InputValidation.StringMaxLength)
                 {
@@ -624,8 +624,8 @@ namespace Azure.Communication.CallAutomation
                 return RestClient.RemoveParticipants(
                      CallConnectionId,
                      request,
-                     options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                     options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                     repeatabilityHeaders.RepeatabilityRequestId,
+                     repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                      cancellationToken
                      );
             }
@@ -688,7 +688,7 @@ namespace Azure.Communication.CallAutomation
 
                 MuteParticipantsRequestInternal request = new MuteParticipantsRequestInternal(
                     options.TargetParticipants.Select(participant => CommunicationIdentifierSerializer.Serialize(participant)));
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 if (options.OperationContext != null && options.OperationContext.Length > CallAutomationConstants.InputValidation.StringMaxLength)
                 {
@@ -702,8 +702,8 @@ namespace Azure.Communication.CallAutomation
                 return RestClient.Mute(
                     CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken);
             }
             catch (Exception ex)
@@ -745,7 +745,7 @@ namespace Azure.Communication.CallAutomation
             {
                 UnmuteParticipantsRequestInternal request = new UnmuteParticipantsRequestInternal(
                     options.TargetParticipants.Select(participant => CommunicationIdentifierSerializer.Serialize(participant)).ToList());
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
                 if (options.OperationContext != null && options.OperationContext.Length > CallAutomationConstants.InputValidation.StringMaxLength)
                 {
                     throw new ArgumentException(CallAutomationErrorMessages.OperationContextExceedsMaxLength);
@@ -758,8 +758,8 @@ namespace Azure.Communication.CallAutomation
                 return RestClient.Unmute(
                     CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken);
             }
             catch (Exception ex)
@@ -803,7 +803,7 @@ namespace Azure.Communication.CallAutomation
 
                 MuteParticipantsRequestInternal request = new MuteParticipantsRequestInternal(
                     options.TargetParticipants.Select(participant => CommunicationIdentifierSerializer.Serialize(participant)));
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 if (options.OperationContext != null && options.OperationContext.Length > CallAutomationConstants.InputValidation.StringMaxLength)
                 {
@@ -817,8 +817,8 @@ namespace Azure.Communication.CallAutomation
                 return await RestClient.MuteAsync(
                     CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -861,7 +861,7 @@ namespace Azure.Communication.CallAutomation
             {
                 UnmuteParticipantsRequestInternal request = new UnmuteParticipantsRequestInternal(
                     options.TargetParticipants.Select(participant => CommunicationIdentifierSerializer.Serialize(participant)).ToList());
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
                 if (options.OperationContext != null && options.OperationContext.Length > CallAutomationConstants.InputValidation.StringMaxLength)
                 {
                     throw new ArgumentException(CallAutomationErrorMessages.OperationContextExceedsMaxLength);
@@ -874,8 +874,8 @@ namespace Azure.Communication.CallAutomation
                 return await RestClient.UnmuteAsync(
                     CallConnectionId,
                     request,
-                    options.RepeatabilityHeaders.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallRecording.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallRecording.cs
@@ -74,10 +74,10 @@ namespace Azure.Communication.CallAutomation
                     }
                 };
 
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
                 return _callRecordingRestClient.StartRecording(request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken: cancellationToken);
             }
             catch (Exception ex)
@@ -119,10 +119,10 @@ namespace Azure.Communication.CallAutomation
                     }
                 };
 
-                options.RepeatabilityHeaders?.GenerateIfRepeatabilityHeadersNotProvided();
+                var repeatabilityHeaders = new RepeatabilityHeaders();
                 return await _callRecordingRestClient.StartRecordingAsync(request,
-                    options.RepeatabilityHeaders?.RepeatabilityRequestId,
-                    options.RepeatabilityHeaders?.GetRepeatabilityFirstSentString(),
+                    repeatabilityHeaders.RepeatabilityRequestId,
+                    repeatabilityHeaders.GetRepeatabilityFirstSentString(),
                     cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/AddParticipantsOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/AddParticipantsOptions.cs
@@ -18,7 +18,6 @@ namespace Azure.Communication.CallAutomation
         public AddParticipantsOptions(IEnumerable<CommunicationIdentifier> participantsToAdd)
         {
             ParticipantsToAdd = participantsToAdd;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -54,11 +53,6 @@ namespace Azure.Communication.CallAutomation
         /// The maximum value is 180 seconds.
         /// </summary>
         public int? InvitationTimeoutInSeconds { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
 
         /// <summary>
         /// Sip Headers, which is used to set custom context for pstn call

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/AnswerCallOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/AnswerCallOptions.cs
@@ -19,7 +19,6 @@ namespace Azure.Communication.CallAutomation
         {
             IncomingCallContext = incomingCallContext;
             CallbackUri = callbackUri;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -36,11 +35,6 @@ namespace Azure.Communication.CallAutomation
         /// Media Streaming Configuration.
         /// </summary>
         public MediaStreamingOptions MediaStreamingOptions { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
 
         /// <summary>
         /// The endpoint URL of the Azure Cognitive Services resource attached

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateCallOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateCallOptions.cs
@@ -23,7 +23,6 @@ namespace Azure.Communication.CallAutomation
             Targets = (IReadOnlyList<CommunicationIdentifier>)targets;
             CallSource = callSource;
             CallbackUri = callbackUri;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -50,11 +49,6 @@ namespace Azure.Communication.CallAutomation
         /// Media Streaming Configuration.
         /// </summary>
         public MediaStreamingOptions MediaStreamingOptions { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
 
         /// <summary>
         /// The endpoint URL of the Azure Cognitive Services resource attached

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/HangUpOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/HangUpOptions.cs
@@ -17,17 +17,11 @@ namespace Azure.Communication.CallAutomation
         public HangUpOptions(bool forEveryone)
         {
             ForEveryone = forEveryone;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
         /// If true, this will terminate the call and hang up on all participants in this call.
         /// </summary>
         public bool ForEveryone { get; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/MuteParticipantsOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/MuteParticipantsOptions.cs
@@ -16,7 +16,6 @@ namespace Azure.Communication.CallAutomation
         public MuteParticipantsOptions(IEnumerable<CommunicationIdentifier> targetParticipants)
         {
             TargetParticipants = targetParticipants;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -30,10 +29,5 @@ namespace Azure.Communication.CallAutomation
         /// The operation context.
         /// </summary>
         public string OperationContext { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/RedirectCallOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/RedirectCallOptions.cs
@@ -19,7 +19,6 @@ namespace Azure.Communication.CallAutomation
         {
             IncomingCallContext = incomingCallContext;
             Target = target;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -31,10 +30,5 @@ namespace Azure.Communication.CallAutomation
         /// The target identity.
         /// </summary>
         public CommunicationIdentifier Target { get; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/RejectCallOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/RejectCallOptions.cs
@@ -17,7 +17,6 @@ namespace Azure.Communication.CallAutomation
         public RejectCallOptions(string incomingCallContext)
         {
             IncomingCallContext = incomingCallContext;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -29,10 +28,5 @@ namespace Azure.Communication.CallAutomation
         /// The reason for rejecting call.
         /// </summary>
         public CallRejectReason CallRejectReason { get; set; } = CallRejectReason.None;
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/RemoveParticipantsOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/RemoveParticipantsOptions.cs
@@ -17,7 +17,6 @@ namespace Azure.Communication.CallAutomation
         public RemoveParticipantsOptions(IEnumerable<CommunicationIdentifier> participantsToRemove)
         {
             ParticipantsToRemove = (IReadOnlyList<CommunicationIdentifier>)participantsToRemove;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -29,10 +28,5 @@ namespace Azure.Communication.CallAutomation
         /// The operation context.
         /// </summary>
         public string OperationContext { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/RepeatabilityHeaders.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/RepeatabilityHeaders.cs
@@ -8,36 +8,17 @@ namespace Azure.Communication.CallAutomation
     /// <summary>
     /// The Repeatability Headers.
     /// </summary>
-    public class RepeatabilityHeaders
+    internal class RepeatabilityHeaders
     {
         /// <summary>
         /// The value of the Repeatability-Request-Id is an opaque string representing a client-generated unique identifier for the request. It is a version 4 (random) UUID.
         /// </summary>
-        public Guid RepeatabilityRequestId { get; private set;  }
+        public Guid RepeatabilityRequestId { get; }
 
         /// <summary>
-        /// The value should be the date and time at which the request was first created.
+        /// The value is the date and time at which the request was first created.
         /// </summary>
-        public DateTimeOffset RepeatabilityFirstSent { get; private set; }
-
-        /// <summary>
-        /// Let SDK provide repeatability headers. This is also the default behaviour if repeatability header is not provided. If you would like to exlucde repeataiblity headers in the request, pass the NULL value for RepeatabilityHeaders class.
-        /// </summary>
-        public RepeatabilityHeaders()
-        {
-            RepeatabilityRequestId = default;
-            RepeatabilityFirstSent = default;
-        }
-
-        /// <summary>
-        /// If specified, the client directs that the request is repeatable; that is, that the client can make the request multiple times with the same RepeatabilityHeaders and get back an appropriate response without the server executing the request multiple times.
-        /// </summary>
-        /// <param name="repeatabilityRequestId"> The value of the Repeatability-Request-Id is an opaque string representing a client-generated unique identifier for the request. It is a version 4 (random) UUID. </param>
-        /// <param name="repeatabilityFirstSent"> The value should be the date and time at which the request was first created.</param>
-        public RepeatabilityHeaders(Guid repeatabilityRequestId, DateTimeOffset repeatabilityFirstSent) {
-            RepeatabilityRequestId = repeatabilityRequestId;
-            RepeatabilityFirstSent = repeatabilityFirstSent;
-        }
+        public DateTimeOffset RepeatabilityFirstSent { get; }
 
         /// <summary>
         /// Function that returns RepeatabilityFirstSent in string format using the IMF-fixdate form of HTTP-date.
@@ -48,13 +29,10 @@ namespace Azure.Communication.CallAutomation
             return RepeatabilityFirstSent.ToString("R");
         }
 
-        internal void GenerateIfRepeatabilityHeadersNotProvided()
+        public RepeatabilityHeaders()
         {
-            if (RepeatabilityRequestId == default && RepeatabilityFirstSent == default)
-            {
-                RepeatabilityRequestId = Guid.NewGuid();
-                RepeatabilityFirstSent = DateTimeOffset.Now;
-            }
+            RepeatabilityRequestId = Guid.NewGuid();
+            RepeatabilityFirstSent = DateTimeOffset.Now;
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/StartRecordingOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/StartRecordingOptions.cs
@@ -18,7 +18,6 @@ namespace Azure.Communication.CallAutomation
         public StartRecordingOptions(CallLocator callLocator)
         {
             CallLocator = callLocator ?? throw new ArgumentNullException(nameof(callLocator));
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -45,11 +44,6 @@ namespace Azure.Communication.CallAutomation
         /// The recording format.
         /// </summary>
         public RecordingFormat RecordingFormat { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
 
         /// <summary>
         /// The sequential order in which audio channels are assigned to participants in the unmixed recording.

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/TransferToParticipantOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/TransferToParticipantOptions.cs
@@ -17,7 +17,6 @@ namespace Azure.Communication.CallAutomation
         public TransferToParticipantOptions(CommunicationIdentifier targetParticipant)
         {
             TargetParticipant = targetParticipant;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -39,10 +38,5 @@ namespace Azure.Communication.CallAutomation
         /// The operationContext for this transfer call.
         /// </summary>
         public string OperationContext { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/UnmuteParticipantsOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/UnmuteParticipantsOptions.cs
@@ -16,7 +16,6 @@ namespace Azure.Communication.CallAutomation
         public UnmuteParticipantsOptions(IEnumerable<CommunicationIdentifier> targetParticipant)
         {
             TargetParticipants = targetParticipant;
-            RepeatabilityHeaders = new RepeatabilityHeaders();
         }
 
         /// <summary>
@@ -30,10 +29,5 @@ namespace Azure.Communication.CallAutomation
         /// The operation context.
         /// </summary>
         public string OperationContext { get; set; }
-
-        /// <summary>
-        /// Repeatability Headers.
-        /// </summary>
-        public RepeatabilityHeaders RepeatabilityHeaders { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientAutomatedLiveTests.cs
@@ -41,7 +41,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                 // create call and assert response
                 var createCallOptions = new CreateCallOptions(new CallSource(user), new CommunicationIdentifier[] { target }, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
-                createCallOptions.RepeatabilityHeaders = null;
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 callConnectionId = response.CallConnectionProperties.CallConnectionId;
                 Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
@@ -52,7 +51,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
-                answerCallOptions.RepeatabilityHeaders = null;
                 AnswerCallResult answerResponse = await client.AnswerCallAsync(answerCallOptions);
 
                 // wait for callConnected
@@ -67,7 +65,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                 // try hangup
                 var hangUpOptions = new HangUpOptions(true);
-                hangUpOptions.RepeatabilityHeaders = null;
                 await response.CallConnection.HangUpAsync(hangUpOptions).ConfigureAwait(false);
                 var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
                 Assert.IsNotNull(disconnectedEvent);
@@ -111,7 +108,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                 var createCallOptions = new CreateCallOptions(new CallSource(user),
                     new CommunicationIdentifier[] { target },
                     new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
-                createCallOptions.RepeatabilityHeaders = null;
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 callConnectionId = response.CallConnectionProperties.CallConnectionId;
                 Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
@@ -122,7 +118,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                 // answer the call
                 var rejectCallOptions = new RejectCallOptions(incomingCallContext);
-                rejectCallOptions.RepeatabilityHeaders = null;
                 Response rejectResponse = await client.RejectCallAsync(rejectCallOptions);
 
                 // check reject response

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionAutomatedLiveTests.cs
@@ -41,7 +41,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                 // create call and assert response
                 var createCallOptions = new CreateCallOptions(new CallSource(user), new CommunicationIdentifier[] { target }, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
-                createCallOptions.RepeatabilityHeaders = null;
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 callConnectionId = response.CallConnectionProperties.CallConnectionId;
                 Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
@@ -52,7 +51,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
-                answerCallOptions.RepeatabilityHeaders = null;
                 AnswerCallResult answerResponse = await client.AnswerCallAsync(answerCallOptions);
 
                 // wait for callConnected
@@ -75,7 +73,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 var removeParticipantsOptions = new RemoveParticipantsOptions(new CommunicationIdentifier[] { target }) {
                     OperationContext = operationContext1,
                 };
-                removeParticipantsOptions.RepeatabilityHeaders = null;
                 Response<RemoveParticipantsResult> removePartResponse = await response.CallConnection.RemoveParticipantsAsync(removeParticipantsOptions);
                 Assert.IsTrue(!removePartResponse.GetRawResponse().IsError);
                 Assert.AreEqual(operationContext1, removePartResponse.Value.OperationContext);

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingAutomatedLiveTests.cs
@@ -32,7 +32,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
             // create call and assert response
             var createCallOptions = new CreateCallOptions(new CallSource(user), new CommunicationIdentifier[] { target }, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
-            createCallOptions.RepeatabilityHeaders = null;
             CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
             string callConnectionId = response.CallConnectionProperties.CallConnectionId;
             Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
@@ -43,7 +42,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
             // answer the call
             var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
-            answerCallOptions.RepeatabilityHeaders = null;
             var answerResponse = await client.AnswerCallAsync(answerCallOptions);
             Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
 
@@ -63,7 +61,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             StartRecordingOptions recordingOptions = new StartRecordingOptions(new ServerCallLocator(serverCallId))
             {
                 RecordingStateCallbackEndpoint = new Uri(TestEnvironment.DispatcherCallback),
-                RepeatabilityHeaders = null
             };
             var recordingResponse = await callRecording.StartRecordingAsync(recordingOptions).ConfigureAwait(false);
             Assert.NotNull(recordingResponse.Value);
@@ -142,7 +139,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
                 // create call and assert response
                 var createCallOptions = new CreateCallOptions(new CallSource(user), new CommunicationIdentifier[] { target }, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
-                createCallOptions.RepeatabilityHeaders = null;
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 callConnectionId = response.CallConnectionProperties.CallConnectionId;
                 Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
@@ -153,7 +149,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
-                answerCallOptions.RepeatabilityHeaders = null;
                 var answerResponse = await client.AnswerCallAsync(answerCallOptions);
                 Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
 
@@ -175,7 +170,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                         RecordingContent = RecordingContent.Audio,
                         RecordingFormat = RecordingFormat.Wav,
                         RecordingStateCallbackEndpoint = new Uri(TestEnvironment.DispatcherCallback),
-                        RepeatabilityHeaders = null
                     });
                 Assert.AreEqual(StatusCodes.Status200OK, startRecordingResponse.GetRawResponse().Status);
                 Assert.NotNull(startRecordingResponse.Value.RecordingId);
@@ -192,7 +186,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
                 // try hangup
                 var hangUpOptions = new HangUpOptions(true);
-                hangUpOptions.RepeatabilityHeaders = null;
                 await response.CallConnection.HangUpAsync(hangUpOptions).ConfigureAwait(false);
                 var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
                 Assert.IsNotNull(disconnectedEvent);
@@ -237,7 +230,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
                 // create call and assert response
                 var createCallOptions = new CreateCallOptions(new CallSource(user), new CommunicationIdentifier[] { target }, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
-                createCallOptions.RepeatabilityHeaders = null;
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 callConnectionId = response.CallConnectionProperties.CallConnectionId;
                 Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
@@ -248,7 +240,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
-                answerCallOptions.RepeatabilityHeaders = null;
                 var answerResponse = await client.AnswerCallAsync(answerCallOptions);
                 Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
 
@@ -270,7 +261,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                         RecordingContent = RecordingContent.Audio,
                         RecordingFormat = RecordingFormat.Wav,
                         RecordingStateCallbackEndpoint = new Uri(TestEnvironment.DispatcherCallback),
-                        RepeatabilityHeaders = null
                     };
                 startRecordingOptions.AudioChannelParticipantOrdering.Add(user);
                 startRecordingOptions.AudioChannelParticipantOrdering.Add(target);
@@ -290,7 +280,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 
                 // try hangup
                 var hangUpOptions = new HangUpOptions(true);
-                hangUpOptions.RepeatabilityHeaders = null;
                 await response.CallConnection.HangUpAsync(hangUpOptions).ConfigureAwait(false);
                 var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
                 Assert.IsNotNull(disconnectedEvent);

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationClientAutomatedLiveTestsBase.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationClientAutomatedLiveTestsBase.cs
@@ -43,6 +43,8 @@ namespace Azure.Communication.CallAutomation.Tests.Infrastructure
         {
             SanitizedHeaders.Add("x-ms-content-sha256");
             SanitizedHeaders.Add("X-FORWARDED-HOST");
+            SanitizedHeaders.Add("Repeatability-Request-ID");
+            SanitizedHeaders.Add("Repeatability-First-Sent");
             JsonPathSanitizers.Add("$..id");
             JsonPathSanitizers.Add("$..rawId");
             JsonPathSanitizers.Add("$..value");

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationClientAutomatedLiveTestsBase.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationClientAutomatedLiveTestsBase.cs
@@ -195,7 +195,6 @@ namespace Azure.Communication.CallAutomation.Tests.Infrastructure
                         using (Recording.DisableRecording())
                         {
                             var hangUpOptions = new HangUpOptions(true);
-                            hangUpOptions.RepeatabilityHeaders = null;
                             await client.GetCallConnection(callConnectionId).HangUpAsync(hangUpOptions).ConfigureAwait(false);
                         }
                     }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationClientLiveTestsBase.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationClientLiveTestsBase.cs
@@ -17,6 +17,8 @@ namespace Azure.Communication.CallAutomation.Tests.Infrastructure
         {
             SanitizedHeaders.Add("x-ms-content-sha256");
             SanitizedHeaders.Add("X-FORWARDED-HOST");
+            SanitizedHeaders.Add("Repeatability-Request-ID");
+            SanitizedHeaders.Add("Repeatability-First-Sent");
             JsonPathSanitizers.Add("$..id");
             JsonPathSanitizers.Add("$..rawId");
             JsonPathSanitizers.Add("$..value");

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Misc/RepeatabilityHeadersTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Misc/RepeatabilityHeadersTests.cs
@@ -9,20 +9,14 @@ namespace Azure.Communication.CallAutomation.Tests.Misc
     public class RepeatabilityHeadersTests
     {
         [Test]
-        public void RepeatablityHeaders_IsNotOverwrittenByDefaultIfSet()
+        public void RepeatablityHeaders_IsSetInConstructor()
         {
-            // arrange
-            var repeatablityRequestId = Guid.NewGuid();
-            var repeatabilityFirstSent = DateTime.UtcNow;
-            // arrange
-            var options = new AnswerCallOptions("context", new Uri("https://contoso.com/callback"))
-            {
-                RepeatabilityHeaders = new RepeatabilityHeaders(repeatablityRequestId, repeatabilityFirstSent)
-            };
+            // arrange & act
+            var repeatabilityHeaders = new RepeatabilityHeaders();
 
-            // act & assert
-            Assert.AreEqual(repeatablityRequestId, options.RepeatabilityHeaders.RepeatabilityRequestId);
-            Assert.AreEqual(repeatabilityFirstSent.ToString("R"), options.RepeatabilityHeaders.GetRepeatabilityFirstSentString());
+            // assert
+            Assert.IsNotNull(repeatabilityHeaders.RepeatabilityFirstSent);
+            Assert.IsNotNull(repeatabilityHeaders.RepeatabilityRequestId);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallAndReject.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallAndReject.json
@@ -98,18 +98,20 @@
     {
       "RequestUri": "https://sanitized.skype.com/calling/callConnections?api-version=2023-01-15-preview",
       "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "254",
-        "Content-Type": "application/json",
-        "traceparent": "00-c39b668924326c532abb7ae23c99973e-c9bd5483da0a901a-00",
-        "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "f48c489060074507e4efc2f3e1c60915",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Tue, 31 Jan 2023 00:06:10 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
+        "RequestHeaders": {
+            "Accept": "application/json",
+            "Authorization": "Sanitized",
+            "Repeatability-Request-ID": "Sanitized",
+            "Repeatability-First-Sent": "Sanitized",
+            "Content-Length": "254",
+            "Content-Type": "application/json",
+            "traceparent": "00-c39b668924326c532abb7ae23c99973e-c9bd5483da0a901a-00",
+            "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
+            "x-ms-client-request-id": "f48c489060074507e4efc2f3e1c60915",
+            "x-ms-content-sha256": "Sanitized",
+            "x-ms-date": "Tue, 31 Jan 2023 00:06:10 GMT",
+            "x-ms-return-client-request-id": "true"
+        },
       "RequestBody": {
         "targets": [
           {
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7856",
         "Content-Type": "application/json",
         "traceparent": "00-7d5b916c2e273897dc47d95c618c0b8e-a9bae005d2dad380-00",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallAndRejectAsync.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallAndRejectAsync.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-3fac3ce9658afef41ba5dbef941c8d2e-0a55e52763d3d5a7-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7845",
         "Content-Type": "application/json",
         "traceparent": "00-817c75ad6eb386094e3a75dd58da80dc-7baacef265304fc3-00",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallToACSGetCallAndHangUpCallTest.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallToACSGetCallAndHangUpCallTest.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-05fb32527aefd3cc3a32d90f0b8739ba-2712767253d03e4d-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7914",
         "Content-Type": "application/json",
         "traceparent": "00-474c320350377c85f622b077fdeb6dc9-e1b6b69aa1a6bbf4-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "0",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "07cab38c29ffcb9aea52d85ad5a4a13c",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallToACSGetCallAndHangUpCallTestAsync.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallAutomationClientAutomatedLiveTests/CreateCallToACSGetCallAndHangUpCallTestAsync.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-966533929e35f9da240bf7b816b0d1cb-feaf35bd6a6755db-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7909",
         "Content-Type": "application/json",
         "traceparent": "00-81b0b9d749bd7ffeee59c24c097626f0-87f9429957d6700b-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "0",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "d0b205080b88a969ac2b57e2e48525f4",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallConnectionAutomatedLiveTests/RemoveAUserCallTest.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallConnectionAutomatedLiveTests/RemoveAUserCallTest.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-9036106d51209cb03239496a0df3fab1-125bffb09a9cb3a9-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7909",
         "Content-Type": "application/json",
         "traceparent": "00-c330b4cfa328e0f4944edb08f63f4f83-db7b2698f0710e6c-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "131",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallConnectionAutomatedLiveTests/RemoveAUserCallTestAsync.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallConnectionAutomatedLiveTests/RemoveAUserCallTestAsync.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-4b75e46411aac32450494df1b09a4190-b77c3b6fdee5fd44-00",
@@ -227,6 +229,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "670076faf798a2600a3155ddd56fc297",
         "x-ms-content-sha256": "Sanitized",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "131",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallConnectionAutomatedLiveTests/RemoveAUserCallTestAsync.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallConnectionAutomatedLiveTests/RemoveAUserCallTestAsync.json
@@ -173,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7904",
         "Content-Type": "application/json",
         "traceparent": "00-75429a3aaa2bb4b9f0e19559e0245d6b-3d221ca26d1028c6-00",
@@ -229,8 +231,6 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Repeatability-Request-ID": "Sanitized",
-        "Repeatability-First-Sent": "Sanitized",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "670076faf798a2600a3155ddd56fc297",
         "x-ms-content-sha256": "Sanitized",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallAndUnmixedAudioTest.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallAndUnmixedAudioTest.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-90509dcfa1bc4ff42942140713e76119-b59d1ef7ebaf13f1-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7909",
         "Content-Type": "application/json",
         "traceparent": "00-4229ae3d404d40a195c6a748a74b08f2-d1f9184465d462b5-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "434",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
@@ -339,6 +345,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "0",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "6e4a73d85cb19c21bd627ff1bf724486",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallAndUnmixedAudioTestAsync.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallAndUnmixedAudioTestAsync.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-318e89ba9e24c01f4b431b44f588197f-6ac61523f6d67ed1-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7936",
         "Content-Type": "application/json",
         "traceparent": "00-45dd962d473154c00cb933454f680b69-0941790eb0e740cd-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "434",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
@@ -339,6 +345,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "0",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "84204bd0384fbb97db1dca3c6cf0676e",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallUnmixedAudioAffinityTest.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallUnmixedAudioAffinityTest.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-eafc7d64a9734ed5f76756ee3e15eefb-7e0861fd25b34fa8-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7909",
         "Content-Type": "application/json",
         "traceparent": "00-0df57df218dc58bbd11c978078d9b027-f44d56c6d666632b-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "592",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
@@ -353,6 +359,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "0",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "07811344f01e085c56d8282b9fc3d591",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallUnmixedAudioAffinityTestAsync.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/CreateACSCallUnmixedAudioAffinityTestAsync.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-ff5e92174949cff93f58aa29a8934f7a-d13944102060e633-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7925",
         "Content-Type": "application/json",
         "traceparent": "00-f515daa39a6fdfbc49b296d46bad41f3-8822b6d1052c6704-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "592",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
@@ -353,6 +359,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "0",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",
         "x-ms-client-request-id": "0889ea6c49f155978c38f9e8dd02c8fb",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/RecordingOperationsTest.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/RecordingOperationsTest.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-a860435e31143ffb93c252c47e357162-7e734a5067cce3c9-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7909",
         "Content-Type": "application/json",
         "traceparent": "00-05bd2dc1676b7423450fd962da85857c-9b65340312ac303b-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "425",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/RecordingOperationsTestAsync.json
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/SessionRecords/CallRecordingAutomatedLiveTests/RecordingOperationsTestAsync.json
@@ -101,6 +101,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "254",
         "Content-Type": "application/json",
         "traceparent": "00-6ad13e5f3eccd77fd5ae6e85fd81a13f-fc62c16b57ec1273-00",
@@ -171,6 +173,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "7930",
         "Content-Type": "application/json",
         "traceparent": "00-d6759919b56416f2eec43cbc7ad2461b-2de95f75eb021f2c-00",
@@ -277,6 +281,8 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Repeatability-Request-ID": "Sanitized",
+        "Repeatability-First-Sent": "Sanitized",
         "Content-Length": "425",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Communication.CallAutomation/1.0.0-alpha.20230130.1 (.NET 7.0.2; Microsoft Windows 10.0.22621)",


### PR DESCRIPTION
- make RepeatabilityHeaders class internal
- automatically set RepeatabilityHeaders in: addParticipants, answerCall, createCall, hangUp, muteParticipants, redirectCall, reject, removeParticipants, startRecording, transferToParticipant, UnmuteParticipants