### PR TITLE
Move DynamicJson tests to use raw string literals

### DIFF
--- a/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
@@ -12,10 +12,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetIntProperty()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : 1
-                }");
+                  "Foo" : 1
+                }
+            """);
 
             int value = jsonData.Foo;
 
@@ -25,12 +26,13 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetNestedIntProperty()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : {
-                    ""Bar"" : 1
+                  "Foo" : {
+                    "Bar" : 1
                   }
-                }");
+                }
+                """);
 
             int value = jsonData.Foo.Bar;
 
@@ -40,10 +42,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetIntProperty()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : 1
-                }");
+                  "Foo" : 1
+                }
+                """);
 
             jsonData.Foo = 2;
 
@@ -53,12 +56,13 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetNestedIntProperty()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : {
-                    ""Bar"" : 1
+                  "Foo" : {
+                    "Bar" : 1
                   }
-                }");
+                }
+                """);
 
             jsonData.Foo.Bar = 2;
 
@@ -68,7 +72,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetArrayValue()
         {
-            dynamic jsonData = GetDynamicJson(@"[0, 1, 2]");
+            dynamic jsonData = GetDynamicJson("""[0, 1, 2]""");
 
             Assert.AreEqual(0, (int)jsonData[0]);
             Assert.AreEqual(1, (int)jsonData[1]);
@@ -78,10 +82,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetNestedArrayValue()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"": [0, 1, 2]
-                }");
+                  "Foo": [0, 1, 2]
+                }
+                """);
 
             Assert.AreEqual(0, (int)jsonData.Foo[0]);
             Assert.AreEqual(1, (int)jsonData.Foo[1]);
@@ -91,10 +96,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetPropertyViaIndexer()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : 1
-                }");
+                  "Foo" : 1
+                }
+                """);
 
             Assert.AreEqual(1, (int)jsonData["Foo"]);
         }
@@ -102,12 +108,13 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetNestedPropertyViaIndexer()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : {
-                    ""Bar"" : 1
+                  "Foo" : {
+                    "Bar" : 1
                   }
-                }");
+                }
+                """);
 
             Assert.AreEqual(1, (int)jsonData.Foo["Bar"]);
         }
@@ -115,7 +122,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetArrayValues()
         {
-            dynamic jsonData = GetDynamicJson(@"[0, 1, 2]");
+            dynamic jsonData = GetDynamicJson("""[0, 1, 2]""");
 
             jsonData[0] = 4;
             jsonData[1] = 5;
@@ -129,10 +136,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetNestedArrayValues()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"": [0, 1, 2]
-                }");
+                  "Foo": [0, 1, 2]
+                }
+                """);
 
             jsonData.Foo[0] = 4;
             jsonData.Foo[1] = 5;
@@ -146,7 +154,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetArrayValuesToDifferentTypes()
         {
-            dynamic jsonData = GetDynamicJson(@"[0, 1, 2, 3]");
+            dynamic jsonData = GetDynamicJson("""[0, 1, 2, 3]""");
 
             jsonData[1] = 4;
             jsonData[2] = true;
@@ -161,10 +169,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetNestedArrayValuesToDifferentTypes()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"": [0, 1, 2, 3]
-                }");
+                  "Foo": [0, 1, 2, 3]
+                }
+                """);
 
             jsonData.Foo[1] = 4;
             jsonData.Foo[2] = true;
@@ -179,7 +188,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetNullPropertyValue()
         {
-            dynamic jsonData = GetDynamicJson(@"{ ""Foo"" : null }");
+            dynamic jsonData = GetDynamicJson("""{ "Foo" : null }""");
 
             Assert.IsNull((CustomType)jsonData.Foo);
             Assert.IsNull((int?)jsonData.Foo);
@@ -188,7 +197,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetNullArrayValue()
         {
-            dynamic jsonData = GetDynamicJson(@"[ null ]");
+            dynamic jsonData = GetDynamicJson("""[ null ]""");
 
             Assert.IsNull((CustomType)jsonData[0]);
             Assert.IsNull((int?)jsonData[0]);
@@ -197,7 +206,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetPropertyValueToNull()
         {
-            dynamic jsonData = GetDynamicJson(@"{ ""Foo"" : null }");
+            dynamic jsonData = GetDynamicJson("""{ "Foo" : null }""");
 
             jsonData.Foo = null;
 
@@ -208,7 +217,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetArrayValueToNull()
         {
-            dynamic jsonData = GetDynamicJson(@"[0]");
+            dynamic jsonData = GetDynamicJson("""[0]""");
 
             jsonData[0] = null;
 
@@ -219,10 +228,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetPropertyViaIndexer()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : 1
-                }");
+                  "Foo" : 1
+                }
+                """);
 
             jsonData["Foo"] = 4;
 
@@ -232,12 +242,13 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetNestedPropertyViaIndexer()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : {
-                    ""Bar"" : 1
+                  "Foo" : {
+                    "Bar" : 1
                   }
-                }");
+                }
+                """);
 
             jsonData["Foo"]["Bar"] = 4;
 
@@ -247,10 +258,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanAddNewProperty()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : 1
-                }");
+                  "Foo" : 1
+                }
+                """);
 
             jsonData.Bar = 2;
 
@@ -261,10 +273,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanMakeChangesAndAddNewProperty()
         {
-            dynamic jsonData = GetDynamicJson(@"
+            dynamic jsonData = GetDynamicJson("""
                 {
-                  ""Foo"" : 1
-                }");
+                  "Foo" : 1
+                }
+                """);
 
             Assert.AreEqual(1, (int)jsonData.Foo);
 

--- a/sdk/core/Azure.Core.Experimental/tests/JsonDataTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/JsonDataTests.cs
@@ -94,13 +94,14 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanAccessProperties()
         {
-            dynamic jsonData = DynamicJsonTests.GetDynamicJson(@"
+            dynamic jsonData = DynamicJsonTests.GetDynamicJson("""
                 {
-                  ""primitive"" : ""Hello"",
-                  ""nested"" : {
-                      ""nestedPrimitive"": true
+                  "primitive" : "Hello",
+                  "nested" : {
+                      "nestedPrimitive": true
                  }
-              }");
+              }
+            """);
 
             Assert.AreEqual("Hello", (string)jsonData.primitive);
             Assert.AreEqual(true, (bool)jsonData.nested.nestedPrimitive);

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
@@ -15,15 +15,16 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetProperty()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Baz"" : {
-                     ""A"" : 3.0
+                  "Baz" : {
+                     "A" : 3.0
                   },
-                  ""Foo"" : 1.2,
-                  ""Bar"" : ""Hi!"",
-                  ""Qux"" : false
-                }";
+                  "Foo" : 1.2,
+                  "Bar" : "Hi!",
+                  "Qux" : false
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -42,15 +43,16 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetProperty()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Baz"" : {
-                     ""A"" : 3
+                  "Baz" : {
+                     "A" : 3
                   },
-                  ""Foo"" : 1,
-                  ""Bar"" : ""Hi!"",
-                  ""Qux"" : false
-                }";
+                  "Foo" : 1,
+                  "Bar" : "Hi!",
+                  "Qux" : false
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -67,29 +69,31 @@ namespace Azure.Core.Experimental.Tests
             MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Baz"" : {
-                     ""A"" : 5
+                  "Baz" : {
+                     "A" : 5
                   },
-                  ""Foo"" : 2,
-                  ""Bar"" : ""Hello"",
-                  ""Qux"" : true
-                }"),
+                  "Foo" : 2,
+                  "Bar" : "Hello",
+                  "Qux" : true
+                }
+                """),
                 jsonString);
         }
 
         [Test]
         public void CanSetPropertyMultipleTimes()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Baz"" : {
-                     ""A"" : 3
+                  "Baz" : {
+                     "A" : 3
                   },
-                  ""Foo"" : 1,
-                  ""Bar"" : ""Hi!""
-                }";
+                  "Foo" : 1,
+                  "Bar" : "Hi!"
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -102,28 +106,30 @@ namespace Azure.Core.Experimental.Tests
             MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Baz"" : {
-                     ""A"" : 3
+                  "Baz" : {
+                     "A" : 3
                   },
-                  ""Foo"" : 3,
-                  ""Bar"" : ""Hi!""
-                }"),
+                  "Foo" : 3,
+                  "Bar" : "Hi!"
+                }
+                """),
                 jsonString);
         }
 
         [Test]
         public void CanSetPropertyToMutableJsonDocument()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : ""Hello""
-                }";
+                  "Foo" : "Hello"
+                }
+                """;
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
-            MutableJsonDocument anotherMDoc = MutableJsonDocument.Parse(@"{ ""Baz"": ""hi"" }");
+            MutableJsonDocument anotherMDoc = MutableJsonDocument.Parse("""{ "Baz": "hi" }""");
 
             mdoc.RootElement.GetProperty("Foo").Set(anotherMDoc);
 
@@ -132,26 +138,28 @@ namespace Azure.Core.Experimental.Tests
             MutableJsonDocumentWriteToTests.WriteToAndParse(mdoc, out string jsonString);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : {
-                     ""Baz"" : ""hi""
+                  "Foo" : {
+                     "Baz" : "hi"
                   }
-                }"),
+                }
+                """),
                 jsonString);
         }
 
         [Test]
         public void CanSetPropertyToJsonDocument()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : ""Hello""
-                }";
+                  "Foo" : "Hello"
+                }
+                """;
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
-            JsonDocument doc = JsonDocument.Parse(@"{ ""Baz"": ""hi"" }");
+            JsonDocument doc = JsonDocument.Parse("""{ "Baz": "hi" }""");
 
             mdoc.RootElement.GetProperty("Foo").Set(doc);
 
@@ -160,22 +168,24 @@ namespace Azure.Core.Experimental.Tests
             MutableJsonDocumentWriteToTests.WriteToAndParse(mdoc, out string jsonString);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : {
-                     ""Baz"" : ""hi""
+                  "Foo" : {
+                     "Baz" : "hi"
                   }
-                }"),
+                }
+                """),
                 jsonString);
         }
 
         [Test]
         public void CanAddPropertyToRootObject()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : 1.2
-                }";
+                  "Foo" : 1.2
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -198,22 +208,24 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(1.2, doc.RootElement.GetProperty("Foo").GetDouble());
             Assert.AreEqual("hi", doc.RootElement.GetProperty("Bar").GetString());
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : 1.2,
-                  ""Bar"" : ""hi""
-                }"), jsonString);
+                  "Foo" : 1.2,
+                  "Bar" : "hi"
+                }
+                """), jsonString);
         }
 
         [Test]
         public void CanAddPropertyToObject()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : {
-                    ""A"": 1.2
+                  "Foo" : {
+                    "A": 1.2
                     }
-                }";
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -234,26 +246,28 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(1.2, doc.RootElement.GetProperty("Foo").GetProperty("A").GetDouble());
             Assert.AreEqual("hi", doc.RootElement.GetProperty("Foo").GetProperty("B").GetString());
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : {
-                    ""A"": 1.2,
-                    ""B"": ""hi""
+                  "Foo" : {
+                    "A": 1.2,
+                    "B": "hi"
                     }
-                }"), jsonString);
+                }
+                """), jsonString);
         }
 
         [Test]
         public void CanAddMutableJsonDocumentProperty()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : ""Hello""
-                }";
+                  "Foo" : "Hello"
+                }
+                """;
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
-            MutableJsonDocument anotherMDoc = MutableJsonDocument.Parse(@"{ ""Baz"": ""hi"" }");
+            MutableJsonDocument anotherMDoc = MutableJsonDocument.Parse("""{ "Baz": "hi" }""");
 
             mdoc.RootElement.SetProperty("A", anotherMDoc);
 
@@ -262,27 +276,29 @@ namespace Azure.Core.Experimental.Tests
             MutableJsonDocumentWriteToTests.WriteToAndParse(mdoc, out string jsonString);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : ""Hello"",
-                  ""A"" : {
-                     ""Baz"" : ""hi""
+                  "Foo" : "Hello",
+                  "A" : {
+                     "Baz" : "hi"
                   }
-                }"),
+                }
+                """),
                 jsonString);
         }
 
         [Test]
         public void CanAddJsonDocumentProperty()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : ""Hello""
-                }";
+                  "Foo" : "Hello"
+                }
+                """;
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
-            JsonDocument doc = JsonDocument.Parse(@"{ ""Baz"": ""hi"" }");
+            JsonDocument doc = JsonDocument.Parse("""{ "Baz": "hi" }""");
 
             mdoc.RootElement.SetProperty("A", doc);
 
@@ -291,24 +307,26 @@ namespace Azure.Core.Experimental.Tests
             MutableJsonDocumentWriteToTests.WriteToAndParse(mdoc, out string jsonString);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : ""Hello"",
-                  ""A"" : {
-                     ""Baz"" : ""hi""
+                  "Foo" : "Hello",
+                  "A" : {
+                     "Baz" : "hi"
                   }
-                }"),
+                }
+                """),
                 jsonString);
         }
 
         [Test]
         public void CanRemovePropertyFromRootObject()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : 1.2,
-                  ""Bar"" : ""Hi!""
-                }";
+                  "Foo" : 1.2,
+                  "Bar" : "Hi!"
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -328,22 +346,24 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(1.2, doc.RootElement.GetProperty("Foo").GetDouble());
             Assert.IsFalse(doc.RootElement.TryGetProperty("Bar", out JsonElement _));
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : 1.2
-                }"), jsonString);
+                  "Foo" : 1.2
+                }
+                """), jsonString);
         }
 
         [Test]
         public void CanRemovePropertyFromObject()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : {
-                    ""A"": 1.2,
-                    ""B"": ""hi""
+                  "Foo" : {
+                    "A": 1.2,
+                    "B": "hi"
                     }
-                }";
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -361,24 +381,26 @@ namespace Azure.Core.Experimental.Tests
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.AreEqual(1.2, doc.RootElement.GetProperty("Foo").GetProperty("A").GetDouble());
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : {
-                    ""A"": 1.2
+                  "Foo" : {
+                    "A": 1.2
                     }
-                }"), jsonString);
+                }
+                """), jsonString);
         }
 
         [Test]
         public void CanReplaceObjectWithAnonymousType()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Baz"" : {
-                     ""A"" : 3.0
+                  "Baz" : {
+                     "A" : 3.0
                   },
-                  ""Foo"" : 1.2
-                }";
+                  "Foo" : 1.2
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -400,13 +422,14 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(1.2, baz.Foo);
             Assert.AreEqual(5.5, baz.Baz.B);
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Baz"" : {
-                     ""B"" : 5.5
+                  "Baz" : {
+                     "B" : 5.5
                   },
-                  ""Foo"" : 1.2
-                }"), jsonString);
+                  "Foo" : 1.2
+                }
+                """), jsonString);
         }
 
         private class BazA
@@ -434,10 +457,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanGetArrayElement()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : [ 1, 2, 3 ]
-                }";
+                  "Foo" : [ 1, 2, 3 ]
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -449,10 +473,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetArrayElement()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : [ 1, 2, 3 ]
-                }";
+                  "Foo" : [ 1, 2, 3 ]
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -468,10 +493,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanSetArrayElement_WriteTo()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : [ 1, 2, 3 ]
-                }";
+                  "Foo" : [ 1, 2, 3 ]
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -482,20 +508,22 @@ namespace Azure.Core.Experimental.Tests
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : [ 5, 6, 7 ]
-                }"),
+                  "Foo" : [ 5, 6, 7 ]
+                }
+                """),
                 jsonString);
         }
 
         [Test]
         public void CanSetArrayElementMultipleTimes()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : [ 1, 2, 3 ]
-                }";
+                  "Foo" : [ 1, 2, 3 ]
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -508,10 +536,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanChangeArrayElementType()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : [ 1, 2, 3 ]
-                }";
+                  "Foo" : [ 1, 2, 3 ]
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -530,10 +559,11 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(true, doc.RootElement.GetProperty("Foo")[2].GetBoolean());
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Foo"" : [ 5, ""string"", true ]
-                }"),
+                  "Foo" : [ 5, "string", true ]
+                }
+                """),
                 jsonString);
         }
 
@@ -542,7 +572,7 @@ namespace Azure.Core.Experimental.Tests
         {
             // This tests reference semantics.
 
-            string json = @"[ { ""Foo"" : 4 } ]";
+            string json = """[ { "Foo" : 4 } ]""";
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
@@ -571,7 +601,7 @@ namespace Azure.Core.Experimental.Tests
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(mdoc, out string jsonString);
 
             Assert.AreEqual(5, doc.RootElement[0].GetInt32());
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[ 5 ]"), jsonString);
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""[ 5 ]"""), jsonString);
         }
 
         [Test]
@@ -590,7 +620,7 @@ namespace Azure.Core.Experimental.Tests
 
             Assert.AreEqual(
                 MutableJsonDocumentWriteToTests.RemoveWhiteSpace(
-                    @"{ ""A"" : { ""B"" : 2 } }"),
+                    """{ "A" : { "B" : 2 } }"""),
                 jsonString);
         }
 
@@ -599,7 +629,7 @@ namespace Azure.Core.Experimental.Tests
         {
             // This tests reference semantics.
 
-            string json = @"[ { ""Foo"" : {} } ]";
+            string json = """[ { "Foo" : {} } ]""";
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
@@ -613,12 +643,13 @@ namespace Azure.Core.Experimental.Tests
 
             MutableJsonDocumentWriteToTests.WriteToAndParse(mdoc, out string jsonString);
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(
-                @"[ {
-                    ""Foo"" : {
-                        ""Bar"" : 5
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
+                [ {
+                    "Foo" : {
+                        "Bar" : 5
                     }
-                } ]"), jsonString);
+                } ]
+                """), jsonString);
         }
 
         [Test]
@@ -626,7 +657,7 @@ namespace Azure.Core.Experimental.Tests
         {
             // This tests reference semantics.
 
-            string json = @"[ { ""Foo"" : 4 } ]";
+            string json = """[ { "Foo" : 4 } ]""";
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
@@ -643,23 +674,25 @@ namespace Azure.Core.Experimental.Tests
 
             MutableJsonDocumentWriteToTests.WriteToAndParse(mdoc, out string jsonString);
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(
-                @"[ {
-                    ""Foo"" : {
-                        ""Bar"" : 5
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
+                [ {
+                    "Foo" : {
+                        "Bar" : 5
                     }
-                } ]"), jsonString);
+                } ]
+                """), jsonString);
         }
 
         [Test]
         public void CanInvalidateElement()
         {
-            string json = @"[
-                {
-                  ""Foo"" : {
-                    ""A"": 6
+            string json = """
+                [{
+                  "Foo" : {
+                    "A": 6
                     }
-                } ]";
+                }]
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -683,18 +716,19 @@ namespace Azure.Core.Experimental.Tests
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.AreEqual(5, doc.RootElement[0].GetInt32());
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[ 5 ]"), jsonString);
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""[ 5 ]"""), jsonString);
         }
 
         [Test]
         public void CanAccessPropertyInChangedStructure()
         {
-            string json = @"[
-                {
-                  ""Foo"" : {
-                    ""A"": 6
+            string json = """
+                [ {
+                  "Foo" : {
+                    "A": 6
                     }
-                } ]";
+                } ]
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -731,26 +765,28 @@ namespace Azure.Core.Experimental.Tests
             // 3. Type round-trips correctly.
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[
-                {
-                  ""Foo"" : {
-                    ""A"": 7
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
+                [ {
+                  "Foo" : {
+                    "A": 7
                     }
-                } ]"), jsonString);
+                } ]
+                """), jsonString);
         }
 
         [Test]
         public void CanAccessChangesInDifferentBranches()
         {
-            string json = @"[
-                {
-                  ""Foo"" : {
-                    ""A"": 6
+            string json = """
+                [ {
+                  "Foo" : {
+                    "A": 6
                     }
                 },
                 {
-                    ""Bar"" : ""hi""
-                }]";
+                    "Bar" : "hi"
+                }]
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -781,27 +817,33 @@ namespace Azure.Core.Experimental.Tests
             // 3. Type round-trips correctly.
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[
-                {
-                  ""Foo"" : {
-                    ""A"": 7
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
+                [ {
+                  "Foo" : {
+                    "A": 7
                     }
                 },
                 {
-                    ""Bar"" : ""new""
-                }]"), jsonString);
+                    "Bar" : "new"
+                }]
+                """), jsonString);
         }
 
         [Test]
         public void PriorChangeToReplacedPropertyIsIgnored()
         {
-            string json = @"{ ""ArrayProperty"": [
+            string json = """
                 {
-                  ""Foo"" : {
-                    ""A"": 6
-                    }
-                } ],
-                  ""Bar"" : ""hi"" }";
+                    "ArrayProperty": [
+                        {
+                           "Foo" : {
+                                "A": 6
+                                }
+                        }
+                    ],
+                    "Bar" : "hi"
+                 }
+            """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -835,20 +877,24 @@ namespace Azure.Core.Experimental.Tests
             string jsonString = BinaryData.FromStream(stream).ToString();
             JsonDocument doc = JsonDocument.Parse(jsonString);
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"{
-                ""ArrayProperty"": [
-                    {
-                      ""Foo"" : {
-                        ""A"": 7
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
+                 {
+                    "ArrayProperty": [
+                        {
+                            "Foo" : {
+                                "A": 7
+                            }
                         }
-                    } ],
-                ""Bar"" : ""hi"" }"), jsonString);
+                     ],
+                    "Bar" : "hi"
+                 }
+                 """), jsonString);
         }
 
         [Test]
         public void CanSetProperty_StringToNumber()
         {
-            string json = @"[ { ""Foo"" : ""hi"" } ]";
+            string json = """[ { "Foo" : "hi" } ]""";
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -862,13 +908,13 @@ namespace Azure.Core.Experimental.Tests
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.AreEqual(1.2, doc.RootElement[0].GetProperty("Foo").GetDouble());
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[ { ""Foo"" : 1.2 } ]"), jsonString);
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""[ { "Foo" : 1.2 } ]"""), jsonString);
         }
 
         [Test]
         public void CanSetProperty_StringToBool()
         {
-            string json = @"[ { ""Foo"" : ""hi"" } ]";
+            string json = """[ { "Foo" : "hi" } ]""";
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -882,13 +928,13 @@ namespace Azure.Core.Experimental.Tests
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.IsFalse(doc.RootElement[0].GetProperty("Foo").GetBoolean());
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[ { ""Foo"" : false } ]"), jsonString);
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""[ { "Foo" : false } ]"""), jsonString);
         }
 
         [Test]
         public void CanSetProperty_StringToObject()
         {
-            string json = @"{ ""Foo"" : ""hi"" }";
+            string json = """{ "Foo" : "hi" }""";
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -905,15 +951,14 @@ namespace Azure.Core.Experimental.Tests
 
             Assert.AreEqual(6, doc.RootElement.GetProperty("Foo").GetProperty("Bar").GetInt32());
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(
-                @"{ ""Foo"" : {""Bar"" : 6 } }"),
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""{ "Foo" : {"Bar" : 6 } }"""),
                 jsonString);
         }
 
         [Test]
         public void CanSetProperty_StringToArray()
         {
-            string json = @"[ { ""Foo"" : ""hi"" } ]";
+            string json = """[ { "Foo" : "hi" } ]""";
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -932,13 +977,13 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(2, doc.RootElement[0].GetProperty("Foo")[1].GetInt32());
             Assert.AreEqual(3, doc.RootElement[0].GetProperty("Foo")[2].GetInt32());
 
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[ { ""Foo"" : [1, 2, 3] }]"), jsonString);
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""[ { "Foo" : [1, 2, 3] }]"""), jsonString);
         }
 
         [Test]
         public void CanSetProperty_StringToNull()
         {
-            string json = @"[ { ""Foo"" : ""hi"" } ]";
+            string json = """[ { "Foo" : "hi" } ]""";
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -952,16 +997,17 @@ namespace Azure.Core.Experimental.Tests
             JsonDocument doc = MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
 
             Assert.AreEqual(JsonValueKind.Null, doc.RootElement[0].GetProperty("Foo").ValueKind);
-            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"[ { ""Foo"" : null } ]"), jsonString);
+            Assert.AreEqual(MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""[ { "Foo" : null } ]"""), jsonString);
         }
 
         [Test]
         public void CanSerialize()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : ""Hello""
-                }";
+                  "Foo" : "Hello"
+                }
+                """;
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
             byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(mdoc);

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentWriteToTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentWriteToTests.cs
@@ -16,8 +16,8 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteBoolean()
         {
-            string jsonTrue = @"true";
-            string jsonFalse = @"false";
+            string jsonTrue = "true";
+            string jsonFalse = "false";
 
             MutableJsonDocument jdTrue = MutableJsonDocument.Parse(jsonTrue);
             MutableJsonDocument jdFalse = MutableJsonDocument.Parse(jsonFalse);
@@ -32,7 +32,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteString()
         {
-            string json = @"""Hi!""";
+            string json = """ "Hi!" """;
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -44,11 +44,12 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteBooleanObjectProperty()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" :  true,
-                  ""Bar"" :  false
-                }";
+                  "Foo" :  true,
+                  "Bar" :  false
+                }
+                """;
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -60,11 +61,12 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteBooleanObjectPropertyWithChangesToOtherBranches()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" : true,
-                  ""Bar"" : 1
-                }";
+                  "Foo" : true,
+                  "Bar" : 1
+                }
+                """;
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -72,21 +74,23 @@ namespace Azure.Core.Experimental.Tests
 
             WriteToAndParse(jd, out string jsonString);
 
-            Assert.AreEqual(RemoveWhiteSpace(@"
+            Assert.AreEqual(RemoveWhiteSpace("""
                 {
-                  ""Foo"" : true,
-                  ""Bar"" : 2
-                }"),
+                  "Foo" : true,
+                  "Bar" : 2
+                }
+                """),
                 RemoveWhiteSpace(jsonString));
         }
 
         [Test]
         public void CanWriteBooleanObjectPropertyWithChangesToBool()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Foo"" :  true
-                }";
+                  "Foo" :  true
+                }
+                """;
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -94,44 +98,46 @@ namespace Azure.Core.Experimental.Tests
 
             WriteToAndParse(jd, out string jsonString);
 
-            Assert.AreEqual(RemoveWhiteSpace(@"
+            Assert.AreEqual(RemoveWhiteSpace("""
                 {
-                  ""Foo"" :  false
-                }"),
+                  "Foo" :  false
+                }
+            """),
                 RemoveWhiteSpace(jsonString));
         }
 
         [Test]
         public void CanWriteObject()
         {
-            string json = @"
+            string json = """
                 {
-                  ""StringProperty"" :  ""Hi!"",
-                  ""IntProperty"" :  16,
-                  ""DoubleProperty"" :  16.56,
-                  ""ObjectProperty"" : {
-                      ""StringProperty"" :  ""Nested"",
-                      ""IntProperty"" :  22,
-                      ""DoubleProperty"" :  22.22
+                  "StringProperty" :  "Hi!",
+                  "IntProperty" :  16,
+                  "DoubleProperty" :  16.56,
+                  "ObjectProperty" : {
+                      "StringProperty" :  "Nested",
+                      "IntProperty" :  22,
+                      "DoubleProperty" :  22.22
                   },
-                  ""ArrayProperty"" : [
+                  "ArrayProperty" : [
                       {
-                          ""StringProperty"" :  ""First"",
-                          ""IntProperty"" :  1,
-                          ""DoubleProperty"" :  1.1
+                          "StringProperty" :  "First",
+                          "IntProperty" :  1,
+                          "DoubleProperty" :  1.1
                       },
                       {
-                          ""StringProperty"" :  ""Second"",
-                          ""IntProperty"" :  2,
-                          ""DoubleProperty"" :  2.2
+                          "StringProperty" :  "Second",
+                          "IntProperty" :  2,
+                          "DoubleProperty" :  2.2
                       },
                       {
-                          ""StringProperty"" :  ""Third"",
-                          ""IntProperty"" :  3,
-                          ""DoubleProperty"" :  3.3
+                          "StringProperty" :  "Third",
+                          "IntProperty" :  3,
+                          "DoubleProperty" :  3.3
                       }
                   ]
-                }";
+                }
+                """;
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -151,7 +157,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteInt()
         {
-            string json = @"16";
+            string json = "16";
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -163,7 +169,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteDouble()
         {
-            string json = @"16.56";
+            string json = "16.56";
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -175,7 +181,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteNumberArray()
         {
-            string json = @"[ 1, 2.2, 3, -4]";
+            string json = "[ 1, 2.2, 3, -4]";
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -187,7 +193,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanWriteStringArray()
         {
-            string json = @"[ ""one"", ""two"", ""three""]";
+            string json = """[ "one", "two", "three"]""";
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonElementTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonElementTests.cs
@@ -14,10 +14,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void ToStringWorksWithNoChanges()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Bar"" : ""Hi!""
-                }";
+                  "Bar" : "Hi!"
+                }
+                """;
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
 
@@ -29,49 +30,54 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void ToStringWorksWithChanges()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Bar"" : ""Hi!""
-                }";
+                  "Bar" : "Hi!"
+                }
+                """;
 
             MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
             mdoc.RootElement.GetProperty("Bar").Set(null);
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Bar"" : null
-                }"),
+                  "Bar" : null
+                }
+                """),
                 MutableJsonDocumentWriteToTests.RemoveWhiteSpace(mdoc.RootElement.ToString()));
         }
 
         [Test]
         public void ChangesToElementAppearInToString()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Bar"" : ""Hi!""
-                }";
+                  "Bar" : "Hi!"
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
             jd.RootElement.GetProperty("Bar").Set("hello");
 
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Bar"" : ""hello""
-                }"),
+                  "Bar" : "hello"
+                }
+                """),
                 MutableJsonDocumentWriteToTests.RemoveWhiteSpace(jd.RootElement.ToString()));
         }
 
         [Test]
         public void ChangesToElementAppearInJsonElement()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Bar"" : ""Hi!""
-                }";
+                  "Bar" : "Hi!"
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -82,20 +88,22 @@ namespace Azure.Core.Experimental.Tests
 
             JsonElement rootElement = jd.RootElement.GetJsonElement();
             Assert.AreEqual(
-                MutableJsonDocumentWriteToTests.RemoveWhiteSpace(@"
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
                 {
-                  ""Bar"" : ""hello""
-                }"),
+                  "Bar" : "hello"
+                }
+                """),
                 MutableJsonDocumentWriteToTests.RemoveWhiteSpace(rootElement.ToString()));
         }
 
         [Test]
         public void CanGetNullElement()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Bar"" : null
-                }";
+                  "Bar" : null
+                }
+                """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -107,10 +115,11 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void ValueKindReflectsChanges()
         {
-            string json = @"
+            string json = """
                 {
-                  ""Bar"" : ""Hi!""
-                }";
+                  "Bar" : "Hi!"
+                }
+            """;
 
             var jd = MutableJsonDocument.Parse(json);
 
@@ -128,7 +137,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanEnumerateArray()
         {
-            string json = @"[0, 1, 2, 3]";
+            string json = "[0, 1, 2, 3]";
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 
@@ -144,7 +153,7 @@ namespace Azure.Core.Experimental.Tests
         [Test]
         public void CanEnumerateArrayWithChanges()
         {
-            string json = @"[0, 1, 2, 3]";
+            string json = "[0, 1, 2, 3]";
 
             MutableJsonDocument jd = MutableJsonDocument.Parse(json);
 

--- a/sdk/core/Azure.Core.Experimental/tests/perf/JsonSamples.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/perf/JsonSamples.cs
@@ -13,125 +13,126 @@ namespace Azure.Core.Experimental.Perf.Benchmarks
     {
         // From https://learn.microsoft.com/rest/api/cognitiveservices-textanalytics/3.1preview4/sentiment/sentiment?tabs=HTTP#examples
         private static BinaryData _documentSentiment = BinaryData.FromString(
-            @"
+            """
             {
-  ""documents"": [
+  "documents": [
     {
-      ""confidenceScores"": {
-        ""negative"": 0,
-        ""neutral"": 0,
-        ""positive"": 1
+      "confidenceScores": {
+        "negative": 0,
+        "neutral": 0,
+        "positive": 1
       },
-      ""id"": ""1"",
-      ""sentences"": [
+      "id": "1",
+      "sentences": [
         {
-          ""targets"": [
+          "targets": [
             {
-              ""confidenceScores"": {
-                ""negative"": 0,
-                ""positive"": 1
+              "confidenceScores": {
+                "negative": 0,
+                "positive": 1
               },
-              ""length"": 10,
-              ""offset"": 6,
-              ""relations"": [
+              "length": 10,
+              "offset": 6,
+              "relations": [
                 {
-                  ""ref"": ""#/documents/0/sentences/0/assessments/0"",
-                  ""relationType"": ""assessment""
+                  "ref": "#/documents/0/sentences/0/assessments/0",
+                  "relationType": "assessment"
                 }
               ],
-              ""sentiment"": ""positive"",
-              ""text"": ""atmosphere""
+              "sentiment": "positive",
+              "text": "atmosphere"
             }
           ],
-          ""confidenceScores"": {
-    ""negative"": 0,
-            ""neutral"": 0,
-            ""positive"": 1
+          "confidenceScores": {
+    "negative": 0,
+            "neutral": 0,
+            "positive": 1
           },
-          ""length"": 17,
-          ""offset"": 0,
-          ""assessments"": [
+          "length": 17,
+          "offset": 0,
+          "assessments": [
             {
-              ""confidenceScores"": {
-                ""negative"": 0,
-                ""positive"": 1
+              "confidenceScores": {
+                "negative": 0,
+                "positive": 1
               },
-              ""isNegated"": false,
-              ""length"": 5,
-              ""offset"": 0,
-              ""sentiment"": ""positive"",
-              ""text"": ""great""
+              "isNegated": false,
+              "length": 5,
+              "offset": 0,
+              "sentiment": "positive",
+              "text": "great"
             }
           ],
-          ""sentiment"": ""positive"",
-          ""text"": ""Great atmosphere.""
+          "sentiment": "positive",
+          "text": "Great atmosphere."
         },
         {
-    ""targets"": [
+    "targets": [
             {
-        ""confidenceScores"": {
-            ""negative"": 0.01,
-                ""positive"": 0.99
+        "confidenceScores": {
+            "negative": 0.01,
+                "positive": 0.99
               },
-              ""length"": 11,
-              ""offset"": 37,
-              ""relations"": [
+              "length": 11,
+              "offset": 37,
+              "relations": [
                 {
-            ""ref"": ""#/documents/0/sentences/1/assessments/0"",
-                  ""relationType"": ""assessment""
+            "ref": "#/documents/0/sentences/1/assessments/0",
+                  "relationType": "assessment"
                 }
               ],
-              ""sentiment"": ""positive"",
-              ""text"": ""restaurants""
+              "sentiment": "positive",
+              "text": "restaurants"
             },
             {
-        ""confidenceScores"": {
-            ""negative"": 0.01,
-                ""positive"": 0.99
+        "confidenceScores": {
+            "negative": 0.01,
+                "positive": 0.99
               },
-              ""length"": 6,
-              ""offset"": 50,
-              ""relations"": [
+              "length": 6,
+              "offset": 50,
+              "relations": [
                 {
-            ""ref"": ""#/documents/0/sentences/1/assessments/0"",
-                  ""relationType"": ""assessment""
+            "ref": "#/documents/0/sentences/1/assessments/0",
+                  "relationType": "assessment"
                 }
               ],
-              ""sentiment"": ""positive"",
-              ""text"": ""hotels""
+              "sentiment": "positive",
+              "text": "hotels"
             }
           ],
-          ""confidenceScores"": {
-        ""negative"": 0.01,
-            ""neutral"": 0.86,
-            ""positive"": 0.13
+          "confidenceScores": {
+        "negative": 0.01,
+            "neutral": 0.86,
+            "positive": 0.13
           },
-          ""length"": 52,
-          ""offset"": 18,
-          ""assessments"": [
+          "length": 52,
+          "offset": 18,
+          "assessments": [
             {
-        ""confidenceScores"": {
-            ""negative"": 0.01,
-                ""positive"": 0.99
+        "confidenceScores": {
+            "negative": 0.01,
+                "positive": 0.99
               },
-              ""isNegated"": false,
-              ""length"": 15,
-              ""offset"": 18,
-              ""sentiment"": ""positive"",
-              ""text"": ""Close to plenty""
+              "isNegated": false,
+              "length": 15,
+              "offset": 18,
+              "sentiment": "positive",
+              "text": "Close to plenty"
             }
           ],
-          ""sentiment"": ""neutral"",
-          ""text"": ""Close to plenty of restaurants, hotels, and transit!""
+          "sentiment": "neutral",
+          "text": "Close to plenty of restaurants, hotels, and transit!"
         }
       ],
-      ""sentiment"": ""positive"",
-      ""warnings"": []
+      "sentiment": "positive",
+      "warnings": []
     }
   ],
-  ""errors"": [],
-  ""modelVersion"": ""2020-04-01""
-}");
+  "errors": [],
+  "modelVersion": "2020-04-01"
+}
+""");
 
         /// <summary>
         /// An example of a large Json response.

--- a/sdk/core/Azure.Core.Experimental/tests/public/JsonDataArrayTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/public/JsonDataArrayTests.cs
@@ -69,7 +69,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotConvertArrayPropertyToLeaf()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
 
             // TODO: Standardize Exception types.
             Assert.Throws<InvalidOperationException>(() => { var model = (int)data.value; });
@@ -81,7 +81,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotConvertArrayPropertyToModel()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
             Assert.Throws<JsonException>(() => { var model = (SampleModel)data.value; });
         }
 
@@ -99,7 +99,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotGetMemberOnArrayProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
             Assert.Throws<InvalidOperationException>(() => { var x = data.value.Property; });
         }
 
@@ -117,7 +117,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotSetMemberOnArrayProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
             Assert.Throws<InvalidOperationException>(() => { data.value.Property = "invalid"; });
         }
 
@@ -135,7 +135,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotGetIndexPropertyOnArrayProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
             Assert.Throws<InvalidOperationException>(() => { var x = data.value["Property"]; });
         }
 
@@ -152,7 +152,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanGetArrayPropertyIndex()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
 
             Assert.AreEqual(1, (int)data.value[0]);
             Assert.AreEqual(2, (int)data.value[1]);
@@ -183,7 +183,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotSetIndexPropertyOnArrayProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
             Assert.Throws<InvalidOperationException>(() => { data.value["Property"] = "invalid"; });
         }
 
@@ -207,7 +207,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanSetArrayPropertyIndex()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
 
             data.value[0] = 5;
             data.value[1] = "valid";
@@ -247,7 +247,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanGetArrayPropertyLength()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
             Assert.AreEqual(3, ((int[])data.value).Length);
         }
 
@@ -266,7 +266,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanEnumerateArrayProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": [1, 2, 3] }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": [1, 2, 3] }""");
 
             int i = 1;
             foreach (int item in data.value)

--- a/sdk/core/Azure.Core.Experimental/tests/public/JsonDataLeafTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/public/JsonDataLeafTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanConvertIntLeafPropertyToInt()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.AreEqual(5, (int)data.value);
         }
 
@@ -35,7 +35,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanConvertIntLeafPropertyToDouble()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.AreEqual(5d, (double)data.value);
         }
 
@@ -49,7 +49,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanConvertIntLeafPropertyToLong()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.AreEqual((long)5, (long)data.value);
         }
 
@@ -65,7 +65,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotConvertIntLeafPropertyToString()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { var s = (string)data.value; }
             );
@@ -83,7 +83,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotConvertIntLeafPropertyToBoolean()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { var b = (bool)data.value; }
             );
@@ -105,7 +105,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotConvertIntLeafPropertyToModel()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
 
             // TODO: Throws JsonException - is that preferred over
             // InvalidOperationException?
@@ -131,7 +131,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotGetMemberOnLeafProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { var x = data.value.Property; }
             );
@@ -152,7 +152,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotSetMemberOnLeafProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { data.value.Property = "invalid"; }
             );
@@ -161,7 +161,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanSetLeafProperty()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             data.value = 6;
             Assert.AreEqual(6, (int)data.value);
         }
@@ -169,7 +169,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanSetLeafPropertyToDifferentType()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             data.value = "valid";
             Assert.AreEqual("valid", (string)data.value);
         }
@@ -194,7 +194,7 @@ namespace Azure.Core.Tests.Public
         {
             // TODO: Make exception messages consistent.
 
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { var x = data.value["Property"]; }
             );
@@ -216,7 +216,7 @@ namespace Azure.Core.Tests.Public
         {
             // TODO: Make exception messages consistent.
 
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { var x = data.value[0]; }
             );
@@ -242,7 +242,7 @@ namespace Azure.Core.Tests.Public
         {
             // TODO: Make exception messages consistent.
 
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { data.value["Property"] = "invalid"; }
             );
@@ -264,7 +264,7 @@ namespace Azure.Core.Tests.Public
         {
             // TODO: Make exception messages consistent.
 
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { data.value[0] = "invalid"; }
             );
@@ -289,7 +289,7 @@ namespace Azure.Core.Tests.Public
         {
             // TODO: This exception says "exepcted kind to be object" - improve this.
 
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.Throws<InvalidOperationException>(
                 () => { foreach (var item in data.value) { } }
             );

--- a/sdk/core/Azure.Core.Experimental/tests/public/JsonDataObjectTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/public/JsonDataObjectTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotConvertObjectToLeaf()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
 
             // TODO: Standardize Exception types.
             Assert.Throws<InvalidOperationException>(() => { var i = (int)data; });
@@ -27,9 +27,12 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CanConvertObjectToModel()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(
-                @"{ ""Message"": ""Hi"",
-                    ""Number"" : 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""
+                {
+                    "Message": "Hi",
+                    "Number" : 5
+                }
+                """);
 
             Assert.AreEqual(new SampleModel("Hi", 5), (SampleModel)data);
         }
@@ -39,10 +42,13 @@ namespace Azure.Core.Tests.Public
         {
             // TODO: this is just how JsonSerializer works - change this
             // test to do something useful.
-            dynamic data = JsonDataTestHelpers.CreateFromJson(
-                @"{ ""Message"": ""Hi"",
-                    ""Number"" : 5,
-                    ""Invalid"" : ""Not on SampleModel"" }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""
+                {
+                    "Message": "Hi",
+                    "Number" : 5,
+                    "Invalid" : "Not on SampleModel"
+                }
+                """);
 
             SampleModel model = data;
 
@@ -56,7 +62,7 @@ namespace Azure.Core.Tests.Public
 
         public void CanGetMemberOnObject()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.AreEqual(5, (int)data.value);
         }
 
@@ -66,7 +72,7 @@ namespace Azure.Core.Tests.Public
 
         public void CanSetMemberOnObject()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": 5 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": 5 }""");
             Assert.AreEqual(5, (int)data.value);
 
             data.value = 6;
@@ -79,7 +85,7 @@ namespace Azure.Core.Tests.Public
 
         public void CanGetIndexPropertyOnObject()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": ""hi"" }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": "Hi" }""");
             string prop = data["value"];
             Assert.AreEqual("hi", prop);
         }
@@ -87,7 +93,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotGetArrayIndexOnObject()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": ""hi"" }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": "Hi" }""");
             Assert.Throws<InvalidOperationException>(
                 () => { var x = data[0]; }
             );
@@ -98,7 +104,7 @@ namespace Azure.Core.Tests.Public
 
         public void CanSetIndexPropertyOnObject()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": ""hi"" }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": "Hi" }""");
             data["value"] = "hello";
             Assert.AreEqual("hello", (string)data["value"]);
         }
@@ -106,7 +112,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotSetArrayIndexOnObject()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""value"": ""hi"" }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "value": "Hi" }""");
             Assert.Throws<InvalidOperationException>(
                 () => { data[0] = "invalid"; }
             );
@@ -118,7 +124,7 @@ namespace Azure.Core.Tests.Public
         [Ignore("To be implemented.")]
         public void CanEnumerateObject()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""first"": 1, ""second"": 2 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "first": 1, "second": 2 }""");
 
             var expectedKeys = new[] { "first", "second" };
             var expectedValues = new[] { 1, 2 };
@@ -135,7 +141,7 @@ namespace Azure.Core.Tests.Public
         [Test]
         public void CannotCallGetDirectly()
         {
-            dynamic data = JsonDataTestHelpers.CreateFromJson(@"{ ""first"": 1, ""second"": 2 }");
+            dynamic data = JsonDataTestHelpers.CreateFromJson("""{ "first": 1, "second": 2 }""");
 
             Assert.Throws<RuntimeBinderException>(() => data.Get("first"));
         }


### PR DESCRIPTION
Since we recently moved to C# 11, now is a good time to move to [raw string literals](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string).  This PR does that for our DynamicJson tests.