### PR TITLE
[Event Hubs] Function Test Fix

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
@@ -1122,7 +1122,11 @@ namespace Azure.Messaging.EventHubs.Tests
         private Func<ProcessErrorEventArgs, Task> CreateAssertingErrorHandler() =>
             args =>
             {
-                Assert.Fail($"Processor Error Surfaced: ({ args.Exception.GetType().Name })[{ args.Exception.Message }]");
+                // If there is an inner exception, it will have more interesting details for investigation.
+
+                var ex = args.Exception.InnerException ?? args.Exception;
+
+                Assert.Fail($"Processor Error Surfaced ({ ex.GetType().Name }): {Environment.NewLine}\t{ args.Exception }");
                 return Task.CompletedTask;
             };
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             if (!string.Equals(EventHubsTestEnvironment.Instance.StorageEndpointSuffix, defaultSuffix, StringComparison.OrdinalIgnoreCase))
             {
-                Assert.Ignore($"This test can only be run in the Azure cloud associated  with the suffix: `{defaultSuffix}`.");
+                Assert.Ignore($"This test can only be run in the Azure cloud associated with the suffix: `{defaultSuffix}`.");
             }
 
             await AssertCanSendReceiveMessage(host =>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             var defaultSuffix = StorageClientProvider<object, ClientOptions>.DefaultStorageEndpointSuffix;
 
-            if (string.Equals(EventHubsTestEnvironment.Instance.StorageEndpointSuffix, defaultSuffix, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(EventHubsTestEnvironment.Instance.StorageEndpointSuffix, defaultSuffix, StringComparison.OrdinalIgnoreCase))
             {
                 Assert.Ignore($"This test can only be run in the Azure cloud associated  with the suffix: `{defaultSuffix}`.");
             }

--- a/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/StorageClientProvider.cs
+++ b/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/StorageClientProvider.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Clients.Shared
         private readonly AzureEventSourceLogForwarder _logForwarder;
         private readonly ILogger _logger;
 
+        public const string DefaultStorageEndpointSuffix = "core.windows.net";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="StorageClientProvider{TClient, TClientOptions}"/> class that uses the registered Azure services.
         /// </summary>
@@ -172,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Clients.Shared
         /// <param name="defaultProtocol">protocol to use for REST requests</param>
         /// <param name="endpointSuffix">endpoint suffix for the storage account</param>
         /// <returns>Uri for the storage resource</returns>
-        protected virtual Uri FormatServiceUri(string accountName, string defaultProtocol = "https", string endpointSuffix = "core.windows.net")
+        protected virtual Uri FormatServiceUri(string accountName, string defaultProtocol = "https", string endpointSuffix = DefaultStorageEndpointSuffix)
         {
             // Todo: Eventually move this into storage sdk
             var uri = string.Format(CultureInfo.InvariantCulture, "{0}://{1}.{2}.{3}", defaultProtocol, accountName, ServiceUriSubDomain, endpointSuffix);


### PR DESCRIPTION
# Summary

The focus of these changes is to fix an assumption in the Functions extension package that the same Storage suffix is valid in all clouds.  The implementation supports the Azure public cloud only, while the test was asserting that the scenario was valid for all clouds.  Going forward, the test will be ignored when the current execution environment is not a supported cloud.

Also riding along is a tweak to a processor test to extract additional error details for failure investigation.