### PR TITLE
Update `CODEOWNERS` and `fabricbot.json` for `iot*` and `iothub`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -407,17 +407,17 @@
 #/<NotInRepo>/                                                     @madhurinms
 
 # PRLabel: %Iot
-/sdk/iot*                                                          @drwill-ms @timtay-microsoft @abhipsaMisra @andyk-ms @brycewang-microsoft @tmahmood-microsoft @ngastelum-ms
+/sdk/iot*                                                          @ethanann-ms @vighatke
+
+# PRLabel: %IotHub
+# ServiceLabel: %IotHub %Service Attention
+/sdk/iothub/                                                       @ethanann-ms @vighatke
 
 # ServiceLabel: %IotCentral %Service Attention
 /sdk/iotcentral/Microsoft.Azure.Management.IotCentral/             @iluican @jlian
 
 # ServiceLabel: %IotDPS %Service Attention
 #/<NotInRepo>/                                                     @iluican @jlian
-
-# PRLabel: %IotHub
-# ServiceLabel: %IotHub %Service Attention
-/sdk/iothub/                                                       @drwill-ms @timtay-microsoft @abhipsaMisra @andyk-ms @brycewang-microsoft @tmahmood-microsoft @ngastelum-ms
 
 # ServiceLabel: %IotHub %Service Attention
 /sdk/iothub/Microsoft.Azure.Management.IotHub/                     @rkmanda @chieftn

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2058,13 +2058,8 @@
             "IoT"
           ],
           "mentionees": [
-            "drwill-ms",
-            "timtay-microsoft",
-            "abhipsaMisra",
-            "brycewang-microsoft",
-            "andyk-ms",
-            "tmahmood-microsoft",
-            "ngastelum-ms"
+            "ethanann-ms",
+            "vighatke"
           ]
         },
         {
@@ -2073,13 +2068,8 @@
             "IoTHub"
           ],
           "mentionees": [
-            "drwill-ms",
-            "timtay-microsoft",
-            "abhipsaMisra",
-            "brycewang-microsoft",
-            "andyk-ms",
-            "tmahmood-microsoft",
-            "ngastelum-ms"
+            "ethanann-ms",
+            "vighatke"
           ]
         },
         {


### PR DESCRIPTION
This PR updates owners for `iot*` and `iothub`, per these comments:
- https://github.com/Azure/azure-sdk-for-net/pull/33854#issuecomment-1414433168
- (about fabricbot) https://github.com/Azure/azure-sdk-for-net/pull/33854#discussion_r1094718655

Related PR:
- https://github.com/Azure/azure-sdk-tools/pull/5088