### PR TITLE
[Text Analytics] Rename `MaxSentenceCount` to `SentenceCount` in abstractive summarization

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Removed the `options` parameter from the following methods for consistency: `TextAnalyticsClient.DynamicClassify` and `TextAnalyticsClient.DynamicClassifyAsync`.
 - Removed the `DynamicClassifyOptions` class.
 - Added the `classificationType` parameter to the following methods: `TextAnalyticsClient.DynamicClassify`, `TextAnalyticsClient.DynamicClassifyAsync`, `TextAnalyticsClient.DynamicClassifyBatch` and `TextAnalyticsClient.DynamicClassifyBatchAsync`.
+- Renamed `AbstractSummaryAction.MaxSentenceCount` to `AbstractSummaryAction.SentenceCount`.
+- Renamed `AbstractSummaryOptions.MaxSentenceCount` to `AbstractSummaryOptions.SentenceCount`.
 
 ### Bugs Fixed
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -14,8 +14,8 @@ namespace Azure.AI.TextAnalytics
         public AbstractSummaryAction(Azure.AI.TextAnalytics.AbstractSummaryOptions options) { }
         public string ActionName { get { throw null; } set { } }
         public bool? DisableServiceLogs { get { throw null; } set { } }
-        public int? MaxSentenceCount { get { throw null; } set { } }
         public string ModelVersion { get { throw null; } set { } }
+        public int? SentenceCount { get { throw null; } set { } }
     }
     public partial class AbstractSummaryActionResult : Azure.AI.TextAnalytics.TextAnalyticsActionResult
     {
@@ -49,7 +49,7 @@ namespace Azure.AI.TextAnalytics
         public AbstractSummaryOptions() { }
         public string AutoDetectionDefaultLanguage { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
-        public int? MaxSentenceCount { get { throw null; } set { } }
+        public int? SentenceCount { get { throw null; } set { } }
     }
     public partial class AbstractSummaryResult : Azure.AI.TextAnalytics.TextAnalyticsResult
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryAction.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.TextAnalytics
         {
             ModelVersion = options.ModelVersion;
             DisableServiceLogs = options.DisableServiceLogs;
-            MaxSentenceCount = options.MaxSentenceCount;
+            SentenceCount = options.SentenceCount;
         }
 
         /// <summary>
@@ -52,9 +52,9 @@ namespace Azure.AI.TextAnalytics
         public string ActionName { get; set; }
 
         /// <summary>
-        /// The maximum number of sentences that the resulting summaries can have. If not set, the service default is
-        /// used.
+        /// The desired number of sentences in the resulting summaries, which the service will attempt to approximate.
+        /// If not set, the service default is used.
         /// </summary>
-        public int? MaxSentenceCount { get; set; }
+        public int? SentenceCount { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryAction.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryAction.cs
@@ -53,7 +53,6 @@ namespace Azure.AI.TextAnalytics
 
         /// <summary>
         /// The desired number of sentences in the resulting summaries, which the service will attempt to approximate.
-        /// If not set, the service default is used.
         /// </summary>
         public int? SentenceCount { get; set; }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
@@ -28,9 +28,9 @@ namespace Azure.AI.TextAnalytics
         public string AutoDetectionDefaultLanguage { get; set; }
 
         /// <summary>
-        /// The maximum number of sentences that the resulting summaries can have. If not set, the service default is
-        /// used.
+        /// The desired number of sentences in the resulting summaries, which the service will attempt to approximate.
+        /// If not set, the service default is used.
         /// </summary>
-        public int? MaxSentenceCount { get; set; }
+        public int? SentenceCount { get; set; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AbstractSummaryOptions.cs
@@ -29,7 +29,6 @@ namespace Azure.AI.TextAnalytics
 
         /// <summary>
         /// The desired number of sentences in the resulting summaries, which the service will attempt to approximate.
-        /// If not set, the service default is used.
         /// </summary>
         public int? SentenceCount { get; set; }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
@@ -2477,7 +2477,7 @@ namespace Azure.AI.TextAnalytics.ServiceClients
                 ModelVersion = options.ModelVersion,
                 StringIndexType = Constants.DefaultStringIndexType,
                 LoggingOptOut = options.DisableServiceLogs,
-                SentenceCount = options.MaxSentenceCount,
+                SentenceCount = options.SentenceCount,
             };
 
             return new AbstractiveSummarizationLROTask(parameters);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Transforms.cs
@@ -783,7 +783,7 @@ namespace Azure.AI.TextAnalytics
                 ModelVersion = action.ModelVersion,
                 StringIndexType = Constants.DefaultStringIndexType,
                 LoggingOptOut = action.DisableServiceLogs,
-                SentenceCount = action.MaxSentenceCount,
+                SentenceCount = action.SentenceCount,
             };
 
             return new AbstractiveSummarizationLROTask(parameters)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractSummaryTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractSummaryTests.cs
@@ -73,7 +73,7 @@ namespace Azure.AI.TextAnalytics.Tests
             }
         };
 
-        private const int MaxSentenceCount = 3;
+        private const int AbstractiveSummarizationSentenceCount = 3;
 
         [RecordedTest]
         public async Task AbstractSummaryWithAADTest()
@@ -141,7 +141,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             AbstractSummaryOptions options = new AbstractSummaryOptions()
             {
-                MaxSentenceCount = MaxSentenceCount,
+                SentenceCount = AbstractiveSummarizationSentenceCount,
                 IncludeStatistics = true,
             };
 
@@ -154,7 +154,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             // Take the first page.
             AbstractSummaryResultCollection resultCollection = resultInPages.FirstOrDefault();
-            ValidateSummaryBatchResult(resultCollection, MaxSentenceCount, true);
+            ValidateSummaryBatchResult(resultCollection, true);
         }
 
         [RecordedTest]
@@ -181,7 +181,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             AbstractSummaryOptions options = new AbstractSummaryOptions()
             {
-                MaxSentenceCount = MaxSentenceCount,
+                SentenceCount = AbstractiveSummarizationSentenceCount,
                 IncludeStatistics = true,
             };
 
@@ -194,7 +194,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             // Take the first page.
             AbstractSummaryResultCollection resultCollection = resultInPages.FirstOrDefault();
-            ValidateSummaryBatchResult(resultCollection, MaxSentenceCount, true);
+            ValidateSummaryBatchResult(resultCollection, true);
         }
 
         [RecordedTest]
@@ -258,7 +258,6 @@ namespace Azure.AI.TextAnalytics.Tests
 
         private void ValidateSummaryBatchResult(
             AbstractSummaryResultCollection results,
-            int? maxSentenceCount = default,
             bool includeStatistics = default,
             bool isLanguageAutoDetected = default)
         {
@@ -317,13 +316,9 @@ namespace Azure.AI.TextAnalytics.Tests
                     Assert.That(summary.Text, Is.Not.Null.And.Not.Empty);
                     Assert.Less(summary.Text.Length, originalDocument.Length);
 
-                    if (maxSentenceCount is not null)
-                    {
-                        char[] separators = { '.', '!', '?' };
-                        string[] sentences = summary.Text.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-                        // BUGBUG: https://github.com/Azure/azure-sdk-for-net/issues/34518
-                        // Assert.LessOrEqual(sentences.Count(), maxSentenceCount);
-                    }
+                    char[] separators = { '.', '!', '?' };
+                    string[] sentences = summary.Text.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+                    Assert.Greater(sentences.Length, 0);
 
                     Assert.IsNotNull(summary.Contexts);
                     Assert.Greater(summary.Contexts.Count, 0);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -862,7 +862,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             TextAnalyticsActions batchActions = new TextAnalyticsActions()
             {
-                AbstractSummaryActions = new List<AbstractSummaryAction>() { new AbstractSummaryAction() { MaxSentenceCount = 2 } },
+                AbstractSummaryActions = new List<AbstractSummaryAction>() { new AbstractSummaryAction() { SentenceCount = 2 } },
                 DisplayName = "AnalyzeOperationAbstractSummary",
             };
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample13_AbstractSummary.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample13_AbstractSummary.cs
@@ -65,7 +65,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
             AbstractSummaryOptions options = new()
             {
-                MaxSentenceCount = 2
+                SentenceCount = 2
             };
 
             // Perform the text analysis operation.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample13_AbstractSummaryAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample13_AbstractSummaryAsync.cs
@@ -66,7 +66,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
             AbstractSummaryOptions options = new()
             {
-                MaxSentenceCount = 2
+                SentenceCount = 2
             };
 
             // Perform the text analysis operation.


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-sdk-for-net/issues/34518

In abstractive summarization, the "sentenceCount" parameter represents the desired number of sentences in the resulting summaries. The service will attempt to approximate this number, but there is no guarantee. This is contrary to the case of extractive summarization, where the "sentenceCount" does represent the guaranteed maximum number of sentences that will be extracted.