### PR TITLE
Enable data plane BuildSnippets for Storage

### DIFF
--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -29,7 +29,6 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: storage
-    BuildSnippets: false
     ArtifactName: packages
     Artifacts:
     - name: Azure.Storage.Blobs


### PR DESCRIPTION
Relates to #33976, which is only needed for control plane snippets.
