### PR TITLE
fix codeowners Azure.Monitor.OpenTelemetry.Exporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -497,7 +497,6 @@
 # PRLabel: %Monitor - Exporter
 # ServiceLabel: %Monitor - Exporter %Service Attention
 /sdk/monitor/Azure.Monitor.OpenTelemetry.*/                        @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar
-/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter*                 @SameergMS @dadunl
 
 # PRLabel: %Monitor - Distro
 # ServiceLabel: %Monitor - Distro %Service Attention


### PR DESCRIPTION
Owners are not being assigned to PRs.

https://github.com/Azure/azure-sdk-for-net/pull/33826/ likely caused this