### PR TITLE
Fix MSI deserialization for empty Guid values

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/CHANGELOG.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `ManagedServiceIdentity` deserialization when services return empty string for `principalId` or `tenantId`.
+
 ### Other Changes
 
 ## 1.4.0 (2023-02-10)

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentity.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/ManagedServiceIdentity.Serialization.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Models
             JsonSerializer.Serialize(writer, model.ManagedServiceIdentityType, options);
             if (Optional.IsCollectionDefined(model.UserAssignedIdentities))
             {
-                writer.WritePropertyName("userAssignedIdentities");
+                writer.WritePropertyName("userAssignedIdentities"u8);
                 writer.WriteStartObject();
                 foreach (var item in model.UserAssignedIdentities)
                 {
@@ -48,9 +48,9 @@ namespace Azure.ResourceManager.Models
             Optional<IDictionary<ResourceIdentifier, UserAssignedIdentity>> userAssignedIdentities = default;
             foreach (var property in element.EnumerateObject())
             {
-                if (property.NameEquals("principalId"))
+                if (property.NameEquals("principalId"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    if (property.Value.ValueKind == JsonValueKind.Null || property.Value.GetString().Length == 0)
                     {
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
@@ -58,9 +58,9 @@ namespace Azure.ResourceManager.Models
                     principalId = property.Value.GetGuid();
                     continue;
                 }
-                if (property.NameEquals("tenantId"))
+                if (property.NameEquals("tenantId"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    if (property.Value.ValueKind == JsonValueKind.Null || property.Value.GetString().Length == 0)
                     {
                         property.ThrowNonNullablePropertyIsNull();
                         continue;
@@ -68,12 +68,12 @@ namespace Azure.ResourceManager.Models
                     tenantId = property.Value.GetGuid();
                     continue;
                 }
-                if (property.NameEquals("type"))
+                if (property.NameEquals("type"u8))
                 {
                     type = JsonSerializer.Deserialize<ManagedServiceIdentityType>("{"+property.ToString()+"}", options);
                     continue;
                 }
-                if (property.NameEquals("userAssignedIdentities"))
+                if (property.NameEquals("userAssignedIdentities"u8))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Unit/ManagedServiceIdentityTest.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Unit/ManagedServiceIdentityTest.cs
@@ -49,6 +49,18 @@ namespace Azure.ResourceManager.Tests
         }
 
         [TestCase]
+        public void TestDeserializerNoneWithEmptyStringIds()
+        {
+            var identityJsonProperty = DeserializerHelper("NoneEmptyStringIds.json");
+#if DEBUG
+            Assert.Throws<JsonException>(delegate { ManagedServiceIdentity.DeserializeManagedServiceIdentity(identityJsonProperty.Value); });
+#else
+            ManagedServiceIdentity back = ManagedServiceIdentity.DeserializeManagedServiceIdentity(identityJsonProperty.Value);
+            Assert.AreEqual(ManagedServiceIdentityType.None, back.ManagedServiceIdentityType);
+#endif
+        }
+
+        [TestCase]
         public void TestDeserializerValidInnerExtraField()
         {
             var identityJsonProperty = DeserializerHelper("SystemAndUserAssignedInnerExtraField.json");

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Unit/TestAssets/Identity/NoneEmptyStringIds.json
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Unit/TestAssets/Identity/NoneEmptyStringIds.json
@@ -1,0 +1,8 @@
+{
+    "identity": {
+      "principalId": "",
+      "tenantId": "",
+      "type": "None"
+    }
+  } 
+  


### PR DESCRIPTION
Resolve #31693

It looks like multiple services may return empty string for `principalId` and `tenantId` when type is `None`. It's not likely that we can ask all of them to change the service behavior. This PR makes the fix on client side.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
