### PR TITLE
[AzureMonitorExporter] transmitter factory

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private readonly AzureMonitorPersistentStorage? _persistentStorage;
         private AzureMonitorResource? _resource;
 
-        public AzureMonitorLogExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(new AzureMonitorTransmitter(options, credential))
+        public AzureMonitorLogExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(TransmitterFactory.Instance.Get(options, credential))
         {
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private readonly AzureMonitorPersistentStorage? _persistentStorage;
         private AzureMonitorResource? _resource;
 
-        public AzureMonitorMetricExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(new AzureMonitorTransmitter(options, credential))
+        public AzureMonitorMetricExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(TransmitterFactory.Instance.Get(options, credential))
         {
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private readonly AzureMonitorPersistentStorage? _persistentStorage;
         private AzureMonitorResource? _resource;
 
-        public AzureMonitorTraceExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(new AzureMonitorTransmitter(options, credential))
+        public AzureMonitorTraceExporter(AzureMonitorExporterOptions options, TokenCredential? credential = null) : this(TransmitterFactory.Instance.Get(options, credential))
         {
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Core;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    /// <summary>
+    /// This Factory encapsulates the <see cref="AzureMonitorTransmitter"/>.
+    /// An ideal users will create a single exporter for each signal (Logs, Metrics, Traces).
+    /// This factory should ensure that only one instance of the Transmitter is created for
+    /// any unique connection string.
+    /// </summary>
+    internal class TransmitterFactory
+    {
+        public static TransmitterFactory Instance = new();
+
+        internal readonly Dictionary<string?, AzureMonitorTransmitter> _transmitters = new();
+        private readonly object _lockObj = new();
+
+        public AzureMonitorTransmitter Get(AzureMonitorExporterOptions azureMonitorExporterOptions, TokenCredential? tokenCredential = null)
+        {
+            var key = azureMonitorExporterOptions.ConnectionString ?? string.Empty;
+
+            if (!_transmitters.TryGetValue(key, out AzureMonitorTransmitter transmitter))
+            {
+                lock (_lockObj)
+                {
+                    if (!_transmitters.TryGetValue(key, out transmitter))
+                    {
+                        transmitter = new AzureMonitorTransmitter(azureMonitorExporterOptions, tokenCredential);
+
+                        _transmitters.Add(key, transmitter);
+                    }
+                }
+            }
+
+            return transmitter;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
@@ -16,7 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         public static TransmitterFactory Instance = new();
 
-        internal readonly Dictionary<string?, AzureMonitorTransmitter> _transmitters = new();
+        internal readonly Dictionary<string, AzureMonitorTransmitter> _transmitters = new();
         private readonly object _lockObj = new();
 
         public AzureMonitorTransmitter Get(AzureMonitorExporterOptions azureMonitorExporterOptions, TokenCredential? tokenCredential = null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TransmitterFactoryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TransmitterFactoryTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class TransmitterFactoryTests
+    {
+        /// <summary>
+        /// Users may not specify their connection string in the <see cref="AzureMonitorExporterOptions"/>.
+        /// In this scenario, the sdk would use the environment variable.
+        ///
+        /// This test confirms that the factory correctly handles a null value.
+        /// </summary>
+        [Fact]
+        public void VerifyNullConnectionString()
+        {
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=00000000-0000-0000-0000-000000000000;");
+
+            try
+            {
+                var factory = new TransmitterFactory();
+                var options = new AzureMonitorExporterOptions();
+
+                var transmitter = factory.Get(options);
+
+                Assert.Single(factory._transmitters);
+                Assert.True(factory._transmitters.ContainsKey(string.Empty));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", null);
+            }
+        }
+
+        [Fact]
+        public void VerifyRepeatedCallsGenerateOnlyOneTransmitter()
+        {
+            var factory = new TransmitterFactory();
+            var options = new AzureMonitorExporterOptions { ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;" };
+
+            var transmitter1 = factory.Get(options);
+            var transmitter2 = factory.Get(options);
+
+            Assert.Single(factory._transmitters);
+            Assert.True(factory._transmitters.ContainsKey(options.ConnectionString));
+            Assert.Equal(transmitter1, transmitter2);
+        }
+    }
+}


### PR DESCRIPTION
An ideal users will create a single exporter for each signal (Logs, Metrics, Traces).
This implements a factory to ensure that only one instance of the Transmitter is created for any unique connection string.

## Changes
- Add new class `TransmitterFactory`
- Add new test `TransmitterFactoryTests`
- Update Exporters to use factory