### PR TITLE
Cherry-Pick fixes for 1.8.2 patch release

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -9,6 +9,9 @@ omitted_paths:
   - samples/*
   - sdk/*/*.Management.*/*
   - sdk/*/*/perf/*
+  - sdk/*/*/integration/*
+  - sdk/*/*/tests/Samples/*
+  - sdk/*/*/tests/samples/*
   - sdk/*/*/samples/*
   - sdk/*/samples/*
   - sdk/*/swagger/*

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -102,15 +102,15 @@
     <PackageReference Update="Azure.ResourceManager" Version="1.3.1" />
 
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.5.10" />
-    <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.1.0" />
-    <PackageReference Update="Microsoft.Identity.Client" Version="4.46.0" />
-    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.23.0" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.1" />
+    <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.2.0" />
+    <PackageReference Update="Microsoft.Identity.Client" Version="4.49.1" />
+    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.25.3" />
     <!--
       TODO: This package needs to be released as GA and arch-board approved before taking a dependency in any stable SDK library.
       Currently, it is referencd by Azure.Identity.BrokeredAuthentication which is still in beta
     -->
-    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.46.0-preview" />
+    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.49.1-preview" />
 
     <!-- TODO: Make sure this package is arch-board approved -->
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Release History
+## 1.8.2 (2023-02-07)
+
+### Bugs Fixed
+- Fixed error message parsing in `AzurePowerShellCredential` which would misinterpret AAD errors with the need to install PowerShell. [#31998](https://github.com/Azure/azure-sdk-for-net/issues/31998)
 
 ## 1.8.1 (2023-01-13)
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
-## 1.8.2 (2023-02-07)
+## 1.8.2 (2023-02-08)
 
 ### Bugs Fixed
 - Fixed error message parsing in `AzurePowerShellCredential` which would misinterpret AAD errors with the need to install PowerShell. [#31998](https://github.com/Azure/azure-sdk-for-net/issues/31998)
+- Fix regional endpoint validation error when using `ManagedIdentityCredential`. [#32498])(https://github.com/Azure/azure-sdk-for-net/issues/32498)
 
 ## 1.8.1 (2023-01-13)
 

--- a/sdk/identity/Azure.Identity/integration/WebApp/Controllers/TestController.cs
+++ b/sdk/identity/Azure.Identity/integration/WebApp/Controllers/TestController.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApp.Controllers
+{
+
+    [ApiController]
+    [Route("[controller]")]
+    public class TestController : ControllerBase
+    {
+
+        [HttpGet(Name = "GetTest")]
+        public IActionResult Get()
+        {
+            string resourceId = Environment.GetEnvironmentVariable("IDENTITY_WEBAPP_USER_DEFINED_IDENTITY")!;
+            string account1 = Environment.GetEnvironmentVariable("IDENTITY_STORAGE_NAME_1")!;
+            string account2 = Environment.GetEnvironmentVariable("IDENTITY_STORAGE_NAME_2")!;
+
+            var credential1 = new ManagedIdentityCredential();
+            var credential2 = new ManagedIdentityCredential(new ResourceIdentifier(resourceId));
+            var client1 = new BlobServiceClient(new Uri($"https://{account1}.blob.core.windows.net/"), credential1);
+            var client2 = new BlobServiceClient(new Uri($"https://{account2}.blob.core.windows.net/"), credential2);
+            try
+            {
+                var results = client1.GetBlobContainers().ToList();
+                results = client2.GetBlobContainers().ToList();
+                return Ok("Successfully acquired a token from ManagedIdentityCredential");
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.ToString());
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/integration/WebApp/Integration.Identity.WebApp.csproj
+++ b/sdk/identity/Azure.Identity/integration/WebApp/Integration.Identity.WebApp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Azure.Identity.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/identity/Azure.Identity/integration/WebApp/Program.cs
+++ b/sdk/identity/Azure.Identity/integration/WebApp/Program.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/sdk/identity/Azure.Identity/integration/WebApp/appsettings.Development.json
+++ b/sdk/identity/Azure.Identity/integration/WebApp/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sdk/identity/Azure.Identity/integration/WebApp/appsettings.json
+++ b/sdk/identity/Azure.Identity/integration/WebApp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/sdk/identity/Azure.Identity/integration/nuget.config
+++ b/sdk/identity/Azure.Identity/integration/nuget.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <!--
+        <add key="repositoryPath" value="./NugetInstall" />
+        <add key="globalPackagesFolder" value="./Nuget" />
+        -->
+        <add key="repositoryPath" value="%AGENT_WORKFOLDER%/NugetInstall" />
+        <add key="globalPackagesFolder" value="%AGENT_WORKFOLDER%/Nuget" />
+    </config>
+    <packageSources>
+        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure SDK Client Library for Azure Identity</Description>
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.8.0</ApiCompatVersion>
+    <ApiCompatVersion>1.8.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021;AZC0011</NoWarn>

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
@@ -27,7 +27,7 @@ namespace Azure.Identity
         internal bool UseLegacyPowerShell { get; set; }
 
         private const string Troubleshooting = "See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/powershellcredential/troubleshoot";
-        private const string AzurePowerShellFailedError = "Azure PowerShell authentication failed due to an unknown error. " + Troubleshooting;
+        internal const string AzurePowerShellFailedError = "Azure PowerShell authentication failed due to an unknown error. " + Troubleshooting;
         private const string RunConnectAzAccountToLogin = "Run Connect-AzAccount to login";
         private const string NoAccountsWereFoundInTheCache = "No accounts were found in the cache";
         private const string CannotRetrieveAccessToken = "cannot retrieve access token";
@@ -170,8 +170,10 @@ namespace Azure.Identity
 
         private static void CheckForErrors(string output)
         {
-            bool noPowerShell = output.IndexOf("not found", StringComparison.OrdinalIgnoreCase) != -1 ||
-                                output.IndexOf("is not recognized", StringComparison.OrdinalIgnoreCase) != -1;
+            bool noPowerShell = (output.IndexOf("not found", StringComparison.OrdinalIgnoreCase) != -1 ||
+                                output.IndexOf("is not recognized", StringComparison.OrdinalIgnoreCase) != -1) &&
+                                // If the error contains AADSTS, this should be treated as a general error to be bubbled to the user
+                                output.IndexOf("AADSTS", StringComparison.OrdinalIgnoreCase) == -1;
             if (noPowerShell)
             {
                 throw new CredentialUnavailableException(PowerShellNotInstalledError);

--- a/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
@@ -12,7 +12,6 @@ namespace Azure.Identity
 {
     internal class MsalConfidentialClient : MsalClientBase<IConfidentialClientApplication>
     {
-        private const string s_instanceMetadata = "{\"tenant_discovery_endpoint\":\"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration\",\"api-version\":\"1.1\",\"metadata\":[{\"preferred_network\":\"login.microsoftonline.com\",\"preferred_cache\":\"login.windows.net\",\"aliases\":[\"login.microsoftonline.com\",\"login.windows.net\",\"login.microsoft.com\",\"sts.windows.net\"]}]}";
         internal readonly string _clientSecret;
         internal readonly bool _includeX5CClaimHeader;
         internal readonly IX509Certificate2Provider _certificateProvider;
@@ -76,7 +75,7 @@ namespace Azure.Identity
             {
                 confClientBuilder.WithAppTokenProvider(_appTokenProviderCallback)
                     .WithAuthority(_authority.AbsoluteUri, TenantId, false)
-                    .WithInstanceDiscoveryMetadata(s_instanceMetadata);
+                    .WithInstanceDiscovery(false);
             }
             else
             {
@@ -104,6 +103,7 @@ namespace Azure.Identity
                 confClientBuilder.WithCertificate(clientCertificate);
             }
 
+            // When the appTokenProviderCallback is set, meaning this is for managed identity, the regional authority is not relevant.
             if (_appTokenProviderCallback == null && !string.IsNullOrEmpty(RegionalAuthority))
             {
                 confClientBuilder.WithAzureRegion(RegionalAuthority);

--- a/sdk/identity/Azure.Identity/tests/ClientSecretCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientSecretCredentialLiveTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using Microsoft.Identity.Client;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Identity.Tests

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -82,12 +82,12 @@ namespace Azure.Identity.Tests
         {
             var sb = new StringBuilder("{");
 
-            if (testEnvironment.TestTenantId != default)
+            if (testEnvironment.IdentityTenantId != default)
             {
-                sb.AppendFormat("\"azure.tenant\": \"{0}\"", testEnvironment.TestTenantId);
+                sb.AppendFormat("\"azure.tenant\": \"{0}\"", testEnvironment.IdentityTenantId);
             }
 
-            if (testEnvironment.TestTenantId != default && cloudName != default)
+            if (testEnvironment.IdentityTenantId != default && cloudName != default)
             {
                 sb.Append(',');
             }
@@ -117,7 +117,7 @@ namespace Azure.Identity.Tests
 
             var username = testEnvironment.Username;
             var password = testEnvironment.Password;
-            var tenantId = testEnvironment.TestTenantId;
+            var tenantId = testEnvironment.IdentityTenantId;
 
             var result = await PublicClientApplicationBuilder.Create(clientId)
                 .WithTenantId(tenantId)
@@ -138,7 +138,7 @@ namespace Azure.Identity.Tests
             var clientId = "aebc6443-996d-45c2-90f0-388ff96faa56";
             var username = testEnvironment.Username;
             var password = testEnvironment.Password;
-            var authorityUri = new Uri(new Uri(testEnvironment.AuthorityHostUrl), testEnvironment.TestTenantId).ToString();
+            var authorityUri = new Uri(new Uri(testEnvironment.AuthorityHostUrl), testEnvironment.IdentityTenantId).ToString();
 
             var client = PublicClientApplicationBuilder.Create(clientId)
                 .WithAuthority(authorityUri)

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
@@ -62,6 +62,7 @@ namespace Azure.Identity.Tests
 
         [RecordedTest]
         [RunOnlyOnPlatforms(Windows = true, OSX = true, ContainerNames = new[] { "ubuntu_netcore_keyring" })]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27263")]
         public async Task DefaultAzureCredential_UseVisualStudioCodeCredential()
         {
             var options = InstrumentClientOptions(new DefaultAzureCredentialOptions
@@ -73,7 +74,7 @@ namespace Azure.Identity.Tests
                 ExcludeVisualStudioCredential = true,
                 ExcludeAzureCliCredential = true,
                 ExcludeVisualStudioCodeCredential = false,
-                VisualStudioCodeTenantId = TestEnvironment.TestTenantId
+                VisualStudioCodeTenantId = TestEnvironment.IdentityTenantId
             });
 
             var cloudName = Guid.NewGuid().ToString();
@@ -102,6 +103,7 @@ namespace Azure.Identity.Tests
 
         [RecordedTest]
         [RunOnlyOnPlatforms(Windows = true, OSX = true, ContainerNames = new[] { "ubuntu_netcore_keyring" })]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27263")]
         public async Task DefaultAzureCredential_UseVisualStudioCodeCredential_ParallelCalls()
         {
             var options = InstrumentClientOptions(new DefaultAzureCredentialOptions
@@ -112,7 +114,7 @@ namespace Azure.Identity.Tests
                 ExcludeManagedIdentityCredential = true,
                 ExcludeAzureCliCredential = true,
                 ExcludeVisualStudioCodeCredential = false,
-                VisualStudioCodeTenantId = TestEnvironment.TestTenantId
+                VisualStudioCodeTenantId = TestEnvironment.IdentityTenantId
             });
 
             var cloudName = Guid.NewGuid().ToString();
@@ -149,7 +151,7 @@ namespace Azure.Identity.Tests
                 ExcludeSharedTokenCacheCredential = true,
                 ExcludeManagedIdentityCredential = true,
                 ExcludeVisualStudioCodeCredential = false,
-                VisualStudioCodeTenantId = TestEnvironment.TestTenantId
+                VisualStudioCodeTenantId = TestEnvironment.IdentityTenantId
             });
 
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();
@@ -188,7 +190,7 @@ namespace Azure.Identity.Tests
                 ExcludeSharedTokenCacheCredential = true,
                 ExcludeManagedIdentityCredential = true,
                 ExcludeVisualStudioCodeCredential = false,
-                VisualStudioCodeTenantId = TestEnvironment.TestTenantId
+                VisualStudioCodeTenantId = TestEnvironment.IdentityTenantId
             });
 
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();

--- a/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
@@ -30,7 +30,6 @@ namespace Azure.Identity.Tests
         public string UserAssignedVault => GetRecordedOptionalVariable("IDENTITYTEST_IMDSTEST_USERASSIGNEDVAULT");
 
         public string TestPassword => GetOptionalVariable("AZURE_IDENTITY_TEST_PASSWORD") ?? "SANITIZED";
-        public string TestTenantId => GetRecordedOptionalVariable("TENANT_ID") ?? GetRecordedVariable("AZURE_IDENTITY_TEST_TENANTID");
         public string KeyvaultScope => GetRecordedOptionalVariable("AZURE_KEYVAULT_SCOPE") ?? "https://vault.azure.net/.default";
 
         public string ServicePrincipalClientId => GetRecordedVariable("IDENTITY_SP_CLIENT_ID");
@@ -39,5 +38,6 @@ namespace Azure.Identity.Tests
         public string ServicePrincipalCertificatePfxPath => GetOptionalVariable("IDENTITY_SP_CERT_PFX") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
         public string ServicePrincipalCertificatePemPath => GetOptionalVariable("IDENTITY_SP_CERT_PEM") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pem");
         public string ServicePrincipalSniCertificatePath => GetOptionalVariable("IDENTITY_SP_CERT_SNI") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
+        public string IdentityTestWebName =>  GetRecordedVariable("IDENTITY_WEBAPP_NAME");
     }
 }

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialWebAppTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialWebAppTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    public class ManagedIdentityCredentialWebAppTests : IdentityRecordedTestBase
+    {
+        private HttpPipeline _pipeline;
+        private Uri _testEndpoint;
+
+        public ManagedIdentityCredentialWebAppTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        [SetUp]
+        public void Setup() {
+            var options = new TokenCredentialOptions();
+            _testEndpoint = new Uri($"https://{TestEnvironment.IdentityTestWebName}.azurewebsites.net/test");
+            _pipeline = HttpPipelineBuilder.Build(InstrumentClientOptions(options), Array.Empty<HttpPipelinePolicy>(), Array.Empty<HttpPipelinePolicy>(), new ResponseClassifier());
+        }
+
+        [RecordedTest]
+        [SyncOnly]
+        // This test leverages the test app found in Azure.Identity\integration\WebApp
+        // It validates that ManagedIdentityCredential can acquire a token in an actual Azure Web App environment
+        public async Task CallTestWebApp()
+        {
+            Request request = _pipeline.CreateRequest();
+            request.Uri.Reset(_testEndpoint);
+            Response response = await _pipeline.SendRequestAsync(request, default);
+
+            Assert.AreEqual((int)HttpStatusCode.OK, response.Status);
+            Assert.AreEqual("Successfully acquired a token from ManagedIdentityCredential", response.Content.ToString(), response.Content.ToString());
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ManagedIdentityCredentialWebAppTests/CallTestWebApp.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ManagedIdentityCredentialWebAppTests/CallTestWebApp.json
@@ -1,0 +1,31 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://chrissidentity-webapp.azurewebsites.net/test",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": "azsdk-net-Identity/1.9.0-alpha.20221205.1 (.NET 6.0.11; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "da316510b79eb7bb601cb0177206c845",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Date": "Mon, 05 Dec 2022 21:01:43 GMT",
+        "Server": "Microsoft-IIS/10.0",
+        "Set-Cookie": [
+          "ARRAffinity=79e06db539acb57119e709978d2cf1da299e8341753d6f6345007fcab3f69bc5;Path=/;HttpOnly;Secure;Domain=chrissidentity-webapp.azurewebsites.net",
+          "ARRAffinitySameSite=79e06db539acb57119e709978d2cf1da299e8341753d6f6345007fcab3f69bc5;Path=/;HttpOnly;SameSite=None;Secure;Domain=chrissidentity-webapp.azurewebsites.net"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": "Successfully acquired a token from ManagedIdentityCredential"
+    }
+  ],
+  "Variables": {
+    "IDENTITY_WEBAPP_NAME": "chrissidentity-webapp",
+    "RandomSeed": "958608913"
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 
 namespace Azure.Identity.Tests
 {
+    [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27020")]
     public class VisualStudioCodeCredentialLiveTests : IdentityRecordedTestBase
     {
         private const string ExpectedServiceName = "VS Code Azure";
@@ -28,7 +29,7 @@ namespace Azure.Identity.Tests
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment, cloudName);
             using IDisposable fixture = await CredentialTestHelpers.CreateRefreshTokenFixtureAsync(TestEnvironment, Mode, ExpectedServiceName, cloudName);
 
-            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
+            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.IdentityTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystem, default));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] { TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
@@ -41,7 +42,7 @@ namespace Azure.Identity.Tests
             var fileSystemService = new TestFileSystemService { ReadAllHandler = s => throw new FileNotFoundException() };
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", refreshToken);
 
-            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
+            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.IdentityTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] { TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
@@ -54,7 +55,7 @@ namespace Azure.Identity.Tests
             var fileSystemService = new TestFileSystemService { ReadAllHandler = s => "{a,}" };
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", refreshToken);
 
-            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
+            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.IdentityTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
@@ -67,7 +68,7 @@ namespace Azure.Identity.Tests
             var fileSystemService = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", refreshToken);
 
-            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
+            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.IdentityTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None);
@@ -97,7 +98,7 @@ namespace Azure.Identity.Tests
             var cloudName = Guid.NewGuid().ToString();
 
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment, cloudName);
-            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
+            var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.IdentityTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystem, default));
 
             Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {TestEnvironment.KeyvaultScope}), CancellationToken.None));
@@ -106,7 +107,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void AuthenticateWithVscCredential_NoRefreshToken()
         {
-            var tenantId = TestEnvironment.TestTenantId;
+            var tenantId = TestEnvironment.IdentityTenantId;
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
 
@@ -119,7 +120,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void AuthenticateWithVscCredential_AuthenticationCodeInsteadOfRefreshToken()
         {
-            var tenantId = TestEnvironment.TestTenantId;
+            var tenantId = TestEnvironment.IdentityTenantId;
             var fileSystemService = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", "{}");
 
@@ -132,7 +133,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void AuthenticateWithVscCredential_InvalidRefreshToken()
         {
-            var tenantId = TestEnvironment.TestTenantId;
+            var tenantId = TestEnvironment.IdentityTenantId;
             var fileSystemService = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", Guid.NewGuid().ToString());
 

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 
 namespace Azure.Identity.Tests
 {
+    [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27263")]
     public class VisualStudioCodeCredentialTests : CredentialTestBase
     {
         public VisualStudioCodeCredentialTests(bool isAsync) : base(isAsync)
@@ -19,7 +20,7 @@ namespace Azure.Identity.Tests
 
         public override TokenCredential GetTokenCredential(TokenCredentialOptions options)
         {
-            using var env = new TestEnvVar(new Dictionary<string, string> { { "TENANT_ID", TenantId } });
+            using var env = new TestEnvVar(new Dictionary<string, string> { { "IDENTITY_TENANT_ID", TenantId } });
             var environment = new IdentityTestEnvironment();
             var vscOptions = new VisualStudioCodeCredentialOptions
             {
@@ -47,7 +48,7 @@ namespace Azure.Identity.Tests
         [NonParallelizable]
         public async Task AuthenticateWithVsCodeCredential([Values(null, TenantIdHint)] string tenantId, [Values(true)] bool allowMultiTenantAuthentication)
         {
-            using var env = new TestEnvVar(new Dictionary<string, string> { { "TENANT_ID", TenantId } });
+            using var env = new TestEnvVar(new Dictionary<string, string> { { "IDENTITY_TENANT_ID", TenantId } });
             var environment = new IdentityTestEnvironment();
             var options = new VisualStudioCodeCredentialOptions { TenantId = environment.TenantId, AdditionallyAllowedTenants = { TenantIdHint }, Transport = new MockTransport() };
             var context = new TokenRequestContext(new[] { Scope }, tenantId: tenantId);
@@ -71,7 +72,7 @@ namespace Azure.Identity.Tests
         {
             Console.WriteLine(parameters.ToDebugString());
 
-            using var env = new TestEnvVar(new Dictionary<string, string> { { "TENANT_ID", TenantId } });
+            using var env = new TestEnvVar(new Dictionary<string, string> { { "IDENTITY_TENANT_ID", TenantId } });
             var environment = new IdentityTestEnvironment();
             var options = new VisualStudioCodeCredentialOptions
             {
@@ -86,7 +87,7 @@ namespace Azure.Identity.Tests
 
             var msalClientMock = new MockMsalPublicClient(AuthenticationResultFactory.Create());
 
-            var cred =  InstrumentClient(
+            var cred = InstrumentClient(
                 new VisualStudioCodeCredential(
                     options,
                     null,

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -1,0 +1,19 @@
+param (
+    [hashtable] $DeploymentOutputs
+)
+
+$webappRoot = "$PSScriptRoot/Azure.Identity/integration" | Resolve-Path
+$workingFolder = $webappRoot;
+if ($null -ne $Env:AGENT_WORKFOLDER) {
+    $workingFolder = $Env:AGENT_WORKFOLDER
+}
+az login --service-principal -u $DeploymentOutputs['IDENTITY_CLIENT_ID'] -p $DeploymentOutputs['IDENTITY_CLIENT_SECRET'] --tenant $DeploymentOutputs['IDENTITY_TENANT_ID']
+az account set --subscription $DeploymentOutputs['IDENTITY_SUBSCRIPTION_ID']
+dotnet publish "$webappRoot/WebApp/Integration.Identity.WebApp.csproj" -o "$workingFolder/Pub" /p:EnableSourceLink=false
+Compress-Archive -Path "$workingFolder/Pub/*" -DestinationPath "$workingFolder/Pub/package.zip" -Force
+az webapp deploy --resource-group $DeploymentOutputs['IDENTITY_RESOURCE_GROUP'] --name $DeploymentOutputs['IDENTITY_WEBAPP_NAME'] --src-path "$workingFolder/Pub/package.zip"
+Remove-Item -Force -Recurse "$workingFolder/Pub"
+if ($null -eq $Env:AGENT_WORKFOLDER) {
+    Remove-Item -Force -Recurse "$webappRoot/%AGENT_WORKFOLDER%"
+}
+az logout

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -1,0 +1,133 @@
+@description('The client OID to grant access to test resources.')
+param testApplicationOid string
+
+@minLength(6)
+@maxLength(50)
+@description('The base resource name.')
+param baseName string = resourceGroup().name
+
+@description('The location of the resource. By default, this is the same as the resource group.')
+param location string = resourceGroup().location
+
+//See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+var blobContributor = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe') //Storage Blob Data Contributor
+var websiteContributor = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772') //Website Contributor
+
+resource usermgdid 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: baseName
+  location: location
+}
+
+resource blobRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: sa
+  name: guid(resourceGroup().id, blobContributor)
+  properties: {
+    principalId: web.identity.principalId
+    roleDefinitionId: blobContributor
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource blobRole2 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: sa2
+  name: guid(resourceGroup().id, blobContributor, usermgdid.id)
+  properties: {
+    principalId: usermgdid.properties.principalId
+    roleDefinitionId: blobContributor
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource webRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: web
+  name: guid(resourceGroup().id, websiteContributor)
+  properties: {
+    principalId: testApplicationOid
+    roleDefinitionId: websiteContributor
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource sa 'Microsoft.Storage/storageAccounts@2021-08-01' = {
+  name: baseName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+  }
+}
+
+resource sa2 'Microsoft.Storage/storageAccounts@2021-08-01' = {
+  name: '${baseName}2'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+  }
+}
+
+resource farm 'Microsoft.Web/serverfarms@2021-03-01' = {
+  name: '${baseName}_asp'
+  location: location
+  sku: {
+    name: 'F1'
+    tier: 'Free'
+    size: 'F1'
+    family: 'F'
+    capacity: 0
+  }
+  properties: { }
+  kind: 'app'
+}
+
+resource web 'Microsoft.Web/sites@2021-03-01' = {
+  name: '${baseName}-webapp'
+  location: location
+  kind: 'app'
+  identity: {
+    type: 'SystemAssigned, UserAssigned'
+    userAssignedIdentities: {
+      '${usermgdid.id}' : { }
+    }
+  }
+  properties: {
+    enabled: true
+    serverFarmId: farm.id
+    httpsOnly: true
+    keyVaultReferenceIdentity: 'SystemAssigned'
+    siteConfig: {
+      netFrameworkVersion: 'v6.0'
+      http20Enabled: true
+      minTlsVersion: '1.2'
+      appSettings: [
+        {
+          name: 'AZURE_REGIONAL_AUTHORITY_NAME'
+          value: 'eastus'
+        }
+        {
+          name: 'IDENTITY_STORAGE_NAME_1'
+          value: sa.name
+        }
+        {
+          name: 'IDENTITY_STORAGE_NAME_2'
+          value: sa2.name
+        }
+        {
+          name: 'IDENTITY_WEBAPP_USER_DEFINED_IDENTITY'
+          value: usermgdid.id
+        }
+      ]
+    }
+  }
+}
+
+output IDENTITY_WEBAPP_NAME string = web.name
+output IDENTITY_WEBAPP_USER_DEFINED_IDENTITY string = usermgdid.id
+output IDENTITY_STORAGE_NAME_1 string = sa.name
+output IDENTITY_STORAGE_NAME_2 string = sa2.name

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -1,36 +1,12 @@
 trigger: none
 
-resources:
-  containers:
-    - container: 'ubuntu_netcore_keyring'
-      # See ./eng/containers/UbuntuNetCoreKeyring/Dockerfile for tool versions
-      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore_keyring:1347171'
-      endpoint: 'azsdkengsys'
-      options: -ti --cap-add=IPC_LOCK
-
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     TimeoutInMinutes: 120
-    AdditionalMatrixConfigs:
-      - Name: identity_container
-        Path: sdk/identity/platform-matrix.json
-        Selection: sparse
-        GenerateContainerJobs: true
     ServiceDirectory: identity
     SupportedClouds: 'Public,UsGov,China,Canary'
     PreSteps:
-      - pwsh: Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
-        displayName: Install Azure PowerShell module
-        condition: and(succeededOrFailed(), startsWith(variables['Agent.JobName'], 'ubuntu_keyring_container'))
-      - script: |
-          set -x
-          export $(dbus-launch)
-          gnome-keyring-daemon --start --daemonize --components=secrets
-          echo "##vso[task.setvariable variable=DBUS_SESSION_BUS_ADDRESS]$DBUS_SESSION_BUS_ADDRESS"
-          echo "##vso[task.setvariable variable=DBUS_SESSION_BUS_PID]$DBUS_SESSION_BUS_PID"
-          echo "##vso[task.setvariable variable=GNOME_KEYRING_CONTROL]$GNOME_KEYRING_CONTROL"
-        condition: and(succeededOrFailed(), startsWith(variables['Agent.JobName'], 'ubuntu_keyring_container'))
       - pwsh: |
           [System.Convert]::FromBase64String($env:PFX_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/test.pfx -AsByteStream
           Set-Content -Path $(Agent.TempDirectory)/test.pem -Value $env:PEM_CONTENTS


### PR DESCRIPTION
Cherry Picks the following fixes ontop of 1.8.1:

Do not handle AADSTS errors as PowerShell not installed https://github.com/Azure/azure-sdk-for-net/pull/32251 
Fix regional endpoint validation error https://github.com/Azure/azure-sdk-for-net/pull/33544