### PR TITLE
[AzureMonitorExporter] fix nullables in Tests

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -278,8 +278,8 @@
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageDownload Include="Azure.Sdk.Tools.Testproxy" Version="[$(TestProxyVersion)]" />
     <PackageReference Update="WindowsAzure.ServiceBus" Version="5.1.0" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="xunit" Version="2.4.1" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageReference Update="xunit" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System.Collections.Generic;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
@@ -562,7 +560,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, netPeerIp));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, netPeerPort));
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbName, "DbName"));
-            string hostName = null;
+            string? hostName = null;
             if (peerService != null)
             {
                 hostName = peerService;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
@@ -122,7 +120,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             protected override void OnEventSourceCreated(EventSource eventSource)
             {
-                if (eventSource?.Name == AzureMonitorExporterEventSource.EventSourceName)
+                if (eventSource.Name == AzureMonitorExporterEventSource.EventSourceName)
                 {
                     this.eventSources.Add(eventSource);
                     this.EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemOutputHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemOutputHelper.cs
@@ -16,7 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             this.output = output;
         }
 
-        public void Write(IEnumerable<TelemetryItem> telemetryItems)
+        public void Write(IEnumerable<TelemetryItem>? telemetryItems)
         {
             if (telemetryItems == null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -16,11 +14,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
     {
         public static void AssertMessageTelemetry(
             TelemetryItem telemetryItem,
-            string expectedSeverityLevel,
+            string? expectedSeverityLevel,
             string expectedMessage,
             IDictionary<string, string> expectedMessageProperties,
-            string expectedSpanId,
-            string expectedTraceId)
+            string? expectedSpanId,
+            string? expectedTraceId)
         {
             Assert.Equal("Message", telemetryItem.Name); // telemetry type
             Assert.Equal("MessageData", telemetryItem.Data.BaseType); // telemetry data type
@@ -92,9 +90,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
         public static void AssertActivity_As_DependencyTelemetry(
             TelemetryItem telemetryItem,
             string expectedName,
-            string expectedTraceId,
-            string expectedSpanId,
-            IDictionary<string, string> expectedProperties,
+            string? expectedTraceId,
+            string? expectedSpanId,
+            IDictionary<string, string>? expectedProperties,
             bool expectedSuccess = true)
         {
             Assert.Equal("RemoteDependency", telemetryItem.Name); // telemetry type
@@ -130,9 +128,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             TelemetryItem telemetryItem,
             ActivityKind activityKind,
             string expectedName,
-            string expectedTraceId,
+            string? expectedTraceId,
             IDictionary<string, string> expectedProperties,
-            string expectedSpanId,
+            string? expectedSpanId,
             bool expectedSuccess = true)
         {
             Assert.Equal("Request", telemetryItem.Name); // telemetry type
@@ -178,8 +176,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             TelemetryItem telemetryItem,
             string expectedExceptionMessage,
             string expectedExceptionTypeName,
-            string expectedTraceId,
-            string expectedSpanId)
+            string? expectedTraceId,
+            string? expectedSpanId)
         {
             Assert.Equal("Exception", telemetryItem.Name); // telemetry type
             Assert.Equal("ExceptionData", telemetryItem.Data.BaseType); // telemetry data type
@@ -216,7 +214,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             double? expectedMetricDataPointMax = null,
             double? expectedMetricDataPointMin = null,
             double? expectedMetricDataPointStdDev = null,
-            Dictionary<string, string> expectedMetricsProperties = null)
+            Dictionary<string, string>? expectedMetricsProperties = null)
         {
             Assert.Equal("Metric", telemetryItem.Name); // telemetry type
             Assert.Equal("MetricData", telemetryItem.Data.BaseType); // telemetry data type

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -43,7 +41,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var logCategoryName = $"logCategoryName{uniqueTestId}";
 
-            ConcurrentBag<TelemetryItem> telemetryItems = null;
+            ConcurrentBag<TelemetryItem>? telemetryItems = null;
 
             var loggerFactory = LoggerFactory.Create(builder =>
             {
@@ -68,12 +66,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             loggerFactory.Dispose();
 
             // ASSERT
-            Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.Single();
+            var telemetryItem = telemetryItems?.Single();
 
             TelemetryItemValidationHelper.AssertMessageTelemetry(
-                telemetryItem: telemetryItem,
+                telemetryItem: telemetryItem!,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Hello {name}.",
                 expectedMessageProperties: new Dictionary<string, string> { { "name", "World" }},
@@ -95,7 +93,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var logCategoryName = $"logCategoryName{uniqueTestId}";
 
-            ConcurrentBag<TelemetryItem> telemetryItems = null;
+            ConcurrentBag<TelemetryItem>? telemetryItems = null;
 
             var loggerFactory = LoggerFactory.Create(builder =>
             {
@@ -128,12 +126,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             loggerFactory.Dispose();
 
             // ASSERT
-            Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.Single();
+            var telemetryItem = telemetryItems?.Single();
 
             TelemetryItemValidationHelper.AssertLog_As_ExceptionTelemetry(
-                telemetryItem: telemetryItem,
+                telemetryItem: telemetryItem!,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Test Exception", // TODO: this fails. Currently the ILogger message is overwriting the Exception.Message.
                 expectedTypeName: "System.Exception");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -64,7 +62,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            meterProvider.Dispose();
+            meterProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -118,7 +116,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            meterProvider.Dispose();
+            meterProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -157,16 +155,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                     .AddView(instrumentName: "MyGuage", name: "MyGuageRenamed");
             }
 
-            var meterProvider = meterProviderBulider.Build();
+            var meterProvider = meterProviderBulider?.Build();
 
             // ACT
             var myObservableGauge = meter.CreateObservableGauge("MyGuage", () =>
                 new Measurement<double>(
                     value: 123.45,
-                    tags: new KeyValuePair<string, object>("tag1", "value1")));
+                    tags: new KeyValuePair<string, object?>("tag1", "value1")));
 
             // CLEANUP
-            meterProvider.Dispose();
+            meterProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -213,7 +211,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             upDownCounter.Add(-4, new("tag1", "value1"), new("tag2", "value2"));
 
             // CLEANUP
-            meterProvider.Dispose();
+            meterProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -263,9 +261,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             metricReader.Collect();
             Assert.True(telemetryItems.Count == 1);
             Assert.True(telemetryItems.TryTake(out var telemetryItem));
-            this.telemetryOutput.Write(telemetryItem);
+            this.telemetryOutput.Write(telemetryItem!);
             TelemetryItemValidationHelper.AssertMetricTelemetry(
-                telemetryItem: telemetryItem,
+                telemetryItem: telemetryItem!,
                 expectedMetricDataPointName: asView ? "MyUpDownCounterRenamed" : "MyUpDownCounter",
                 expectedMetricDataPointNamespace: meterName,
                 expectedMetricDataPointValue: -2,
@@ -274,9 +272,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             metricReader.Collect();
             Assert.True(telemetryItems.Count == 1);
             Assert.True(telemetryItems.TryTake(out telemetryItem));
-            this.telemetryOutput.Write(telemetryItem);
+            this.telemetryOutput.Write(telemetryItem!);
             TelemetryItemValidationHelper.AssertMetricTelemetry(
-                telemetryItem: telemetryItem,
+                telemetryItem: telemetryItem!,
                 expectedMetricDataPointName: asView ? "MyUpDownCounterRenamed" : "MyUpDownCounter",
                 expectedMetricDataPointNamespace: meterName,
                 expectedMetricDataPointValue: 4,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -250,12 +250,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedSpanId: spanId,
                 expectedProperties: null);
 
-            Assert.True(logTelemetryItems.Any(), "Unit test failed to collect telemetry.");
+            Assert.True(logTelemetryItems?.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(logTelemetryItems);
-            var logTelemetryItem = logTelemetryItems.Single();
+            var logTelemetryItem = logTelemetryItems?.Single();
 
             TelemetryItemValidationHelper.AssertMessageTelemetry(
-                telemetryItem: logTelemetryItem,
+                telemetryItem: logTelemetryItem!,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Hello {name}.",
                 expectedMessageProperties: new Dictionary<string, string> { { "name", "World" } },

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable disable // TODO: remove and fix errors
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -49,7 +51,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ACT
             string spanId, traceId;
-            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind) ?? throw new Exception("Failed to create Activity"))
+            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind ))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
@@ -61,7 +63,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider?.Dispose();
+            tracerProvider.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -94,7 +96,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ACT
             string spanId, traceId;
-            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind) ?? throw new Exception("Failed to create Activity"))
+            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
@@ -106,7 +108,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider?.Dispose();
+            tracerProvider.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -137,9 +139,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 .Build();
 
             // ACT
-            string spanId, traceId;
+            string spanId = null, traceId = null;
 
-            using (var activity = activitySource.StartActivity(name: "ActivityWithException") ?? throw new Exception("Failed to create Activity"))
+            using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
@@ -156,7 +158,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider?.Dispose();
+            tracerProvider.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -198,7 +200,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var logCategoryName = $"logCategoryName{uniqueTestId}"; ;
 
-            ConcurrentBag<TelemetryItem>? logTelemetryItems = null;
+            ConcurrentBag<TelemetryItem> logTelemetryItems = null;
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
@@ -219,7 +221,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             string spanId, traceId;
             string activityName = $"TestActivity {nameof(VerifyLogWithinActivity)} {logLevel}";
 
-            using (var activity = activitySource.StartActivity(name: activityName) ?? throw new Exception("Failed to create Activity"))
+            using (var activity = activitySource.StartActivity(name: activityName))
             {
                 spanId = activity.SpanId.ToHexString();
                 traceId = activity.TraceId.ToHexString();
@@ -235,7 +237,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider?.Dispose();
+            tracerProvider.Dispose();
             loggerFactory.Dispose();
 
             // ASSERT
@@ -250,12 +252,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedSpanId: spanId,
                 expectedProperties: null);
 
-            Assert.True(logTelemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            Assert.True(logTelemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(logTelemetryItems);
-            var logTelemetryItem = logTelemetryItems?.Single();
+            var logTelemetryItem = logTelemetryItems.Single();
 
             TelemetryItemValidationHelper.AssertMessageTelemetry(
-                telemetryItem: logTelemetryItem!,
+                telemetryItem: logTelemetryItem,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Hello {name}.",
                 expectedMessageProperties: new Dictionary<string, string> { { "name", "World" } },
@@ -278,14 +280,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 .Build();
 
             // ACT
-            string spanId, traceId;
+            string spanId = null, traceId = null;
 
-            using (var activity = activitySource.StartActivity(name: "ActivityWithException") ?? throw new Exception("Failed to create Activity"))
+            using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
-                var eventTags = new Dictionary<string, object?>
+                var eventTags = new Dictionary<string, object>
                 {
                     { "integer", 1 },
                     { "string", "Hello, World!" },
@@ -295,7 +297,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider?.Dispose();
+            tracerProvider.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -51,7 +49,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ACT
             string spanId, traceId;
-            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind ))
+            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind) ?? throw new Exception("Failed to create Activity"))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
@@ -63,7 +61,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -96,7 +94,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ACT
             string spanId, traceId;
-            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind))
+            using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind) ?? throw new Exception("Failed to create Activity"))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
@@ -108,7 +106,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -139,9 +137,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 .Build();
 
             // ACT
-            string spanId = null, traceId = null;
+            string spanId, traceId;
 
-            using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
+            using (var activity = activitySource.StartActivity(name: "ActivityWithException") ?? throw new Exception("Failed to create Activity"))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
@@ -158,7 +156,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -200,7 +198,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var logCategoryName = $"logCategoryName{uniqueTestId}"; ;
 
-            ConcurrentBag<TelemetryItem> logTelemetryItems = null;
+            ConcurrentBag<TelemetryItem>? logTelemetryItems = null;
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
@@ -221,7 +219,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             string spanId, traceId;
             string activityName = $"TestActivity {nameof(VerifyLogWithinActivity)} {logLevel}";
 
-            using (var activity = activitySource.StartActivity(name: activityName))
+            using (var activity = activitySource.StartActivity(name: activityName) ?? throw new Exception("Failed to create Activity"))
             {
                 spanId = activity.SpanId.ToHexString();
                 traceId = activity.TraceId.ToHexString();
@@ -237,7 +235,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
             loggerFactory.Dispose();
 
             // ASSERT
@@ -280,14 +278,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 .Build();
 
             // ACT
-            string spanId = null, traceId = null;
+            string spanId, traceId;
 
-            using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
+            using (var activity = activitySource.StartActivity(name: "ActivityWithException") ?? throw new Exception("Failed to create Activity"))
             {
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
-                var eventTags = new Dictionary<string, object>
+                var eventTags = new Dictionary<string, object?>
                 {
                     { "integer", 1 },
                     { "string", "Hello, World!" },
@@ -297,7 +295,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -53,6 +51,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             string spanId, traceId;
             using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind ))
             {
+                Assert.NotNull(activity);
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
@@ -63,7 +62,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -98,6 +97,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             string spanId, traceId;
             using (var activity = activitySource.StartActivity(name: "SayHello", kind: activityKind))
             {
+                Assert.NotNull(activity);
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
@@ -108,7 +108,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -139,10 +139,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 .Build();
 
             // ACT
-            string spanId = null, traceId = null;
+            string? spanId, traceId;
 
             using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
             {
+                Assert.NotNull(activity);
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
@@ -158,7 +159,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
@@ -200,7 +201,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             var logCategoryName = $"logCategoryName{uniqueTestId}"; ;
 
-            ConcurrentBag<TelemetryItem> logTelemetryItems = null;
+            ConcurrentBag<TelemetryItem>? logTelemetryItems = null;
 
             var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
@@ -223,6 +224,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             using (var activity = activitySource.StartActivity(name: activityName))
             {
+                Assert.NotNull(activity);
                 spanId = activity.SpanId.ToHexString();
                 traceId = activity.TraceId.ToHexString();
 
@@ -237,7 +239,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
             loggerFactory.Dispose();
 
             // ASSERT
@@ -252,12 +254,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedSpanId: spanId,
                 expectedProperties: null);
 
-            Assert.True(logTelemetryItems.Any(), "Unit test failed to collect telemetry.");
-            this.telemetryOutput.Write(logTelemetryItems);
-            var logTelemetryItem = logTelemetryItems.Single();
+            Assert.True(logTelemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(logTelemetryItems!);
+            var logTelemetryItem = logTelemetryItems?.Single();
 
             TelemetryItemValidationHelper.AssertMessageTelemetry(
-                telemetryItem: logTelemetryItem,
+                telemetryItem: logTelemetryItem!,
                 expectedSeverityLevel: expectedSeverityLevel,
                 expectedMessage: "Hello {name}.",
                 expectedMessageProperties: new Dictionary<string, string> { { "name", "World" } },
@@ -280,14 +282,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 .Build();
 
             // ACT
-            string spanId = null, traceId = null;
+            string? spanId, traceId;
 
             using (var activity = activitySource.StartActivity(name: "ActivityWithException"))
             {
+                Assert.NotNull(activity);
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
-                var eventTags = new Dictionary<string, object>
+                var eventTags = new Dictionary<string, object?>
                 {
                     { "integer", 1 },
                     { "string", "Hello, World!" },
@@ -297,7 +300,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             }
 
             // CLEANUP
-            tracerProvider.Dispose();
+            tracerProvider?.Dispose();
 
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ExceptionExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ExceptionExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Globalization;
 using System.Threading;
@@ -20,7 +18,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void ExtractsStackTraceWithInvariantCultureMatchesErrorsReportedByOSsWithDifferentLanguages()
         {
-            CultureInfo stackTraceCulture = null;
+            CultureInfo? stackTraceCulture = null;
             var exception = new StubException();
             exception.OnToString = () =>
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/IngestionRedirectPolicyTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/IngestionRedirectPolicyTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -120,7 +118,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             pipeline.SendAsync(message, CancellationToken.None);
 
             Assert.Equal("http://new.host/", mockTransport.Requests[1].Uri.ToString());
-            Assert.True(mockTransport.Requests[1].Headers.TryGetValue(HttpHeader.Names.Authorization, out string token));
+            Assert.True(mockTransport.Requests[1].Headers.TryGetValue(HttpHeader.Names.Authorization, out string? token));
             Assert.Equal(testToken, token);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricsDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricsDataTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
@@ -32,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 .Build();
 
             var dataPointType = DataPointType.Aggregation;
-            string name = null;
+            string? name = null;
             if (metricType == MetricType.DoubleSum)
             {
                 name = "TestDoubleCounter";
@@ -73,12 +71,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 .Build();
 
             var dataPointType = DataPointType.Aggregation;
-            string name = null;
+            string? name = null;
             if (metricType == MetricType.DoubleSum)
             {
                 name = "TestDoubleCounter";
                 var doubleCounter = meter.CreateCounter<double>(name);
-                doubleCounter.Add(123.45, new KeyValuePair<string, object>("tag", "value"));
+                doubleCounter.Add(123.45, new KeyValuePair<string, object?>("tag", "value"));
             }
             else if (metricType == MetricType.DoubleGauge)
             {
@@ -87,7 +85,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                     name,
                     () => new List<Measurement<double>>()
                     {
-                    new(123.45, new KeyValuePair<string, object>("tag", "value")),
+                    new(123.45, new KeyValuePair<string, object?>("tag", "value")),
                     });
             }
 
@@ -181,8 +179,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void ThrowsIfMetricIsNull()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             var metricPoint = new MetricPoint();
             Assert.Throws<ArgumentNullException>(() => new MetricsData(Version, null, metricPoint));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -47,6 +45,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
                 startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.SetTag(SemanticConventions.AttributeDbSystem, dbSystem);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -64,12 +63,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             using var parentActivity = activitySource.StartActivity("ParentActivity", ActivityKind.Internal);
             using var childActivity = activitySource.StartActivity("ChildActivity", ActivityKind.Internal);
 
+            Assert.NotNull(parentActivity);
             var monitorTagsParent = TraceHelper.EnumerateActivityTags(parentActivity);
 
             var remoteDependencyDataTypeForParent = new RemoteDependencyData(2, parentActivity, ref monitorTagsParent).Type;
 
             Assert.Null(remoteDependencyDataTypeForParent);
 
+            Assert.NotNull(childActivity);
             var monitorTagsChild = TraceHelper.EnumerateActivityTags(childActivity);
 
             var remoteDependencyDataTypeForChild = new RemoteDependencyData(2, childActivity, ref monitorTagsChild).Type;
@@ -86,6 +87,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
                 startTime: DateTime.UtcNow);
+            Assert.NotNull(activity);
             activity.Stop();
 
             var httpUrl = "https://www.foo.bar/search";
@@ -117,6 +119,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
                 startTime: DateTime.UtcNow);
+            Assert.NotNull(activity);
             activity.Stop();
 
             activity.SetStatus(Status.Ok);
@@ -148,6 +151,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
                 startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
 
             activity.DisplayName = "HTTP GET";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable disable // TODO: remove and fix errors
+
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -43,8 +45,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
             activity.SetTag(SemanticConventions.AttributeDbSystem, dbSystem);
 
@@ -60,10 +61,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DependencyTypeisSetToInProcForInternalSpanWithParent()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
-            using var parentActivity = activitySource.StartActivity("ParentActivity", ActivityKind.Internal)
-                ?? throw new Exception("Failed to create Activity");
-            using var childActivity = activitySource.StartActivity("ChildActivity", ActivityKind.Internal)
-                ?? throw new Exception("Failed to create Activity");
+            using var parentActivity = activitySource.StartActivity("ParentActivity", ActivityKind.Internal);
+            using var childActivity = activitySource.StartActivity("ChildActivity", ActivityKind.Internal);
 
             var monitorTagsParent = TraceHelper.EnumerateActivityTags(parentActivity);
 
@@ -86,8 +85,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
             activity.Stop();
 
             var httpUrl = "https://www.foo.bar/search";
@@ -118,8 +116,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
             activity.Stop();
 
             activity.SetStatus(Status.Ok);
@@ -149,8 +146,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -45,7 +43,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.SetTag(SemanticConventions.AttributeDbSystem, dbSystem);
 
@@ -61,8 +60,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DependencyTypeisSetToInProcForInternalSpanWithParent()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
-            using var parentActivity = activitySource.StartActivity("ParentActivity", ActivityKind.Internal);
-            using var childActivity = activitySource.StartActivity("ChildActivity", ActivityKind.Internal);
+            using var parentActivity = activitySource.StartActivity("ParentActivity", ActivityKind.Internal)
+                ?? throw new Exception("Failed to create Activity");
+            using var childActivity = activitySource.StartActivity("ChildActivity", ActivityKind.Internal)
+                ?? throw new Exception("Failed to create Activity");
 
             var monitorTagsParent = TraceHelper.EnumerateActivityTags(parentActivity);
 
@@ -85,7 +86,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
             activity.Stop();
 
             var httpUrl = "https://www.foo.bar/search";
@@ -116,7 +118,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
             activity.Stop();
 
             activity.SetStatus(Status.Ok);
@@ -146,7 +149,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -43,7 +41,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
+
             activity.Stop();
 
             var httpUrl = "https://www.foo.bar/search";
@@ -78,7 +78,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             var httpResponseCode = httpStatusCode ?? "0";
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
@@ -103,7 +104,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             var httpResponseCode = httpStatusCode ?? "0";
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable disable // TODO: remove and fix errors
+
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -41,9 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
-
+                startTime: DateTime.UtcNow);
             activity.Stop();
 
             var httpUrl = "https://www.foo.bar/search";
@@ -78,8 +78,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
             var httpResponseCode = httpStatusCode ?? "0";
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
@@ -104,8 +103,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
             var httpResponseCode = httpStatusCode ?? "0";
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -44,6 +42,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
                 startTime: DateTime.UtcNow);
+            Assert.NotNull(activity);
             activity.Stop();
 
             var httpUrl = "https://www.foo.bar/search";
@@ -79,6 +78,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
                 startTime: DateTime.UtcNow);
+            Assert.NotNull(activity);
 
             var httpResponseCode = httpStatusCode ?? "0";
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
@@ -104,6 +104,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Server,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
                 startTime: DateTime.UtcNow);
+            Assert.NotNull(activity);
 
             var httpResponseCode = httpStatusCode ?? "0";
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System.Collections.Generic;
 using System.Net;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
@@ -16,8 +14,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void NullResource()
         {
-            Resource resource = null;
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            Resource? resource = null;
+            var azMonResource = resource!.UpdateRoleNameAndInstance();
 
             Assert.Null(azMonResource);
         }
@@ -28,8 +26,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
             var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.StartsWith("unknown_service", azMonResource.RoleName);
-            Assert.Equal(Dns.GetHostName(), azMonResource.RoleInstance);
+            Assert.StartsWith("unknown_service", azMonResource?.RoleName);
+            Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
         }
 
         [Fact]
@@ -38,8 +36,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(serviceName: "my-service");
             var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.Equal("my-service", azMonResource.RoleName);
-            Assert.Equal(Dns.GetHostName(), azMonResource.RoleInstance);
+            Assert.Equal("my-service", azMonResource?.RoleName);
+            Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
         }
 
         [Fact]
@@ -48,8 +46,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(serviceInstance: "my-instance");
             var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.StartsWith("unknown_service", azMonResource.RoleName);
-            Assert.Equal("my-instance", azMonResource.RoleInstance);
+            Assert.StartsWith("unknown_service", azMonResource?.RoleName);
+            Assert.Equal("my-instance", azMonResource?.RoleInstance);
         }
 
         [Fact]
@@ -58,8 +56,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(serviceNamespace: "my-namespace");
             var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.StartsWith("[my-namespace]/unknown_service", azMonResource.RoleName);
-            Assert.Equal(Dns.GetHostName(), azMonResource.RoleInstance);
+            Assert.StartsWith("[my-namespace]/unknown_service", azMonResource?.RoleName);
+            Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
         }
 
         [Fact]
@@ -68,8 +66,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
             var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.Equal("my-service", azMonResource.RoleName);
-            Assert.Equal("my-instance", azMonResource.RoleInstance);
+            Assert.Equal("my-service", azMonResource?.RoleName);
+            Assert.Equal("my-instance", azMonResource?.RoleInstance);
         }
 
         [Fact]
@@ -78,8 +76,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(serviceName: "my-service", serviceNamespace: "my-namespace", serviceInstance: "my-instance");
             var azMonResource = resource.UpdateRoleNameAndInstance();
 
-            Assert.Equal("[my-namespace]/my-service", azMonResource.RoleName);
-            Assert.Equal("my-instance", azMonResource.RoleInstance);
+            Assert.Equal("[my-namespace]/my-service", azMonResource?.RoleName);
+            Assert.Equal("my-instance", azMonResource?.RoleInstance);
         }
 
         /// <summary>
@@ -95,7 +93,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         /// var resource = tracerProvider.GetResource();
         /// </code>
         /// </remarks>
-        private static Resource CreateTestResource(string serviceName = null, string serviceNamespace = null, string serviceInstance = null)
+        private static Resource CreateTestResource(string? serviceName = null, string? serviceNamespace = null, string? serviceInstance = null)
         {
             var testAttributes = new Dictionary<string, object>();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StorageTransmissionEvaluatorTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StorageTransmissionEvaluatorTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System.Reflection;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using Xunit;
@@ -19,23 +17,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var storageTransmissionEvaluator = new StorageTransmissionEvaluator(SampleSize);
             var sampleSize = typeof(StorageTransmissionEvaluator)
                 .GetField("_sampleSize", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(storageTransmissionEvaluator);
+                ?.GetValue(storageTransmissionEvaluator);
             var previousExportStartTimeInMilliseconds = typeof(StorageTransmissionEvaluator)
                 .GetField("_previousExportStartTimeInMilliseconds", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(storageTransmissionEvaluator);
+                ?.GetValue(storageTransmissionEvaluator);
             var exportDurationInSeconds = typeof(StorageTransmissionEvaluator)
                 .GetField("_exportDurationsInMilliseconds", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(storageTransmissionEvaluator) as long[];
+                ?.GetValue(storageTransmissionEvaluator) as long[];
             var exportIntervalsInSeconds = typeof(StorageTransmissionEvaluator)
                 .GetField("_exportIntervalsInMilliseconds", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(storageTransmissionEvaluator) as long[];
+                ?.GetValue(storageTransmissionEvaluator) as long[];
 
-            Assert.Equal(SampleSize, (int)sampleSize);
+            Assert.Equal(SampleSize, (int)sampleSize!);
             Assert.NotNull(exportIntervalsInSeconds);
             Assert.NotNull(exportDurationInSeconds);
-            Assert.Equal(SampleSize, exportIntervalsInSeconds.Length);
-            Assert.Equal(SampleSize, exportDurationInSeconds.Length);
-            Assert.Equal(0, (long)previousExportStartTimeInMilliseconds);
+            Assert.Equal(SampleSize, exportIntervalsInSeconds!.Length);
+            Assert.Equal(SampleSize, exportDurationInSeconds!.Length);
+            Assert.Equal(0, (long)previousExportStartTimeInMilliseconds!);
         }
 
         [Fact]
@@ -81,7 +79,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // than avg export interval.
             typeof(StorageTransmissionEvaluator)
                 .GetField("_currentBatchExportDurationInMilliseconds", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(storageTransmissionEvaluator, 10000);
+                ?.SetValue(storageTransmissionEvaluator, 10000);
             var maxFiles = storageTransmissionEvaluator.GetMaxFilesToTransmitFromStorage();
 
             Assert.Equal(0, maxFiles);
@@ -119,17 +117,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var exportIntervalsInSecondsBefore = typeof(StorageTransmissionEvaluator)
                 .GetField("_exportIntervalsInMilliseconds", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(storageTransmissionEvaluator) as long[];
+                ?.GetValue(storageTransmissionEvaluator) as long[];
 
             var exportDurationInSecondsBefore = typeof(StorageTransmissionEvaluator)
                 .GetField("_exportDurationsInMilliseconds", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(storageTransmissionEvaluator) as long[];
+                ?.GetValue(storageTransmissionEvaluator) as long[];
 
             // Add data points equal to sample size
             for (int i = 0; i < SampleSize; i++)
             {
-                Assert.Equal(2000, exportIntervalsInSecondsBefore[i]);
-                Assert.Equal(2000, exportDurationInSecondsBefore[i]);
+                Assert.Equal(2000, exportIntervalsInSecondsBefore![i]);
+                Assert.Equal(2000, exportDurationInSecondsBefore![i]);
             }
 
             // Add 3 more data points with different time values
@@ -143,15 +141,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // First 3 elements should be updated
             for (int i = 0; i < 3; i++)
             {
-                Assert.Equal(1000, exportIntervalsInSecondsBefore[i]);
-                Assert.Equal(1000, exportDurationInSecondsBefore[i]);
+                Assert.Equal(1000, exportIntervalsInSecondsBefore![i]);
+                Assert.Equal(1000, exportDurationInSecondsBefore![i]);
             }
 
             // Last two should remain the same
             for (int i = 3; i < SampleSize; i++)
             {
-                Assert.Equal(2000, exportIntervalsInSecondsBefore[i]);
-                Assert.Equal(2000, exportDurationInSecondsBefore[i]);
+                Assert.Equal(2000, exportIntervalsInSecondsBefore![i]);
+                Assert.Equal(2000, exportDurationInSecondsBefore![i]);
             }
 
             // Adding samples more than sample szie should not throw any exception

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -55,7 +53,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            using var activity = CreateTestActivity(new Dictionary<string, object>());
+            using var activity = CreateTestActivity(new Dictionary<string, object?>());
             monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(OperationType.Unknown, monitorTags.activityType);
@@ -72,11 +70,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 ["key1"] = null,
-                ["key2"] = new string[] { "test", null },
-                ["key3"] = new string[] { null, null }
+                ["key2"] = new string?[] { "test", null },
+                ["key3"] = new string?[] { null, null }
             };
 
             using var activity = CreateTestActivity(tagObjects);
@@ -99,7 +97,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object> { ["somekey"] = "value" }; ;
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?> { ["somekey"] = "value" }; ;
             using var activity = CreateTestActivity(tagObjects);
             monitorTags.ForEach(activity.TagObjects);
 
@@ -117,7 +115,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 [SemanticConventions.AttributeNetHostIp] = "127.0.0.1",
                 [SemanticConventions.AttributeHttpScheme] = "https",
@@ -148,7 +146,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
@@ -179,7 +177,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 ["intArray"] = new int[] { 1, 2, 3 },
             };
@@ -203,7 +201,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 ["doubleArray"] = new double[] { 1.1, 2.2, 3.3 },
             };
@@ -227,7 +225,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 ["strArray"] = new string[] { "test1", "test2", "test3" },
             };
@@ -251,7 +249,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 ["boolArray"] = new bool[] { true, false, true },
             };
@@ -275,7 +273,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 ["objArray"] = new Test[] { new Test(), new Test(), new Test() { TestProperty = 0 } },
             };
@@ -299,7 +297,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 UnMappedTags = AzMonList.Initialize()
             };
 
-            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
             {
                 ["intKey"] = 1,
                 ["doubleKey"] = 1.1,
@@ -324,7 +322,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal("1,2,3", AzMonList.GetTagValue(ref monitorTags.UnMappedTags, "arrayKey"));
         }
 
-        private static Activity CreateTestActivity(IEnumerable<KeyValuePair<string, object>> additionalAttributes = null)
+        private static Activity CreateTestActivity(IEnumerable<KeyValuePair<string, object?>>? additionalAttributes = null)
         {
             var startTimestamp = DateTime.UtcNow;
             var endTimestamp = startTimestamp.AddSeconds(60);
@@ -333,10 +331,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var parentSpanId = ActivitySpanId.CreateRandom();
 
-            Dictionary<string, object> attributes = null;
+            Dictionary<string, object?>? attributes = null;
             if (additionalAttributes != null)
             {
-                attributes = new Dictionary<string, object>();
+                attributes = new Dictionary<string, object?>();
                 foreach (var attribute in additionalAttributes)
                 {
                     attributes.Add(attribute.Key, attribute.Value);
@@ -353,10 +351,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 null,
                 startTime: startTimestamp);
 
-            activity.SetEndTime(endTimestamp);
-            activity.Stop();
+            activity?.SetEndTime(endTimestamp);
+            activity?.Stop();
 
-            return activity;
+            return activity ?? throw new Exception("Failed to create Activity");
         }
 
         private class Test

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -92,8 +92,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
+
+            Assert.NotNull(activity);
             var resource = CreateTestResource();
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -120,9 +121,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.DisplayName = "/getaction";
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
@@ -153,9 +154,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.DisplayName = "displayname";
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
@@ -175,9 +176,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.DisplayName = "displayname";
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -194,9 +195,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.SetTag(SemanticConventions.AttributeHttpClientIP, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -213,9 +214,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.SetTag(SemanticConventions.AttributeNetPeerIp, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -232,9 +233,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             var userAgent = "Mozilla / 5.0(Windows NT 10.0;WOW64) AppleWebKit / 537.36(KHTML, like Gecko) Chrome / 91.0.4472.101 Safari / 537.36";
             activity.SetTag(SemanticConventions.AttributeHttpUserAgent, userAgent);
 
@@ -252,9 +253,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
             var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
@@ -269,9 +270,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
             var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
@@ -286,8 +287,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
+
+            Assert.NotNull(activity);
             var resource = CreateTestResource();
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -305,8 +307,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
+
+            Assert.NotNull(activity);
             var resource = CreateTestResource(null, null, "serviceinstance");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -326,9 +329,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             activity.DisplayName = "displayname";
             if (httpMethod != null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -41,7 +39,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: default,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             var resource = CreateTestResource();
 
@@ -66,7 +65,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: default,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
 
@@ -92,7 +92,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
             var resource = CreateTestResource();
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -112,14 +113,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [InlineData("/route")]
         [InlineData("{controller}/{action}/{id}")]
         [InlineData(null)]
-        public void HttpMethodAndHttpRouteIsUsedForHttpRequestOperationName(string route)
+        public void HttpMethodAndHttpRouteIsUsedForHttpRequestOperationName(string? route)
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.DisplayName = "/getaction";
 
@@ -138,7 +140,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             }
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.Equal(expectedOperationName, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -151,7 +153,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.DisplayName = "displayname";
 
@@ -159,7 +162,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/path?id=1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.Equal("GET /path", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -172,12 +175,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.DisplayName = "displayname";
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.Equal("displayname", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -190,12 +194,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.SetTag(SemanticConventions.AttributeHttpClientIP, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -208,12 +213,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.SetTag(SemanticConventions.AttributeNetPeerIp, "127.0.0.1");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -226,13 +232,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             var userAgent = "Mozilla / 5.0(Windows NT 10.0;WOW64) AppleWebKit / 537.36(KHTML, like Gecko) Chrome / 91.0.4472.101 Safari / 537.36";
             activity.SetTag(SemanticConventions.AttributeHttpUserAgent, userAgent);
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.Equal(userAgent, telemetryItem.Tags["ai.user.userAgent"]);
         }
@@ -245,10 +252,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.Null(telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -261,10 +269,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
 
             Assert.False(telemetryItem.Tags.TryGetValue("ai.user.userAgent", out var userAgent));
         }
@@ -277,7 +286,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
             var resource = CreateTestResource();
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -295,7 +305,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
             var resource = CreateTestResource(null, null, "serviceinstance");
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -308,14 +319,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Theory]
         [InlineData("GET")]
         [InlineData(null)]
-        public void RequestNameMatchesOperationName(string httpMethod)
+        public void RequestNameMatchesOperationName(string? httpMethod)
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
                 ActivityName,
                 ActivityKind.Server,
                 null,
-                startTime: DateTime.UtcNow);
+                startTime: DateTime.UtcNow)
+                ?? throw new Exception("Failed to create Activity");
 
             activity.DisplayName = "displayname";
             if (httpMethod != null)
@@ -323,7 +335,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, httpMethod);
             }
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, null);
+            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
             var requestData = new RequestData(2, activity, ref monitorTags);
 
             Assert.Equal(requestData.Name, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
@@ -342,7 +354,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         /// var resource = tracerProvider.GetResource();
         /// </code>
         /// </remarks>
-        private static Resource CreateTestResource(string serviceName = null, string serviceNamespace = null, string serviceInstance = null)
+        private static Resource CreateTestResource(string? serviceName = null, string? serviceNamespace = null, string? serviceInstance = null)
         {
             var testAttributes = new Dictionary<string, object>();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
@@ -48,9 +48,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityName,
                 ActivityKind.Client,
                 parentContext: default,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
 
             if (telemetryType == "RequestData")
@@ -86,9 +86,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 parentContext: default,
                 null,
                 links,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             string? expectedMSlinks = GetExpectedMSlinks(links);
             string? actualMSlinks = null;
 
@@ -137,9 +137,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 parentContext: default,
                 null,
                 links,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
 
             if (telemetryType == "RequestData")
@@ -190,9 +190,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 parentContext: default,
                 null,
                 links,
-                startTime: DateTime.UtcNow)
-                ?? throw new Exception("Failed to create Activity");
+                startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             string? expectedMslinks = GetExpectedMSlinks(links);
             string? actualMSlinks = null;
 
@@ -230,9 +230,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
                 ActivityName,
-                ActivityKind.Server)
-                ?? throw new Exception("Failed to create Activity");
+                ActivityKind.Server);
 
+            Assert.NotNull(activity);
             activity.RecordException(new Exception(exceptionMessage));
 
             Activity[] activityList = new Activity[1];
@@ -246,10 +246,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal("Exception", telemetryItems[0].Name);
             Assert.Equal("Request", telemetryItems[1].Name);
 
-            var telemetryExceptionData = (telemetryItems[0].Data.BaseData as TelemetryExceptionData) ?? throw new Exception("Invalid BaseData");
-            Assert.Equal(exceptionMessage, telemetryExceptionData?.Exceptions.First().Message);
-            Assert.Equal("System.Exception", telemetryExceptionData?.Exceptions.First().TypeName);
-            Assert.Equal("System.Exception: Exception Message", telemetryExceptionData?.Exceptions.First().Stack);
+            var telemetryExceptionData = (telemetryItems[0].Data.BaseData as TelemetryExceptionData);
+            Assert.NotNull(telemetryExceptionData);
+            Assert.Equal(exceptionMessage, telemetryExceptionData.Exceptions.First().Message);
+            Assert.Equal("System.Exception", telemetryExceptionData.Exceptions.First().TypeName);
+            Assert.Equal("System.Exception: Exception Message", telemetryExceptionData.Exceptions.First().Stack);
         }
 
         [Fact]
@@ -259,9 +260,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
                 ActivityName,
-                ActivityKind.Server)
-                ?? throw new Exception("Failed to create Activity");
+                ActivityKind.Server);
 
+            Assert.NotNull(activity);
             var tagsCollection = new ActivityTagsCollection
             {
                 { "key1", "value1" },
@@ -295,8 +296,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
                 ActivityName,
-                ActivityKind.Server)
-                ?? throw new Exception("Failed to create Activity");
+                ActivityKind.Server);
+
+            Assert.NotNull(activity);
 
             // Checking with empty string here as OTel
             // adds the exception only if it non-null and non-empty.
@@ -321,8 +323,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
                 ActivityName,
-                ActivityKind.Server)
-                ?? throw new Exception("Failed to create Activity");
+                ActivityKind.Server);
+
+            Assert.NotNull(activity);
 
             // Type is not null when using RecordException so creating the event manually
             // similar to https://github.com/open-telemetry/opentelemetry-dotnet/blob/872a52f5291804c7af19e90307b5cc097b2da709/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs#L96-L113

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
@@ -89,7 +89,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow)
                 ?? throw new Exception("Failed to create Activity");
 
-            string expectedMSlinks = GetExpectedMSlinks(links);
+            string? expectedMSlinks = GetExpectedMSlinks(links);
             string? actualMSlinks = null;
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -128,7 +128,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 links.Add(activityLink);
             }
 
-            string expectedMSlinks = GetExpectedMSlinks(links.GetRange(0, MaxLinksAllowed));
+            string? expectedMSlinks = GetExpectedMSlinks(links.GetRange(0, MaxLinksAllowed));
             string? actualMSlinks = null;
 
             using var activity = activitySource.StartActivity(
@@ -193,7 +193,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow)
                 ?? throw new Exception("Failed to create Activity");
 
-            string expectedMslinks = GetExpectedMSlinks(links);
+            string? expectedMslinks = GetExpectedMSlinks(links);
             string? actualMSlinks = null;
 
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
@@ -346,7 +346,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal("Request", telemetryItems[0].Name);
         }
 
-        private string GetExpectedMSlinks(IEnumerable<ActivityLink> links)
+        private string? GetExpectedMSlinks(IEnumerable<ActivityLink> links)
         {
             if (links != null && links.Any())
             {


### PR DESCRIPTION
Towards #34013

This PR fixes about half of our tests.

## Changes
- update `xunit` to v2.4.2.
  This version adds NullableAttributes to methods like `Assert.NotNull()`
- update `xunit.runner.visualstudio` to v2.4.2
- remove `#disable nullable` in tests and fix issues.