### PR TITLE
Add missing locations to AzureLocation

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -332,8 +332,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SouthCentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
+        public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAENorth { get { throw null; } }
         public static Azure.Core.AzureLocation UKSouth { get { throw null; } }
@@ -349,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation WestIndia { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS2 { get { throw null; } }
+        public static Azure.Core.AzureLocation WestUS3 { get { throw null; } }
         public bool Equals(Azure.Core.AzureLocation other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -332,8 +332,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SouthCentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
+        public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAENorth { get { throw null; } }
         public static Azure.Core.AzureLocation UKSouth { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -332,8 +332,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SouthCentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
+        public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAENorth { get { throw null; } }
         public static Azure.Core.AzureLocation UKSouth { get { throw null; } }
@@ -349,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation WestIndia { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS2 { get { throw null; } }
+        public static Azure.Core.AzureLocation WestUS3 { get { throw null; } }
         public bool Equals(Azure.Core.AzureLocation other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -332,8 +332,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SouthCentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
+        public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAENorth { get { throw null; } }
         public static Azure.Core.AzureLocation UKSouth { get { throw null; } }
@@ -349,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation WestIndia { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS2 { get { throw null; } }
+        public static Azure.Core.AzureLocation WestUS3 { get { throw null; } }
         public bool Equals(Azure.Core.AzureLocation other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -332,8 +332,10 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation SouthCentralUS { get { throw null; } }
         public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
         public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
         public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
+        public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAECentral { get { throw null; } }
         public static Azure.Core.AzureLocation UAENorth { get { throw null; } }
         public static Azure.Core.AzureLocation UKSouth { get { throw null; } }
@@ -349,6 +351,7 @@ namespace Azure.Core
         public static Azure.Core.AzureLocation WestIndia { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS { get { throw null; } }
         public static Azure.Core.AzureLocation WestUS2 { get { throw null; } }
+        public static Azure.Core.AzureLocation WestUS3 { get { throw null; } }
         public bool Equals(Azure.Core.AzureLocation other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }

--- a/sdk/core/Azure.Core/src/AzureLocation.cs
+++ b/sdk/core/Azure.Core/src/AzureLocation.cs
@@ -50,6 +50,16 @@ namespace Azure.Core
         public static AzureLocation WestUS { get; } = CreateStaticReference("westus", "West US");
 
         /// <summary>
+        /// Public cloud location for West US 2.
+        /// </summary>
+        public static AzureLocation WestUS2 { get; } = CreateStaticReference("westus2", "West US 2");
+
+        /// <summary>
+        /// Public cloud location for West US 3.
+        /// </summary>
+        public static AzureLocation WestUS3 { get; } = CreateStaticReference("westus3", "West US 3");
+
+        /// <summary>
         /// Public cloud location for North Central US.
         /// </summary>
         public static AzureLocation NorthCentralUS { get; } = CreateStaticReference("northcentralus", "North Central US");
@@ -135,11 +145,6 @@ namespace Azure.Core
         public static AzureLocation WestCentralUS { get; } = CreateStaticReference("westcentralus", "West Central US");
 
         /// <summary>
-        /// Public cloud location for West US 2.
-        /// </summary>
-        public static AzureLocation WestUS2 { get; } = CreateStaticReference("westus2", "West US 2");
-
-        /// <summary>
         /// Public cloud location for Korea Central.
         /// </summary>
         public static AzureLocation KoreaCentral { get; } = CreateStaticReference("koreacentral", "Korea Central");
@@ -188,6 +193,11 @@ namespace Azure.Core
         /// Public cloud location for South Africa West.
         /// </summary>
         public static AzureLocation SouthAfricaWest { get; } = CreateStaticReference("southafricawest", "South Africa West");
+
+        /// <summary>
+        /// Public cloud location for Sweden Central.
+        /// </summary>
+        public static AzureLocation SwedenCentral { get; } = CreateStaticReference("swedencentral", "Sweden Central");
 
         /// <summary>
         /// Public cloud location for Switzerland North.
@@ -253,6 +263,11 @@ namespace Azure.Core
         /// Public cloud location for China East 2.
         /// </summary>
         public static AzureLocation ChinaEast2 { get; } = CreateStaticReference("chinaeast2", "China East 2");
+
+        /// <summary>
+        /// Public cloud location for Qatar Central.
+        /// </summary>
+        public static AzureLocation QatarCentral { get; } = CreateStaticReference("qatarcentral", "Qatar Central");
 
         /// <summary>
         /// Public cloud location for US DoD Central.


### PR DESCRIPTION
This PR adds missing locations that I cross referenced with pwsh command `Get-AzLocation` and added those that I couldn't find in `AzureLocation`.

Added:
 - westus3
 - swedencentral
 - qatarcentral