### PR TITLE
[AzureMonitorExporter] fix more nullables with `NotNullWhenAttribute`

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
@@ -77,7 +77,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
             else if (connectionString.TryGetNonRequiredValue(Constants.EndpointSuffixKey, out string? endpointSuffix))
             {
                 var location = connectionString.GetNonRequired(Constants.LocationKey);
-                if (!TryBuildUri(prefix: Constants.IngestionPrefix, suffix: endpointSuffix!, location: location, uri: out uri))
+                if (!TryBuildUri(prefix: Constants.IngestionPrefix, suffix: endpointSuffix, location: location, uri: out uri))
                 {
                     throw new ArgumentException($"The value for {Constants.EndpointSuffixKey} is invalid. '{endpointSuffix}'");
                 }
@@ -126,7 +126,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
         /// <summary>
         /// This method wraps <see cref="AzureCoreConnectionString.GetNonRequired(string)"/> in a null check.
         /// </summary>
-        internal static bool TryGetNonRequiredValue(this AzureCoreConnectionString connectionString, string key, out string? value)
+        internal static bool TryGetNonRequiredValue(this AzureCoreConnectionString connectionString, string key, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? value)
         {
             value = connectionString.GetNonRequired(key);
             return value != null;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NullableAttributes.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NullableAttributes.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// The following code was borrowed from https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+// These classes are available in .NET versions after NetStandard2.0
+// For more information see: https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/nullable-analysis
+
+#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#pragma warning disable SA1649 // File name should match first type name
+
+    /// <summary>
+    /// Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+#pragma warning restore SA1649 // File name should match first type name
+}
+#endif

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
                     if (TryCreateTelemetryDirectory(path: environmentVars["LOCALAPPDATA"]?.ToString(), createdDirectoryPath: out dirPath)
                         || TryCreateTelemetryDirectory(path: environmentVars["TEMP"]?.ToString(), createdDirectoryPath: out dirPath))
                     {
-                        s_defaultStorageDirectory = dirPath!;
+                        s_defaultStorageDirectory = dirPath;
                         return s_defaultStorageDirectory;
                     }
                 }
@@ -38,7 +38,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
                         || TryCreateTelemetryDirectory(path: "/var/tmp/", createdDirectoryPath: out dirPath)
                         || TryCreateTelemetryDirectory(path: "/tmp/", createdDirectoryPath: out dirPath))
                     {
-                        s_defaultStorageDirectory = dirPath!;
+                        s_defaultStorageDirectory = dirPath;
                         return s_defaultStorageDirectory;
                     }
                 }
@@ -53,7 +53,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
         /// <param name="path">Base directory.</param>
         /// <param name="createdDirectoryPath">Full directory.</param>
         /// <returns><see langword= "true"/> if directory is created.</returns>
-        private static bool TryCreateTelemetryDirectory(string? path, out string? createdDirectoryPath)
+        private static bool TryCreateTelemetryDirectory(string? path, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? createdDirectoryPath)
         {
             createdDirectoryPath = null;
             if (path == null)


### PR DESCRIPTION
Towards #34013

This is a follow up to #33870.
In that PR, I had to use the [Null-Forgiving operator](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-forgiving) (`!`) to declare that the out parameter of a TryGet method was not null.

The better way to do this is to use a [null-state attribute](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis).


## Changes
- remove null-forgiving operator (`!`)
- add `internal sealed class NotNullWhenAttribute` because our project targets NetStardard2.0
  - this is the same thing OTel did in their repo: https://github.com/open-telemetry/opentelemetry-dotnet/blob/1273e83d557cccf0514a8941988c5fdc894afe04/src/OpenTelemetry.Api/Internal/Guard.cs#L52


## How to use:

Assume you write the following method:
```csharp
public bool TryParse(string number, out int? value)
```

The compiler is not aware that `value` is not null and gives an error.

Instead you can write:
```csharp
public bool TryParse(string number, [NotNullWhen(true)] out int? value)
```

Which indicates that when this method returns `true`, the value of `value` is not null.