### PR TITLE
[ASP.NET Extensions] Data Protection Bump

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -142,7 +142,7 @@
 
   <!-- Packages intended for Extensions libraries only -->
   <ItemGroup Condition="'$(IsExtensionClientLibrary)' == 'true'">
-    <PackageReference Update="Microsoft.AspNetCore.DataProtection" Version="3.1.31" />
+    <PackageReference Update="Microsoft.AspNetCore.DataProtection" Version="3.1.32" />
     <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Connections" Version="1.0.15" />
     <PackageReference Update="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the version of the `Microsoft.AspNetCore.DataProtection` package to mitigate CVE-2021-24112.  The vulnerable package is a transitive dependency that only exists in the dependency chain for applications explicitly targeting `netcoreapp3.0`, which reached end of support in March, 2020.

# References and Related

- [Release Data Protection Extensions Packages (#34071)](https://github.com/Azure/azure-sdk-for-net/issues/34071)
