### PR TITLE
[Text Analytics] Log warn-text response header

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Features Added
 
+- Added support for logging the "warn-text" response header.
+
 ### Breaking Changes
+
 > Note: The following breaking changes only apply when upgrading from the previous beta version (5.3.0-beta.1) and do not impact stable versions.
+
 - Renamed the `WellKnownFhirVersion` enum to `FhirVersion`.
 - Changed the type of the `AnalyzeHealthcareEntitiesResult.FhirBundle` property from `IReadOnlyDictionary<string, object>` to `BinaryData`.
 - Removed the `options` parameter from the following methods for consistency: `TextAnalyticsClient.DynamicClassify` and `TextAnalyticsClient.DynamicClassifyAsync`.
@@ -19,6 +23,7 @@
 ## 5.3.0-beta.1 (2022-12-01)
 
 ### Features Added
+
 - Added support for dynamic classification.
   - Added the following methods: `TextAnalyticsClient.DynamicClassify` and `TextAnalyticsClient.DynamicClassifyAsync`.
   - Added the following methods: `TextAnalyticsClient.DynamicClassifyBatch` and `TextAnalyticsClient.DynamicClassifyBatchAsync`.
@@ -63,6 +68,7 @@
   - Added the `ScriptKind` enum.
 
 ### Other Changes
+
 The client now defaults to targeting service API version `2022-10-01-preview`.
 
 ## 5.2.0 (2022-09-08)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClientOptionsExtensions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClientOptionsExtensions.cs
@@ -16,6 +16,7 @@ namespace Azure.AI.TextAnalytics
             loggedHeaderNames.Add("apim-request-id");
             loggedHeaderNames.Add("Strict-Transport-Security");
             loggedHeaderNames.Add("x-content-type-options");
+            loggedHeaderNames.Add("warn-text");
 
             clientOptions.Diagnostics.LoggedQueryParameters.Add("jobId");
             clientOptions.Diagnostics.LoggedQueryParameters.Add("$top");


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-sdk-for-net/issues/33421

The service returns a `warn-text` header to communicate to users when an API version is retired, e.g. "Microsoft Cognitive Service Language APIs version 2022-04-01-preview and will be removed." This change adds the header to the list of logged headers.