### PR TITLE
Pass options to DynamicJson child elements

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
@@ -45,14 +45,14 @@ namespace Azure.Core.Dynamic
 
             if (_element.TryGetProperty(name, out MutableJsonElement element))
             {
-                return new DynamicJson(element);
+                return new DynamicJson(element, _options);
             }
 
             if (PascalCaseGetters() && char.IsUpper(name[0]))
             {
                 if (_element.TryGetProperty(GetAsCamelCase(name), out element))
                 {
-                    return new DynamicJson(element);
+                    return new DynamicJson(element, _options);
                 }
             }
 
@@ -88,7 +88,7 @@ namespace Azure.Core.Dynamic
                 case string propertyName:
                     return GetProperty(propertyName);
                 case int arrayIndex:
-                    return new DynamicJson(_element.GetIndexElement(arrayIndex));
+                    return new DynamicJson(_element.GetIndexElement(arrayIndex), _options);
             }
 
             throw new InvalidOperationException($"Tried to access indexer with an unsupported index type: {index}");
@@ -152,7 +152,7 @@ namespace Azure.Core.Dynamic
                 case int arrayIndex:
                     MutableJsonElement element = _element.GetIndexElement(arrayIndex);
                     element.Set(value);
-                    return new DynamicJson(element);
+                    return new DynamicJson(element, _options);
             }
 
             throw new InvalidOperationException($"Tried to access indexer with an unsupported index type: {index}");

--- a/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTests.cs
@@ -688,6 +688,28 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(null, dynamicJson.Foo);
         }
 
+        [Test]
+        public void CanGetPascalCaseNestedProperties()
+        {
+            string json = """
+                {
+                    "root" : {
+                        "child" : [
+                            {
+                                "item": {
+                                    "leaf" : true
+                                }
+                            }
+                        ]
+                    }
+                }
+                """;
+
+            dynamic dynamicJson = BinaryData.FromString(json).ToDynamic(DynamicJsonOptions.AzureDefault);
+            Assert.IsTrue(dynamicJson.root.child[0].item.leaf);
+            Assert.IsTrue(dynamicJson.Root.Child[0].Item.Leaf);
+        }
+
         #region Helpers
         internal static dynamic GetDynamicJson(string json)
         {


### PR DESCRIPTION
In the prior implementation to support PascalCase accessors on DynamicJson, we failed to pass the caller-specified options into child elements.  This results in a bug where only the top-level properties on DynamicJson can be accessed with PascalCase.

This change fixes that issue by passing options to the child elements so they will have the same characteristics as the parent.

Addresses https://github.com/Azure/azure-sdk-for-net/issues/33856