### PR TITLE
Fix creat recognize request of call automation media

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
@@ -311,6 +311,7 @@ namespace Azure.Communication.CallAutomation
                 RecognizeOptionsInternal recognizeConfigurationsInternal = new RecognizeOptionsInternal(CommunicationIdentifierSerializer.Serialize(recognizeChoiceOptions.TargetParticipant))
                 {
                     InterruptPrompt = recognizeChoiceOptions.InterruptPrompt,
+                    InitialSilenceTimeoutInSeconds = (int)recognizeChoiceOptions.InitialSilenceTimeout.TotalSeconds
                 };
 
                 recognizeChoiceOptions.RecognizeChoices


### PR DESCRIPTION
# Contributing to the Azure SDK

The createRecognizeRequests needs to map the cognitionconfiguration field called InitialSilenceTimeout to InitialSilenceTimeoutInSeconds. Currently the recognizeRequestInternal for recognize choice miss this field. This fix adds the population of the field from cognitionconfiguration
