### PR TITLE
Potential wrong use of assertion

### DIFF
--- a/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/src/Customization/TrafficManagerEndpointCollection.cs
+++ b/sdk/trafficmanager/Azure.ResourceManager.TrafficManager/src/Customization/TrafficManagerEndpointCollection.cs
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.TrafficManager
         /// /// <param name="profileData">The parent profile data. </param>
         internal TrafficManagerEndpointCollection(ArmClient client, ResourceIdentifier id, TrafficManagerProfileData profileData) : this(client, id)
         {
-            Argument.AssertNull(profileData, nameof(profileData));
+            Argument.AssertNotNull(profileData, nameof(profileData));
 
             this._profileData = profileData;
         }


### PR DESCRIPTION
We encountered an error while using the SDK where GetAll would always throw. After looking through the code we saw that where an instance of this class is created (TrafficManagerProfileResource), the ctor with the 3rd parameter is never called. I'm guessing that's from the AutoRest codegen.

Maybe adding AssertNotNull rather than AssertNull would fix the problem in the codegen?

How we made it work was to use reflection to get _profileData and set it before calling GetAll()

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
