### PR TITLE
update based on latest swagger

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallAutomationClient.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallAutomationClient.cs
@@ -632,7 +632,7 @@ namespace Azure.Communication.CallAutomation
                     ? null
                     : new PhoneNumberIdentifierModel(options?.CallInvite?.SourceCallerIdNumber?.PhoneNumber),
                 SourceDisplayName = options?.CallInvite?.SourceDisplayName,
-                SourceIdentity = CommunicationIdentifierSerializer.Serialize(Source),
+                SourceIdentity = Source == null ? null : CommunicationIdentifierSerializer.Serialize(Source),
             };
             // Add custom cognitive service domain name
             if (options.AzureCognitiveServicesEndpointUrl != null)
@@ -704,7 +704,7 @@ namespace Azure.Communication.CallAutomation
             scope.Start();
             try
             {
-                return new CallConnection(callConnectionId, CallConnectionRestClient, CallMediaRestClient, _clientDiagnostics, EventProcessor, Source);
+                return new CallConnection(callConnectionId, CallConnectionRestClient, CallMediaRestClient, _clientDiagnostics, EventProcessor);
             }
             catch (Exception ex)
             {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallConnection.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallConnection.cs
@@ -20,21 +20,19 @@ namespace Azure.Communication.CallAutomation
         internal CallConnectionRestClient RestClient { get; }
         internal CallMediaRestClient CallMediaRestClient { get; }
         internal EventProcessor EventProcessor { get; }
-        internal CommunicationUserIdentifier Source { get; }
 
         /// <summary>
         /// The call connection id.
         /// </summary>
         public virtual string CallConnectionId { get; internal set; }
 
-        internal CallConnection(string callConnectionId, CallConnectionRestClient callConnectionRestClient, CallMediaRestClient callCallMediaRestClient, ClientDiagnostics clientDiagnostics, EventProcessor eventProcessor, CommunicationUserIdentifier source = null)
+        internal CallConnection(string callConnectionId, CallConnectionRestClient callConnectionRestClient, CallMediaRestClient callCallMediaRestClient, ClientDiagnostics clientDiagnostics, EventProcessor eventProcessor)
         {
             CallConnectionId = callConnectionId;
             RestClient = callConnectionRestClient;
             CallMediaRestClient = callCallMediaRestClient;
             _clientDiagnostics = clientDiagnostics;
             EventProcessor = eventProcessor;
-            Source = source;
         }
 
         /// <summary>Initializes a new instance of <see cref="CallConnection"/> for mocking.</summary>
@@ -416,7 +414,7 @@ namespace Azure.Communication.CallAutomation
             }
         }
 
-        private AddParticipantRequestInternal CreateAddParticipantRequest(AddParticipantOptions options)
+        private static AddParticipantRequestInternal CreateAddParticipantRequest(AddParticipantOptions options)
         {
             // validate ParticipantToAdd is not null
             Argument.AssertNotNull(options.ParticipantToAdd, nameof(options.ParticipantToAdd));
@@ -427,7 +425,6 @@ namespace Azure.Communication.CallAutomation
                     ? null
                     : new PhoneNumberIdentifierModel(options.ParticipantToAdd.SourceCallerIdNumber.PhoneNumber),
                 SourceDisplayName = options.ParticipantToAdd.SourceDisplayName,
-                SourceIdentity = Source == null ? null : CommunicationIdentifierSerializer.Serialize(Source),
                 OperationContext = options.OperationContext == default ? Guid.NewGuid().ToString() : options.OperationContext
             };
 

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/AddParticipantRequestInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/AddParticipantRequestInternal.Serialization.cs
@@ -25,11 +25,6 @@ namespace Azure.Communication.CallAutomation
                 writer.WritePropertyName("sourceDisplayName");
                 writer.WriteStringValue(SourceDisplayName);
             }
-            if (Optional.IsDefined(SourceIdentity))
-            {
-                writer.WritePropertyName("sourceIdentity");
-                writer.WriteObjectValue(SourceIdentity);
-            }
             writer.WritePropertyName("participantToAdd");
             writer.WriteObjectValue(ParticipantToAdd);
             if (Optional.IsDefined(InvitationTimeoutInSeconds))

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/AddParticipantRequestInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/AddParticipantRequestInternal.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using Azure.Communication;
 using Azure.Core;
 
 namespace Azure.Communication.CallAutomation
@@ -34,11 +33,6 @@ namespace Azure.Communication.CallAutomation
         /// adding a PSTN participant or teams user.  Note: Will not update the display name in the roster.
         /// </summary>
         public string SourceDisplayName { get; set; }
-        /// <summary>
-        /// (Optional) The identifier of the source of the call for this invite operation. If SourceDisplayName
-        /// is not set, the display name of the source will be used by default when adding a PSTN participant or teams user.
-        /// </summary>
-        public CommunicationIdentifierModel SourceIdentity { get; set; }
         /// <summary> The participant to invite. </summary>
         public CommunicationIdentifierModel ParticipantToAdd { get; }
         /// <summary>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/AddParticipantRequestInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/AddParticipantRequestInternal.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using Azure.Communication;
 using Azure.Core;
 
 namespace Azure.Communication.CallAutomation

--- a/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
@@ -10,7 +10,7 @@ tag: package-2023-01-15-preview
 model-namespace: false
 
 require:
-    - https://github.com/williamzhao87/azure-rest-api-specs/blob/cb2cd38aa4a7258e59a912edbb21a21468fb9c6f/specification/communication/data-plane/CallAutomation/readme.md
+    - https://github.com/williamzhao87/azure-rest-api-specs/blob/0d0cd5af40aa17af76ce0307ac5512351c38e3bc/specification/communication/data-plane/CallAutomation/readme.md
 title: Azure Communication Services
 
 generation1-convenience-client: true


### PR DESCRIPTION
- remove SourceIdentity from AddParticipantRequest
- SourceIdentity is now optional in CreateCallRequest