### PR TITLE
[AzureMonitorExporter] refactor Statsbeat: update namespace, rename class

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -10,6 +10,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 using OpenTelemetry;
@@ -51,10 +52,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             try
             {
                 // Do not initialize statsbeat for statsbeat.
-                if (connectionVars != null && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(Statsbeat.Statsbeat_ConnectionString_EU).InstrumentationKey && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(Statsbeat.Statsbeat_ConnectionString_NonEU).InstrumentationKey)
+                if (connectionVars != null && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_EU).InstrumentationKey && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_NonEU).InstrumentationKey)
                 {
                     // TODO: Implement IDisposable for transmitter and dispose statsbeat.
-                    _ = new Statsbeat(connectionVars);
+                    _ = new AzureMonitorStatsbeat(connectionVars);
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -13,9 +13,9 @@ using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
-namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
 {
-    internal sealed class Statsbeat : IDisposable
+    internal sealed class AzureMonitorStatsbeat : IDisposable
     {
         internal const string Statsbeat_ConnectionString_NonEU = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://NonEU.in.applicationinsights.azure.com/";
 
@@ -97,7 +97,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             "westus3",
         };
 
-        internal Statsbeat(ConnectionVars connectionStringVars)
+        internal AzureMonitorStatsbeat(ConnectionVars connectionStringVars)
         {
             _statsbeat_ConnectionString = GetStatsbeatConnectionString(connectionStringVars?.IngestionEndpoint);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/VmMetadataResponse.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/VmMetadataResponse.cs
@@ -3,7 +3,7 @@
 
 #nullable disable // TODO: remove and fix errors
 
-namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
 {
     internal class VmMetadataResponse
     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StatsbeatTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StatsbeatTests.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
 using Xunit;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
@@ -26,9 +26,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var customer_ConnectionString = $"InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://{euEndpoint}.in.applicationinsights.azure.com/";
             var connectionStringVars = ConnectionStringParser.GetValues(customer_ConnectionString);
-            var statsBeatInstance = new Statsbeat(connectionStringVars);
+            var statsBeatInstance = new AzureMonitorStatsbeat(connectionStringVars);
 
-            Assert.Equal(Statsbeat.Statsbeat_ConnectionString_EU, statsBeatInstance._statsbeat_ConnectionString);
+            Assert.Equal(AzureMonitorStatsbeat.Statsbeat_ConnectionString_EU, statsBeatInstance._statsbeat_ConnectionString);
         }
 
         [Theory]
@@ -69,9 +69,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var customer_ConnectionString = $"InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://{nonEUEndpoint}.in.applicationinsights.azure.com/";
             var connectionStringVars = ConnectionStringParser.GetValues(customer_ConnectionString);
-            var statsBeatInstance = new Statsbeat(connectionStringVars);
+            var statsBeatInstance = new AzureMonitorStatsbeat(connectionStringVars);
 
-            Assert.Equal(Statsbeat.Statsbeat_ConnectionString_NonEU, statsBeatInstance._statsbeat_ConnectionString);
+            Assert.Equal(AzureMonitorStatsbeat.Statsbeat_ConnectionString_NonEU, statsBeatInstance._statsbeat_ConnectionString);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var customer_ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://foo.in.applicationinsights.azure.com/";
 
             var connectionStringVars = ConnectionStringParser.GetValues(customer_ConnectionString);
-            Assert.Throws<InvalidOperationException>(() => new Statsbeat(connectionStringVars));
+            Assert.Throws<InvalidOperationException>(() => new AzureMonitorStatsbeat(connectionStringVars));
         }
     }
 }


### PR DESCRIPTION
Statsbeat classes are in the "Statsbeat" directory, but don't have a matching namespace.

## Changes
- update namespace to match directory "Internals.Statsbeat"
- rename class to avoid conflicting with namespace.