### PR TITLE
Remove virtual from ToBytes method

### DIFF
--- a/sdk/core/Azure.Core.Amqp/api/Azure.Core.Amqp.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Amqp/api/Azure.Core.Amqp.netstandard2.0.cs
@@ -28,7 +28,7 @@ namespace Azure.Core.Amqp
         public Azure.Core.Amqp.AmqpMessageProperties Properties { get { throw null; } }
         public static Azure.Core.Amqp.AmqpAnnotatedMessage FromBytes(System.BinaryData messageBytes) { throw null; }
         public bool HasSection(Azure.Core.Amqp.AmqpMessageSection section) { throw null; }
-        public virtual System.BinaryData ToBytes() { throw null; }
+        public System.BinaryData ToBytes() { throw null; }
     }
     public partial class AmqpMessageBody
     {

--- a/sdk/core/Azure.Core.Amqp/src/AmqpAnnotatedMessage.cs
+++ b/sdk/core/Azure.Core.Amqp/src/AmqpAnnotatedMessage.cs
@@ -161,7 +161,7 @@ namespace Azure.Core.Amqp
         /// <seealso href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format"/>
         /// </summary>
         /// <returns>A <see cref="BinaryData"/> instance representing the serialized message.</returns>
-        public virtual BinaryData ToBytes()
+        public BinaryData ToBytes()
         {
             var stream = AmqpAnnotatedMessageConverter.ToAmqpMessage(this).ToStream();
             return BinaryData.FromStream(stream);


### PR DESCRIPTION
No need to mock the method call as it is not a service call. 