### PR TITLE
[AzureMonitorOpenTelemetryDisto] Read options from IConfiguration for Services.AddAzureMonitorOpenTelemetry()

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry/src/AzureMonitorOpenTelemetryExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry/src/AzureMonitorOpenTelemetryExtensions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Azure.Monitor.OpenTelemetry
 {
@@ -18,6 +20,8 @@ namespace Azure.Monitor.OpenTelemetry
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         public static IServiceCollection AddAzureMonitorOpenTelemetry(this IServiceCollection services)
         {
+            services.TryAddSingleton<IConfigureOptions<AzureMonitorOpenTelemetryOptions>,
+                                    DefaultAzureMonitorOpenTelemetryOptions>();
             return services.AddAzureMonitorOpenTelemetry(o => o = new AzureMonitorOpenTelemetryOptions());
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry/src/AzureMonitorOpenTelemetryImplementations.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry/src/AzureMonitorOpenTelemetryImplementations.cs
@@ -55,7 +55,10 @@ namespace Azure.Monitor.OpenTelemetry
                         builderOptions.IncludeFormattedMessage = true;
                         builderOptions.ParseStateValues = true;
                         builderOptions.IncludeScopes = false;
-                        builderOptions.AddAzureMonitorLogExporter(o => logExporterOptions.SetValueToExporterOptions(o));
+                        // TODO: In the follow up PR remove the hard-coded value for AddAzureMonitorLogExporter.
+                        // Follow up PR includes the support for logging to read from DI.
+                        // builderOptions.AddAzureMonitorLogExporter(o => logExporterOptions.SetValueToExporterOptions(o));
+                        builderOptions.AddAzureMonitorLogExporter(o => o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000");
                     });
                 }
             });

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry/src/DefaultAzureMonitorOpenTelemetryOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry/src/DefaultAzureMonitorOpenTelemetryOptions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Monitor.OpenTelemetry
+{
+    internal class DefaultAzureMonitorOpenTelemetryOptions : IConfigureOptions<AzureMonitorOpenTelemetryOptions>
+    {
+        private const string AzureMonitorOpenTelemetrySectionFromConfig = "AzureMonitorOpenTelemetry";
+        private readonly IConfiguration? _configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultAzureMonitorOpenTelemetryOptions"/> class.
+        /// </summary>
+        /// <param name="configuration"><see cref="IConfiguration"/> from which configuration for ApplicationInsights can be retrieved.</param>
+        public DefaultAzureMonitorOpenTelemetryOptions(IConfiguration? configuration = null)
+        {
+            _configuration = configuration;
+        }
+
+        public void Configure(AzureMonitorOpenTelemetryOptions options)
+        {
+            if (_configuration != null)
+            {
+                _configuration.GetSection(AzureMonitorOpenTelemetrySectionFromConfig).Bind(options);
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry/tests/Azure.Monitor.OpenTelemetry.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry/tests/Azure.Monitor.OpenTelemetry.Demo/Program.cs
@@ -11,13 +11,15 @@ using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// builder.Services.AddAzureMonitorOpenTelemetry();
+builder.Services.AddAzureMonitorOpenTelemetry();
+/*
 builder.Services.AddAzureMonitorOpenTelemetry(o =>
 {
     o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
     // Set the Credential property to enable AAD based authentication:
     // o.Credential = new DefaultAzureCredential();
 });
+*/
 
 // To customize sampling, Set ApplicationInsightsSampler to desired sampling ratio and
 // configure with OpenTelemetryTracerProvider.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry/tests/Azure.Monitor.OpenTelemetry.Demo/appsettings.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry/tests/Azure.Monitor.OpenTelemetry.Demo/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "AzureMonitorOpenTelemetry": {
+        "ConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000123"
+    }
+}


### PR DESCRIPTION
Sample telemetry which has read connection string from appSettings.json

```
{"name":"Request","time":"2023-03-01T06:16:03.5424326Z","sampleRate":90,"iKey":"00000000-0000-0000-0000-000000000123","tags":{"ai.operation.id":"8739551e7827c7231a539bd2c43fc6a1","ai.user.userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36","ai.operation.name":"GET /favicon.ico","ai.location.ip":null,"ai.cloud.role":"unknown_service:Azure.Monitor.OpenTelemetry.Demo","ai.cloud.roleInstance":"rajrang-ai","ai.internal.sdkVersion":"dotnet7.0.3:otel1.4.0:ext1.0.0-alpha.20230228.1"},"data":{"baseType":"RequestData","baseData":{"id":"3d27f5119d5afbfb","name":"GET /favicon.ico","duration":"00:00:00.0146805","success":false,"responseCode":"404","url":"http://localhost:12256/favicon.ico","properties":{"http.flavor":"1.1","_MS.ProcessedByMetricExtractors":"(Name: X,Ver:\u00271.1\u0027)"},"ver":2}}}
```