### PR TITLE
[Service Bus] Remove post-op cancellation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -457,17 +457,17 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     }
 
                     entries.Add(entry);
+                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 }
 
                 request.Map[ManagementConstants.Properties.Messages] = entries;
 
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
                     _connectionScope,
                     _managementLink,
                     request,
                     timeout).ConfigureAwait(false);
-
-                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 if (amqpResponseMessage.StatusCode == AmqpResponseStatusCode.OK)
                 {
@@ -547,13 +547,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 request.Map[ManagementConstants.Properties.SequenceNumbers] = sequenceNumbers;
 
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
                         _connectionScope,
                         _managementLink,
                         request,
                         timeout).ConfigureAwait(false);
-
-                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 if (amqpResponseMessage.StatusCode != AmqpResponseStatusCode.OK)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/RuleManager/ServiceBusRuleManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/RuleManager/ServiceBusRuleManager.cs
@@ -175,7 +175,6 @@ namespace Azure.Messaging.ServiceBus
                 throw;
             }
 
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             ServiceBusEventSource.Log.CreateRuleComplete(Identifier, options.Name);
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -344,7 +344,7 @@ namespace Azure.Messaging.ServiceBus
                 Logger.CreateMessageBatchException(Identifier, ex.ToString());
                 throw;
             }
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
             Logger.CreateMessageBatchComplete(Identifier);
             return batch;
         }
@@ -395,7 +395,6 @@ namespace Azure.Messaging.ServiceBus
                 messageBatch.Unlock();
             }
 
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.SendMessageComplete(Identifier);
         }
 
@@ -502,7 +501,6 @@ namespace Azure.Messaging.ServiceBus
                 throw;
             }
 
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.ScheduleMessagesComplete(Identifier);
             return sequenceNumbers;
         }
@@ -564,7 +562,6 @@ namespace Azure.Messaging.ServiceBus
                 throw;
             }
 
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.CancelScheduledMessagesComplete(Identifier);
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove some checks for cancellation that were occurring after a service operation had been completed.  Because the operation was complete, cancellation was not performed and it is more accurate to return the result of the operation.

# References and Related

- [[QUERY] Late ThrowIfCancellationRequested check in SendMessagesAsync (#34472)](https://github.com/Azure/azure-sdk-for-net/issues/34472)