### PR TITLE
Make ACR live tests run serially

### DIFF
--- a/sdk/containerregistry/service.projects
+++ b/sdk/containerregistry/service.projects
@@ -25,4 +25,10 @@
   <ItemGroup Condition="'$(SDKType)' == 'mgmt'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.Management.ContainerRegistry*\**\*.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Update="$(MSBuildThisFileDirectory)Azure.Containers.ContainerRegistry\tests\*.csproj">
+      <TestInParallel>false</TestInParallel>
+    </ProjectReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
We have periodic tests failures in our live tests, and some are due to tests accessing the same resource at the same time.

In an effort to address https://github.com/Azure/azure-sdk-for-net/issues/32948, this PR implements the instructions in the TestFramework README regarding [Running live tests serially](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/core/Azure.Core.TestFramework#running-live-tests-serially).