### PR TITLE
[App Config] Fixing Build Snippets

### DIFF
--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -31,7 +31,6 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: appconfiguration
-    BuildSnippets: false
     ArtifactName: packages
     Artifacts:
     - name: Azure.Data.AppConfiguration


### PR DESCRIPTION
I was not able to repro the snippets failing to build locally using the command included in the linked issue. As far as I can tell all of the App Config snippets can compile. Build Snippets is succeeding in the pipeline as well.

Removing `BuildSnippets: false` from the _ci.yml_ file

Resolves https://github.com/Azure/azure-sdk-for-net/issues/33973

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
