### PR TITLE
[AzureMonitorExporter] add EnableStatsbeat to Options

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -72,5 +72,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// Disable offline storage.
         /// </summary>
         public bool DisableOfflineStorage { get; set; }
+
+        /// <summary>
+        /// Internal flag to control if Statsbeat is enabled.
+        /// </summary>
+        internal bool EnableStatsbeat { get; set; } = true;
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -49,20 +49,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private static void InitializeStatsbeat(AzureMonitorExporterOptions options, ConnectionVars connectionVars)
         {
-            if (options.EnableStatsbeat)
+            if (options.EnableStatsbeat && connectionVars != null)
             {
                 try
                 {
-                    // Do not initialize statsbeat for statsbeat.
-                    if (connectionVars != null && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_EU).InstrumentationKey && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_NonEU).InstrumentationKey)
-                    {
-                        // TODO: Implement IDisposable for transmitter and dispose statsbeat.
-                        _ = new AzureMonitorStatsbeat(connectionVars);
-                    }
+                    // TODO: Implement IDisposable for transmitter and dispose statsbeat.
+                    _ = new AzureMonitorStatsbeat(connectionVars);
                 }
                 catch (Exception ex)
                 {
-                    AzureMonitorExporterEventSource.Log.WriteWarning($"ErrorInitializingStatsBeatfor:{connectionVars.InstrumentationKey}", ex);
+                    AzureMonitorExporterEventSource.Log.WriteWarning($"ErrorInitializingStatsbeatFor:{connectionVars.InstrumentationKey}", ex);
                 }
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -44,23 +44,26 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             _fileBlobProvider = InitializeOfflineStorage(options);
 
             // TODO: uncomment following line for enablement.
-            // InitializeStatsbeat(_connectionVars);
+            // InitializeStatsbeat(options, _connectionVars);
         }
 
-        private static void InitializeStatsbeat(ConnectionVars connectionVars)
+        private static void InitializeStatsbeat(AzureMonitorExporterOptions options, ConnectionVars connectionVars)
         {
-            try
+            if (options.EnableStatsbeat)
             {
-                // Do not initialize statsbeat for statsbeat.
-                if (connectionVars != null && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_EU).InstrumentationKey && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_NonEU).InstrumentationKey)
+                try
                 {
-                    // TODO: Implement IDisposable for transmitter and dispose statsbeat.
-                    _ = new AzureMonitorStatsbeat(connectionVars);
+                    // Do not initialize statsbeat for statsbeat.
+                    if (connectionVars != null && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_EU).InstrumentationKey && connectionVars.InstrumentationKey != ConnectionStringParser.GetValues(AzureMonitorStatsbeat.Statsbeat_ConnectionString_NonEU).InstrumentationKey)
+                    {
+                        // TODO: Implement IDisposable for transmitter and dispose statsbeat.
+                        _ = new AzureMonitorStatsbeat(connectionVars);
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                AzureMonitorExporterEventSource.Log.WriteWarning($"ErrorInitializingStatsBeatfor:{connectionVars.InstrumentationKey}", ex);
+                catch (Exception ex)
+                {
+                    AzureMonitorExporterEventSource.Log.WriteWarning($"ErrorInitializingStatsBeatfor:{connectionVars.InstrumentationKey}", ex);
+                }
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -115,15 +115,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
             // schedule of 24 hrs == 86400000 milliseconds.
             // TODO: Follow up in spec to confirm the behavior
             // in case if the app exits before 24hrs duration.
-            var exporterOptions = new AzureMonitorExporterOptions();
-            exporterOptions.DisableOfflineStorage = true;
-            exporterOptions.ConnectionString = _statsbeat_ConnectionString;
+            var exporterOptions = new AzureMonitorExporterOptions
+            {
+                DisableOfflineStorage = true,
+                ConnectionString = _statsbeat_ConnectionString,
+                EnableStatsbeat = false, // to avoid recursive Statsbeat.
+            };
 
             _attachStatsbeatMeterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter("AttachStatsbeatMeter")
-            .AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions), AttachStatsbeatInterval)
-            { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
-            .Build();
+                .AddMeter("AttachStatsbeatMeter")
+                .AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions), AttachStatsbeatInterval)
+                { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
+                .Build();
         }
 
         private static string GetOS()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -171,10 +171,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         private static AzureMonitorTransmitter GetTransmitter(MockResponse mockResponse)
         {
             MockTransport mockTransport = new MockTransport(mockResponse);
-            AzureMonitorExporterOptions options = new AzureMonitorExporterOptions();
-            options.ConnectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}";
-            options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory() + "\\test";
-            options.Transport = mockTransport;
+            AzureMonitorExporterOptions options = new AzureMonitorExporterOptions
+            {
+                ConnectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}",
+                StorageDirectory = StorageHelper.GetDefaultStorageDirectory() + "\\test",
+                Transport = mockTransport,
+                EnableStatsbeat = false, // disabled in tests.
+            };
             AzureMonitorTransmitter transmitter = new AzureMonitorTransmitter(options);
 
             // Overwrite storage with mock


### PR DESCRIPTION
This gives us control to explicitly disable this feature in unit tests.


## Changes
- add internal-only `EnableStatsbeat` to `AzureMonitorExporterOptions`
- Evaluate bool in `Transmitter` (same pattern used for Storage).