### PR TITLE
Only build snippets on latest TFM

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -127,6 +127,8 @@
     <RequiredTargetFrameworks>net7.0;net6.0</RequiredTargetFrameworks>
     <!-- Also test net461 on Windows. -->
     <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(RequiredTargetFrameworks);net461</RequiredTargetFrameworks>
+    <!-- But only build snippets for the latest. -->
+    <RequiredTargetFrameworks Condition="'$(BuildSnippets)' == 'true'">net7.0</RequiredTargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsMgmtSubLibrary)' == 'true' and !$(MSBuildProjectName.Equals('Azure.ResourceManager.Tests'))">

--- a/sdk/core/Azure.Core.TestFramework/tests/Azure.Core.TestFramework.Tests.csproj
+++ b/sdk/core/Azure.Core.TestFramework/tests/Azure.Core.TestFramework.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks);net6.0</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,5 +23,5 @@
     <Compile Include="..\..\..\..\common\ManagementTestShared\Redesign\*.cs" LinkBase="Shared\Mgmt" />
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />
   </ItemGroup>
-  
+
 </Project>

--- a/sdk/core/Azure.Core/samples/Configuration.md
+++ b/sdk/core/Azure.Core/samples/Configuration.md
@@ -103,7 +103,12 @@ internal class PollyPolicy : HttpPipelinePolicy
                 return message.Response;
             });
     }
-    // async version omitted for brevity
+
+    public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+    {
+        // async version omitted for brevity
+        throw new NotImplementedException();
+    }
 }
 ```
 

--- a/sdk/core/Azure.Core/tests/samples/PollyPolicy.cs
+++ b/sdk/core/Azure.Core/tests/samples/PollyPolicy.cs
@@ -39,12 +39,14 @@ namespace Azure.Core.Samples
                     return message.Response;
                 });
         }
-#if SNIPPET
-        // async version omitted for brevity
-    }
-#endif
-        #endregion
 
+#if SNIPPET
+        public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            // async version omitted for brevity
+            throw new NotImplementedException();
+        }
+#else
         public override async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
             await Policy.Handle<IOException>()
@@ -71,5 +73,7 @@ namespace Azure.Core.Samples
                     return message.Response;
                 });
         }
+#endif
     }
+    #endregion
 }


### PR DESCRIPTION
Also fixes #33975 by reformatting snippets in sdk/core.
