### PR TITLE
[AzureMonitorExporter] Fix how arrays stored in Activity Tags are serialized.

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ArrayExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ArrayExtensions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    internal static class ArrayExtensions
+    {
+        /// <summary>
+        /// Builds a comma delimited string of the components of an array.
+        /// </summary>
+        /// <remarks>
+        /// For example: new int[] { 1, 2, 3 } would be returned as "1,2,3".
+        /// </remarks>
+        /// <param name="input">An array to be evaluated.</param>
+        /// <returns>A comma delimited string of the components of the input array.</returns>
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(input))]
+        public static string? ToCommaDelimitedString(this Array? input)
+        {
+            if (input == null)
+            {
+                return null;
+            }
+
+            StringBuilder sb = new(input.Length);
+            foreach (var item in input)
+            {
+                // TODO: Consider changing it to JSon array.
+                if (item != null)
+                {
+                    sb.Append(item);
+                    sb.Append(',');
+                }
+            }
+
+            // remove trailing comma
+            if (sb.Length > 0)
+            {
+                sb.Length--;
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TagEnumerationState.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TagEnumerationState.cs
@@ -80,23 +80,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                 if (activityTag.Value is Array array)
                 {
-                    StringBuilder sw = new StringBuilder();
-                    foreach (var item in array)
-                    {
-                        // TODO: Consider changing it to JSon array.
-                        if (item != null)
-                        {
-                            sw.Append(item);
-                            sw.Append(',');
-                        }
-                    }
-
-                    if (sw.Length > 0)
-                    {
-                        sw.Length--;
-                    }
-
-                    AzMonList.Add(ref UnMappedTags, new KeyValuePair<string, object>(activityTag.Key, sw.ToString()));
+                    AzMonList.Add(ref UnMappedTags, new KeyValuePair<string, object>(activityTag.Key, array.ToCommaDelimitedString()));
                     continue;
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -222,7 +222,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             foreach (var tag in activityEvent.Tags)
             {
-                messageData.Properties.Add(tag.Key, tag.Value.ToString());
+                if (tag.Value is Array arrayValue)
+                {
+                    messageData.Properties.Add(tag.Key, arrayValue.ToCommaDelimitedString());
+                }
+                else
+                {
+                    messageData.Properties.Add(tag.Key, tag.Value.ToString());
+                }
             }
 
             return new MonitorBase

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -14,11 +14,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 {
     internal static class TelemetryItemValidationHelper
     {
-        public static void AssertLog_As_MessageTelemetry(
+        public static void AssertMessageTelemetry(
             TelemetryItem telemetryItem,
             string expectedSeverityLevel,
             string expectedMessage,
-            IDictionary<string, string> expectedMeessageProperties,
+            IDictionary<string, string> expectedMessageProperties,
             string expectedSpanId,
             string expectedTraceId)
         {
@@ -43,10 +43,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
 
             var messageData = (MessageData)telemetryItem.Data.BaseData;
-            Assert.Equal(expectedSeverityLevel, messageData.SeverityLevel);
+
+            if (expectedSeverityLevel == null)
+            {
+                Assert.Null(messageData.SeverityLevel);
+            }
+            else
+            {
+                Assert.Equal(expectedSeverityLevel, messageData.SeverityLevel);
+            }
+
             Assert.Equal(expectedMessage, messageData.Message);
 
-            foreach (var prop in expectedMeessageProperties)
+            foreach (var prop in expectedMessageProperties)
             {
                 Assert.Equal(prop.Value, messageData.Properties[prop.Key]);
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -72,11 +72,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             this.telemetryOutput.Write(telemetryItems);
             var telemetryItem = telemetryItems.Single();
 
-            TelemetryItemValidationHelper.AssertLog_As_MessageTelemetry(
+            TelemetryItemValidationHelper.AssertMessageTelemetry(
                 telemetryItem: telemetryItem,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Hello {name}.",
-                expectedMeessageProperties: new Dictionary<string, string> { { "name", "World" }},
+                expectedMessageProperties: new Dictionary<string, string> { { "name", "World" }},
                 expectedSpanId: null,
                 expectedTraceId: null);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -316,57 +316,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedSpanId: spanId,
                 expectedTraceId: traceId);
         }
-
-        //[Fact]
-        //public void InvestigatingBug()
-        //{
-        //    // SETUP
-        //    var uniqueTestId = Guid.NewGuid();
-
-        //    var activitySourceName = $"activitySourceName{uniqueTestId}";
-        //    using var activitySource = new ActivitySource(activitySourceName);
-
-        //    var tracerProvider = Sdk.CreateTracerProviderBuilder()
-        //        .AddSource(activitySourceName)
-        //        .AddAzureMonitorTraceExporterForTest(out ConcurrentBag<TelemetryItem> telemetryItems)
-        //        .Build();
-
-        //    // ACT
-        //    string spanId = null, traceId = null;
-
-        //    using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
-        //    {
-        //        traceId = activity.TraceId.ToHexString();
-        //        spanId = activity.SpanId.ToHexString();
-
-        //        activity.SetTag("intArray", new int[] { 1, 2, 3 });
-
-        //        var eventTags = new Dictionary<string, object>
-        //        {
-        //            { "intArray", new int[] { 1, 2, 3 } }
-        //        };
-        //        activity?.AddEvent(new("Gonna try it!", DateTimeOffset.Now, new(eventTags)));
-        //    }
-
-        //    // CLEANUP
-        //    tracerProvider.Dispose();
-
-        //    // ASSERT
-        //    Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
-        //    this.telemetryOutput.Write(telemetryItems);
-
-        //    var dependencyTelemetryItem = telemetryItems.First(x => x.Name == "RemoteDependency");
-        //    var dependencyData = dependencyTelemetryItem.Data.BaseData as RemoteDependencyData;
-        //    Assert.Equal("1,2,3", dependencyData.Properties["intArray"]); // TODO: This is correct
-
-        //    var messageTelemetryItem = telemetryItems.First(x => x.Name == "Message");
-        //    var messageData = messageTelemetryItem.Data.BaseData as MessageData;
-        //    Assert.Equal("System.Int32[]" , messageData.Properties["intArray"]); // TODO: This is wrong
-
-        //    var array = new int[] { 1, 2, 3 };
-        //    Assert.Equal("System.Int32[]", array.ToString());
-        //    object testObject = array;
-        //    Assert.Equal("System.Int32[]", testObject.ToString());
-        //}
     }
 }


### PR DESCRIPTION
I found a bug in the way we serialize some arrays stored Activity Tags.

For example:
```csharp
using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind))
{
    activity?.SetTag("intArray", new int[] { 1, 2, 3 });
}
```

this would be serialized as key: "intArray" value: "1,2,3".


However,
```csharp
using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
{
	var eventTags = new Dictionary<string, object>
	{
		{ "intArray", new int[] { 1, 2, 3 } }
	};
	activity?.AddEvent(new("Gonna try it!", DateTimeOffset.Now, new(eventTags)));
}
```

this is being serialized as key: "intArray" value: "System.Int32[]"


The fix here is to consistently check for Array type and serialize the component items.


## Changes
- Add extension method `Array.ToCommaDelimitedString()` to serialize an Array as a comma delimited string.
  This copies the implementation from `AzMonList`'s `TagEnumerationState` to use in the `TraceHelper`.
- Refactor unit tests
- Added a unit test for ActivityEvent.


## Screenshot
![image](https://user-images.githubusercontent.com/28785781/218222012-202e9895-123d-4d29-ad23-2a40c0d3a8fa.png)
