### PR TITLE
Azure OpenAI: Address unintended namespace changes from last PR

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -93,8 +93,8 @@ namespace Azure.AI.OpenAI
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.OpenAI.Completions>> GetCompletionsAsync(string deploymentId, Azure.AI.OpenAI.CompletionsOptions completionsOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> GetCompletionsAsync(string deploymentId, Azure.Core.RequestContent content, Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.OpenAI.Completions>> GetCompletionsAsync(string deploymentId, string prompt, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.OpenAI.Custom.StreamingCompletions> GetCompletionsStreaming(string deploymentId, Azure.AI.OpenAI.CompletionsOptions completionsOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.OpenAI.Custom.StreamingCompletions>> GetCompletionsStreamingAsync(string deploymentId, Azure.AI.OpenAI.CompletionsOptions completionsOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.OpenAI.StreamingCompletions> GetCompletionsStreaming(string deploymentId, Azure.AI.OpenAI.CompletionsOptions completionsOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.OpenAI.StreamingCompletions>> GetCompletionsStreamingAsync(string deploymentId, Azure.AI.OpenAI.CompletionsOptions completionsOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.OpenAI.Embeddings> GetEmbeddings(string deploymentId, Azure.AI.OpenAI.EmbeddingsOptions embeddingsOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GetEmbeddings(string deploymentId, Azure.Core.RequestContent content, Azure.RequestContext context = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.OpenAI.Embeddings>> GetEmbeddingsAsync(string deploymentId, Azure.AI.OpenAI.EmbeddingsOptions embeddingsOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -108,9 +108,6 @@ namespace Azure.AI.OpenAI
             V2022_12_01 = 1,
         }
     }
-}
-namespace Azure.AI.OpenAI.Custom
-{
     public partial class StreamingChoice
     {
         internal StreamingChoice() { }
@@ -126,7 +123,7 @@ namespace Azure.AI.OpenAI.Custom
         public string Id { get { throw null; } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public System.Collections.Generic.IAsyncEnumerable<Azure.AI.OpenAI.Custom.StreamingChoice> GetChoicesStreaming([System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Collections.Generic.IAsyncEnumerable<Azure.AI.OpenAI.StreamingChoice> GetChoicesStreaming([System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace Microsoft.Extensions.Azure

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/OpenAIClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/OpenAIClient.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.AI.OpenAI.Custom;
 using Azure.Core;
 using Azure.Core.Pipeline;
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChoice.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChoice.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
-namespace Azure.AI.OpenAI.Custom
+namespace Azure.AI.OpenAI
 {
     public class StreamingChoice
     {

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingCompletions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingCompletions.cs
@@ -11,7 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Sse;
 
-namespace Azure.AI.OpenAI.Custom
+namespace Azure.AI.OpenAI
 {
     public class StreamingCompletions : IDisposable
     {

--- a/sdk/openai/Azure.AI.OpenAI/src/Helpers/AsyncAutoResetEvent.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Helpers/AsyncAutoResetEvent.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Azure.AI.OpenAI.Custom
+namespace Azure.AI.OpenAI
 {
     // Adapted from https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-2-asyncautoresetevent/
     internal class AsyncAutoResetEvent

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAIInferenceTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAIInferenceTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-using Azure.AI.OpenAI.Custom;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 


### PR DESCRIPTION
A PR just a bit earlier unintentionally picked up IDE-generated namespaces in the course of feedback iterations:
[Azure OpenAI: Add support for faster, streaming Completions responses for ChatGPT-style use #33990](https://github.com/Azure/azure-sdk-for-net/pull/33990)

- The new, public Streaming objects should live in the same root namespace of `Azure.AI.OpenAI`
- The internal Helper types (e.g. for server-sent events) don't need a new namespace. 