### PR TITLE
Attempt fix GetMetrics_ReturnsExpectedResult failing in live tests

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             _loggerProvider = new TestLoggerProvider();
             _loggerFactory.AddProvider(_loggerProvider);
             _mockQueue = new Mock<QueueClient>(new Uri("https://test.queue.core.windows.net/testqueue"), new QueueClientOptions());
+            _mockQueue.Setup(x => x.Name).Returns("testqueue");
             _metricsProvider = new QueueMetricsProvider(_mockQueue.Object, _loggerFactory);
         }
 
@@ -73,14 +74,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 
             await Task.Delay(TimeSpan.FromSeconds(5));
 
-            metrics = await _metricsProvider.GetMetricsAsync();
+            metrics = await _provider.GetMetricsAsync();
 
             Assert.AreEqual(5, metrics.QueueLength);
             Assert.True(metrics.QueueTime.Ticks > 0);
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
             // verify non-generic interface works as expected
-            metrics = (QueueTriggerMetrics)(await _metricsProvider.GetMetricsAsync());
+            metrics = (QueueTriggerMetrics)(await _provider.GetMetricsAsync());
             Assert.AreEqual(5, metrics.QueueLength);
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -38,8 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             _loggerProvider = new TestLoggerProvider();
             _loggerFactory.AddProvider(_loggerProvider);
             _mockQueue = new Mock<QueueClient>(new Uri("https://test.queue.core.windows.net/testqueue"), new QueueClientOptions());
-            _mockQueue.Setup(x => x.Name).Returns("testqueue");
-            _metricsProvider = new QueueMetricsProvider(Fixture.Queue, _loggerFactory);
+            _metricsProvider = new QueueMetricsProvider(_mockQueue.Object, _loggerFactory);
         }
 
         [OneTimeSetUp]
@@ -59,7 +58,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
         [Test]
         public async Task GetMetrics_ReturnsExpectedResult()
         {
-            var metrics = await _metricsProvider.GetMetricsAsync();
+            QueueMetricsProvider _provider = new QueueMetricsProvider(Fixture.Queue, _loggerFactory);
+            var metrics = await _provider.GetMetricsAsync();
 
             Assert.AreEqual(0, metrics.QueueLength);
             Assert.AreEqual(TimeSpan.Zero, metrics.QueueTime);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 
         public class TestFixture : IDisposable
         {
-            private const string TestQueuePrefix = "queuelistenertests";
+            private const string TestQueuePrefix = "metricsprovidertests";
 
             public TestFixture()
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -16,6 +16,12 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using Microsoft.Azure.WebJobs.Host;
+using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.Timers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 {
@@ -33,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             _loggerProvider = new TestLoggerProvider();
             _loggerFactory.AddProvider(_loggerProvider);
             _mockQueue = new Mock<QueueClient>(new Uri("https://test.queue.core.windows.net/testqueue"), new QueueClientOptions());
+            _mockQueue.Setup(x => x.Name).Returns("testqueue");
             _metricsProvider = new QueueMetricsProvider(_mockQueue.Object, _loggerFactory);
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -16,6 +16,11 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Azure.WebJobs.Host.Timers;
+using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 {
@@ -34,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             _loggerFactory.AddProvider(_loggerProvider);
             _mockQueue = new Mock<QueueClient>(new Uri("https://test.queue.core.windows.net/testqueue"), new QueueClientOptions());
             _mockQueue.Setup(x => x.Name).Returns("testqueue");
-            _metricsProvider = new QueueMetricsProvider(_mockQueue.Object, _loggerFactory);
+            _metricsProvider = new QueueMetricsProvider(Fixture.Queue, _loggerFactory);
         }
 
         [OneTimeSetUp]

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -16,11 +16,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
-using Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners;
-using Microsoft.Azure.WebJobs.Host.Protocols;
-using Microsoft.Azure.WebJobs.Host.Scale;
-using Microsoft.Azure.WebJobs.Host.Timers;
-using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 {
@@ -108,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 
         public class TestFixture : IDisposable
         {
-            private const string TestQueuePrefix = "metricsprovidertests";
+            private const string TestQueuePrefix = "metrictests";
 
             public TestFixture()
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -16,12 +16,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
-using Microsoft.Azure.WebJobs.Host;
-using Azure.Storage.Queues.Models;
-using Microsoft.Azure.WebJobs.Host.Scale;
-using Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners;
-using Microsoft.Azure.WebJobs.Host.Protocols;
-using Microsoft.Azure.WebJobs.Host.Timers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 {


### PR DESCRIPTION
Our live tests started failing across the board for the `GetMetrics_ReturnsExpectedResult` tests after this PR change was made.

https://github.com/Azure/azure-sdk-for-net/pull/34193

Still trying to figure if there's a bug in the QueueMetricsProvider when it was moved out of QueueListener or the tests itself.