### PR TITLE
[Quantum] Fix wrong test yml parameter (no sdk change)

### DIFF
--- a/sdk/quantum/tests.yml
+++ b/sdk/quantum/tests.yml
@@ -4,4 +4,4 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: quantum
-    TimeoutInMinutes: 10
+    TestTimeoutInMinutes: 10


### PR DESCRIPTION
This test.yml is using an old parameter name, so the build is currently broken. This PR updates to the latest name, per:
https://github.com/Azure/azure-sdk-for-net/blob/main/eng/pipelines/templates/stages/archetype-sdk-client.yml
