### PR TITLE
[AzureMonitorDistro/Exporter] Update connection string and fix VS build error

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -64,7 +64,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 return ConnectionStringParser.GetValues(options.ConnectionString);
             }
 
-            throw new InvalidOperationException("A connection string was not found. This MUST be provided via either AzureMonitorExporterOptions or set in the environment variable 'APPLICATIONINSIGHTS_CONNECTION_STRING'");
+            throw new InvalidOperationException("A connection string was not found. Please set your connection string.");
         }
 
         private static ApplicationInsightsRestClient InitializeRestClient(AzureMonitorExporterOptions options, ConnectionVars connectionVars, TokenCredential? credential)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
@@ -44,7 +44,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
             catch (Exception ex)
             {
                 AzureMonitorExporterEventSource.Log.WriteError("ConnectionStringError", ex);
-                throw new InvalidOperationException("Connection String Error: A valid connection string is required to send telemetry data to Azure Monitor. Please set your connection string.", ex);
+                throw new InvalidOperationException("Connection String Error: " + ex.Message, ex);
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry/Azure.Monitor.OpenTelemetry.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry/Azure.Monitor.OpenTelemetry.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Tests", "tests\Azure.Monitor.OpenTelemetry.Tests\Azure.Monitor.OpenTelemetry.Tests.csproj", "{E047E7C5-F248-49DF-BC2C-A690BC5F0F71}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{3E77BE70-A052-44F1-9E79-CB6D266DB1B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +44,10 @@ Global
 		{E047E7C5-F248-49DF-BC2C-A690BC5F0F71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E047E7C5-F248-49DF-BC2C-A690BC5F0F71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E047E7C5-F248-49DF-BC2C-A690BC5F0F71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E77BE70-A052-44F1-9E79-CB6D266DB1B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E77BE70-A052-44F1-9E79-CB6D266DB1B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E77BE70-A052-44F1-9E79-CB6D266DB1B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E77BE70-A052-44F1-9E79-CB6D266DB1B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Fixes https://github.com/Azure/azure-sdk-for-net/pull/34700/files#r1125061244
- Added existing project `Azure.Core.TestFramework.csproj` to solve Visual Studio build errors

New changes ensures that a generic string is thrown only when connection string is empty. If it is invalid, it gives appropriate messages. For example, if connection string is set to test it throws below message. 

[ConnectionStringError - System.InvalidOperationException: Connection string doesn't have value for keyword 'test'.

