### PR TITLE
Remove DECODE_PRECENT variable after agent update

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -10,7 +10,6 @@ variables:
     BuildConfiguration: 'Release'
   DocFxVersion: 'v2.56.1'
   CollectCoverage: false
-  DECODE_PERCENTS: false
   NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages/
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1


### PR DESCRIPTION
After the changes to the KeyVault task at https://github.com/microsoft/azure-pipelines-tasks/pull/17566 we need to remove this opt-out otherwise we now end up with values that are not decoded which need to be. This became an issue for any values with a % that were set with the VSO setvariable syntax.
