### PR TITLE
[Service Bus] Remove cancellation check

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -457,7 +457,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     }
 
                     entries.Add(entry);
-                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 }
 
                 request.Map[ManagementConstants.Properties.Messages] = entries;


### PR DESCRIPTION
# Summary

The focus of these changes is to remove a check of the cancellation token during message scheduling, as the impact of doing so for each message is higher than the benefit.

# References and Related

- [Discussion from [Service Bus] Remove post-op cancellation](https://github.com/Azure/azure-sdk-for-net/pull/34515#discussion_r1116303569)
