### PR TITLE
Azure OpenAI: update test automation resource management

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
@@ -21,11 +21,11 @@ namespace Azure.AI.OpenAI.Tests
             public const string EmbeddingsDeploymentIdVariable = "OPENAI_EMBEDDINGS_DEPLOYMENT_ID";
             public const string EndpointVariable = "OPENAI_ENDPOINT";
             public const string ResourceGroupName = "openai-test-rg";
-            public const string CognitiveServicesAccountName = "openai-test-account";
+            public const string CognitiveServicesAccountName = "openai-sdk-test-automation-account";
             public const string CompletionsModelName = "text-davinci-002";
             public const string EmbeddingsModelName = "text-similarity-davinci-001";
             public const string SubDomainPrefix = "sdk";
-            public static AzureLocation Location = AzureLocation.EastUS;
+            public static AzureLocation Location = AzureLocation.WestEurope;
         }
 
         private static readonly object _deploymentIdLock = new object();
@@ -110,7 +110,7 @@ namespace Azure.AI.OpenAI.Tests
                         CognitiveServicesAccountDeploymentResource embeddingsModelResource = GetEnsureDeployedModelResource(
                             openAIResource,
                             Constants.EmbeddingsModelName,
-                            CognitiveServicesAccountDeploymentScaleType.Manual);
+                            CognitiveServicesAccountDeploymentScaleType.Standard);
 
                         _endpoint = new Uri(openAIResource.Data.Properties.Endpoint);
                         _completionsDeploymentId = completionsModelResource.Id.Name;

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTest.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "api-key": "***********",
         "Content-Length": "61",
         "Content-Type": "application/json",
-        "traceparent": "00-76bfea092e9affd1e6c64b79982ac218-07d43e8849faaa3d-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230207.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
-        "x-ms-client-request-id": "244c78836c9c0b824052fcb9d90f48d4",
+        "traceparent": "00-731f77fee574791bd27e82c377c84a63-68bd50c9575b352f-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "c5fd72a86caf55da2377431cca76b1e6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,43 +22,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "dd2cd533-5299-4c65-8678-3f4b7d320411",
+        "apim-request-id": "16cdac60-746c-41df-a1e2-011a37af6c40",
         "Cache-Control": "must-revalidate, no-cache",
-        "Content-Length": "425",
         "Content-Type": "application/json",
-        "Date": "Tue, 07 Feb 2023 17:50:47 GMT",
+        "Date": "Tue, 14 Feb 2023 23:03:16 GMT",
         "openai-model": "text-davinci-002",
-        "openai-processing-ms": "412.342",
+        "openai-processing-ms": "409.3606",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-accel-buffering": "no",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "244c78836c9c0b824052fcb9d90f48d4",
-        "x-ms-region": "East US",
-        "X-Request-ID": "00613983-6d20-4f40-a6e3-027cf80d1d3f"
+        "x-ms-client-request-id": "c5fd72a86caf55da2377431cca76b1e6",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "3c9c1f52-2c1e-44f6-84d4-73e5524d804d"
       },
       "ResponseBody": {
-        "id": "cmpl-6hMPApdk9aRyxyQvZq5GzGzK1kljh",
+        "id": "cmpl-6jycOzMOMdS3e4r0RyeycfFyPLSdv",
         "object": "text_completion",
-        "created": 1675792248,
+        "created": 1676415796,
         "model": "text-davinci-002",
         "choices": [
           {
-            "text": " Or Hello!\n\nHello!",
+            "text": "\u0027\n});\n\n\n// var obj = {\n//     name: \u0027",
             "index": 0,
-            "finish_reason": "stop",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           },
           {
-            "text": " again, the young woman tells a reporter the story of the night she was destroyed",
+            "text": ",\u2019 I suggested.\n\n\u2018I don\u2019t exactly",
             "index": 1,
-            "finish_reason": "length",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           }
         ],
         "usage": {
-          "completion_tokens": 23,
           "prompt_tokens": 8,
-          "total_tokens": 31
+          "completion_tokens": 32,
+          "total_tokens": 40
         }
       }
     }
@@ -67,8 +67,8 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "2106470494",
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "330935542",
     "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTestAsync.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "api-key": "***********",
         "Content-Length": "61",
         "Content-Type": "application/json",
-        "traceparent": "00-11b6b2d09353a965eb1b65ba469d9c41-b0b53ed280a23f45-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230207.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
-        "x-ms-client-request-id": "e0739062a0dcb4445ff0c115f3b7b2d5",
+        "traceparent": "00-91f381e335caef6ec60652ddae7559e3-2c9fc1631b862efb-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "d93800d680c0988ad981cf6217137822",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,43 +22,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "4bd3895d-0d96-431e-9139-e0fe8dd515f4",
+        "apim-request-id": "f482fe1d-8c62-4742-9f9b-be03fbf2073c",
         "Cache-Control": "must-revalidate, no-cache",
-        "Content-Length": "405",
         "Content-Type": "application/json",
-        "Date": "Tue, 07 Feb 2023 17:50:51 GMT",
+        "Date": "Tue, 14 Feb 2023 23:03:23 GMT",
         "openai-model": "text-davinci-002",
-        "openai-processing-ms": "600.227",
+        "openai-processing-ms": "329.296",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-accel-buffering": "no",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "e0739062a0dcb4445ff0c115f3b7b2d5",
-        "x-ms-region": "East US",
-        "X-Request-ID": "98ad2bde-5d6f-4d43-b724-30691f3d1cc3"
+        "x-ms-client-request-id": "d93800d680c0988ad981cf6217137822",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "d79595fd-5f3b-413c-b3a3-3ba5c4c5ea25"
       },
       "ResponseBody": {
-        "id": "cmpl-6hMPDnK29CpqXIWdu33NTdH9Sv6vf",
+        "id": "cmpl-6jycV2Es4owEGF0L7J8zJELYum61f",
         "object": "text_completion",
-        "created": 1675792251,
+        "created": 1676415803,
         "model": "text-davinci-002",
         "choices": [
           {
-            "text": "\u0022);\n    }\n}",
+            "text": "!\n\n\u6B22\u8FCE\uFF0C\u4E16\u754C",
             "index": 0,
-            "finish_reason": "stop",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           },
           {
-            "text": "\n\nno progress synonym\n\nrepeating yourself or the same things or",
+            "text": ", I know, but I\u0027ll still - it looks as though we\u0027re really",
             "index": 1,
-            "finish_reason": "length",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           }
         ],
         "usage": {
-          "completion_tokens": 22,
           "prompt_tokens": 8,
-          "total_tokens": 30
+          "completion_tokens": 31,
+          "total_tokens": 39
         }
       }
     }
@@ -67,8 +67,8 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "307927404",
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "2044677211",
     "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTestWithTokenCredential.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTestWithTokenCredential.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "58",
         "Content-Type": "application/json",
-        "traceparent": "00-0659be8ccee4281ec7c868ef94d62fd0-fc0061d8a994fa12-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "a3e430bdd76116c26d605c9c4d7eb20c",
+        "traceparent": "00-293adb78de6537beec509470a6844559-9afde2c64a500d40-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "73b434b090c86adfc7b5bf8cecc3ac78",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,43 +22,43 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "ec9f00e1-243f-49bd-8499-f58f613dec19",
+        "apim-request-id": "607b0d8b-d60f-477f-aa0b-8f85c471831f",
         "Cache-Control": "must-revalidate, no-cache",
-        "Content-Length": "416",
+        "Content-Length": "445",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 22:15:51 GMT",
+        "Date": "Tue, 14 Feb 2023 23:03:17 GMT",
         "openai-model": "text-davinci-002",
-        "openai-processing-ms": "395.7558",
+        "openai-processing-ms": "639.5447",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-accel-buffering": "no",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "a3e430bdd76116c26d605c9c4d7eb20c",
-        "x-ms-region": "East US",
-        "X-Request-ID": "35188e79-b011-4726-9a1f-fb59715dafd5"
+        "x-ms-client-request-id": "73b434b090c86adfc7b5bf8cecc3ac78",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "38969110-3f01-4222-bbd1-87cc02691102"
       },
       "ResponseBody": {
-        "id": "cmpl-6fFgNG6JXFLiTsKLXVqm5ERvxfQ3E",
+        "id": "cmpl-6jycPZ2yBxF7r0VvAnGxds2bSUfXx",
         "object": "text_completion",
-        "created": 1675289751,
+        "created": 1676415797,
         "model": "text-davinci-002",
         "choices": [
           {
-            "text": "\n\nI hope this message finds you well.",
+            "text": "\n\nHello, world!\n\nI am here to learn and share my",
             "index": 0,
-            "finish_reason": "stop",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           },
           {
-            "text": ".\n\nSure! Here are some ideas:\n\n-What inspired you",
+            "text": " open in the Git Bash window?\n\nYes, you can have multiple prompts",
             "index": 1,
-            "finish_reason": "length",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           }
         ],
         "usage": {
-          "completion_tokens": 26,
           "prompt_tokens": 9,
-          "total_tokens": 35
+          "completion_tokens": 32,
+          "total_tokens": 41
         }
       }
     }
@@ -67,8 +67,7 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "1120173980",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "1944507215"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTestWithTokenCredentialAsync.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/CompletionTestWithTokenCredentialAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "58",
         "Content-Type": "application/json",
-        "traceparent": "00-719d2e2cafdcac5fa759098d440c009a-b4ba71d4b9460efc-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "70fba0d03347f5b5ec46788192ad2730",
+        "traceparent": "00-2ec4480cb2d31b0715e175aa67913ae6-af4ca5ab0e6f17a2-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "cf72dee095ef76cd9304461d6acd31a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,42 +22,42 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "11167587-5461-4298-88d6-7ea7d0df9612",
+        "apim-request-id": "9b8fabea-23d2-465b-a774-4ae08118abfc",
         "Cache-Control": "must-revalidate, no-cache",
-        "Content-Length": "417",
+        "Content-Length": "463",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 22:18:16 GMT",
+        "Date": "Tue, 14 Feb 2023 23:03:23 GMT",
         "openai-model": "text-davinci-002",
-        "openai-processing-ms": "487.5849",
+        "openai-processing-ms": "252.3201",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-accel-buffering": "no",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "70fba0d03347f5b5ec46788192ad2730",
-        "x-ms-region": "East US",
-        "X-Request-ID": "60c34215-5a54-4215-bf23-cb8a96abce8b"
+        "x-ms-client-request-id": "cf72dee095ef76cd9304461d6acd31a9",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "fb8d6c7e-a3d3-44e7-bb71-e489ea4138ef"
       },
       "ResponseBody": {
-        "id": "cmpl-6fFii022csOp651wKer9kestlsScc",
+        "id": "cmpl-6jycWwul2s0oQP3fqRkjPVKbJbce3",
         "object": "text_completion",
-        "created": 1675289896,
+        "created": 1676415804,
         "model": "text-davinci-002",
         "choices": [
           {
-            "text": "\n\nMy name is Kaitlyn and I am a web developer.\n",
+            "text": " I am a bot, and this action has been performed automatically by a computer.",
             "index": 0,
-            "finish_reason": "length",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           },
           {
-            "text": "\n   var roll = dice.roll(20, 2, { sides:",
+            "text": ", it just requires I talk fast.\n\nI need to think about that",
             "index": 1,
-            "finish_reason": "length",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           }
         ],
         "usage": {
-          "completion_tokens": 32,
           "prompt_tokens": 9,
+          "completion_tokens": 32,
           "total_tokens": 41
         }
       }
@@ -67,8 +67,7 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "1552489521",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "1377940996"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/EmbeddingTest.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/EmbeddingTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-similarity-davinci-001/embeddings?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-similarity-davinci-001/embeddings?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "api-key": "***********",
         "Content-Length": "38",
         "Content-Type": "application/json",
-        "traceparent": "00-52c3844570dd8e2f1c9059dffd85cd59-5dcef2de2b7f4a80-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "5e7c7807a6a0fcb24960558666ad7097",
+        "traceparent": "00-d92ead1675cf6699c214159d4ce6510c-5b782bbd8052caab-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "7019a9e873ebb5d8d29c02e3454c5a87",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -19,16 +19,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "564da0ad-a38e-4a48-baef-818f1fecc8a5",
+        "apim-request-id": "f71cb21e-efcb-4409-b354-6ef7c17ed18b",
         "Content-Length": "269906",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 21:15:33 GMT",
-        "openai-processing-ms": "155.2084",
+        "Date": "Tue, 14 Feb 2023 23:03:17 GMT",
+        "openai-processing-ms": "164.743",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5e7c7807a6a0fcb24960558666ad7097",
-        "x-ms-region": "East US",
-        "X-Request-ID": "eb2b1d9a-eaf1-4b9d-addb-cd0301c08ec2"
+        "x-ms-client-request-id": "7019a9e873ebb5d8d29c02e3454c5a87",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "66e7f27b-7f2e-4148-ac9a-413b727cfdbd"
       },
       "ResponseBody": {
         "object": "list",
@@ -12337,11 +12337,9 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "741312662",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "284194314"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/EmbeddingTestAsync.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/EmbeddingTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-similarity-davinci-001/embeddings?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-similarity-davinci-001/embeddings?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "api-key": "***********",
         "Content-Length": "38",
         "Content-Type": "application/json",
-        "traceparent": "00-916d3342c19dfeab405b3fec858b1bb3-15d39057c2d25699-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "5c9a96efcac90dd1b99caae1fba40e72",
+        "traceparent": "00-efd6f5b10e092ee62e51ea2baeb7060f-bafc2357c5815162-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "4115932a84de8b5e47dd598baaa40241",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -19,16 +19,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "2211ad89-036e-49c6-bfc8-7042312b6e2d",
+        "apim-request-id": "1bbe33f8-a60d-446a-871d-3170924af500",
         "Content-Length": "269906",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 21:17:31 GMT",
-        "openai-processing-ms": "141.335",
+        "Date": "Tue, 14 Feb 2023 23:03:24 GMT",
+        "openai-processing-ms": "123.9002",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "5c9a96efcac90dd1b99caae1fba40e72",
-        "x-ms-region": "East US",
-        "X-Request-ID": "d6b00a33-5734-4ab7-87b0-c0286765ca1b"
+        "x-ms-client-request-id": "4115932a84de8b5e47dd598baaa40241",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "2bad294a-7c7a-4353-9d38-8282eb00928e"
       },
       "ResponseBody": {
         "object": "list",
@@ -12337,11 +12337,9 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "1379800438",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "527342524"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/InstanceTest.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/InstanceTest.json
@@ -4,8 +4,6 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "1208376369",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/InstanceTestAsync.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/InstanceTestAsync.json
@@ -4,8 +4,6 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "1861052373",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/RequestFailedExceptionTest.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/RequestFailedExceptionTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/BAD_DEPLOYMENT_ID/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/BAD_DEPLOYMENT_ID/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "api-key": "***********",
         "Content-Length": "26",
         "Content-Type": "application/json",
-        "traceparent": "00-5f031b4accd749af0558e96b4b772150-3cde94da2ab1397c-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "9f64237b877eab8f62ed138c53843a05",
+        "traceparent": "00-1832669fc2d8729dade3176fc57cf4e9-8d5d5313fdca85fa-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "c51b43dca621ec76c34b7677947207a8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,14 +20,14 @@
       },
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "9472f957-915e-44af-9bfd-21ea74ec2c00",
+        "apim-request-id": "47321a34-8290-4367-8774-37b887260462",
         "Content-Length": "104",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 21:14:51 GMT",
-        "OpenAI-Processing-Ms": "7.0151",
+        "Date": "Tue, 14 Feb 2023 23:03:18 GMT",
+        "OpenAI-Processing-Ms": "0.9795",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-region": "East US"
+        "x-ms-region": "West Europe"
       },
       "ResponseBody": {
         "error": {
@@ -38,11 +38,9 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "496595640",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "782122506"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/RequestFailedExceptionTestAsync.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/RequestFailedExceptionTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/BAD_DEPLOYMENT_ID/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/BAD_DEPLOYMENT_ID/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "api-key": "***********",
         "Content-Length": "26",
         "Content-Type": "application/json",
-        "traceparent": "00-c58dc9ee89ea59a7300514794258af33-4727af5624633a77-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "8fd10efae2907053898276f9dceff2e7",
+        "traceparent": "00-f94b55fdd57bfc75d7aa41d9f5d3e94e-134f188e325dc925-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "0fd9c75f56e67c4bf1fafd2488e6ce6f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,14 +20,14 @@
       },
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "cb13bc63-2a05-4587-9462-930b5f38f383",
+        "apim-request-id": "38ee4199-aa4a-4da0-ba7d-23d15081f710",
         "Content-Length": "104",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 21:18:01 GMT",
-        "OpenAI-Processing-Ms": "7.5387",
+        "Date": "Tue, 14 Feb 2023 23:03:24 GMT",
+        "OpenAI-Processing-Ms": "0.9767",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-region": "East US"
+        "x-ms-region": "West Europe"
       },
       "ResponseBody": {
         "error": {
@@ -38,11 +38,9 @@
     }
   ],
   "Variables": {
-    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "229414873",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "1101529303"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/SimpleCompletionTest.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/SimpleCompletionTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "Content-Type": "application/json",
-        "traceparent": "00-c36d1df8ff468e34712672beb7a1c7b5-f08e34d254994e38-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "adca5bafdaea6aee60c733103f4f9c4f",
+        "traceparent": "00-9b1988fb6b30a141a229c67acac4ae56-a2bcfe92ce4f480f-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "243e4417a236fa534548d8823f6fcb82",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,36 +21,36 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "b884ee08-f0df-41bb-b76d-319315eb63dc",
+        "apim-request-id": "6d5cee38-131e-4dee-a2ef-be3a550af53e",
         "Cache-Control": "must-revalidate, no-cache",
-        "Content-Length": "301",
+        "Content-Length": "297",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 22:12:50 GMT",
+        "Date": "Tue, 14 Feb 2023 23:03:19 GMT",
         "openai-model": "text-davinci-002",
-        "openai-processing-ms": "671.8067",
+        "openai-processing-ms": "322.284",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-accel-buffering": "no",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "adca5bafdaea6aee60c733103f4f9c4f",
-        "x-ms-region": "East US",
-        "X-Request-ID": "370cf839-cce2-41dc-9d11-56bd91b3bc12"
+        "x-ms-client-request-id": "243e4417a236fa534548d8823f6fcb82",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "f4729a29-2065-4bf4-ad76-1e56d5ee1315"
       },
       "ResponseBody": {
-        "id": "cmpl-6fFdSeF5vkJ7KDKwRXaQEt8guQ7VO",
+        "id": "cmpl-6jycRhbb2b5RWPBfmTpBU7mKluCWE",
         "object": "text_completion",
-        "created": 1675289570,
+        "created": 1676415799,
         "model": "text-davinci-002",
         "choices": [
           {
-            "text": "\u0027)\n  })\n});\nEOS\n      File.open(\u0027b",
+            "text": "\\n\u0022));\ncout \u003C\u003C sum(3, 4);\n    ",
             "index": 0,
-            "finish_reason": "length",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "length"
           }
         ],
         "usage": {
-          "completion_tokens": 16,
           "prompt_tokens": 3,
+          "completion_tokens": 16,
           "total_tokens": 19
         }
       }
@@ -60,8 +60,7 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "1307936796",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "592584723"
   }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/SimpleCompletionTestAsync.json
+++ b/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/OpenAIInferenceTests/SimpleCompletionTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sdk6955.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
+      "RequestUri": "https://sdk2319.openai.azure.com/openai/deployments/text-davinci-002/completions?api-version=2022-12-01",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "27",
         "Content-Type": "application/json",
-        "traceparent": "00-0634d8239a498e8f49cf3a8c375342fd-cc18c923cd7e1586-00",
-        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230201.1 (.NET 7.0.2; Microsoft Windows 10.0.25281)",
-        "x-ms-client-request-id": "8572c3e3cba4b6afd32bb1642072c1fa",
+        "traceparent": "00-2c9f5238dcf9e405fce318d9d5755b47-61a87a4ab7d54c76-00",
+        "User-Agent": "azsdk-net-AI.OpenAI/1.0.0-alpha.20230214.1 (.NET 7.0.2; Microsoft Windows 10.0.22623)",
+        "x-ms-client-request-id": "cefc73be1aca7a6559d20cb04feac9da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,37 +21,37 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "apim-request-id": "fd9d0856-8a8e-4738-934e-d5858279e3a6",
+        "apim-request-id": "abb131c9-58ec-4abd-95de-5f9055712ef1",
         "Cache-Control": "must-revalidate, no-cache",
-        "Content-Length": "314",
+        "Content-Length": "278",
         "Content-Type": "application/json",
-        "Date": "Wed, 01 Feb 2023 22:16:09 GMT",
+        "Date": "Tue, 14 Feb 2023 23:03:25 GMT",
         "openai-model": "text-davinci-002",
-        "openai-processing-ms": "361.4298",
+        "openai-processing-ms": "140.9207",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-accel-buffering": "no",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "8572c3e3cba4b6afd32bb1642072c1fa",
-        "x-ms-region": "East US",
-        "X-Request-ID": "7014f351-9502-4981-a5af-c849ed63c9da"
+        "x-ms-client-request-id": "cefc73be1aca7a6559d20cb04feac9da",
+        "x-ms-region": "West Europe",
+        "X-Request-ID": "4914a549-0bb2-4234-a201-3892b1afd92a"
       },
       "ResponseBody": {
-        "id": "cmpl-6fFgfnGYHeGoH6INOjxHUc4ETMwPN",
+        "id": "cmpl-6jycXCQW7E0ZuAHAWmpHDcfgAW0e3",
         "object": "text_completion",
-        "created": 1675289769,
+        "created": 1676415805,
         "model": "text-davinci-002",
         "choices": [
           {
-            "text": "\n\nHello, my name is Martina.\n\nI\u0027m from Colombia",
+            "text": "2\n\nThat\u0027s great!",
             "index": 0,
-            "finish_reason": "length",
-            "logprobs": null
+            "logprobs": null,
+            "finish_reason": "stop"
           }
         ],
         "usage": {
-          "completion_tokens": 16,
           "prompt_tokens": 3,
-          "total_tokens": 19
+          "completion_tokens": 7,
+          "total_tokens": 10
         }
       }
     }
@@ -60,8 +60,7 @@
     "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com",
     "OPENAI_DEPLOYMENT_ID": "text-davinci-002",
     "OPENAI_EMBEDDINGS_DEPLOYMENT_ID": "text-similarity-davinci-001",
-    "OPENAI_ENDPOINT": "https://sdk6955.openai.azure.com/",
-    "RandomSeed": "535922919",
-    "SUBSCRIPTION_ID": "e72e5254-f265-4e95-9bd2-9ee8e7329051"
+    "OPENAI_ENDPOINT": "https://sdk2319.openai.azure.com/",
+    "RandomSeed": "34581406"
   }
 }


### PR DESCRIPTION
This change makes minor modifications to the Azure OpenAI test automation project to optimize internal resource utilization amidst high customer demand:

- WestEurope will be used for the test resource, instead of EastUS
- Standard scale type will be used for inference model deployments, instead of Manual
- The test resource name has a slightly more self-documenting name

Tests were re-run to regenerate matching recordings.