### PR TITLE
[Discussion only] One approach to enabling Console.WriteLine() on DynamicJson out of the box

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/DynamicJson.Operators.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicJson.Operators.cs
@@ -21,66 +21,79 @@ namespace Azure.Core.Dynamic
         /// Converts the value to a <see cref="bool"/>.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator bool(DynamicJson value) => value._element.GetBoolean();
+        public static explicit operator bool(DynamicJson value) => value._element.GetBoolean();
 
         /// <summary>
         /// Converts the value to a <see cref="int"/>.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator int(DynamicJson value) => value._element.GetInt32();
+        public static explicit operator int(DynamicJson value) => value._element.GetInt32();
 
         /// <summary>
         /// Converts the value to a <see cref="long"/>.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator long(DynamicJson value) => value._element.GetInt64();
+        public static explicit operator long(DynamicJson value) => value._element.GetInt64();
 
         /// <summary>
         /// Converts the value to a <see cref="string"/>.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator string?(DynamicJson value) => value._element.GetString();
+        public static implicit operator string?(DynamicJson value)
+        {
+            if (value._element.ValueKind == JsonValueKind.String)
+            {
+                return value._element.GetString();
+            }
+
+            if (value._element.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+
+            return value._element.ToString();
+        }
 
         /// <summary>
         /// Converts the value to a <see cref="float"/>.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator float(DynamicJson value) => value._element.GetSingle();
+        public static explicit operator float(DynamicJson value) => value._element.GetSingle();
 
         /// <summary>
         /// Converts the value to a <see cref="double"/>.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator double(DynamicJson value) => value._element.GetDouble();
+        public static explicit operator double(DynamicJson value) => value._element.GetDouble();
 
         /// <summary>
         /// Converts the value to a <see cref="bool"/> or null.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator bool?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetBoolean();
+        public static explicit operator bool?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetBoolean();
 
         /// <summary>
         /// Converts the value to a <see cref="int"/> or null.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator int?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetInt32();
+        public static explicit operator int?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetInt32();
 
         /// <summary>
         /// Converts the value to a <see cref="long"/> or null.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator long?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetInt64();
+        public static explicit operator long?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetInt64();
 
         /// <summary>
         /// Converts the value to a <see cref="float"/> or null.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator float?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetSingle();
+        public static explicit operator float?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetSingle();
 
         /// <summary>
         /// Converts the value to a <see cref="double"/> or null.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        public static implicit operator double?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetDouble();
+        public static explicit operator double?(DynamicJson value) => value._element.ValueKind == JsonValueKind.Null ? null : value._element.GetDouble();
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/public/JsonDataArrayTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/public/JsonDataArrayTests.cs
@@ -55,6 +55,14 @@ namespace Azure.Core.Tests.Public
             // TODO: Standardize Exception types.
             Assert.Throws<InvalidOperationException>(() => { var model = (int)data; });
             Assert.Throws<InvalidOperationException>(() => { var model = (bool)data; });
+
+            // This doesn't throw in this implementation.
+            // Basically, we would now be saying, if you cast to a string, I will call
+            // ToString() for you - we are changing the cast semantics away from maintaining
+            // consistency with the GetString()/JsonElement APIs.
+            // The caller can call ToString() themselves if their intention is to use
+            // ToString() instead of getting the value of the JSON element as a string.
+            // So, I don't think we want to use this approach.
             Assert.Throws<InvalidOperationException>(() => { var model = (string)data; });
             Assert.Throws<JsonException>(() => { var model = (DateTime)data; });
         }


### PR DESCRIPTION
If the only implicit cast on DynamicJson was to string, Console.WriteLine() would work out of the box.

I did a quick look into what this would look like - it effectively re-maps the semantics of a string cast to call ToString() if the underlying JSON doesn't have a string type.

It has the easier-to-spot disadvantages that now we wouldn't implicitly cast to a primitive type, so something like this would no longer work:
```
dynamic json = BinaryData.FromString("""{ "Foo" : 1 }""").ToDynamic();
int i = json.Foo;
```

Among the less-clear (to me :)) disadvantages are that now you _can_ do:
```
dynamic json = BinaryData.FromString("""{ "Foo" : 1 }""").ToDynamic();
string s = json.Foo;
```

When the following isn't allowed by the C# compiler:
```
int i = 1;
string s = (string)i;
```

This feels like we're removing too much type safety that could lead to errors.

Callers still have the option to call ToString() on any DynamicJson if those are the semantics they intend.

