### PR TITLE
[Messaging Extensions] Release Prep (Feb 2023)

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added the an overload for `IAsyncCollector<EventData>` allowing a partition key to be specified.  Because `IAsyncCollector<T>` is owned by the Functions runtime, this method could not be directly added.  Instead, this has been implemented as an extension method within the Event Hubs extension package.  Unfortunately, this knowingly makes the overload unable to be mocked.
 
-- Target-based scaling support has been added, allowing instances for Event Hubs-triggered Functions to more accurately calculate their scale needs, adjust more quickly as the number of events waiting to be processed changes. This will also reduce duplicate event processing as the instance count changes.
+- Target-based scaling support has been added, allowing instances for Event Hubs-triggered Functions to more accurately calculate their scale needs and adjust more quickly as the number of events waiting to be processed changes. This will also reduce duplicate event processing as the instance count changes.
 
 - A new setting, `UnprocessedEventThreshold` has been added to help tune target-based scaling.  More details can be found in the [host.json documentation](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs?tabs=in-process%2Cextensionv5&pivots=programming-language-csharp#hostjson-settings).
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,18 +1,18 @@
 # Release History
 
-## 5.2.0-beta.1 (Unreleased)
+## 5.2.0 (2023-02-23)
 
 ### Features Added
 
 - Added the an overload for `IAsyncCollector<EventData>` allowing a partition key to be specified.  Because `IAsyncCollector<T>` is owned by the Functions runtime, this method could not be directly added.  Instead, this has been implemented as an extension method within the Event Hubs extension package.  Unfortunately, this knowingly makes the overload unable to be mocked.
 
-### Breaking Changes
+- Target-based scaling support has been added, allowing instances for Event Hubs-triggered Functions to more accurately calculate their scale needs, adjust more quickly as the number of events waiting to be processed changes. This will also reduce duplicate event processing as the instance count changes.
+
+- A new setting, `UnprocessedEventThreshold` has been added to help tune target-based scaling.  More details can be found in the [host.json documentation](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs?tabs=in-process%2Cextensionv5&pivots=programming-language-csharp#hostjson-settings).
 
 ### Bugs Fixed
 
 - Fixed a bug with creation of the event processor used by the trigger, where configuring an `eventHubName` that does not match the one that appears as `EntityPath` in the connection string would throw.  The behavior now follows that of other clients and gives precedence to the entity path in the connection string.
-
-### Other Changes
 
 ## 5.1.2 (2022-08-10)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>5.2.0-beta.1</Version>
+    <Version>5.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.1.2</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.9.0-beta.1 (Unreleased)
+## 5.9.0 (2023-02-23)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Target-based scaling support has been added, allowing instances for Service Bus-triggered Functions to more accurately calculate their scale needs and adjust more quickly as the number of messages waiting to be processed changes.
 
 ## 5.8.1 (2022-11-09)
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
@@ -112,7 +112,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
 
         internal static ParameterBindingData ConvertReceivedMessageToBindingData(ServiceBusReceivedMessage message)
         {
-            ReadOnlyMemory<byte> messageBytes = message.GetRawAmqpMessage().ToBytes().ToMemory();
+// TEMP (target scale release):
+//ReadOnlyMemory<byte> messageBytes = message.GetRawAmqpMessage().ToBytes().ToMemory();
+ReadOnlyMemory<byte> messageBytes = Array.Empty<byte>();
+// END TEMP
+
             byte[] lockTokenBytes = Guid.Parse(message.LockToken).ToByteArray();
 
             // The lock token is a 16 byte GUID

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -35,8 +35,10 @@
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
   </ItemGroup>
 
+  <!--
   <ItemGroup>
     <ProjectReference Include="..\..\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj" />
   </ItemGroup>
+  -->
 
 </Project>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>5.9.0-beta.1</Version>
+    <Version>5.9.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.8.1</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessageInteropTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessageInteropTests.cs
@@ -36,55 +36,57 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.MessageInterop
             Assert.AreEqual(book, returned);
         }
 
-        [Test]
-        public void ParameterBindingDataTest()
-        {
-            var lockToken = Guid.NewGuid();
-            var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
-                body: BinaryData.FromString("body"),
-                messageId: "messageId",
-                correlationId: "correlationId",
-                sessionId: "sessionId",
-                replyTo: "replyTo",
-                replyToSessionId: "replyToSessionId",
-                contentType: "contentType",
-                subject: "label",
-                to: "to",
-                partitionKey: "partitionKey",
-                viaPartitionKey: "viaPartitionKey",
-                deadLetterSource: "deadLetterSource",
-                enqueuedSequenceNumber: 1,
-                lockTokenGuid: lockToken);
+// TEMP (target scale release):
+        //[Test]
+        //public void ParameterBindingDataTest()
+        //{
+        //    var lockToken = Guid.NewGuid();
+        //    var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+        //        body: BinaryData.FromString("body"),
+        //        messageId: "messageId",
+        //        correlationId: "correlationId",
+        //        sessionId: "sessionId",
+        //        replyTo: "replyTo",
+        //        replyToSessionId: "replyToSessionId",
+        //        contentType: "contentType",
+        //        subject: "label",
+        //        to: "to",
+        //        partitionKey: "partitionKey",
+        //        viaPartitionKey: "viaPartitionKey",
+        //        deadLetterSource: "deadLetterSource",
+        //        enqueuedSequenceNumber: 1,
+        //        lockTokenGuid: lockToken);
 
-            var bindingData = ServiceBusExtensionConfigProvider.ConvertReceivedMessageToBindingData(message);
-            Assert.AreEqual("application/octet-stream", bindingData.ContentType);
-            Assert.AreEqual("1.0", bindingData.Version);
-            Assert.AreEqual("AzureServiceBusReceivedMessage", bindingData.Source);
+        //    var bindingData = ServiceBusExtensionConfigProvider.ConvertReceivedMessageToBindingData(message);
+        //    Assert.AreEqual("application/octet-stream", bindingData.ContentType);
+        //    Assert.AreEqual("1.0", bindingData.Version);
+        //    Assert.AreEqual("AzureServiceBusReceivedMessage", bindingData.Source);
 
-            var bytes = bindingData.Content.ToMemory();
-            var lockTokenBytes = bytes.Slice(0, 16).ToArray();
-            Assert.AreEqual(lockToken.ToByteArray(), lockTokenBytes);
+        //    var bytes = bindingData.Content.ToMemory();
+        //    var lockTokenBytes = bytes.Slice(0, 16).ToArray();
+        //    Assert.AreEqual(lockToken.ToByteArray(), lockTokenBytes);
 
-            var deserialized = ServiceBusReceivedMessage.FromAmqpMessage(
-                AmqpAnnotatedMessage.FromBytes(
-                    BinaryData.FromBytes(bytes.Slice(16, bytes.Length - 16))),
-                BinaryData.FromBytes(lockTokenBytes));
+        //    var deserialized = ServiceBusReceivedMessage.FromAmqpMessage(
+        //        AmqpAnnotatedMessage.FromBytes(
+        //            BinaryData.FromBytes(bytes.Slice(16, bytes.Length - 16))),
+        //        BinaryData.FromBytes(lockTokenBytes));
 
-            Assert.AreEqual(message.Body.ToArray(), deserialized.Body.ToArray());
-            Assert.AreEqual(message.MessageId, deserialized.MessageId);
-            Assert.AreEqual(message.CorrelationId, deserialized.CorrelationId);
-            Assert.AreEqual(message.SessionId, deserialized.SessionId);
-            Assert.AreEqual(message.ReplyTo, deserialized.ReplyTo);
-            Assert.AreEqual(message.ReplyToSessionId, deserialized.ReplyToSessionId);
-            Assert.AreEqual(message.ContentType, deserialized.ContentType);
-            Assert.AreEqual(message.Subject, deserialized.Subject);
-            Assert.AreEqual(message.To, deserialized.To);
-            Assert.AreEqual(message.PartitionKey, deserialized.PartitionKey);
-            Assert.AreEqual(message.TransactionPartitionKey, deserialized.TransactionPartitionKey);
-            Assert.AreEqual(message.DeadLetterSource, deserialized.DeadLetterSource);
-            Assert.AreEqual(message.EnqueuedSequenceNumber, deserialized.EnqueuedSequenceNumber);
-            Assert.AreEqual(message.LockToken, deserialized.LockToken);
-        }
+        //    Assert.AreEqual(message.Body.ToArray(), deserialized.Body.ToArray());
+        //    Assert.AreEqual(message.MessageId, deserialized.MessageId);
+        //    Assert.AreEqual(message.CorrelationId, deserialized.CorrelationId);
+        //    Assert.AreEqual(message.SessionId, deserialized.SessionId);
+        //    Assert.AreEqual(message.ReplyTo, deserialized.ReplyTo);
+        //    Assert.AreEqual(message.ReplyToSessionId, deserialized.ReplyToSessionId);
+        //    Assert.AreEqual(message.ContentType, deserialized.ContentType);
+        //    Assert.AreEqual(message.Subject, deserialized.Subject);
+        //    Assert.AreEqual(message.To, deserialized.To);
+        //    Assert.AreEqual(message.PartitionKey, deserialized.PartitionKey);
+        //    Assert.AreEqual(message.TransactionPartitionKey, deserialized.TransactionPartitionKey);
+        //    Assert.AreEqual(message.DeadLetterSource, deserialized.DeadLetterSource);
+        //    Assert.AreEqual(message.EnqueuedSequenceNumber, deserialized.EnqueuedSequenceNumber);
+        //    Assert.AreEqual(message.LockToken, deserialized.LockToken);
+        //}
+// END TEMP
 
         private ServiceBusMessage GetBrokeredMessage(XmlObjectSerializer serializer, TestBook book)
         {


### PR DESCRIPTION
# Summary

The purpose of these changes is to prepare the Event Hubs and Service Bus extensions packages for an out-of-band release.

# References and Related

- [[Functions] Restore Service Bus binding code after February release (#34482)](https://github.com/Azure/azure-sdk-for-net/issues/34482)