### PR TITLE
[AzureMonitorExporter] fix nullables in more tests

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionDetails.cs
@@ -14,7 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         /// <summary>
         /// Creates a new instance of ExceptionDetails from a System.Exception and a parent ExceptionDetails.
         /// </summary>
-        internal TelemetryExceptionDetails(Exception exception, string message, TelemetryExceptionDetails parentExceptionDetails)
+        internal TelemetryExceptionDetails(Exception exception, string message, TelemetryExceptionDetails? parentExceptionDetails)
         {
             if (exception == null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//#nullable disable // TODO: remove and fix errors
-
 using OpenTelemetry.Trace;
 using System;
 using System.Reflection;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
+//#nullable disable // TODO: remove and fix errors
 
 using OpenTelemetry.Trace;
 using System;
@@ -24,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var exporter = new AzureMonitorTraceExporter(new AzureMonitorExporterOptions { ConnectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}" });
 
-            GetInternalFields(exporter, out string ikey, out string endpoint);
+            GetInternalFields(exporter, out string? ikey, out string? endpoint);
             Assert.Equal(testIkey, ikey);
             Assert.Equal(testEndpoint, endpoint);
         }
@@ -36,7 +36,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var exporter = new AzureMonitorTraceExporter(new AzureMonitorExporterOptions { ConnectionString = $"InstrumentationKey={testIkey};" });
 
-            GetInternalFields(exporter, out string ikey, out string endpoint);
+            GetInternalFields(exporter, out string? ikey, out string? endpoint);
             Assert.Equal(testIkey, ikey);
             Assert.Equal(Constants.DefaultIngestionEndpoint, endpoint);
         }
@@ -58,11 +58,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void AzureMonitorExporter_BadArgs()
         {
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
             TracerProviderBuilder builder = null;
-            Assert.Throws<ArgumentNullException>(() => builder.AddAzureMonitorTraceExporter());
+            Assert.Throws<ArgumentNullException>(() => builder!.AddAzureMonitorTraceExporter());
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
         }
 
-        private void GetInternalFields(AzureMonitorTraceExporter exporter, out string ikey, out string endpoint)
+        private void GetInternalFields(AzureMonitorTraceExporter exporter, out string? ikey, out string? endpoint)
         {
             // TODO: NEED A BETTER APPROACH FOR TESTING. WE DECIDED AGAINST MAKING FIELDS "internal".
             // instrumentationKey: AzureMonitorTraceExporter.AzureMonitorTransmitter.instrumentationKey
@@ -70,21 +72,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             ikey = typeof(AzureMonitorTraceExporter)
                 .GetField("_instrumentationKey", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(exporter)
-                .ToString();
+                ?.GetValue(exporter)
+                ?.ToString();
 
             var transmitter = typeof(AzureMonitorTraceExporter)
                 .GetField("_transmitter", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(exporter);
+                ?.GetValue(exporter);
 
             var serviceRestClient = typeof(AzureMonitorTransmitter)
                 .GetField("_applicationInsightsRestClient", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(transmitter);
+                ?.GetValue(transmitter);
 
             endpoint = typeof(ApplicationInsightsRestClient)
                 .GetField("_host", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(serviceRestClient)
-                .ToString();
+                ?.GetValue(serviceRestClient)
+                ?.ToString();
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -59,6 +57,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
+            Assert.NotNull(transmitter._fileBlobProvider);
             Assert.Empty(transmitter._fileBlobProvider.GetBlobs());
         }
 
@@ -76,6 +75,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
+            Assert.NotNull(transmitter._fileBlobProvider);
             Assert.Single(transmitter._fileBlobProvider.GetBlobs());
         }
 
@@ -95,6 +95,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
+            Assert.NotNull(transmitter._fileBlobProvider);
             Assert.Single(transmitter._fileBlobProvider.GetBlobs());
         }
 
@@ -120,8 +121,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
+            Assert.NotNull(transmitter._fileBlobProvider);
             Assert.Single(transmitter._fileBlobProvider.GetBlobs());
-            transmitter._fileBlobProvider.TryGetBlob(out var blob);
+            Assert.True(transmitter._fileBlobProvider.TryGetBlob(out var blob));
             blob.TryRead(out var content);
 
             Assert.NotNull(content);
@@ -190,13 +192,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 parentContext: default,
                 startTime: DateTime.UtcNow);
 
+            Assert.NotNull(activity);
             return activity;
         }
 
         private static TelemetryItem CreateTelemetryItem(Activity activity)
         {
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            return new TelemetryItem(activity, ref monitorTags, null, null);
+            return new TelemetryItem(activity, ref monitorTags, null, string.Empty);
         }
 
         private class MockFileProvider : PersistentBlobProvider
@@ -224,7 +227,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             protected override bool OnTryGetBlob(out PersistentBlob blob)
             {
-                blob = this.GetBlobs().FirstOrDefault();
+                blob = this.GetBlobs().First();
 
                 return true;
             }
@@ -232,7 +235,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
         private class MockFileBlob : PersistentBlob
         {
-            private byte[] _buffer;
+            private byte[] _buffer = Array.Empty<byte>();
 
             private readonly List<PersistentBlob> _mockStorage;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -52,8 +50,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Client,
                 parentContext: default,
                 startTime: DateTime.UtcNow,
-                tags: new Dictionary<string, object>() { ["sampleRate"] = SampleRate });
+                tags: new Dictionary<string, object?>() { ["sampleRate"] = SampleRate });
 
+            Assert.NotNull(activity);
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
             var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, "00000000-0000-0000-0000-000000000000");
             var expTelemetryItem = new TelemetryItem("Exception", telemetryItem, default, default, default);
@@ -83,8 +82,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 ActivityKind.Client,
                 parentContext: default,
                 startTime: DateTime.UtcNow,
-                tags: new Dictionary<string, object>() { ["sampleRate"] = SampleRate });
+                tags: new Dictionary<string, object?>() { ["sampleRate"] = SampleRate });
 
+            Assert.NotNull(activity);
             var monitorTags = TraceHelper.EnumerateActivityTags(activity);
             var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, "00000000-0000-0000-0000-000000000000");
 
@@ -112,10 +112,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
             }
 
-            tracerProvider.ForceFlush();
+            tracerProvider?.ForceFlush();
 
             Assert.NotEmpty(telemetryItems);
-            Assert.Equal(100F, telemetryItems.FirstOrDefault().SampleRate);
+            Assert.Equal(100F, telemetryItems.First().SampleRate);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
             }
 
-            tracerProvider.ForceFlush();
+            tracerProvider?.ForceFlush();
 
             Assert.Empty(telemetryItems);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -47,7 +45,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void CallingConvertToExceptionDetailsWithNullExceptionThrowsArgumentNullException()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => new TelemetryExceptionDetails(null, "Exception Message", null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]
@@ -92,7 +92,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void TestNullMethodInfoInStack()
         {
             var frameMock = new Mock<System.Diagnostics.StackFrame>(null, 0, 0);
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             frameMock.Setup(x => x.GetMethod()).Returns((MethodBase)null);
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             Models.StackFrame stackFrame = new Models.StackFrame(frameMock.Object, 0);
 
@@ -109,8 +113,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             StackTrace st = new StackTrace(exception, true);
             var frame = st.GetFrame(0);
-            var line = frame.GetFileLineNumber();
-            var fileName = frame.GetFileName();
+            var line = frame?.GetFileLineNumber();
+            var fileName = frame?.GetFileName();
 
             var exceptionDetails = new TelemetryExceptionDetails(exception, exception.Message, null);
             var stack = exceptionDetails.ParsedStack;
@@ -357,7 +361,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [MethodImpl(MethodImplOptions.NoInlining)]
         private Exception CreateException(int stackDepth)
         {
-            Exception exception = null;
+            Exception? exception = null;
 
             try
             {
@@ -368,7 +372,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 exception = exp;
             }
 
-            return exception;
+            return exception!;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/E2E.Tests/AzureMonitorTraceExporterLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/E2E.Tests/AzureMonitorTraceExporterLiveTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 #if !NETCOREAPP3_1
 namespace Azure.Monitor.OpenTelemetry.Exporter.E2E.Tests
 {
@@ -56,16 +54,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.E2E.Tests
             }
 
             // Export
-            tracerProvider.ForceFlush();
+            tracerProvider?.ForceFlush();
 
             // Query
             var client = CreateClient();
 
             string query = $"AppDependencies | where AppRoleName == '{nameof(VerifyTraceExporter)}' | top 1 by TimeGenerated";
 
-            LogsTable table = await CheckForRecord(client, query);
-
-            var rowCount = table.Rows.Count();
+            LogsTable? table = await CheckForRecord(client, query);
+            var rowCount = table?.Rows.Count();
 
             // Assert
 
@@ -76,13 +73,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.E2E.Tests
             }
             else
             {
-                Assert.True(table.Rows.Count() == 1);
+                Assert.True(table?.Rows.Count() == 1);
             }
         }
 
-        private async Task<LogsTable> CheckForRecord(LogsQueryClient client, string query)
+        private async Task<LogsTable?> CheckForRecord(LogsQueryClient client, string query)
         {
-            LogsTable table = null;
+            LogsTable? table = null;
             int count = 0;
 
             // Try every 30 secs for total of 5 minutes.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/Controllers/HomeController.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/Controllers/HomeController.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System.Net;
 
 using Microsoft.AspNetCore.Mvc;
@@ -24,7 +22,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebAp
         /// <param name="id">Set this value to a random value and use this value to distinguish requests in any unit tests.</param>
         /// <returns></returns>
         [HttpGet("{id?}")]
-        public ActionResult<string> Get(string id = null) => StatusCode((int)HttpStatusCode.OK);
+        public ActionResult<string> Get(string? id = null) => StatusCode((int)HttpStatusCode.OK);
 
         /// <summary>
         /// This URI will return the <see cref="HttpStatusCode"/> matching the provided value.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/BasicTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/BasicTests.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Azure.Core.TestFramework;
 using Microsoft.AspNetCore.Mvc.Testing;
 
 using Xunit;
@@ -32,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
         {
             // Arrange
             var client = this.factory.CreateClient();
-            var request = new Uri(client.BaseAddress, $"api/home/statuscode/{(int)httpStatusCode}");
+            var request = new Uri(client.BaseAddress!, $"api/home/statuscode/{(int)httpStatusCode}");
 
             // Act
             var response = await client.GetAsync(request);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
@@ -15,7 +13,6 @@ using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 using Xunit;
@@ -39,7 +36,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
         {
             string testValue = Guid.NewGuid().ToString();
 
-            ConcurrentBag<TelemetryItem> telemetryItems = null;
+            ConcurrentBag<TelemetryItem>? telemetryItems = null;
 
             // Arrange
             var client = this.factory
@@ -54,11 +51,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
                 .CreateClient();
 
             // Act
-            var request = new Uri(client.BaseAddress, $"api/home/{testValue}");
+            var request = new Uri(client.BaseAddress!, $"api/home/{testValue}");
             var response = await client.GetAsync(request);
 
             // Shutdown
             response.EnsureSuccessStatusCode();
+            Assert.NotNull(telemetryItems);
             this.WaitForActivityExport(telemetryItems);
 
             // Assert


### PR DESCRIPTION
Towards #34013 

This PR fixes most of the remaining tests.
Remaining: Demo and Benchmarks projects.

## Changes
- fix nullables in tests
- i used `#pragma disable` whenever a test is validating null behavior.