### PR TITLE
Update package versions for Azure.Core and Azure.Core.Experimental

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -83,9 +83,9 @@
     <!-- Azure SDK packages -->
 	  <PackageReference Update="Azure.Communication.Identity" Version="1.2.0" />
     <PackageReference Update="Azure.Communication.Common" Version="1.2.1" />
-    <PackageReference Update="Azure.Core" Version="1.28.0" />
+    <PackageReference Update="Azure.Core" Version="1.29.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.3.0" />
-    <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.24" />
+    <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.25" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.5.0" />
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.7.5" />


### PR DESCRIPTION
Update post release of Azure.Core 1.29.0 and Azure.Core.Experimental 0.1.0-preview.25.