### PR TITLE
[Event Hubs Extension] Extensions class rename

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.netstandard2.0.cs
@@ -8,6 +8,10 @@ namespace Microsoft.Azure.WebJobs
         public string Connection { get { throw null; } set { } }
         public string EventHubName { get { throw null; } }
     }
+    public static partial class EventHubsWebJobsExtensions
+    {
+        public static System.Threading.Tasks.Task AddAsync(this Microsoft.Azure.WebJobs.IAsyncCollector<Azure.Messaging.EventHubs.EventData> instance, Azure.Messaging.EventHubs.EventData eventData, string partitionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
     [Microsoft.Azure.WebJobs.Description.BindingAttribute]
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
     public sealed partial class EventHubTriggerAttribute : System.Attribute
@@ -16,10 +20,6 @@ namespace Microsoft.Azure.WebJobs
         public string Connection { get { throw null; } set { } }
         public string ConsumerGroup { get { throw null; } set { } }
         public string EventHubName { get { throw null; } }
-    }
-    public static partial class IAsyncCollectorExtensions
-    {
-        public static System.Threading.Tasks.Task AddAsync(this Microsoft.Azure.WebJobs.IAsyncCollector<Azure.Messaging.EventHubs.EventData> instance, Azure.Messaging.EventHubs.EventData eventData, string partitionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace Microsoft.Azure.WebJobs.EventHubs

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/EventHubsWebJobsExtensions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/EventHubsWebJobsExtensions.cs
@@ -9,8 +9,8 @@ using Microsoft.Azure.WebJobs.EventHubs;
 
 namespace Microsoft.Azure.WebJobs
 {
-    public static class IAsyncCollectorExtensions
-	{
+    public static class EventHubsWebJobsExtensions
+    {
         /// <summary>
         /// Add an event to be published using the provided <paramref name="partitionKey"/> for partition assignment.
         /// </summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to rename the class used for the async collector extensions to something more generic so that it does not resemble an interface itself and can be used to house additional extensions in the future.
