### PR TITLE
[Extensions] AzureClientFactory disposable support

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -239,7 +239,7 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.10" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.32" />
     <PackageReference Update="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
 		<PackageReference Update="Microsoft.Graph" Version="4.52.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/sdk/extensions/Azure.Extensions.sln
+++ b/sdk/extensions/Azure.Extensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30327.8
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Azure.Extensions.AspNetCore.DataProtection.Blobs", "Azure.Extensions.AspNetCore.DataProtection.Blobs", "{12C39FF8-57E3-4A24-AE05-42A104EC9C69}"
 EndProject
@@ -33,13 +33,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Azure.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Azure", "Microsoft.Extensions.Azure\src\Microsoft.Extensions.Azure.csproj", "{56BF6473-7C0F-451B-BC65-26F5DAB2B318}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventGrid", "..\eventgrid\Azure.Messaging.EventGrid\src\Azure.Messaging.EventGrid.csproj", "{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.EventGrid", "..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj", "{55E693C2-FC07-4976-A55E-7937A9C65C36}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.WebJobs.Extensions.EventGrid", "..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj", "{55E693C2-FC07-4976-A55E-7937A9C65C36}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests", "..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\tests\Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.csproj", "{86AC9757-9309-4895-9547-4B28B7357617}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests", "..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\tests\Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.csproj", "{86AC9757-9309-4895-9547-4B28B7357617}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Azure.Samples", "Microsoft.Extensions.Azure\samples\Microsoft.Extensions.Azure.Samples.csproj", "{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Azure.Samples", "Microsoft.Extensions.Azure\samples\Microsoft.Extensions.Azure.Samples.csproj", "{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -195,18 +193,6 @@ Global
 		{56BF6473-7C0F-451B-BC65-26F5DAB2B318}.Release|x64.Build.0 = Release|Any CPU
 		{56BF6473-7C0F-451B-BC65-26F5DAB2B318}.Release|x86.ActiveCfg = Release|Any CPU
 		{56BF6473-7C0F-451B-BC65-26F5DAB2B318}.Release|x86.Build.0 = Release|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Debug|x64.Build.0 = Debug|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Debug|x86.Build.0 = Debug|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Release|x64.ActiveCfg = Release|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Release|x64.Build.0 = Release|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Release|x86.ActiveCfg = Release|Any CPU
-		{076DF7F2-5FB4-47BD-90EB-D4F440FCE6D7}.Release|x86.Build.0 = Release|Any CPU
 		{55E693C2-FC07-4976-A55E-7937A9C65C36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{55E693C2-FC07-4976-A55E-7937A9C65C36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{55E693C2-FC07-4976-A55E-7937A9C65C36}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -243,18 +229,6 @@ Global
 		{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}.Release|x64.Build.0 = Release|Any CPU
 		{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}.Release|x86.ActiveCfg = Release|Any CPU
 		{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}.Release|x86.Build.0 = Release|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x64.Build.0 = Debug|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x86.Build.0 = Debug|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x64.ActiveCfg = Release|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x64.Build.0 = Release|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x86.ActiveCfg = Release|Any CPU
-		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Added support for clients to be disposed via `IDisposable` or `IAsyncDisposable` when the service factory is disposed.
+- Changed tracking for client initialization to ensure that behavior is correct for value types registered as clients.
+
 ### Other Changes
 
 ## 1.6.0 (2022-10-12)

--- a/sdk/extensions/Microsoft.Extensions.Azure/README.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/README.md
@@ -48,7 +48,7 @@ public void ConfigureServices(IServiceCollection services)
         builder.ConfigureDefaults(options => options.Retry.Mode = RetryMode.Exponential);
 
         // Advanced configure global defaults
-        builder.ConfigureDefaults((options, provider) =>  options.AddPolicy(provider.GetService<DependencyInjectionEnabledPolicy>(), HttpPipelinePosition.PerCall));
+        builder.ConfigureDefaults((options, provider) => options.AddPolicy(provider.GetService<DependencyInjectionEnabledPolicy>(), HttpPipelinePosition.PerCall));
 
         // Register blob service client and initialize it using the Storage section of configuration
         builder.AddBlobServiceClient(Configuration.GetSection("Storage"))

--- a/sdk/extensions/Microsoft.Extensions.Azure/samples/Startup.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/samples/Startup.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.Azure.Samples
                 builder.ConfigureDefaults(options => options.Retry.Mode = RetryMode.Exponential);
 
                 // Advanced configure global defaults
-                builder.ConfigureDefaults((options, provider) =>  options.AddPolicy(provider.GetService<DependencyInjectionEnabledPolicy>(), HttpPipelinePosition.PerCall));
+                builder.ConfigureDefaults((options, provider) => options.AddPolicy(provider.GetService<DependencyInjectionEnabledPolicy>(), HttpPipelinePosition.PerCall));
 
                 // Register blob service client and initialize it using the Storage section of configuration
                 builder.AddBlobServiceClient(Configuration.GetSection("Storage"))

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/AzureClientFactoryBuilder.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/AzureClientFactoryBuilder.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Core;
 using Azure.Core.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using System;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Extensions.Azure
 {

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/AzureClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/AzureClientFactory.cs
@@ -3,22 +3,22 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Azure
 {
-    internal class AzureClientFactory<TClient, TOptions>: IAzureClientFactory<TClient>
+    internal class AzureClientFactory<TClient, TOptions>: IAzureClientFactory<TClient>, IDisposable, IAsyncDisposable
     {
         private readonly Dictionary<string, ClientRegistration<TClient>> _clientRegistrations;
 
         private readonly IServiceProvider _serviceProvider;
         private readonly IOptionsMonitor<AzureClientsGlobalOptions> _globalOptions;
-
         private readonly IOptionsMonitor<AzureClientCredentialOptions<TClient>> _clientsOptions;
-
         private readonly IOptionsMonitor<TOptions> _monitor;
-
         private readonly AzureEventSourceLogForwarder _logForwarder;
+
+        private volatile bool _disposed;
 
         public AzureClientFactory(
             IServiceProvider serviceProvider,
@@ -29,6 +29,7 @@ namespace Microsoft.Extensions.Azure
             AzureEventSourceLogForwarder logForwarder)
         {
             _clientRegistrations = new Dictionary<string, ClientRegistration<TClient>>();
+
             foreach (var registration in clientRegistrations)
             {
                 _clientRegistrations[registration.Name] = registration;
@@ -51,6 +52,36 @@ namespace Microsoft.Extensions.Azure
             }
 
             return registration.GetClient(_serviceProvider, _monitor.Get(name), _clientsOptions.Get(name).CredentialFactory(_serviceProvider));
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                foreach (var registration in _clientRegistrations.Values)
+                {
+                    registration.Dispose();
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                var disposeTasks = new List<Task>(_clientRegistrations.Values.Count);
+
+                foreach (var registration in _clientRegistrations.Values)
+                {
+                    disposeTasks.Add(registration.DisposeAsync().AsTask());
+                }
+
+                await Task.WhenAll(disposeTasks).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
@@ -492,7 +492,7 @@ namespace Azure.Core.Extensions.Tests
         }
 
         [Test]
-        public void DisposibleWorksWithMixedClients()
+        public void DisposableWorksWithMixedClients()
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var services = new ServiceCollection();

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
@@ -457,7 +457,7 @@ namespace Azure.Core.Extensions.Tests
             var services = new ServiceCollection();
             var disposed = false;
 
-            Action disposeCallback= () =>
+            Action disposeCallback = () =>
             {
                 disposed = true;
                 tcs.TrySetResult(true);

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
@@ -375,6 +375,36 @@ namespace Azure.Core.Extensions.Tests
         }
 
         [Test]
+        public void CanRegisterStructClient()
+        {
+            var name = "Test";
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddAzureClients(builder =>
+                builder.AddClient<ValueClient, object>(options => new ValueClient(name)));
+
+            ServiceProvider provider = serviceCollection.BuildServiceProvider();
+            ValueClient client = provider.GetService<ValueClient>();
+
+            Assert.AreEqual(name, client.Name);
+        }
+
+        [Test]
+        public void CanRegisterPrimitive()
+        {
+            var value = 55;
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddAzureClients(builder =>
+                builder.AddClient<int, object>(options => value));
+
+            ServiceProvider provider = serviceCollection.BuildServiceProvider();
+            int clientValue = provider.GetService<int>();
+
+            Assert.AreEqual(value, clientValue);
+        }
+
+        [Test]
         public void CanRegisterCustomClientWithOptionsAndCredential()
         {
             var serviceCollection = new ServiceCollection();
@@ -566,6 +596,12 @@ namespace Azure.Core.Extensions.Tests
 
         private class NonDisposableClient
         {
+        }
+
+        private struct ValueClient
+        {
+            public string Name { get; }
+            public ValueClient(string name) => Name = name;
         }
     }
 }

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/AzureClientFactoryTests.cs
@@ -521,7 +521,7 @@ namespace Azure.Core.Extensions.Tests
             var client = factory.CreateClient(nameof(NonDisposableClient));
 
             var disposableFactory = provider.GetRequiredService<IAzureClientFactory<DisposableClient>>();
-            var dispsableClient = disposableFactory.CreateClient(nameof(DisposableClient));
+            var disposableClient = disposableFactory.CreateClient(nameof(DisposableClient));
 
             var asyncDisposableFactory = provider.GetRequiredService<IAzureClientFactory<AsyncDisposableClient>>();
             var asyncDispsableClient = asyncDisposableFactory.CreateClient(nameof(AsyncDisposableClient));

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
-using Azure.Core.TestFramework;
 using Azure.Identity;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/Microsoft.Extensions.Azure.Tests.csproj
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/Microsoft.Extensions.Azure.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-		<ProjectReference Include="$(AzureCoreTestFramework)" />
+    <ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\src\Microsoft.Extensions.Azure.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

The focus of these changes is to add support for clients to be disposed via `IDisposable` or `IAsyncDisposable` when the service factory is disposed.

# References and Related

- [[BUG] Clients registered with AddAzureClients are not disposed (#33131)](https://github.com/Azure/azure-sdk-for-net/issues/33131)