### PR TITLE
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format

### DIFF
--- a/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
+++ b/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
@@ -22,7 +22,7 @@ stages:
           matrix:
             Windows:
               Pool: 'azsdk-pool-mms-win-2022-general'
-              Image: 'MMS2022Compliant'
+              Image: 'MMS2022'
             Linux:
               Pool: azsdk-pool-mms-ubuntu-2204-general
               Image: MMSUbuntu22.04

--- a/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
+++ b/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
@@ -22,7 +22,7 @@ stages:
           matrix:
             Windows:
               Pool: 'azsdk-pool-mms-win-2022-general'
-              Image: 'MMS2022'
+              Image: 'MMS2022Compliant'
             Linux:
               Pool: azsdk-pool-mms-ubuntu-2204-general
               Image: MMSUbuntu22.04

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -10,7 +10,7 @@ pr:
 
 pool:
   name: azsdk-pool-mms-win-2022-general
-  vmImage: MMS2022
+  vmImage: MMS2022Compliant
 
 variables:
   - template: templates/variables/globals.yml

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -10,7 +10,7 @@ pr:
 
 pool:
   name: azsdk-pool-mms-win-2022-general
-  vmImage: MMS2022Compliant
+  vmImage: windows-2022
 
 variables:
   - template: templates/variables/globals.yml

--- a/eng/pipelines/templates/jobs/ci.mgmt.yml
+++ b/eng/pipelines/templates/jobs/ci.mgmt.yml
@@ -1,4 +1,4 @@
-parameters: 
+parameters:
 - name: ShouldPublish
   type: boolean
   default: false
@@ -11,7 +11,7 @@ jobs:
     timeoutInMinutes: 100
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022
+      vmImage: MMS2022Compliant
     steps:
       #- script: "echo $(system.pullrequest.pullrequestnumber), https://github.com/$(build.repository.id), https://github.com/$(build.repository.ID)"
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
@@ -57,7 +57,7 @@ jobs:
           OSVmImage: "MMSUbuntu20.04"
         Windows:
           Pool: azsdk-pool-mms-win-2022-general
-          OSVmImage: MMS2022
+          OSVmImage: MMS2022Compliant
         MacOs:
           Pool: Azure Pipelines
           OSVmImage: "macos-11"
@@ -89,7 +89,7 @@ jobs:
       - Build
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022
+      vmImage: MMS2022Compliant
     steps:
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
@@ -111,8 +111,8 @@ jobs:
   - job: Compliance
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022
-    steps:      
+      vmImage: MMS2022Compliant
+    steps:
       - template: /eng/common/pipelines/templates/steps/credscan.yml
         parameters:
           BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines

--- a/eng/pipelines/templates/jobs/ci.mgmt.yml
+++ b/eng/pipelines/templates/jobs/ci.mgmt.yml
@@ -11,7 +11,7 @@ jobs:
     timeoutInMinutes: 100
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022Compliant
+      vmImage: windows-2022
     steps:
       #- script: "echo $(system.pullrequest.pullrequestnumber), https://github.com/$(build.repository.id), https://github.com/$(build.repository.ID)"
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
@@ -57,7 +57,7 @@ jobs:
           OSVmImage: "MMSUbuntu20.04"
         Windows:
           Pool: azsdk-pool-mms-win-2022-general
-          OSVmImage: MMS2022Compliant
+          OSVmImage: windows-2022
         MacOs:
           Pool: Azure Pipelines
           OSVmImage: "macos-11"
@@ -89,7 +89,7 @@ jobs:
       - Build
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022Compliant
+      vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
@@ -111,7 +111,7 @@ jobs:
   - job: Compliance
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022Compliant
+      vmImage: windows-2022
     steps:
       - template: /eng/common/pipelines/templates/steps/credscan.yml
         parameters:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -44,7 +44,7 @@ jobs:
   - job: Build
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022Compliant
+      vmImage: windows-2022
 
     variables:
       Codeql.Enabled: true
@@ -219,7 +219,7 @@ jobs:
     - job: Compliance
       pool:
         name: azsdk-pool-mms-win-2022-general
-        vmImage: MMS2022Compliant
+        vmImage: windows-2022
       steps:
         - task: UsePythonVersion@0
           displayName: "Use Python 3.6"

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -44,7 +44,7 @@ jobs:
   - job: Build
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022
+      vmImage: MMS2022Compliant
 
     variables:
       Codeql.Enabled: true
@@ -219,7 +219,7 @@ jobs:
     - job: Compliance
       pool:
         name: azsdk-pool-mms-win-2022-general
-        vmImage: MMS2022
+        vmImage: MMS2022Compliant
       steps:
         - task: UsePythonVersion@0
           displayName: "Use Python 3.6"

--- a/eng/pipelines/templates/jobs/mgmt-release.yml
+++ b/eng/pipelines/templates/jobs/mgmt-release.yml
@@ -21,7 +21,7 @@ jobs:
     dependsOn: ${{ parameters.DependsOn }}
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022Compliant
+      vmImage: windows-2022
 
     steps:
       - checkout: self

--- a/eng/pipelines/templates/jobs/mgmt-release.yml
+++ b/eng/pipelines/templates/jobs/mgmt-release.yml
@@ -1,4 +1,4 @@
-parameters: 
+parameters:
 - name: BuildToolsPath
   type: string
   default: '$(Build.SourcesDirectory)/azure-sdk-build-tools'
@@ -21,8 +21,8 @@ jobs:
     dependsOn: ${{ parameters.DependsOn }}
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022
-  
+      vmImage: MMS2022Compliant
+
     steps:
       - checkout: self
 
@@ -31,7 +31,7 @@ jobs:
       - download: current
         artifact: packages
         displayName: Download published Nuget Packages
-      
+
       - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
         parameters:
           PackagesPath: '$(PIPELINE.WORKSPACE)/packages'
@@ -69,7 +69,7 @@ jobs:
           displayName: 'Use NuGet ${{ parameters.NugetVersion }}'
           inputs:
             versionSpec: ${{ parameters.NugetVersion }}
-        
+
         - task: NuGetCommand@2
           displayName: 'Publish to Nuget'
           inputs:
@@ -77,9 +77,9 @@ jobs:
             packagesToPush: '$(PIPELINE.WORKSPACE)/packages/**/*.nupkg;!$(PIPELINE.WORKSPACE)/packages/**/*.symbols.nupkg'
             nuGetFeedType: external
             publishFeedCredentials: Nuget.org
-      
+
       - ${{ if eq(parameters.ShouldPublishToDevOps, 'true') }}:
-      
+
         - pwsh: |
             # For safety default to publishing to the private feed.
             # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -53,15 +53,15 @@ jobs:
           TestTargetFramework: net6.0
         Windows_NetFramework:
           Pool: "azsdk-pool-mms-win-2022-general"
-          OSVmImage: "MMS2022"
+          OSVmImage: "MMS2022Compliant"
           TestTargetFramework: net461
         Windows_Net60:
           Pool: "azsdk-pool-mms-win-2022-general"
-          OSVmImage: "MMS2022"
+          OSVmImage: "MMS2022Compliant"
           TestTargetFramework: net6.0
         Windows_Net70:
           Pool: "azsdk-pool-mms-win-2022-general"
-          OSVmImage: "MMS2022"
+          OSVmImage: "MMS2022Compliant"
           TestTargetFramework: net7.0
     pool:
       name: $(Pool)

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -53,15 +53,15 @@ jobs:
           TestTargetFramework: net6.0
         Windows_NetFramework:
           Pool: "azsdk-pool-mms-win-2022-general"
-          OSVmImage: "MMS2022Compliant"
+          OSVmImage: "windows-2022"
           TestTargetFramework: net461
         Windows_Net60:
           Pool: "azsdk-pool-mms-win-2022-general"
-          OSVmImage: "MMS2022Compliant"
+          OSVmImage: "windows-2022"
           TestTargetFramework: net6.0
         Windows_Net70:
           Pool: "azsdk-pool-mms-win-2022-general"
-          OSVmImage: "MMS2022Compliant"
+          OSVmImage: "windows-2022"
           TestTargetFramework: net7.0
     pool:
       name: $(Pool)

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -14,7 +14,7 @@ stages:
         environment: esrp
         pool:
           name: azsdk-pool-mms-win-2022-general
-          vmImage: MMS2022
+          vmImage: MMS2022Compliant
 
         strategy:
           runOnce:
@@ -53,7 +53,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022
+                  vmImage: MMS2022Compliant
 
                 strategy:
                   runOnce:
@@ -131,7 +131,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022
+                  vmImage: MMS2022Compliant
 
                 strategy:
                   runOnce:
@@ -191,7 +191,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022
+                  vmImage: MMS2022Compliant
 
                 strategy:
                   runOnce:
@@ -217,7 +217,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022
+                  vmImage: MMS2022Compliant
 
                 strategy:
                   runOnce:
@@ -255,7 +255,7 @@ stages:
       displayName: Publish package to daily feed
       pool:
         name: azsdk-pool-mms-win-2022-general
-        vmImage: MMS2022
+        vmImage: MMS2022Compliant
       steps:
       - checkout: none
       - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -14,7 +14,7 @@ stages:
         environment: esrp
         pool:
           name: azsdk-pool-mms-win-2022-general
-          vmImage: MMS2022Compliant
+          vmImage: windows-2022
 
         strategy:
           runOnce:
@@ -53,7 +53,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022Compliant
+                  vmImage: windows-2022
 
                 strategy:
                   runOnce:
@@ -131,7 +131,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022Compliant
+                  vmImage: windows-2022
 
                 strategy:
                   runOnce:
@@ -191,7 +191,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022Compliant
+                  vmImage: windows-2022
 
                 strategy:
                   runOnce:
@@ -217,7 +217,7 @@ stages:
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
-                  vmImage: MMS2022Compliant
+                  vmImage: windows-2022
 
                 strategy:
                   runOnce:
@@ -255,7 +255,7 @@ stages:
       displayName: Publish package to daily feed
       pool:
         name: azsdk-pool-mms-win-2022-general
-        vmImage: MMS2022Compliant
+        vmImage: windows-2022
       steps:
       - checkout: none
       - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
@@ -23,7 +23,7 @@ stages:
           matrix:
             Windows:
               Pool: 'azsdk-pool-mms-win-2022-general'
-              Image: 'MMS2022Compliant'
+              Image: 'windows-2022'
             Linux:
               Pool: 'azsdk-pool-mms-ubuntu-2004-general'
               Image: 'MMSUbuntu20.04'

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
@@ -23,7 +23,7 @@ stages:
           matrix:
             Windows:
               Pool: 'azsdk-pool-mms-win-2022-general'
-              Image: 'MMS2022'
+              Image: 'MMS2022Compliant'
             Linux:
               Pool: 'azsdk-pool-mms-ubuntu-2004-general'
               Image: 'MMSUbuntu20.04'

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -16,12 +16,12 @@
         "TestTargetFramework": "net7.0"
       },
       "Windows2022_NET461": {
-        "OSVmImage": "MMS2022",
+        "OSVmImage": "MMS2022Compliant",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net461"
       },
       "Windows2022_NET7.0": {
-        "OSVmImage": "MMS2022",
+        "OSVmImage": "MMS2022Compliant",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net7.0"
       },
@@ -49,7 +49,7 @@
     {
       "Agent": {
         "Windows2022_NET7.0": {
-          "OSVmImage": "MMS2022",
+          "OSVmImage": "MMS2022Compliant",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "net7.0"
         }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -16,12 +16,12 @@
         "TestTargetFramework": "net7.0"
       },
       "Windows2022_NET461": {
-        "OSVmImage": "MMS2022Compliant",
+        "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net461"
       },
       "Windows2022_NET7.0": {
-        "OSVmImage": "MMS2022Compliant",
+        "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net7.0"
       },
@@ -49,7 +49,7 @@
     {
       "Agent": {
         "Windows2022_NET7.0": {
-          "OSVmImage": "MMS2022Compliant",
+          "OSVmImage": "windows-2022",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "net7.0"
         }

--- a/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix-integration.json
+++ b/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix-integration.json
@@ -16,12 +16,12 @@
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET6.0": {
-        "OSVmImage": "MMS2022",
+        "OSVmImage": "MMS2022Compliant",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET461": {
-        "OSVmImage": "MMS2022",
+        "OSVmImage": "MMS2022Compliant",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net461"
       },
@@ -75,7 +75,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022",
+          "OSVmImage": "MMS2022Compliant",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix-integration.json
+++ b/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix-integration.json
@@ -16,12 +16,12 @@
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET6.0": {
-        "OSVmImage": "MMS2022Compliant",
+        "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET461": {
-        "OSVmImage": "MMS2022Compliant",
+        "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net461"
       },
@@ -75,7 +75,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022Compliant",
+          "OSVmImage": "windows-2022",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix1.json
+++ b/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix1.json
@@ -32,7 +32,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022",
+          "OSVmImage": "MMS2022Compliant",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix1.json
+++ b/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix1.json
@@ -32,7 +32,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022Compliant",
+          "OSVmImage": "windows-2022",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix2.json
+++ b/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix2.json
@@ -35,7 +35,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022",
+          "OSVmImage": "MMS2022Compliant",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix2.json
+++ b/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix2.json
@@ -35,7 +35,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022Compliant",
+          "OSVmImage": "windows-2022",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/inputs/platform-matrix1.json
+++ b/eng/scripts/splittestdependencies/tests/inputs/platform-matrix1.json
@@ -24,7 +24,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022",
+          "OSVmImage": "MMS2022Compliant",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/inputs/platform-matrix1.json
+++ b/eng/scripts/splittestdependencies/tests/inputs/platform-matrix1.json
@@ -24,7 +24,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022Compliant",
+          "OSVmImage": "windows-2022",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/inputs/platform_2_include_agents.json
+++ b/eng/scripts/splittestdependencies/tests/inputs/platform_2_include_agents.json
@@ -24,7 +24,7 @@
       {
         "Agent": {
           "windows2022": {
-            "OSVmImage": "MMS2022",
+            "OSVmImage": "MMS2022Compliant",
             "Pool": "azsdk-pool-mms-win-2022-general",
             "TestTargetFramework": "netcoreapp3.1"
           }

--- a/eng/scripts/splittestdependencies/tests/inputs/platform_2_include_agents.json
+++ b/eng/scripts/splittestdependencies/tests/inputs/platform_2_include_agents.json
@@ -24,7 +24,7 @@
       {
         "Agent": {
           "windows2022": {
-            "OSVmImage": "MMS2022Compliant",
+            "OSVmImage": "windows-2022",
             "Pool": "azsdk-pool-mms-win-2022-general",
             "TestTargetFramework": "netcoreapp3.1"
           }

--- a/eng/scripts/splittestdependencies/tests/inputs/sync-platform-matrix.json
+++ b/eng/scripts/splittestdependencies/tests/inputs/sync-platform-matrix.json
@@ -16,12 +16,12 @@
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET6.0": {
-        "OSVmImage": "MMS2022Compliant",
+        "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET461": {
-        "OSVmImage": "MMS2022Compliant",
+        "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net461"
       },
@@ -49,7 +49,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022Compliant",
+          "OSVmImage": "windows-2022",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/eng/scripts/splittestdependencies/tests/inputs/sync-platform-matrix.json
+++ b/eng/scripts/splittestdependencies/tests/inputs/sync-platform-matrix.json
@@ -16,12 +16,12 @@
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET6.0": {
-        "OSVmImage": "MMS2022",
+        "OSVmImage": "MMS2022Compliant",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net6.0"
       },
       "windows2022_NET461": {
-        "OSVmImage": "MMS2022",
+        "OSVmImage": "MMS2022Compliant",
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net461"
       },
@@ -49,7 +49,7 @@
     {
       "Agent": {
         "windows2022": {
-          "OSVmImage": "MMS2022",
+          "OSVmImage": "MMS2022Compliant",
           "Pool": "azsdk-pool-mms-win-2022-general",
           "TestTargetFramework": "netcoreapp3.1"
         }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/phone-numbers-livetest-matrix.json
@@ -20,13 +20,13 @@
             },
 
             "windows2022_NET6.0": {
-                "OSVmImage": "MMS2022Compliant",
+                "OSVmImage": "windows-2022",
                 "Pool": "azsdk-pool-mms-win-2022-general",
                 "TestTargetFramework": "net6.0",
                 "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "TRUE"
             },
             "windows2022_NET461": {
-                "OSVmImage": "MMS2022Compliant",
+                "OSVmImage": "windows-2022",
                 "Pool": "azsdk-pool-mms-win-2022-general",
                 "TestTargetFramework": "net461",
                 "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "TRUE"
@@ -56,7 +56,7 @@
         {
             "Agent": {
                 "Windows2022": {
-                    "OSVmImage": "MMS2022Compliant",
+                    "OSVmImage": "windows-2022",
                     "Pool": "azsdk-pool-mms-win-2022-general",
                     "TestTargetFramework": "net7.0"
                 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/phone-numbers-livetest-matrix.json
@@ -20,13 +20,13 @@
             },
 
             "windows2022_NET6.0": {
-                "OSVmImage": "MMS2022",
+                "OSVmImage": "MMS2022Compliant",
                 "Pool": "azsdk-pool-mms-win-2022-general",
                 "TestTargetFramework": "net6.0",
                 "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "TRUE"
             },
             "windows2022_NET461": {
-                "OSVmImage": "MMS2022",
+                "OSVmImage": "MMS2022Compliant",
                 "Pool": "azsdk-pool-mms-win-2022-general",
                 "TestTargetFramework": "net461",
                 "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "TRUE"
@@ -56,7 +56,7 @@
         {
             "Agent": {
                 "Windows2022": {
-                    "OSVmImage": "MMS2022",
+                    "OSVmImage": "MMS2022Compliant",
                     "Pool": "azsdk-pool-mms-win-2022-general",
                     "TestTargetFramework": "net7.0"
                 }

--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -6,8 +6,8 @@
           "Pool": "azsdk-pool-mms-ubuntu-2004-storage"
       },
       "windows-2022": {
-          "OSVmImage": "MMS2022",
-          "Pool": "azsdk-pool-mms-win-2019-storage"
+          "OSVmImage": "MMS2022Compliant",
+          "Pool": "azsdk-pool-mms-win-2022-storage"
       }
     },
     "TestTargetFramework": [

--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -6,7 +6,7 @@
           "Pool": "azsdk-pool-mms-ubuntu-2004-storage"
       },
       "windows-2022": {
-          "OSVmImage": "MMS2022Compliant",
+          "OSVmImage": "windows-2022",
           "Pool": "azsdk-pool-mms-win-2022-storage"
       }
     },


### PR DESCRIPTION
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format.

This discussion explains why we chose given `vmImage` format:

[Mike Harder: 1ES Hosted Pool image name changes](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1676491855184?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1676491855184&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1676491855184)
posted in Azure SDK / Engineering System 🛠️ at Wednesday, February 15, 2023 12:10 PM

For further context, please see:
- https://github.com/Azure/azure-sdk-tools/issues/3407