### PR TITLE
Fixed bug where GenerateSasUri did not honor TrimBlobNameSlashes when creating the SAS

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 12.16.0-beta.1 (Unreleased)
 - Added support for service version 2022-11-02.
+- Fixed bug where GenerateSasUri did not honor TrimBlobNameSlashes when creating the SAS (#34591).
 
 ## 12.15.0 (2023-02-21)
 - Includes all features from 12.15.0-beta.1.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -6665,7 +6665,7 @@ namespace Azure.Storage.Blobs.Specialized
                     nameof(builder.BlobVersionId),
                     nameof(BlobSasBuilder));
             }
-            BlobUriBuilder sasUri = new BlobUriBuilder(Uri)
+            BlobUriBuilder sasUri = new BlobUriBuilder(Uri, ClientConfiguration.TrimBlobNameSlashes)
             {
                 Sas = builder.ToSasQueryParameters(ClientConfiguration.SharedKeyCredential)
             };

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -1403,7 +1403,7 @@ namespace Azure.Storage.Blobs.Test
             BlobClient sourceBlob = sourceContainer.GetBlobClient(blob_name);
             BlobClient destBlob = destinationContainer.GetBlobClient(blob_name);
 
-            //Act
+            // Act
             Response<BlobDownloadInfo> sourceResponse = await sourceBlob.DownloadAsync();
             Response<BlobDownloadInfo> destResponse = await destBlob.DownloadAsync();
 
@@ -6916,7 +6916,7 @@ namespace Azure.Storage.Blobs.Test
                 constants.Sas.SharedKeyCredential,
                 GetOptions()));
 
-            //Act
+            // Act
             Uri sasUri = blobClient.GenerateSasUri(permissions, expiresOn);
 
             // Assert
@@ -7313,6 +7313,59 @@ namespace Azure.Storage.Blobs.Test
             TestHelper.AssertExpectedException(
                 () => blobClient.GenerateSasUri(sasBuilder),
                  new InvalidOperationException("SAS Uri cannot be generated. BlobSasBuilder.BlobVersionId does not match snapshot value in the URI in the Client. BlobSasBuilder.BlobVersionId must either be left empty or match the snapshot value in the URI in the Client"));
+        }
+
+        [RecordedTest]
+        public async Task GenerateSas_TrimBlobSlashes()
+        {
+            // Arrange
+            StorageSharedKeyCredential sharedKeyCredential = Tenants.GetNewSharedKeyCredentials();
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string containerName = test.Container.Name;
+            string blobName = $"/{GetNewBlobName()}";
+
+            BlobUriBuilder blobUriBuilder = new BlobUriBuilder(test.Container.Uri, false)
+            {
+                BlobContainerName = containerName,
+                BlobName = blobName,
+            };
+
+            // Set up options with TrimBlobNameSlashes set to false
+            BlobClientOptions options = GetOptions();
+            options.TrimBlobNameSlashes = false;
+            BlobSasPermissions permissions = BlobSasPermissions.Read;
+            DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
+            AppendBlobClient createClient = InstrumentClient(new AppendBlobClient(
+                blobUriBuilder.ToUri(),
+                sharedKeyCredential,
+                options));
+
+            await createClient.CreateAsync();
+
+            // Act
+            BlobBaseClient blobClient = InstrumentClient(new BlobBaseClient(
+                blobUriBuilder.ToUri(),
+                sharedKeyCredential,
+                options));
+
+            Uri sasUri = blobClient.GenerateSasUri(permissions, expiresOn);
+
+            // Assert
+            BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
+            {
+                BlobContainerName = containerName,
+                BlobName = blobName
+            };
+            BlobUriBuilder expectedUri = new BlobUriBuilder(test.Container.Uri, false)
+            {
+                BlobContainerName = containerName,
+                BlobName = blobName,
+                Sas = sasBuilder.ToSasQueryParameters(sharedKeyCredential)
+            };
+            Assert.AreEqual(expectedUri.ToUri(), sasUri);
+
+            BlobBaseClient sasClient = InstrumentClient(new BlobBaseClient(sasUri, options));
+            Assert.IsTrue(await sasClient.ExistsAsync());
         }
         #endregion
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/GenerateSas_TrimBlobSlashes.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/GenerateSas_TrimBlobSlashes.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ddfbc6a-530c-022f-0b5d-635dd03b887e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-01a60b5990cec1f6d8da2a7db3e4477c-811556fdf569654b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a91fa2a0-d6a9-5547-e450-c65ac87dee48",
+        "x-ms-date": "Tue, 07 Mar 2023 23:12:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 07 Mar 2023 23:12:56 GMT",
+        "ETag": "\u00220x8DB1F617D34AB90\u0022",
+        "Last-Modified": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a91fa2a0-d6a9-5547-e450-c65ac87dee48",
+        "x-ms-request-id": "8a7646ca-201e-005a-484a-511306000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ddfbc6a-530c-022f-0b5d-635dd03b887e//test-blob-64a68cbb-6d96-d733-234d-fb6305c61322",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c5ee7524f0fd4c12cfbffab8e5d40a09-33426cdc463fd6e4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "62ad05ba-1f42-3257-6f47-865bdbe3501e",
+        "x-ms-date": "Tue, 07 Mar 2023 23:12:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "ETag": "\u00220x8DB1F617D4BED7D\u0022",
+        "Last-Modified": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "62ad05ba-1f42-3257-6f47-865bdbe3501e",
+        "x-ms-request-id": "8a76470f-201e-005a-054a-511306000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-03-07T23:12:57.7473917Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ddfbc6a-530c-022f-0b5d-635dd03b887e//test-blob-64a68cbb-6d96-d733-234d-fb6305c61322?sv=2022-11-02\u0026se=2023-03-08T00%3A12%3A55Z\u0026sr=b\u0026sp=r\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-39eddcc62f03966d2aa7b41f495ce4af-44f6944a0f78c32e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ffa93683-b019-bae0-1d8a-bed358799371",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "ETag": "\u00220x8DB1F617D4BED7D\u0022",
+        "Last-Modified": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "ffa93683-b019-bae0-1d8a-bed358799371",
+        "x-ms-creation-time": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "8a76474e-201e-005a-3e4a-511306000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-03-07T23:12:57.7473917Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ddfbc6a-530c-022f-0b5d-635dd03b887e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-274e16a60d2dfbf4d442c7181bafb940-9999d4fbfd7273fa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a5d7a23b-513a-8b04-c3c6-36350159843d",
+        "x-ms-date": "Tue, 07 Mar 2023 23:12:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a5d7a23b-513a-8b04-c3c6-36350159843d",
+        "x-ms-request-id": "8a764771-201e-005a-5d4a-511306000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2023-03-07T15:12:55.3250364-08:00",
+    "RandomSeed": "190686581",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/GenerateSas_TrimBlobSlashesAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/GenerateSas_TrimBlobSlashesAsync.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1250c891-6e8f-daa5-357f-9561f01caba4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-de4ee4cba727eb865d205a0ec02ed66f-189dcf5f2706a06a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c88f16f0-4118-f38c-0cf5-abd11e0e4b7d",
+        "x-ms-date": "Tue, 07 Mar 2023 23:12:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "ETag": "\u00220x8DB1F617D8160B4\u0022",
+        "Last-Modified": "Tue, 07 Mar 2023 23:12:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c88f16f0-4118-f38c-0cf5-abd11e0e4b7d",
+        "x-ms-request-id": "8a7647b9-201e-005a-1d4a-511306000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1250c891-6e8f-daa5-357f-9561f01caba4//test-blob-76b7edeb-144d-d4f4-d598-930454744595",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-571169e17baa3f0d6066b4a929d9bb7f-2cf88e54d2005472-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a7459c3f-1ee9-dcb4-21bb-f380ae879e97",
+        "x-ms-date": "Tue, 07 Mar 2023 23:12:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "ETag": "\u00220x8DB1F617D939A5D\u0022",
+        "Last-Modified": "Tue, 07 Mar 2023 23:12:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a7459c3f-1ee9-dcb4-21bb-f380ae879e97",
+        "x-ms-request-id": "8a7647ef-201e-005a-4a4a-511306000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-03-07T23:12:58.2171229Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1250c891-6e8f-daa5-357f-9561f01caba4//test-blob-76b7edeb-144d-d4f4-d598-930454744595?sv=2022-11-02\u0026se=2023-03-08T00%3A12%3A55Z\u0026sr=b\u0026sp=r\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-50441233c129d6dcce139935ad34a568-4c11209c46b39566-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b7c421fe-9d2f-cbab-e093-b7d1ef0bbc14",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "ETag": "\u00220x8DB1F617D939A5D\u0022",
+        "Last-Modified": "Tue, 07 Mar 2023 23:12:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "0",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b7c421fe-9d2f-cbab-e093-b7d1ef0bbc14",
+        "x-ms-creation-time": "Tue, 07 Mar 2023 23:12:58 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "8a764811-201e-005a-674a-511306000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-03-07T23:12:58.2171229Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-1250c891-6e8f-daa5-357f-9561f01caba4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-75607aa695c5b022fc02ad0352491e40-cdc8943935e37122-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.16.0-alpha.20230306.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8d813ef7-e7c3-1368-6a1b-a909ba1e1955",
+        "x-ms-date": "Tue, 07 Mar 2023 23:12:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 07 Mar 2023 23:12:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8d813ef7-e7c3-1368-6a1b-a909ba1e1955",
+        "x-ms-request-id": "8a764834-201e-005a-084a-511306000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2023-03-07T15:12:55.8325645-08:00",
+    "RandomSeed": "327290775",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}


### PR DESCRIPTION
Resolves [#34591](https://github.com/Azure/azure-sdk-for-net/issues/34591)

I already checked through the other GenerateSasUri methods on the other Blob Clients and they did not need this fix. I also checked some other methods which only were using BlobUriBuilder(Uri) without the TrimBlobNameSlashes parameter and they did not need that parameter to be specified.