### PR TITLE
Fix tests that rely on reflection

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -164,7 +164,7 @@ namespace Azure.Core.Extensions.Tests
             Assert.AreEqual("ConfigurationTenantId", clientCertificateCredential.TenantId);
 
             var additionalTenants = (string[]) typeof(ClientCertificateCredential)
-                .GetField("_additionallyAllowedTenantIds", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance).First(f => f.Name.EndsWith("dditionallyAllowedTenantIds"))
                 .GetValue(clientCertificateCredential);
             Assert.IsEmpty(additionalTenants);
         }
@@ -204,7 +204,7 @@ namespace Azure.Core.Extensions.Tests
             Assert.AreEqual("ConfigurationTenantId", clientCertificateCredential.TenantId);
 
             var actualTenants = (string[]) typeof(ClientCertificateCredential)
-                .GetField("_additionallyAllowedTenantIds", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance).First(f => f.Name.EndsWith("dditionallyAllowedTenantIds"))
                 .GetValue(clientCertificateCredential);
             var expectedTenants = additionalTenants.Split(';')
                 .Select(t => t.Trim())
@@ -232,7 +232,7 @@ namespace Azure.Core.Extensions.Tests
             Assert.AreEqual("ConfigurationTenantId", clientSecretCredential.TenantId);
 
             var additionalTenants = (string[]) typeof(ClientSecretCredential)
-                .GetField("_additionallyAllowedTenantIds", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance).First(f => f.Name.EndsWith("dditionallyAllowedTenantIds"))
                 .GetValue(clientSecretCredential);
             Assert.IsEmpty(additionalTenants);
         }
@@ -262,7 +262,7 @@ namespace Azure.Core.Extensions.Tests
             Assert.AreEqual("ConfigurationTenantId", clientSecretCredential.TenantId);
 
             var actualTenants = typeof(ClientSecretCredential)
-                .GetField("_additionallyAllowedTenantIds", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetFields(BindingFlags.NonPublic | BindingFlags.Instance).First(f => f.Name.EndsWith("dditionallyAllowedTenantIds"))
                 .GetValue(clientSecretCredential);
             var expectedTenants = additionalTenants.Split(';')
                 .Select(t => t.Trim())

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/Microsoft.Extensions.Azure.Tests.csproj
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/Microsoft.Extensions.Azure.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+		<ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\src\Microsoft.Extensions.Azure.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We recently changed an internal field name in Azure.Identity that broke these tests. This fix allows either the new or old property name so that project and package refs work until the change is published to NuGet.