### PR TITLE
[Service Bus Extension] Restore project reference

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Target-based scaling support has been added, allowing instances for Event Hubs-triggered Functions to more accurately calculate their scale needs and adjust more quickly as the number of events waiting to be processed changes. This will also reduce duplicate event processing as the instance count changes.
 
-- A new setting, `UnprocessedEventThreshold` has been added to help tune target-based scaling.  More details can be found in the [host.json documentation](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs?tabs=in-process%2Cextensionv5&pivots=programming-language-csharp#hostjson-settings).
+- A new setting, `UnprocessedEventThreshold`, has been added to help tune target-based scaling.  More details can be found in the [host.json documentation](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs?tabs=in-process%2Cextensionv5&pivots=programming-language-csharp#hostjson-settings).
 
 ### Bugs Fixed
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
@@ -112,10 +112,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
 
         internal static ParameterBindingData ConvertReceivedMessageToBindingData(ServiceBusReceivedMessage message)
         {
-// TEMP (target scale release):
-//ReadOnlyMemory<byte> messageBytes = message.GetRawAmqpMessage().ToBytes().ToMemory();
-ReadOnlyMemory<byte> messageBytes = Array.Empty<byte>();
-// END TEMP
+            ReadOnlyMemory<byte> messageBytes = message.GetRawAmqpMessage().ToBytes().ToMemory();
 
             byte[] lockTokenBytes = Guid.Parse(message.LockToken).ToByteArray();
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -35,10 +35,7 @@
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
   </ItemGroup>
 
-  <!--
   <ItemGroup>
     <ProjectReference Include="..\..\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj" />
   </ItemGroup>
-  -->
-
 </Project>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessageInteropTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/MessageInteropTests.cs
@@ -36,57 +36,55 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.MessageInterop
             Assert.AreEqual(book, returned);
         }
 
-// TEMP (target scale release):
-        //[Test]
-        //public void ParameterBindingDataTest()
-        //{
-        //    var lockToken = Guid.NewGuid();
-        //    var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
-        //        body: BinaryData.FromString("body"),
-        //        messageId: "messageId",
-        //        correlationId: "correlationId",
-        //        sessionId: "sessionId",
-        //        replyTo: "replyTo",
-        //        replyToSessionId: "replyToSessionId",
-        //        contentType: "contentType",
-        //        subject: "label",
-        //        to: "to",
-        //        partitionKey: "partitionKey",
-        //        viaPartitionKey: "viaPartitionKey",
-        //        deadLetterSource: "deadLetterSource",
-        //        enqueuedSequenceNumber: 1,
-        //        lockTokenGuid: lockToken);
+        [Test]
+        public void ParameterBindingDataTest()
+        {
+            var lockToken = Guid.NewGuid();
+            var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+                body: BinaryData.FromString("body"),
+                messageId: "messageId",
+                correlationId: "correlationId",
+                sessionId: "sessionId",
+                replyTo: "replyTo",
+                replyToSessionId: "replyToSessionId",
+                contentType: "contentType",
+                subject: "label",
+                to: "to",
+                partitionKey: "partitionKey",
+                viaPartitionKey: "viaPartitionKey",
+                deadLetterSource: "deadLetterSource",
+                enqueuedSequenceNumber: 1,
+                lockTokenGuid: lockToken);
 
-        //    var bindingData = ServiceBusExtensionConfigProvider.ConvertReceivedMessageToBindingData(message);
-        //    Assert.AreEqual("application/octet-stream", bindingData.ContentType);
-        //    Assert.AreEqual("1.0", bindingData.Version);
-        //    Assert.AreEqual("AzureServiceBusReceivedMessage", bindingData.Source);
+            var bindingData = ServiceBusExtensionConfigProvider.ConvertReceivedMessageToBindingData(message);
+            Assert.AreEqual("application/octet-stream", bindingData.ContentType);
+            Assert.AreEqual("1.0", bindingData.Version);
+            Assert.AreEqual("AzureServiceBusReceivedMessage", bindingData.Source);
 
-        //    var bytes = bindingData.Content.ToMemory();
-        //    var lockTokenBytes = bytes.Slice(0, 16).ToArray();
-        //    Assert.AreEqual(lockToken.ToByteArray(), lockTokenBytes);
+            var bytes = bindingData.Content.ToMemory();
+            var lockTokenBytes = bytes.Slice(0, 16).ToArray();
+            Assert.AreEqual(lockToken.ToByteArray(), lockTokenBytes);
 
-        //    var deserialized = ServiceBusReceivedMessage.FromAmqpMessage(
-        //        AmqpAnnotatedMessage.FromBytes(
-        //            BinaryData.FromBytes(bytes.Slice(16, bytes.Length - 16))),
-        //        BinaryData.FromBytes(lockTokenBytes));
+            var deserialized = ServiceBusReceivedMessage.FromAmqpMessage(
+                AmqpAnnotatedMessage.FromBytes(
+                    BinaryData.FromBytes(bytes.Slice(16, bytes.Length - 16))),
+                BinaryData.FromBytes(lockTokenBytes));
 
-        //    Assert.AreEqual(message.Body.ToArray(), deserialized.Body.ToArray());
-        //    Assert.AreEqual(message.MessageId, deserialized.MessageId);
-        //    Assert.AreEqual(message.CorrelationId, deserialized.CorrelationId);
-        //    Assert.AreEqual(message.SessionId, deserialized.SessionId);
-        //    Assert.AreEqual(message.ReplyTo, deserialized.ReplyTo);
-        //    Assert.AreEqual(message.ReplyToSessionId, deserialized.ReplyToSessionId);
-        //    Assert.AreEqual(message.ContentType, deserialized.ContentType);
-        //    Assert.AreEqual(message.Subject, deserialized.Subject);
-        //    Assert.AreEqual(message.To, deserialized.To);
-        //    Assert.AreEqual(message.PartitionKey, deserialized.PartitionKey);
-        //    Assert.AreEqual(message.TransactionPartitionKey, deserialized.TransactionPartitionKey);
-        //    Assert.AreEqual(message.DeadLetterSource, deserialized.DeadLetterSource);
-        //    Assert.AreEqual(message.EnqueuedSequenceNumber, deserialized.EnqueuedSequenceNumber);
-        //    Assert.AreEqual(message.LockToken, deserialized.LockToken);
-        //}
-// END TEMP
+            Assert.AreEqual(message.Body.ToArray(), deserialized.Body.ToArray());
+            Assert.AreEqual(message.MessageId, deserialized.MessageId);
+            Assert.AreEqual(message.CorrelationId, deserialized.CorrelationId);
+            Assert.AreEqual(message.SessionId, deserialized.SessionId);
+            Assert.AreEqual(message.ReplyTo, deserialized.ReplyTo);
+            Assert.AreEqual(message.ReplyToSessionId, deserialized.ReplyToSessionId);
+            Assert.AreEqual(message.ContentType, deserialized.ContentType);
+            Assert.AreEqual(message.Subject, deserialized.Subject);
+            Assert.AreEqual(message.To, deserialized.To);
+            Assert.AreEqual(message.PartitionKey, deserialized.PartitionKey);
+            Assert.AreEqual(message.TransactionPartitionKey, deserialized.TransactionPartitionKey);
+            Assert.AreEqual(message.DeadLetterSource, deserialized.DeadLetterSource);
+            Assert.AreEqual(message.EnqueuedSequenceNumber, deserialized.EnqueuedSequenceNumber);
+            Assert.AreEqual(message.LockToken, deserialized.LockToken);
+        }
 
         private ServiceBusMessage GetBrokeredMessage(XmlObjectSerializer serializer, TestBook book)
         {


### PR DESCRIPTION
# Summary

The focus of these changes is to restore the project reference and the in-flight work to support the isolated hosting model.

# References and Related

- [[Functions] Restore Service Bus binding code after February release (#34482)](https://github.com/Azure/azure-sdk-for-net/issues/34482)