### PR TITLE
{AzureStorage} fixes Azure/azure-sdk-for-net#33899 Adding the CreatedOn property

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobDownloadDetails.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobDownloadDetails.cs
@@ -61,6 +61,11 @@ namespace Azure.Storage.Blobs.Models
         public ETag ETag { get; internal set; }
 
         /// <summary>
+        /// CreatedOn.
+        /// </summary>
+        public DateTimeOffset? CreatedOn { get; internal set; }
+
+        /// <summary>
         /// This header returns the value that was specified for the Content-Encoding request header
         /// </summary>
         public string ContentEncoding { get; internal set; }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Models/FileDownloadDetails.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Models/FileDownloadDetails.cs
@@ -41,6 +41,11 @@ namespace Azure.Storage.Files.DataLake.Models
         public ETag ETag { get; internal set; }
 
         /// <summary>
+        /// CreatedOn.
+        /// </summary>
+        public DateTimeOffset? CreatedOn { get; internal set; }
+
+        /// <summary>
         /// This header returns the value that was specified for the Content-Encoding request header.
         /// </summary>
         public string ContentEncoding { get; internal set; }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileDownloadDetails.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileDownloadDetails.cs
@@ -40,6 +40,11 @@ namespace Azure.Storage.Files.Shares.Models
         public ETag ETag { get; internal set; }
 
         /// <summary>
+        /// CreatedOn.
+        /// </summary>
+        public DateTimeOffset? CreatedOn { get; internal set; }
+
+        /// <summary>
         /// Returns the value that was specified for the Content-Encoding request header.
         /// </summary>
         public IEnumerable<string> ContentEncoding { get; internal set; }


### PR DESCRIPTION
fixes Azure/azure-sdk-for-net#33899 

Adding the CreatedOn property to the BlobDownloadDetails class. 

All other similar blob "properties" and "info" classes include this property.  https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.Storage.Blobs/src/Models/BlobDownloadDetails.cs`

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
