### PR TITLE
[AzureMonitorExporter] fix more nullables with `NotNullIfNotNullAttribute`

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -29,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 {
                     // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
 
-                    Properties.Add(new KeyValuePair<string, string>(tag.Key, tag.Value.ToString().Truncate(SchemaConstants.MetricsData_Properties_MaxValueLength)!));
+                    Properties.Add(new KeyValuePair<string, string>(tag.Key, tag.Value.ToString().Truncate(SchemaConstants.MetricsData_Properties_MaxValueLength)));
                 }
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NullableAttributes.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/NullableAttributes.cs
@@ -10,6 +10,7 @@
 namespace System.Diagnostics.CodeAnalysis
 {
 #pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable SA1402 // File may only contain a single type
 
     /// <summary>
     /// Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.
@@ -27,6 +28,21 @@ namespace System.Diagnostics.CodeAnalysis
         public bool ReturnValue { get; }
     }
 
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
 #pragma warning restore SA1649 // File name should match first type name
+#pragma warning restore SA1402 // File may only contain a single type
 }
 #endif

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StringExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StringExtensions.cs
@@ -16,6 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// <param name="input">A string to be evaluated.</param>
         /// <param name="maxLength">A specified length which is used to evaluate the input string.</param>
         /// <returns>The input string if less than max length, or a substring that begins at 0.</returns>
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(input))]
         public static string? Truncate(this string? input, int maxLength)
         {
             if (input == null)


### PR DESCRIPTION
Towards #34013

## Changes
- add `internal sealed class NotNullIfNotNullAttribute`.
- correctly annotate `StringExtensions.Truncate()` and update references.

## How to use
Assume you write the following method:
```csharp
public string? Truncate(this string? input, int maxLength)
```
which is used like this:
```csharp
if (someString != null)
{
    var sanitizedString = someString.Truncate(someLength)
}
```

The compiler won't immediately identify that the output of our `Truncate` method is not null. 

To fix this, you would use the attribute on the method like this:
```csharp
[return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(input))]
public static string? Truncate(this string? input, int maxLength)
```