### PR TITLE
[AzureMonitorExporter] Add AAD support through property

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -13,6 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public AzureMonitorExporterOptions() { }
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.v2_1) { }
         public string? ConnectionString { get { throw null; } set { } }
+        public Azure.Core.TokenCredential? Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public string? StorageDirectory { get { throw null; } set { } }
         public Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion Version { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
@@ -34,7 +34,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var options = new AzureMonitorExporterOptions();
             configure?.Invoke(options);
 
-            return loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(options, credential)));
+            return loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(options, options.Credential ?? credential)));
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
@@ -59,7 +59,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     configure(exporterOptions);
                 }
 
-                return new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions, credential))
+                return new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions, exporterOptions.Credential ?? credential))
                            { TemporalityPreference = MetricReaderTemporalityPreference.Delta };
             });
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -26,6 +26,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public string? ConnectionString { get; set; }
 
         /// <summary>
+        /// Get or sets the value of <see cref="TokenCredential" />.
+        /// </summary>
+        public TokenCredential? Credential { get; set; }
+
+        /// <summary>
         /// The <see cref="ServiceVersion"/> of the Azure Monitor ingestion API.
         /// </summary>
         public ServiceVersion Version { get; set; } = LatestVersion;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterTraceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterTraceExtensions.cs
@@ -62,7 +62,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 return new CompositeProcessor<Activity>(new BaseProcessor<Activity>[]
                 {
                     new StandardMetricsExtractionProcessor(),
-                    new BatchActivityExportProcessor(new AzureMonitorTraceExporter(exporterOptions, credential))
+                    new BatchActivityExportProcessor(new AzureMonitorTraceExporter(exporterOptions, exporterOptions.Credential?? credential))
                 });
             });
         }


### PR DESCRIPTION
Enabling AAD support through property will help the Azure Monitor Distro to keep simpler Public API's.
