### PR TITLE
Refactor azmonlistextensions

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -45,7 +45,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 case OperationType.Http:
                     Data = httpUrl.Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
-                    Target = monitorTags.MappedTags.GetDependencyTarget(OperationType.Http).Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
+                    Target = monitorTags.MappedTags.GetHttpDependencyTarget().Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
                     Type = "Http";
                     ResultCode = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpStatusCode)
                         ?.ToString().Truncate(SchemaConstants.RemoteDependencyData_ResultCode_MaxLength)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -220,6 +220,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return host;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string GetTargetUsingNetPeerAttributes(this AzMonList tagObjects, string defaultPort)
+        {
+            string target = tagObjects.GetHostUsingNetPeerAttributes();
+            if (!string.IsNullOrWhiteSpace(target))
+            {
+                var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
+                if (!string.IsNullOrWhiteSpace(netPeerPort) && netPeerPort != defaultPort)
+                {
+                    target = $"{target}:{netPeerPort}";
+                }
+            }
+
+            return target;
+        }
+
         ///<summary>
         /// Gets Http dependency target from activity tag objects.
         ///</summary>
@@ -260,16 +276,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
             }
 
-            target = tagObjects.GetHostUsingNetPeerAttributes();
-            if (!string.IsNullOrWhiteSpace(target))
-            {
-                var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
-                if (!string.IsNullOrWhiteSpace(netPeerPort) && netPeerPort != defaultPort)
-                {
-                    target = $"{target}:{netPeerPort}";
-                }
-                return target;
-            }
+            target = tagObjects.GetTargetUsingNetPeerAttributes(defaultPort);
 
             return target;
         }
@@ -288,15 +295,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
             if (string.IsNullOrWhiteSpace(target))
             {
-                target = tagObjects.GetHostUsingNetPeerAttributes();
-                if (!string.IsNullOrWhiteSpace(target))
-                {
-                    var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
-                    if (!string.IsNullOrWhiteSpace(netPeerPort) && netPeerPort != defaultPort)
-                    {
-                        target = $"{target}:{netPeerPort}";
-                    }
-                }
+                target = tagObjects.GetTargetUsingNetPeerAttributes(defaultPort);
             }
 
             string dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -221,11 +221,84 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         }
 
         ///<summary>
+        /// Gets Http dependency target from activity tag objects.
+        ///</summary>
+        internal static string GetHttpDependencyTarget(this AzMonList tagObjects)
+        {
+            string target;
+            string defaultPort = GetDefaultHttpPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpScheme)?.ToString());
+            var peerService = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributePeerService)?.ToString();
+            if (!string.IsNullOrWhiteSpace(peerService))
+            {
+                target = peerService;
+                return target;
+            }
+
+            var httpHost = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpHost)?.ToString();
+            if (!string.IsNullOrWhiteSpace(httpHost))
+            {
+                string portSection = $":{defaultPort}";
+                if (httpHost.EndsWith(portSection, StringComparison.OrdinalIgnoreCase))
+                {
+                    var truncatedHost = httpHost.Substring(0, httpHost.IndexOf(portSection, StringComparison.OrdinalIgnoreCase));
+                    target = truncatedHost;
+                }
+                else
+                {
+                    target = httpHost;
+                }
+                return target;
+            }
+
+            var httpUrl = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpUrl)?.ToString();
+            if (!string.IsNullOrWhiteSpace(httpUrl) && Uri.TryCreate(httpUrl.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
+            {
+                target = uri.Authority;
+                if (!string.IsNullOrWhiteSpace(target))
+                {
+                    return target;
+                }
+            }
+
+            target = tagObjects.GetHostUsingNetPeerAttributes();
+            if (!string.IsNullOrWhiteSpace(target))
+            {
+                var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
+                if (!string.IsNullOrWhiteSpace(netPeerPort) && netPeerPort != defaultPort)
+                {
+                    target = $"{target}:{netPeerPort}";
+                }
+                return target;
+            }
+
+            return target;
+        }
+
+        ///<summary>
         /// Gets Database dependency target from activity tag objects.
         ///</summary>
         internal static string GetDbDependencyTarget(this AzMonList tagObjects)
         {
-            string target = tagObjects.GetDependencyTarget(OperationType.Db);
+            string target = null;
+            string defaultPort = GetDefaultDbPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString());
+            var peerService = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributePeerService)?.ToString();
+            if (!string.IsNullOrWhiteSpace(peerService))
+            {
+                target = peerService;
+            }
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                target = tagObjects.GetHostUsingNetPeerAttributes();
+                if (!string.IsNullOrWhiteSpace(target))
+                {
+                    var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
+                    if (!string.IsNullOrWhiteSpace(netPeerPort) && netPeerPort != defaultPort)
+                    {
+                        target = $"{target}:{netPeerPort}";
+                    }
+                }
+            }
+
             string dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
             bool isTargetEmpty = string.IsNullOrWhiteSpace(target);
             bool isDbNameEmpty = string.IsNullOrWhiteSpace(dbName);
@@ -246,72 +319,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         }
 
         ///<summary>
-        /// Gets Http dependency target from activity tag objects.
+        /// Gets dependency target from activity tag objects.
         ///</summary>
         internal static string GetDependencyTarget(this AzMonList tagObjects, OperationType type)
         {
-            string target;
-            string defaultPort;
             switch (type)
             {
                 case OperationType.Http:
-                    defaultPort = GetDefaultHttpPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpScheme)?.ToString());
-                    break;
+                    return tagObjects.GetHttpDependencyTarget();
                 case OperationType.Db:
-                    defaultPort = GetDefaultDbPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString());
-                    break;
+                    return tagObjects.GetDbDependencyTarget();
                 default:
-                    defaultPort = "0";
-                    break;
+                    return null;
             }
-
-            var peerService = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributePeerService)?.ToString();
-            if (!string.IsNullOrWhiteSpace(peerService))
-            {
-                target = peerService;
-                return target;
-            }
-
-            if (type == OperationType.Http)
-            {
-                var httpHost = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpHost)?.ToString();
-                if (!string.IsNullOrWhiteSpace(httpHost))
-                {
-                    string portSection = $":{defaultPort}";
-                    if (httpHost.EndsWith(portSection, StringComparison.OrdinalIgnoreCase))
-                    {
-                        var truncatedHost = httpHost.Substring(0, httpHost.IndexOf(portSection, StringComparison.OrdinalIgnoreCase));
-                        target = truncatedHost;
-                    }
-                    else
-                    {
-                        target = httpHost;
-                    }
-                    return target;
-                }
-                var httpUrl = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpUrl)?.ToString();
-                if (!string.IsNullOrWhiteSpace(httpUrl) && Uri.TryCreate(httpUrl.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
-                {
-                    target = uri.Authority;
-                    if (!string.IsNullOrWhiteSpace(target))
-                    {
-                        return target;
-                    }
-                }
-            }
-
-            target = tagObjects.GetHostUsingNetPeerAttributes();
-            if (!string.IsNullOrWhiteSpace(target))
-            {
-                var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
-                if (!string.IsNullOrWhiteSpace(netPeerPort) && netPeerPort != defaultPort)
-                {
-                    target = $"{target}:{netPeerPort}";
-                }
-                return target;
-            }
-
-            return target;
         }
 
         internal static string GetHttpDependencyName(this AzMonList tagObjects, string httpUrl)


### PR DESCRIPTION
Splitting the GetDependencyTarget in to two separate methods for getting target based on specific type. 

Also, adding another helper method to get the target based on OperationType --> Will need this for standard metrics part.