### PR TITLE
Re-enable BuildSnippets for Tables

### DIFF
--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -25,7 +25,6 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: tables
-    BuildSnippets: false
     ArtifactName: packages
     Artifacts:
     - name: Azure.Data.Tables


### PR DESCRIPTION
Should've been part of #33998, but that was merged before snippets were
disabled in #33989.
