### PR TITLE
MutableJsonDocument namespace, IDisposable

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
@@ -150,12 +150,15 @@ namespace Azure.Core.Dynamic
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }
+}
+namespace Azure.Core.Json
+{
     public partial class MutableJsonDocument
     {
         internal MutableJsonDocument() { }
-        public Azure.Core.Dynamic.MutableJsonElement RootElement { get { throw null; } }
-        public static Azure.Core.Dynamic.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
-        public static Azure.Core.Dynamic.MutableJsonDocument Parse(string json) { throw null; }
+        public Azure.Core.Json.MutableJsonElement RootElement { get { throw null; } }
+        public static Azure.Core.Json.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
+        public static Azure.Core.Json.MutableJsonDocument Parse(string json) { throw null; }
         public void WriteTo(System.IO.Stream stream, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -164,16 +167,16 @@ namespace Azure.Core.Dynamic
         private object _dummy;
         private int _dummyPrimitive;
         public System.Text.Json.JsonValueKind ValueKind { get { throw null; } }
-        public Azure.Core.Dynamic.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
+        public Azure.Core.Json.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
         public bool GetBoolean() { throw null; }
         public double GetDouble() { throw null; }
         public int GetInt32() { throw null; }
         public long GetInt64() { throw null; }
-        public Azure.Core.Dynamic.MutableJsonElement GetProperty(string name) { throw null; }
+        public Azure.Core.Json.MutableJsonElement GetProperty(string name) { throw null; }
         public float GetSingle() { throw null; }
         public string? GetString() { throw null; }
         public void RemoveProperty(string name) { }
-        public void Set(Azure.Core.Dynamic.MutableJsonElement value) { }
+        public void Set(Azure.Core.Json.MutableJsonElement value) { }
         public void Set(bool value) { }
         public void Set(double value) { }
         public void Set(int value) { }
@@ -181,22 +184,22 @@ namespace Azure.Core.Dynamic
         public void Set(object value) { }
         public void Set(float value) { }
         public void Set(string value) { }
-        public Azure.Core.Dynamic.MutableJsonElement SetProperty(string name, object value) { throw null; }
+        public Azure.Core.Json.MutableJsonElement SetProperty(string name, object value) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryGetProperty(string name, out Azure.Core.Dynamic.MutableJsonElement value) { throw null; }
+        public bool TryGetProperty(string name, out Azure.Core.Json.MutableJsonElement value) { throw null; }
         [System.Diagnostics.DebuggerDisplayAttribute("{Current,nq}")]
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<Azure.Core.Dynamic.MutableJsonElement>, System.Collections.Generic.IEnumerator<Azure.Core.Dynamic.MutableJsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
+        public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<Azure.Core.Json.MutableJsonElement>, System.Collections.Generic.IEnumerator<Azure.Core.Json.MutableJsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public Azure.Core.Dynamic.MutableJsonElement Current { get { throw null; } }
+            public Azure.Core.Json.MutableJsonElement Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
-            public Azure.Core.Dynamic.MutableJsonElement.ArrayEnumerator GetEnumerator() { throw null; }
+            public Azure.Core.Json.MutableJsonElement.ArrayEnumerator GetEnumerator() { throw null; }
             public bool MoveNext() { throw null; }
             public void Reset() { }
-            System.Collections.Generic.IEnumerator<Azure.Core.Dynamic.MutableJsonElement> System.Collections.Generic.IEnumerable<Azure.Core.Dynamic.MutableJsonElement>.GetEnumerator() { throw null; }
+            System.Collections.Generic.IEnumerator<Azure.Core.Json.MutableJsonElement> System.Collections.Generic.IEnumerable<Azure.Core.Json.MutableJsonElement>.GetEnumerator() { throw null; }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
@@ -118,9 +118,10 @@ namespace Azure.Core.Dynamic
         internal abstract void WriteTo(System.IO.Stream stream);
         public static void WriteTo(System.IO.Stream stream, Azure.Core.Dynamic.DynamicData data) { }
     }
-    public partial class DynamicJson : Azure.Core.Dynamic.DynamicData, System.Dynamic.IDynamicMetaObjectProvider
+    public sealed partial class DynamicJson : Azure.Core.Dynamic.DynamicData, System.Dynamic.IDynamicMetaObjectProvider, System.IDisposable
     {
         internal DynamicJson() { }
+        public void Dispose() { }
         public static implicit operator bool (Azure.Core.Dynamic.DynamicJson value) { throw null; }
         public static implicit operator double (Azure.Core.Dynamic.DynamicJson value) { throw null; }
         public static implicit operator int (Azure.Core.Dynamic.DynamicJson value) { throw null; }
@@ -153,19 +154,20 @@ namespace Azure.Core.Dynamic
 }
 namespace Azure.Core.Json
 {
-    public partial class MutableJsonDocument
+    public sealed partial class MutableJsonDocument : System.IDisposable
     {
         internal MutableJsonDocument() { }
         public Azure.Core.Json.MutableJsonElement RootElement { get { throw null; } }
+        public void Dispose() { }
         public static Azure.Core.Json.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
         public static Azure.Core.Json.MutableJsonDocument Parse(string json) { throw null; }
         public void WriteTo(System.IO.Stream stream, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MutableJsonElement
+    public readonly partial struct MutableJsonElement
     {
-        private object _dummy;
-        private int _dummyPrimitive;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public System.Text.Json.JsonValueKind ValueKind { get { throw null; } }
         public Azure.Core.Json.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
         public bool GetBoolean() { throw null; }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
@@ -150,12 +150,15 @@ namespace Azure.Core.Dynamic
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }
+}
+namespace Azure.Core.Json
+{
     public partial class MutableJsonDocument
     {
         internal MutableJsonDocument() { }
-        public Azure.Core.Dynamic.MutableJsonElement RootElement { get { throw null; } }
-        public static Azure.Core.Dynamic.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
-        public static Azure.Core.Dynamic.MutableJsonDocument Parse(string json) { throw null; }
+        public Azure.Core.Json.MutableJsonElement RootElement { get { throw null; } }
+        public static Azure.Core.Json.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
+        public static Azure.Core.Json.MutableJsonDocument Parse(string json) { throw null; }
         public void WriteTo(System.IO.Stream stream, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -164,16 +167,16 @@ namespace Azure.Core.Dynamic
         private object _dummy;
         private int _dummyPrimitive;
         public System.Text.Json.JsonValueKind ValueKind { get { throw null; } }
-        public Azure.Core.Dynamic.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
+        public Azure.Core.Json.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
         public bool GetBoolean() { throw null; }
         public double GetDouble() { throw null; }
         public int GetInt32() { throw null; }
         public long GetInt64() { throw null; }
-        public Azure.Core.Dynamic.MutableJsonElement GetProperty(string name) { throw null; }
+        public Azure.Core.Json.MutableJsonElement GetProperty(string name) { throw null; }
         public float GetSingle() { throw null; }
         public string? GetString() { throw null; }
         public void RemoveProperty(string name) { }
-        public void Set(Azure.Core.Dynamic.MutableJsonElement value) { }
+        public void Set(Azure.Core.Json.MutableJsonElement value) { }
         public void Set(bool value) { }
         public void Set(double value) { }
         public void Set(int value) { }
@@ -181,22 +184,22 @@ namespace Azure.Core.Dynamic
         public void Set(object value) { }
         public void Set(float value) { }
         public void Set(string value) { }
-        public Azure.Core.Dynamic.MutableJsonElement SetProperty(string name, object value) { throw null; }
+        public Azure.Core.Json.MutableJsonElement SetProperty(string name, object value) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryGetProperty(string name, out Azure.Core.Dynamic.MutableJsonElement value) { throw null; }
+        public bool TryGetProperty(string name, out Azure.Core.Json.MutableJsonElement value) { throw null; }
         [System.Diagnostics.DebuggerDisplayAttribute("{Current,nq}")]
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<Azure.Core.Dynamic.MutableJsonElement>, System.Collections.Generic.IEnumerator<Azure.Core.Dynamic.MutableJsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
+        public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<Azure.Core.Json.MutableJsonElement>, System.Collections.Generic.IEnumerator<Azure.Core.Json.MutableJsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public Azure.Core.Dynamic.MutableJsonElement Current { get { throw null; } }
+            public Azure.Core.Json.MutableJsonElement Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
-            public Azure.Core.Dynamic.MutableJsonElement.ArrayEnumerator GetEnumerator() { throw null; }
+            public Azure.Core.Json.MutableJsonElement.ArrayEnumerator GetEnumerator() { throw null; }
             public bool MoveNext() { throw null; }
             public void Reset() { }
-            System.Collections.Generic.IEnumerator<Azure.Core.Dynamic.MutableJsonElement> System.Collections.Generic.IEnumerable<Azure.Core.Dynamic.MutableJsonElement>.GetEnumerator() { throw null; }
+            System.Collections.Generic.IEnumerator<Azure.Core.Json.MutableJsonElement> System.Collections.Generic.IEnumerable<Azure.Core.Json.MutableJsonElement>.GetEnumerator() { throw null; }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
@@ -118,9 +118,10 @@ namespace Azure.Core.Dynamic
         internal abstract void WriteTo(System.IO.Stream stream);
         public static void WriteTo(System.IO.Stream stream, Azure.Core.Dynamic.DynamicData data) { }
     }
-    public partial class DynamicJson : Azure.Core.Dynamic.DynamicData, System.Dynamic.IDynamicMetaObjectProvider
+    public sealed partial class DynamicJson : Azure.Core.Dynamic.DynamicData, System.Dynamic.IDynamicMetaObjectProvider, System.IDisposable
     {
         internal DynamicJson() { }
+        public void Dispose() { }
         public static implicit operator bool (Azure.Core.Dynamic.DynamicJson value) { throw null; }
         public static implicit operator double (Azure.Core.Dynamic.DynamicJson value) { throw null; }
         public static implicit operator int (Azure.Core.Dynamic.DynamicJson value) { throw null; }
@@ -153,19 +154,20 @@ namespace Azure.Core.Dynamic
 }
 namespace Azure.Core.Json
 {
-    public partial class MutableJsonDocument
+    public sealed partial class MutableJsonDocument : System.IDisposable
     {
         internal MutableJsonDocument() { }
         public Azure.Core.Json.MutableJsonElement RootElement { get { throw null; } }
+        public void Dispose() { }
         public static Azure.Core.Json.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
         public static Azure.Core.Json.MutableJsonDocument Parse(string json) { throw null; }
         public void WriteTo(System.IO.Stream stream, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MutableJsonElement
+    public readonly partial struct MutableJsonElement
     {
-        private object _dummy;
-        private int _dummyPrimitive;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public System.Text.Json.JsonValueKind ValueKind { get { throw null; } }
         public Azure.Core.Json.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
         public bool GetBoolean() { throw null; }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -150,12 +150,15 @@ namespace Azure.Core.Dynamic
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }
+}
+namespace Azure.Core.Json
+{
     public partial class MutableJsonDocument
     {
         internal MutableJsonDocument() { }
-        public Azure.Core.Dynamic.MutableJsonElement RootElement { get { throw null; } }
-        public static Azure.Core.Dynamic.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
-        public static Azure.Core.Dynamic.MutableJsonDocument Parse(string json) { throw null; }
+        public Azure.Core.Json.MutableJsonElement RootElement { get { throw null; } }
+        public static Azure.Core.Json.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
+        public static Azure.Core.Json.MutableJsonDocument Parse(string json) { throw null; }
         public void WriteTo(System.IO.Stream stream, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -164,16 +167,16 @@ namespace Azure.Core.Dynamic
         private object _dummy;
         private int _dummyPrimitive;
         public System.Text.Json.JsonValueKind ValueKind { get { throw null; } }
-        public Azure.Core.Dynamic.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
+        public Azure.Core.Json.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
         public bool GetBoolean() { throw null; }
         public double GetDouble() { throw null; }
         public int GetInt32() { throw null; }
         public long GetInt64() { throw null; }
-        public Azure.Core.Dynamic.MutableJsonElement GetProperty(string name) { throw null; }
+        public Azure.Core.Json.MutableJsonElement GetProperty(string name) { throw null; }
         public float GetSingle() { throw null; }
         public string? GetString() { throw null; }
         public void RemoveProperty(string name) { }
-        public void Set(Azure.Core.Dynamic.MutableJsonElement value) { }
+        public void Set(Azure.Core.Json.MutableJsonElement value) { }
         public void Set(bool value) { }
         public void Set(double value) { }
         public void Set(int value) { }
@@ -181,22 +184,22 @@ namespace Azure.Core.Dynamic
         public void Set(object value) { }
         public void Set(float value) { }
         public void Set(string value) { }
-        public Azure.Core.Dynamic.MutableJsonElement SetProperty(string name, object value) { throw null; }
+        public Azure.Core.Json.MutableJsonElement SetProperty(string name, object value) { throw null; }
         public override string ToString() { throw null; }
-        public bool TryGetProperty(string name, out Azure.Core.Dynamic.MutableJsonElement value) { throw null; }
+        public bool TryGetProperty(string name, out Azure.Core.Json.MutableJsonElement value) { throw null; }
         [System.Diagnostics.DebuggerDisplayAttribute("{Current,nq}")]
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<Azure.Core.Dynamic.MutableJsonElement>, System.Collections.Generic.IEnumerator<Azure.Core.Dynamic.MutableJsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
+        public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<Azure.Core.Json.MutableJsonElement>, System.Collections.Generic.IEnumerator<Azure.Core.Json.MutableJsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public Azure.Core.Dynamic.MutableJsonElement Current { get { throw null; } }
+            public Azure.Core.Json.MutableJsonElement Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
-            public Azure.Core.Dynamic.MutableJsonElement.ArrayEnumerator GetEnumerator() { throw null; }
+            public Azure.Core.Json.MutableJsonElement.ArrayEnumerator GetEnumerator() { throw null; }
             public bool MoveNext() { throw null; }
             public void Reset() { }
-            System.Collections.Generic.IEnumerator<Azure.Core.Dynamic.MutableJsonElement> System.Collections.Generic.IEnumerable<Azure.Core.Dynamic.MutableJsonElement>.GetEnumerator() { throw null; }
+            System.Collections.Generic.IEnumerator<Azure.Core.Json.MutableJsonElement> System.Collections.Generic.IEnumerable<Azure.Core.Json.MutableJsonElement>.GetEnumerator() { throw null; }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -118,9 +118,10 @@ namespace Azure.Core.Dynamic
         internal abstract void WriteTo(System.IO.Stream stream);
         public static void WriteTo(System.IO.Stream stream, Azure.Core.Dynamic.DynamicData data) { }
     }
-    public partial class DynamicJson : Azure.Core.Dynamic.DynamicData, System.Dynamic.IDynamicMetaObjectProvider
+    public sealed partial class DynamicJson : Azure.Core.Dynamic.DynamicData, System.Dynamic.IDynamicMetaObjectProvider, System.IDisposable
     {
         internal DynamicJson() { }
+        public void Dispose() { }
         public static implicit operator bool (Azure.Core.Dynamic.DynamicJson value) { throw null; }
         public static implicit operator double (Azure.Core.Dynamic.DynamicJson value) { throw null; }
         public static implicit operator int (Azure.Core.Dynamic.DynamicJson value) { throw null; }
@@ -153,19 +154,20 @@ namespace Azure.Core.Dynamic
 }
 namespace Azure.Core.Json
 {
-    public partial class MutableJsonDocument
+    public sealed partial class MutableJsonDocument : System.IDisposable
     {
         internal MutableJsonDocument() { }
         public Azure.Core.Json.MutableJsonElement RootElement { get { throw null; } }
+        public void Dispose() { }
         public static Azure.Core.Json.MutableJsonDocument Parse(System.BinaryData utf8Json) { throw null; }
         public static Azure.Core.Json.MutableJsonDocument Parse(string json) { throw null; }
         public void WriteTo(System.IO.Stream stream, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct MutableJsonElement
+    public readonly partial struct MutableJsonElement
     {
-        private object _dummy;
-        private int _dummyPrimitive;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public System.Text.Json.JsonValueKind ValueKind { get { throw null; } }
         public Azure.Core.Json.MutableJsonElement.ArrayEnumerator EnumerateArray() { throw null; }
         public bool GetBoolean() { throw null; }

--- a/sdk/core/Azure.Core.Experimental/src/BinaryDataExtensions.cs
+++ b/sdk/core/Azure.Core.Experimental/src/BinaryDataExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.Core.Json;
 
 namespace Azure.Core.Dynamic
 {

--- a/sdk/core/Azure.Core.Experimental/src/DynamicJson.ArrayEnumerator.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicJson.ArrayEnumerator.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Azure.Core.Json;
 
 namespace Azure.Core.Dynamic
 {

--- a/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Dynamic
     /// Dynamic layer over MutableJsonDocument.
     /// </summary>
     [JsonConverter(typeof(JsonConverter))]
-    public partial class DynamicJson : DynamicData
+    public sealed partial class DynamicJson : DynamicData, IDisposable
     {
         private static readonly MethodInfo GetPropertyMethod = typeof(DynamicJson).GetMethod(nameof(GetProperty), BindingFlags.NonPublic | BindingFlags.Instance)!;
         private static readonly MethodInfo SetPropertyMethod = typeof(DynamicJson).GetMethod(nameof(SetProperty), BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -102,6 +102,17 @@ namespace Azure.Core.Dynamic
         public override string ToString()
         {
             return _element.ToString();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // TODO: There is a challenge here that DynamicJson wraps an element
+            // that may or may not represent the root of the document.
+
+            // We can perhaps make the recommendation that a user should only call
+            // dispose on a DynamicJson returned from GetDynamic()?
+            _element.DisposeRoot();
         }
 
         private class JsonConverter : JsonConverter<DynamicJson>

--- a/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
@@ -107,11 +107,6 @@ namespace Azure.Core.Dynamic
         /// <inheritdoc/>
         public void Dispose()
         {
-            // TODO: There is a challenge here that DynamicJson wraps an element
-            // that may or may not represent the root of the document.
-
-            // We can perhaps make the recommendation that a user should only call
-            // dispose on a DynamicJson returned from GetDynamic()?
             _element.DisposeRoot();
         }
 

--- a/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Azure.Core.Json;
 
 namespace Azure.Core.Dynamic
 {

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonChange.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonChange.cs
@@ -5,7 +5,7 @@ using System;
 using System.Text;
 using System.Text.Json;
 
-namespace Azure.Core.Dynamic
+namespace Azure.Core.Json
 {
     internal struct MutableJsonChange
     {

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.ChangeTracker.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.ChangeTracker.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Azure.Core.Dynamic
+namespace Azure.Core.Json
 {
     public partial class MutableJsonDocument
     {

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.WriteTo.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.WriteTo.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Text.Json;
 
-namespace Azure.Core.Dynamic
+namespace Azure.Core.Json
 {
     public partial class MutableJsonDocument
     {

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Azure.Core.Dynamic
+namespace Azure.Core.Json
 {
     /// <summary>
     /// A mutable representation of a JSON value.

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.cs
@@ -14,12 +14,12 @@ namespace Azure.Core.Json
     /// A mutable representation of a JSON value.
     /// </summary>
     [JsonConverter(typeof(JsonConverter))]
-    public partial class MutableJsonDocument
+    public sealed partial class MutableJsonDocument : IDisposable
     {
         internal static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new JsonSerializerOptions();
 
         private readonly Memory<byte> _original;
-        private readonly JsonElement _originalElement;
+        private readonly JsonDocument _originalDocument;
 
         internal ChangeTracker Changes { get; } = new();
 
@@ -38,7 +38,7 @@ namespace Azure.Core.Json
                     }
                 }
 
-                return new MutableJsonElement(this, _originalElement, string.Empty);
+                return new MutableJsonElement(this, _originalDocument.RootElement, string.Empty);
             }
         }
 
@@ -71,7 +71,7 @@ namespace Azure.Core.Json
         {
             if (!Changes.HasChanges)
             {
-                _originalElement.WriteTo(writer);
+                _originalDocument.RootElement.WriteTo(writer);
                 return;
             }
 
@@ -115,10 +115,16 @@ namespace Azure.Core.Json
             return new MutableJsonDocument(JsonDocument.Parse(jsonMemory), jsonMemory);
         }
 
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _originalDocument.Dispose();
+        }
+
         internal MutableJsonDocument(JsonDocument jsonDocument, Memory<byte> utf8Json) : this(jsonDocument.RootElement)
         {
             _original = utf8Json;
-            _originalElement = jsonDocument.RootElement;
+            _originalDocument = jsonDocument;
         }
 
         /// <summary>
@@ -142,7 +148,7 @@ namespace Azure.Core.Json
 
             Type inputType = type ?? (value == null ? typeof(object) : value.GetType());
             _original = JsonSerializer.SerializeToUtf8Bytes(value, inputType, options);
-            _originalElement = JsonDocument.Parse(_original).RootElement;
+            _originalDocument = JsonDocument.Parse(_original);
         }
 
         private class JsonConverter : JsonConverter<MutableJsonDocument>

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.ArrayEnumerator.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.ArrayEnumerator.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Text;
 using System.Text.Json;
 
 namespace Azure.Core.Json

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.ArrayEnumerator.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.ArrayEnumerator.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 
-namespace Azure.Core.Dynamic
+namespace Azure.Core.Json
 {
     public partial struct MutableJsonElement
     {

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 
-namespace Azure.Core.Dynamic
+namespace Azure.Core.Json
 {
     /// <summary>
     /// A mutable representation of a JSON element.

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.cs
@@ -538,6 +538,11 @@ namespace Azure.Core.Json
             return new Utf8JsonReader(stream.GetBuffer().AsSpan().Slice(0, (int)stream.Position));
         }
 
+        internal void DisposeRoot()
+        {
+            _root.Dispose();
+        }
+
         private void EnsureObject()
         {
             if (_element.ValueKind != JsonValueKind.Object)

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonElement.cs
@@ -12,7 +12,7 @@ namespace Azure.Core.Json
     /// <summary>
     /// A mutable representation of a JSON element.
     /// </summary>
-    public partial struct MutableJsonElement
+    public readonly partial struct MutableJsonElement
     {
         private readonly MutableJsonDocument _root;
         private readonly JsonElement _element;

--- a/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
@@ -353,6 +353,41 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(5, (int)json.OptionalValue);
         }
 
+        [Test]
+        public void CanDispose()
+        {
+            dynamic json = GetDynamicJson("""
+                {
+                  "Foo" : "Hello"
+                }
+                """);
+
+            json.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { var foo = json.Foo; });
+        }
+
+        [Test]
+        public void CanDisposeViaUsing()
+        {
+            string json = """
+                {
+                  "Foo" : "Hello"
+                }
+                """;
+
+            dynamic outer = default;
+            using (dynamic jsonData = GetDynamicJson(json))
+            {
+                Assert.IsTrue(jsonData.Foo == "Hello");
+                outer = jsonData;
+
+                Assert.IsTrue(outer.Foo == "Hello");
+            }
+
+            Assert.Throws<ObjectDisposedException>(() => { var foo = outer.Foo; });
+        }
+
         #region Helpers
         internal static dynamic GetDynamicJson(string json)
         {

--- a/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
@@ -388,6 +388,23 @@ namespace Azure.Core.Experimental.Tests
             Assert.Throws<ObjectDisposedException>(() => { var foo = outer.Foo; });
         }
 
+        [Test]
+        public void DisposingAChildDisposesTheParent()
+        {
+            dynamic json = GetDynamicJson("""
+                {
+                  "Foo" : {
+                    "A": "Hello"
+                  }
+                }
+                """);
+
+            dynamic child = json.Foo.A;
+            child.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { var foo = json.Foo; });
+        }
+
         #region Helpers
         internal static dynamic GetDynamicJson(string json)
         {

--- a/sdk/core/Azure.Core.Experimental/tests/JsonDataDynamicMutableTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/JsonDataDynamicMutableTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Azure.Core.Dynamic;
 using Azure.Core.GeoJson;
+using Azure.Core.Json;
 using NUnit.Framework;
 
 namespace Azure.Core.Experimental.Tests

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
@@ -1015,5 +1015,20 @@ namespace Azure.Core.Experimental.Tests
 
             Assert.AreEqual("Hello", doc.RootElement.GetProperty("Foo").GetString());
         }
+
+        [Test]
+        public void CanDispose()
+        {
+            string json = """
+                {
+                  "Foo" : "Hello"
+                }
+                """;
+
+            MutableJsonDocument mdoc = MutableJsonDocument.Parse(json);
+            mdoc.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { var foo = mdoc.RootElement.GetProperty("Foo"); });
+        }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.IO;
-using System.Security.Cryptography;
 using System.Text.Json;
-using Azure.Core.Dynamic;
+using Azure.Core.Json;
 using NUnit.Framework;
 
 namespace Azure.Core.Experimental.Tests

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentWriteToTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentWriteToTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
-using Azure.Core.Dynamic;
+using Azure.Core.Json;
 using NUnit.Framework;
 
 namespace Azure.Core.Experimental.Tests

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonElementTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonElementTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
-using Azure.Core.Dynamic;
+using Azure.Core.Json;
 using NUnit.Framework;
 
 namespace Azure.Core.Experimental.Tests

--- a/sdk/core/Azure.Core.Experimental/tests/perf/MutableJsonDataBenchmark.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/perf/MutableJsonDataBenchmark.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 using System.Text.Json;
-using Azure.Core.Dynamic;
+using Azure.Core.Json;
 using BenchmarkDotNet.Attributes;
 
 namespace Azure.Core.Experimental.Perf.Benchmarks


### PR DESCRIPTION
Addresses items in https://github.com/Azure/azure-sdk-for-net/issues/33856

- Move MutableJsonDocument and related types out of Azure.Core.Dynamic into Azure.Core.Json
- Make MutableJsonDocument and DynamicJson disposable so they can dispose the inner JsonDocument