### PR TITLE
Storage Webjobs `BlobReciptManager` Classifies "LeaseAlreadyPresent"

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Classifiers/LeaseAlreadyPresentResponseClassificationHandler.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Classifiers/LeaseAlreadyPresentResponseClassificationHandler.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Classifiers
+{
+    internal class LeaseAlreadyPresentResponseClassificationHandler : ResponseClassificationHandler
+    {
+        private readonly bool isError;
+
+        private LeaseAlreadyPresentResponseClassificationHandler(bool isError)
+        {
+            this.isError = isError;
+        }
+
+        public override bool TryClassify(HttpMessage message, out bool isError)
+        {
+            if (message.Response.Status != 409 ||
+                !message.Response.Headers.TryGetValue("x-ms-error-code", out string errorCode) ||
+                errorCode != "LeaseAlreadyPresent")
+            {
+                isError = false;
+                return false;
+            }
+
+            isError = this.isError;
+            return true;
+        }
+
+        /// <summary>
+        /// Gets a response classifier for 409 lease already present.
+        /// </summary>
+        /// <param name="classifyAsError">Whether to classify this response as an error.</param>
+        /// <returns>The <see cref="ResponseClassificationHandler"/>.</returns>
+        public static ResponseClassificationHandler GetClassifier(bool classifyAsError)
+        {
+            return new LeaseAlreadyPresentResponseClassificationHandler(classifyAsError);
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
-    <PackageReference Include="Azure.Storage.Blobs" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
     <PackageReference Include="Azure.Storage.Queues" />
   </ItemGroup>
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/RequestFailedExceptionExtensions.Blobs.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/RequestFailedExceptionExtensions.Blobs.cs
@@ -33,29 +33,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
         }
 
         /// <summary>
-        /// Determines whether the exception is due to a 409 Conflict error with the error code LeaseAlreadyPresent.
-        /// </summary>
-        /// <param name="exception">The storage exception.</param>
-        /// <returns>
-        /// <see langword="true"/> if the exception is due to a 409 Conflict error with the error code
-        /// LeaseAlreadyPresent; otherwise <see langword="false"/>.
-        /// </returns>
-        public static bool IsConflictLeaseAlreadyPresent(this RequestFailedException exception)
-        {
-            if (exception == null)
-            {
-                throw new ArgumentNullException(nameof(exception));
-            }
-
-            if (exception.Status != 409)
-            {
-                return false;
-            }
-
-            return exception.ErrorCode == "LeaseAlreadyPresent";
-        }
-
-        /// <summary>
         /// Determines whether the exception is due to a 409 Conflict error with the error code
         /// LeaseIdMismatchWithLeaseOperation.
         /// </summary>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobReciptManagerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobReciptManagerTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.Diagnostics;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests
+{
+    public class BlobReciptManagerTests
+    {
+        private const string ConnectionName = "AzureWebJobsStorage";
+        private const string ContainerName = "container-blobreciptmanagertests";
+        private BlobServiceClient blobServiceClient;
+
+        [SetUp]
+        public void SetUp()
+        {
+            blobServiceClient = AzuriteNUnitFixture.Instance.GetBlobServiceClient();
+            blobServiceClient.GetBlobContainerClient(ContainerName).DeleteIfExists();
+            // make sure our system containers are present
+            CreateContainer(blobServiceClient, ContainerName);
+        }
+
+        private static BlobContainerClient CreateContainer(BlobServiceClient blobServiceClient, string containerName)
+        {
+            var container = blobServiceClient.GetBlobContainerClient(containerName);
+            container.CreateIfNotExists();
+            return container;
+        }
+
+        private static BlobContainerClient GetContainerReference(BlobServiceClient blobServiceClient, string containerName)
+        {
+            return blobServiceClient.GetBlobContainerClient(containerName);
+        }
+
+        [Test]
+        public async Task TryAcquireLeaseNotLogLeaseConflict()
+        {
+            // Arrange
+            BlobContainerClient container = GetContainerReference(blobServiceClient, ContainerName);
+            BlobClient blob = container.GetBlobClient(Guid.NewGuid().ToString());
+            await blob.UploadAsync(BinaryData.FromString("Hello world"));
+
+            BlobLeaseClient leaseClient = blob.GetBlobLeaseClient();
+            BlobLease lease = await leaseClient.AcquireAsync(BlobLeaseClient.InfiniteLeaseDuration);
+
+            // Act
+            var messages = new List<string>();
+            using (var listener = new AzureEventSourceListener((e, message) =>
+            {
+                if (e.EventSource.Name == "Azure-Core")
+                {
+                    messages.Add(message);
+                }
+            }, System.Diagnostics.Tracing.EventLevel.Warning))
+            {
+                await new BlobReceiptManager(blobServiceClient)
+                    .TryAcquireLeaseAsync(container.GetBlockBlobClient(blob.Name), CancellationToken.None);
+            }
+
+            // Assert
+            Assert.IsEmpty(messages);
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33403.182
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{3B089351-285A-4829-8F60-30768A7469BD}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,6 +15,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Storage.Queues", "Azure.Storage.Queues\src\Azure.Storage.Queues.csproj", "{E3D3BB3C-3A88-435C-91A1-63E90B86F3B3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\src\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj", "{DD47DD4C-48D4-41AA-99E7-D0E7CC8D4EA6}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3AAC39AF-A6CF-459B-8948-4C2C347C0FA4} = {3AAC39AF-A6CF-459B-8948-4C2C347C0FA4}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests", "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\tests\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.csproj", "{B3C2CA6A-0DB5-4EA3-B533-3B5F34988750}"
 EndProject
@@ -116,10 +119,6 @@ Global
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.4.33403.182
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{3B089351-285A-4829-8F60-30768A7469BD}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,9 +15,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Storage.Queues", "Azure.Storage.Queues\src\Azure.Storage.Queues.csproj", "{E3D3BB3C-3A88-435C-91A1-63E90B86F3B3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs", "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\src\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj", "{DD47DD4C-48D4-41AA-99E7-D0E7CC8D4EA6}"
-	ProjectSection(ProjectDependencies) = postProject
-		{3AAC39AF-A6CF-459B-8948-4C2C347C0FA4} = {3AAC39AF-A6CF-459B-8948-4C2C347C0FA4}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests", "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\tests\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Tests.csproj", "{B3C2CA6A-0DB5-4EA3-B533-3B5F34988750}"
 EndProject
@@ -119,6 +116,10 @@ Global
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Blob Storage Webjobs extension attempts to acquire lease that may already have a lease present as part of a standard workflow customers cannot control and handles a conflict on its own. From the customer perspective, this is not an error. Therefore, it should not log a 409 response to customer logging.

Resolves #21511