### PR TITLE
Handle special case when HeaderStringValues.Count == 1

### DIFF
--- a/sdk/core/Azure.Core/perf/Azure.Core.Perf.csproj
+++ b/sdk/core/Azure.Core/perf/Azure.Core.Perf.csproj
@@ -24,8 +24,6 @@
     <None Update="TestData\JsonFormattedString.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <Compile Include="../src/Shared/AzureEventSource.cs " />
-    <Compile Include="../src/Shared/HttpMessageSanitizer.cs " />
   </ItemGroup>
 
 </Project>

--- a/sdk/core/Azure.Core/perf/HeaderStringValueToStringVsEnumerator.cs
+++ b/sdk/core/Azure.Core/perf/HeaderStringValueToStringVsEnumerator.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// |           Method | Count |      Mean |     Error |    StdDev |   Gen0 | Allocated |
+// |----------------- |------ |----------:|----------:|----------:|-------:|----------:|
+// |     CallToString |     1 |  2.282 ns | 0.0029 ns | 0.0024 ns |      - |         - |
+// | CreateEnumerator |     1 | 41.830 ns | 0.2883 ns | 0.2697 ns | 0.0004 |      40 B |
+// |     CallToString |     2 | 29.230 ns | 0.2876 ns | 0.2691 ns | 0.0005 |      56 B |
+// | CreateEnumerator |     2 | 52.589 ns | 0.1854 ns | 0.1643 ns | 0.0005 |      56 B |
+// |     CallToString |     5 | 57.748 ns | 0.1114 ns | 0.0870 ns | 0.0011 |     112 B |
+// | CreateEnumerator |     5 | 76.548 ns | 0.2156 ns | 0.1800 ns | 0.0011 |     104 B |
+
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Azure.Core.Perf
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    public class HeaderStringValueToStringVsEnumerator
+    {
+#if NET6_0_OR_GREATER
+        private static string[] _acceptValues = { "chunked", "compress", "deflate", "gzip", "identity"};
+        private HeaderStringValues _headerStringValues;
+
+        [Params(1,2,5)]
+        public int Count { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var response = new HttpResponseMessage();
+            response.Headers.Add("Transfer-Encoding", _acceptValues.Take(Count));
+
+            _headerStringValues = response.Headers.NonValidated["Transfer-Encoding"];
+        }
+
+        [Benchmark]
+        public string CallToString() => _headerStringValues.ToString();
+
+        [Benchmark]
+        public string CreateEnumerator()
+        {
+            var count = _headerStringValues.Count;
+            var interpolatedStringHandler = new DefaultInterpolatedStringHandler(count-1, count);
+            var isFirst = true;
+            foreach (var str in _headerStringValues)
+            {
+                if (isFirst)
+                {
+                    isFirst = false;
+                }
+                else
+                {
+                    interpolatedStringHandler.AppendLiteral(",");
+                }
+                interpolatedStringHandler.AppendFormatted(str);
+            }
+            return string.Create(null, ref interpolatedStringHandler);
+        }
+#endif
+    }
+}

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -214,7 +214,7 @@ namespace Azure.Core.Pipeline
             if (headers.NonValidated.TryGetValues(name, out HeaderStringValues values) ||
                 content is not null && content.Headers.NonValidated.TryGetValues(name, out values))
             {
-                value = JoinHeaderValues(values);
+                value = values.ToString();
                 return true;
             }
 #else
@@ -254,14 +254,14 @@ namespace Azure.Core.Pipeline
 #if NET6_0_OR_GREATER
             foreach (var (key, value) in headers.NonValidated)
             {
-                yield return new HttpHeader(key, JoinHeaderValues(value));
+                yield return new HttpHeader(key, value.ToString());
             }
 
             if (content is not null)
             {
                 foreach (var (key, value) in content.Headers.NonValidated)
                 {
-                    yield return new HttpHeader(key, JoinHeaderValues(value));
+                    yield return new HttpHeader(key, value.ToString());
                 }
             }
 #else
@@ -319,37 +319,7 @@ namespace Azure.Core.Pipeline
 #if NET6_0_OR_GREATER
         private static string JoinHeaderValues(HeaderStringValues values)
         {
-            var count = values.Count;
-            if (count == 0)
-            {
-                return string.Empty;
-            }
-
-            // Special case when HeaderStringValues.Count == 1, because HttpHeaders also special cases it and creates HeaderStringValues instance from a single string
-            // https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs#L150
-            // https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L1105
-            // Which is later used in HeaderStringValues.ToString:
-            // https://github.com/dotnet/runtime/blob/729bf92e6e2f91aa337da9459bef079b14a0bf34/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs#L47
-            if (count == 1)
-            {
-                return values.ToString();
-            }
-
-            var interpolatedStringHandler = new DefaultInterpolatedStringHandler(count-1, count);
-            var isFirst = true;
-            foreach (var str in values)
-            {
-                if (isFirst)
-                {
-                    isFirst = false;
-                }
-                else
-                {
-                    interpolatedStringHandler.AppendLiteral(",");
-                }
-                interpolatedStringHandler.AppendFormatted(str);
-            }
-            return string.Create(null, ref interpolatedStringHandler);
+            return values.Count != 0 ? values.ToString() : string.Empty;
         }
 #else
         private static string JoinHeaderValues(IEnumerable<string> values)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -214,7 +214,7 @@ namespace Azure.Core.Pipeline
             if (headers.NonValidated.TryGetValues(name, out HeaderStringValues values) ||
                 content is not null && content.Headers.NonValidated.TryGetValues(name, out values))
             {
-                value = values.ToString();
+                value = JoinHeaderValues(values);
                 return true;
             }
 #else
@@ -254,14 +254,14 @@ namespace Azure.Core.Pipeline
 #if NET6_0_OR_GREATER
             foreach (var (key, value) in headers.NonValidated)
             {
-                yield return new HttpHeader(key, value.ToString());
+                yield return new HttpHeader(key, JoinHeaderValues(value));
             }
 
             if (content is not null)
             {
                 foreach (var (key, value) in content.Headers.NonValidated)
                 {
-                    yield return new HttpHeader(key, value.ToString());
+                    yield return new HttpHeader(key, JoinHeaderValues(value));
                 }
             }
 #else
@@ -319,7 +319,39 @@ namespace Azure.Core.Pipeline
 #if NET6_0_OR_GREATER
         private static string JoinHeaderValues(HeaderStringValues values)
         {
-            return values.Count != 0 ? values.ToString() : string.Empty;
+            var count = values.Count;
+            if (count == 0)
+            {
+                return string.Empty;
+            }
+
+            // Special case when HeaderStringValues.Count == 1, because HttpHeaders also special cases it and creates HeaderStringValues instance from a single string
+            // https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs#L150
+            // https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L1105
+            // Which is later used in HeaderStringValues.ToString:
+            // https://github.com/dotnet/runtime/blob/729bf92e6e2f91aa337da9459bef079b14a0bf34/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs#L47
+            if (count == 1)
+            {
+                return values.ToString();
+            }
+
+            // While HeaderStringValueToStringVsEnumerator performance test shows that `HeaderStringValues.ToString` is faster than DefaultInterpolatedStringHandler,
+            // we can't use it here because it uses ", " as default separator and doesn't allow customization.
+            var interpolatedStringHandler = new DefaultInterpolatedStringHandler(count-1, count);
+            var isFirst = true;
+            foreach (var str in values)
+            {
+                if (isFirst)
+                {
+                    isFirst = false;
+                }
+                else
+                {
+                    interpolatedStringHandler.AppendLiteral(",");
+                }
+                interpolatedStringHandler.AppendFormatted(str);
+            }
+            return string.Create(null, ref interpolatedStringHandler);
         }
 #else
         private static string JoinHeaderValues(IEnumerable<string> values)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -325,6 +325,16 @@ namespace Azure.Core.Pipeline
                 return string.Empty;
             }
 
+            // Special case when HeaderStringValues.Count == 1, because HttpHeaders also special cases it and creates HeaderStringValues instance from a single string
+            // https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs#L150
+            // https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L1105
+            // Which is later used in HeaderStringValues.ToString:
+            // https://github.com/dotnet/runtime/blob/729bf92e6e2f91aa337da9459bef079b14a0bf34/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs#L47
+            if (count == 1)
+            {
+                return values.ToString();
+            }
+
             var interpolatedStringHandler = new DefaultInterpolatedStringHandler(count-1, count);
             var isFirst = true;
             foreach (var str in values)


### PR DESCRIPTION
When `HeaderStringValues.Count == 1`, `HttpHeaders` special cases it and creates `HeaderStringValues` instance from a single string: https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs#L150
https://github.com/dotnet/runtime/blob/ef5e27eacecf34a36d72a8feb9082f408779675a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L1105
          
Then, `HeaderStringValues.ToString` simply returns that value:
https://github.com/dotnet/runtime/blob/729bf92e6e2f91aa337da9459bef079b14a0bf34/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs#L47

While `HeaderStringValueToStringVsEnumerator` performance test shows that `HeaderStringValues.ToString` is always faster than `DefaultInterpolatedStringHandler`, we can't use it for `HeaderStringValues.Count > 1` because it uses `", "` as default separator and doesn't allow customization. Hence, custom enumeration logic is required.

Benchmark results:
```
|           Method | Count |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|----------------- |------ |----------:|----------:|----------:|-------:|----------:|
|     CallToString |     1 |  2.282 ns | 0.0029 ns | 0.0024 ns |      - |         - |
| CreateEnumerator |     1 | 41.830 ns | 0.2883 ns | 0.2697 ns | 0.0004 |      40 B |
|     CallToString |     2 | 29.230 ns | 0.2876 ns | 0.2691 ns | 0.0005 |      56 B |
| CreateEnumerator |     2 | 52.589 ns | 0.1854 ns | 0.1643 ns | 0.0005 |      56 B |
|     CallToString |     5 | 57.748 ns | 0.1114 ns | 0.0870 ns | 0.0011 |     112 B |
| CreateEnumerator |     5 | 76.548 ns | 0.2156 ns | 0.1800 ns | 0.0011 |     104 B |
```