### PR TITLE
[OperationalInsights] Fix DateTimeOffset format string

### DIFF
--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsAvailableServiceTier.Serialization.cs
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsAvailableServiceTier.Serialization.cs
@@ -91,7 +91,7 @@ namespace Azure.ResourceManager.OperationalInsights.Models
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    lastSkuUpdate = property.Value.GetDateTimeOffset();
+                    lastSkuUpdate = property.Value.GetDateTimeOffset("O");
                     continue;
                 }
             }

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsCapacityReservationProperties.Serialization.cs
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsCapacityReservationProperties.Serialization.cs
@@ -32,7 +32,7 @@ namespace Azure.ResourceManager.OperationalInsights.Models
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    lastSkuUpdate = property.Value.GetDateTimeOffset();
+                    lastSkuUpdate = property.Value.GetDateTimeOffset("O");
                     continue;
                 }
                 if (property.NameEquals("minCapacity"u8))

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceSku.Serialization.cs
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/Generated/Models/OperationalInsightsWorkspaceSku.Serialization.cs
@@ -55,7 +55,7 @@ namespace Azure.ResourceManager.OperationalInsights.Models
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
                     }
-                    lastSkuUpdate = property.Value.GetDateTimeOffset();
+                    lastSkuUpdate = property.Value.GetDateTimeOffset("O");
                     continue;
                 }
             }

--- a/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/autorest.md
+++ b/sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/src/autorest.md
@@ -22,7 +22,6 @@ format-by-name-rules:
   '*Uris': 'Uri'
   'clusterId': 'uuid'
   'dataExportId': 'uuid'
-  'lastSkuUpdatedOn': 'datetime'
   '*ResourceId': 'arm-id'
   'queryPackId': 'uuid'
   'customerId': 'uuid'
@@ -99,9 +98,9 @@ rename-mapping:
   WorkspacePatch.properties.modifiedDate: -|date-time
   DataExport.properties.enable: IsEnabled
   AvailableServiceTier.enabled: IsEnabled
-  AvailableServiceTier.lastSkuUpdate: LastSkuUpdatedOn
-  CapacityReservationProperties.lastSkuUpdate: LastSkuUpdatedOn
-  WorkspaceSku.lastSkuUpdate: LastSkuUpdatedOn
+  AvailableServiceTier.lastSkuUpdate: LastSkuUpdatedOn|date-time
+  CapacityReservationProperties.lastSkuUpdate: LastSkuUpdatedOn|date-time
+  WorkspaceSku.lastSkuUpdate: LastSkuUpdatedOn|date-time
   IntelligencePack.enabled: IsEnabled
   WorkspaceFeatures.disableLocalAuth: IsLocalAuthDisabled
   WorkspaceFeatures.enableDataExport: IsDataExportEnabled


### PR DESCRIPTION
Resolve #33536, #33571

The generated code should be `property.Value.GetDateTimeOffset("O")` instead of `property.Value.GetDateTimeOffset()`. 

The former method will call an [extension method](https://github.com/Azure/autorest.csharp/blob/c8280c0cacac4c06c7bdcd4414438a517db41eab/src/assets/Generator.Shared/JsonElementExtensions.cs#L66-L71) of `JsonElement` written by us to treat the `JsonElement` as Int64 (Unix Timestamp) or string and the string case can support multiple formats despite the "O" format (`ISO8601`) being passed in. See [code](https://github.com/Azure/autorest.csharp/blob/c8280c0cacac4c06c7bdcd4414438a517db41eab/src/assets/Generator.Shared/TypeFormatters.cs#L125-L132).

The latter method calls the original `GetDateTimeOffset()` of `JsonElement` and seems to only support `ISO8601` format.


# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
