### PR TITLE
Fix binlog artifact upload

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -117,9 +117,9 @@ jobs:
           mergeTestResults: true
       - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
         parameters:
-          ArtifactPath: $(Build.ArtifactStagingDirectory)/*.binlog
-          ArtifactName: logs
-          CustomCondition: eq(variables['System.Debug'], 'true')
+          ArtifactPath: $(Build.ArtifactStagingDirectory)/test.binlog
+          ArtifactName: binlog_$(Agent.JobName)
+          CustomCondition: and(ne(variables['DiagnosticArguments'], ''), eq(variables['System.Debug'], 'true'))
       - template: /eng/pipelines/templates/steps/upload-dumps.yml
       - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
         condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))

--- a/eng/pipelines/templates/steps/dotnet-diagnostics.yml
+++ b/eng/pipelines/templates/steps/dotnet-diagnostics.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - pwsh: |
-    if ('${{ eq(variables['System.Debug'], 'true') }}' -eq 'true') {
+    if ('$(System.Debug)' -eq 'true') {
       Write-Host "##vso[task.setvariable variable=DiagnosticArguments;]/binaryLogger:LogFile=${{ parameters.LogFilePath }}"
     } else {
       Write-Host "##vso[task.setvariable variable=DiagnosticArguments;]"


### PR DESCRIPTION
@heaths I was trying to set System.Debug=true on a pipeline and keep hitting failures around the binlog stuff. I don't think this has ever worked I've fixed this so that the logs get generated and uploaded. I also noticed that the binlog only gets uploaded for the tests today if you want the build and packaging we still need to add a similar upload step in ci.yml. 