### PR TITLE
[AzureMonitorExporter] misc cleanup

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -19,8 +19,8 @@
 ### Features Added
 
 * Added support for parsing AADAudience from ConnectionString ([#33593](https://github.com/Azure/azure-sdk-for-net/pull/33593))
-* Activity Events (SpanEvents), except those representing Exception, will be exported to TraceTelemetry table([#32980](https://github.com/Azure/azure-sdk-for-net/pull/32980))
-Exceptions reported via ActivityEvents will continue to be exported to ExceptionTelemetry table
+* Activity Events (SpanEvents), except those representing Exception, will be exported to TraceTelemetry table ([#32980](https://github.com/Azure/azure-sdk-for-net/pull/32980))
+  Exceptions reported via ActivityEvents will continue to be exported to ExceptionTelemetry table
 
 ### Bugs Fixed
 
@@ -55,7 +55,7 @@ Exceptions reported via ActivityEvents will continue to be exported to Exception
 
 * Update OpenTelemetry dependencies ([#32047](https://github.com/Azure/azure-sdk-for-net/pull/32047))
   - OpenTelemetry v1.4.0-beta.2
-* Debugging Output now includes Telemetry sent from storage. ([#32172](https://github.com/Azure/azure-sdk-for-net/pull/32172))
+* Debugging Output now includes Telemetry sent from storage ([#32172](https://github.com/Azure/azure-sdk-for-net/pull/32172))
 
 ## 1.0.0-beta.4 (2022-10-07)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -71,7 +71,7 @@
   - Users may disable by setting `AzureMonitorExporterOptions.DisableOfflineStorage` ([#28446](https://github.com/Azure/azure-sdk-for-net/pull/28446))
 * Added support for exception telemetry from ILogger ([#26670](https://github.com/Azure/azure-sdk-for-net/pull/26670))
 * Support for exporting Activity exception event ([#29676](https://github.com/Azure/azure-sdk-for-net/pull/29676))
-* Added support for sampling using [Application Insights based sampler](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Extensions.AzureMonitor).  ([#31118](https://github.com/Azure/azure-sdk-for-net/pull/31118))
+* Added support for sampling using [Application Insights based sampler](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Extensions.AzureMonitor) ([#31118](https://github.com/Azure/azure-sdk-for-net/pull/31118))
 
 ### Breaking Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Other Changes
 
 * Update OpenTelemetry dependencies
-  ([#34128](https://github.com/Azure/azure-sdk-for-net/pull/34128)
+  ([#34128](https://github.com/Azure/azure-sdk-for-net/pull/34128))
   - OpenTelemetry 1.4.0-rc.4
 
 ## 1.0.0-beta.7 (2023-02-07)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorExporterEventSource.cs
@@ -36,6 +36,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         [Event(4, Message = "{0} - {1}", Level = EventLevel.Informational)]
         public void WriteInformational(string name, string message) => this.Write(EventLevel.Informational, 4, name, message);
 
+        [NonEvent]
+        public void WriteInformational(string name, Exception exception) => this.WriteException(EventLevel.Warning, 4, name, exception);
+
         [Event(5, Message = "{0} - {1}", Level = EventLevel.Verbose)]
         public void WriteVerbose(string name, string message) => this.Write(EventLevel.Verbose, 5, name, message);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/Statsbeat.cs
@@ -217,7 +217,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
             catch (Exception ex)
             {
-                AzureMonitorExporterEventSource.Log.WriteInformational("Failed to get VM metadata details", ex.ToInvariantString());
+                AzureMonitorExporterEventSource.Log.WriteInformational("Failed to get VM metadata details", ex);
                 return null;
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
@@ -42,6 +42,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void VerifyEventSource_Informational() => Test(writeAction: AzureMonitorExporterEventSource.Log.WriteInformational, expectedId: 4, expectedName: "WriteInformational");
 
         [Fact]
+        public void VerifyEventSource_Informational_WithException() => TestException(writeAction: AzureMonitorExporterEventSource.Log.WriteInformational, expectedId: 4, expectedName: "WriteInformational");
+
+        [Fact]
+        public void VerifyEventSource_Informational_WithAggregateException() => TestAggregateException(writeAction: AzureMonitorExporterEventSource.Log.WriteInformational, expectedId: 4, expectedName: "WriteInformational");
+
+        [Fact]
         public void VerifyEventSource_Verbose() => Test(writeAction: AzureMonitorExporterEventSource.Log.WriteVerbose, expectedId: 5, expectedName: "WriteVerbose");
 
         private void Test(Action<string, string> writeAction, int expectedId, string expectedName)


### PR DESCRIPTION
## Changelog
- fix missing ")" in changelog. 
  https://github.com/Azure/azure-sdk-for-net/pull/34128#discussion_r1110605733
- add `[NonEvent]LogInformation()` to EventSource and update Statsbeat to use.
  This puts the `exception.ToInvariantString()` behind a `IsEnabled()` check, this is done for all other calls.