### PR TITLE
Ensure Options are passed down to ManagedIdentityClient

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -45,9 +45,11 @@ namespace Azure.Identity
         /// </param>
         /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
         public ManagedIdentityCredential(string clientId = null, TokenCredentialOptions options = null)
-            : this(clientId, CredentialPipeline.GetInstance(options))
+            : this(
+                new ManagedIdentityClient(new ManagedIdentityClientOptions { ClientId = clientId, Pipeline = CredentialPipeline.GetInstance(options), Options = options }))
         {
             _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
+            _clientId = clientId;
         }
 
         /// <summary>
@@ -60,7 +62,7 @@ namespace Azure.Identity
         /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
         public ManagedIdentityCredential(ResourceIdentifier resourceId, TokenCredentialOptions options = null)
             : this(
-                new ManagedIdentityClient(new ManagedIdentityClientOptions { ResourceIdentifier = resourceId, Pipeline = CredentialPipeline.GetInstance(options) }))
+                new ManagedIdentityClient(new ManagedIdentityClientOptions { ResourceIdentifier = resourceId, Pipeline = CredentialPipeline.GetInstance(options), Options = options }))
         {
             _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
             _clientId = resourceId.ToString();

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -45,11 +45,8 @@ namespace Azure.Identity
         /// </param>
         /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
         public ManagedIdentityCredential(string clientId = null, TokenCredentialOptions options = null)
-            : this(
-                new ManagedIdentityClient(new ManagedIdentityClientOptions { ClientId = clientId, Pipeline = CredentialPipeline.GetInstance(options), Options = options }))
+            : this(clientId, CredentialPipeline.GetInstance(options), options)
         {
-            _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
-            _clientId = clientId;
         }
 
         /// <summary>
@@ -61,23 +58,22 @@ namespace Azure.Identity
         /// </param>
         /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
         public ManagedIdentityCredential(ResourceIdentifier resourceId, TokenCredentialOptions options = null)
-            : this(
-                new ManagedIdentityClient(new ManagedIdentityClientOptions { ResourceIdentifier = resourceId, Pipeline = CredentialPipeline.GetInstance(options), Options = options }))
+            : this(resourceId, CredentialPipeline.GetInstance(options), options)
         {
-            _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
-            _clientId = resourceId.ToString();
         }
 
-        internal ManagedIdentityCredential(string clientId, CredentialPipeline pipeline, bool preserveTransport = false)
-            : this(new ManagedIdentityClient(new ManagedIdentityClientOptions { Pipeline = pipeline, ClientId = clientId, PreserveTransport = preserveTransport }))
+        internal ManagedIdentityCredential(string clientId, CredentialPipeline pipeline, TokenCredentialOptions options = null, bool preserveTransport = false)
+            : this(new ManagedIdentityClient(new ManagedIdentityClientOptions { Pipeline = pipeline, ClientId = clientId, Options = options, PreserveTransport = preserveTransport }))
         {
             _clientId = clientId;
+            _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
         }
 
-        internal ManagedIdentityCredential(ResourceIdentifier resourceId, CredentialPipeline pipeline, bool preserveTransport = false)
-            : this(new ManagedIdentityClient(new ManagedIdentityClientOptions{Pipeline = pipeline, ResourceIdentifier = resourceId, PreserveTransport = preserveTransport}))
+        internal ManagedIdentityCredential(ResourceIdentifier resourceId, CredentialPipeline pipeline, TokenCredentialOptions options = null, bool preserveTransport = false)
+            : this(new ManagedIdentityClient(new ManagedIdentityClientOptions { Pipeline = pipeline, ResourceIdentifier = resourceId, Options = options, PreserveTransport = preserveTransport }))
         {
             _clientId = resourceId.ToString();
+            _logAccountDetails = options?.Diagnostics?.IsAccountIdentifierLoggingEnabled ?? false;
         }
 
         internal ManagedIdentityCredential(ManagedIdentityClient client)

--- a/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
@@ -58,7 +58,7 @@ namespace Azure.Identity
             : base(pipeline, tenantId, clientId, options)
         {
             _appTokenProviderCallback = appTokenProviderCallback;
-            _authority = options?.AuthorityHost ?? AzureAuthorityHosts.AzurePublicCloud;
+            _authority = options?.AuthorityHost ?? pipeline.AuthorityHost ?? AzureAuthorityHosts.AzurePublicCloud;
         }
 
         internal string RegionalAuthority { get; } = EnvironmentVariables.AzureRegionalAuthorityName;
@@ -146,7 +146,7 @@ namespace Azure.Identity
 
             if (!string.IsNullOrEmpty(tenantId))
             {
-                builder.WithAuthority(Pipeline.AuthorityHost.AbsoluteUri, tenantId);
+                builder.WithTenantId(tenantId);
             }
             return await builder
                 .ExecuteAsync(async, cancellationToken)

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialImdsLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialImdsLiveTests.cs
@@ -74,9 +74,7 @@ namespace Azure.Identity.Tests
         {
             options = InstrumentClientOptions(options ?? new TokenCredentialOptions());
 
-            var pipeline = CredentialPipeline.GetInstance(options);
-
-            var cred = new ManagedIdentityCredential(new ManagedIdentityClient(pipeline, clientId));
+            var cred = new ManagedIdentityCredential(clientId, options);
 
             return cred;
         }

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -137,9 +137,7 @@ namespace Azure.Identity.Tests
             var pipeline = new CredentialPipeline(authority, _pipeline, new ClientDiagnostics(options));
 
             ManagedIdentityCredential credential = InstrumentClient(
-                new ManagedIdentityCredential(
-                    new ManagedIdentityClient(
-                        new ManagedIdentityClientOptions { Pipeline = pipeline, ClientId = "mock-client-id", Options = options })));
+                new ManagedIdentityCredential("mock-client-id", pipeline, options));
 
             AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
@@ -216,9 +214,9 @@ namespace Azure.Identity.Tests
 
             ManagedIdentityCredential credential = (clientId, includeResourceIdentifier) switch
             {
-                (Item1: null, Item2: true) => InstrumentClient(new ManagedIdentityCredential(new ResourceIdentifier(_expectedResourceId), pipeline, true)),
-                (Item1: not null, Item2: false) => InstrumentClient(new ManagedIdentityCredential(clientId, pipeline, true)),
-                _ => InstrumentClient(new ManagedIdentityCredential(clientId: null, pipeline, true))
+                (Item1: null, Item2: true) => InstrumentClient(new ManagedIdentityCredential(new ResourceIdentifier(_expectedResourceId), pipeline, preserveTransport: true)),
+                (Item1: not null, Item2: false) => InstrumentClient(new ManagedIdentityCredential(clientId, pipeline, preserveTransport: true)),
+                _ => InstrumentClient(new ManagedIdentityCredential(clientId: null, pipeline, preserveTransport: true))
             };
 
             AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
@@ -605,7 +603,7 @@ namespace Azure.Identity.Tests
 
         [NonParallelizable]
         [Test]
-        public async Task VerifyMsiUnavailableOnIMDSAggregateExcpetion()
+        public async Task VerifyMsiUnavailableOnIMDSAggregateException()
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "http://169.254.169.001/" } });
 
@@ -623,7 +621,7 @@ namespace Azure.Identity.Tests
 
         [NonParallelizable]
         [Test]
-        public async Task VerifyMsiUnavailableOnIMDSRequestFailedExcpetion()
+        public async Task VerifyMsiUnavailableOnIMDSRequestFailedException()
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "http://169.254.169.001/" } });
 

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -139,7 +139,7 @@ namespace Azure.Identity.Tests
             ManagedIdentityCredential credential = InstrumentClient(
                 new ManagedIdentityCredential("mock-client-id", pipeline, options));
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default, tenantId: "mock-tenant-id"));
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 

--- a/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
@@ -25,7 +25,7 @@ namespace Azure.Identity.Tests.Mock
             => new EnvironmentCredential(Pipeline, Options);
 
         public override TokenCredential CreateManagedIdentityCredential()
-            => new ManagedIdentityCredential(new ManagedIdentityClient(Pipeline, Options.ManagedIdentityClientId));
+            => new ManagedIdentityCredential(Options.ManagedIdentityClientId, Pipeline, Options);
 
         public override TokenCredential CreateSharedTokenCacheCredential()
             => new SharedTokenCacheCredential(Options.SharedTokenCacheTenantId, Options.SharedTokenCacheUsername, Options, Pipeline);


### PR DESCRIPTION
Specifically, this is to pass the AuthorityHost to the MSAL client