### PR TITLE
add request payload for get metrics sample

### DIFF
--- a/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample5_GetMetrics.md
+++ b/sdk/loadtestservice/Azure.Developer.LoadTesting/samples/Sample5_GetMetrics.md
@@ -24,8 +24,14 @@ string testRunId = "my-loadtest-run";
 // all other data to be sent to testRun
 var data = new
 {
-    testid = testId,
-    displayName = "My display name"
+    filters = new[]
+    {
+        new
+        {
+            name = "SamplerName",
+            values= new[] { "HTTP Request" }
+        }
+    },
 };
 
 try
@@ -45,7 +51,8 @@ try
             testRunId,
             metricNamespacesJson.RootElement.GetProperty("value")[0].GetProperty("name").GetString(),
             metricDefinitionsJson.RootElement.GetProperty("value")[0].GetProperty("name").GetString(),
-            testRunJson.RootElement.GetProperty("startDateTime").GetString() + "/" + testRunJson.RootElement.GetProperty("endDateTime")
+            testRunJson.RootElement.GetProperty("startDateTime").GetString() + "/" + testRunJson.RootElement.GetProperty("endDateTime"),
+            RequestContent.Create(data)
         );
 }
 catch (Exception ex)


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-net/issues/34499

Added request payload as per the documentation of API https://learn.microsoft.com/en-us/rest/api/loadtesting/dataplane(2022-11-01)/load-test-run/list-metrics?tabs=HTTP#metricrequestpayload