### PR TITLE
Enable sparse checkout of GHDocs publishing

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -197,7 +197,7 @@ stages:
                   runOnce:
                     deploy:
                       steps:
-                        - checkout: self
+                        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
                         - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
                           parameters:
                             FolderForUpload: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}'


### PR DESCRIPTION
More clean-up from some recent work I did around the gh doc publishing. 