### PR TITLE
Fix for #34784: [BUG] Unexpected type for header

### DIFF
--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -198,9 +198,15 @@ namespace Azure.Core
         /// </summary>
         public void Dispose()
         {
-            Request?.Dispose();
-            _response?.Dispose();
+            Request.Dispose();
             _propertyBag.Dispose();
+
+            var response = _response;
+            if (response != null)
+            {
+                _response = null;
+                response.Dispose();
+            }
         }
 
         private class ResponseShouldNotBeUsedStream : Stream

--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -24,6 +24,7 @@ namespace Azure.Core
         /// <param name="responseClassifier">The response classifier.</param>
         public HttpMessage(Request request, ResponseClassifier responseClassifier)
         {
+            Argument.AssertNotNull(request, nameof(Request));
             Request = request;
             ResponseClassifier = responseClassifier;
             BufferResponse = true;

--- a/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
+++ b/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
@@ -270,8 +270,11 @@ namespace Azure.Core
 
         internal void Dispose()
         {
-            CheckDisposed();
 #if DEBUG
+            if (_disposed)
+            {
+                return;
+            }
             _disposed = true;
 #endif
             _count = 0;

--- a/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
+++ b/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
@@ -297,7 +297,7 @@ namespace Azure.Core
 #if DEBUG
             if (_disposed)
             {
-                throw new InvalidOperationException($"{nameof(ArrayBackedPropertyBag<TKey, TValue>)} instance is already disposed");
+                throw new ObjectDisposedException($"{nameof(ArrayBackedPropertyBag<TKey, TValue>)} instance is already disposed");
             }
 #endif
         }

--- a/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
+++ b/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
@@ -68,7 +68,7 @@ namespace Azure.Core
             {
                 0 => _first,
                 1 => _second,
-                _ => _rest![index - 2] // Must throw if _rest is null
+                _ => GetRest()[index - 2]
             };
         }
 
@@ -146,7 +146,7 @@ namespace Azure.Core
 
                     return false;
                 default:
-                    Kvp[] rest = _rest!; // _rest can't be null when _count >= 2
+                    Kvp[] rest = GetRest();
                     if (IsFirst(key))
                     {
                         _first = _second;
@@ -237,7 +237,7 @@ namespace Azure.Core
             else if (index == 1)
                 _second = value;
             else
-                _rest![index - 2] = value; // _rest can't be null when _count >= 2
+                GetRest()[index - 2] = value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -245,7 +245,7 @@ namespace Azure.Core
         {
             0 => _first.Value,
             1 => _second.Value,
-            _ => _rest![index - 2].Value // _rest can't be null when _count >= 2
+            _ => GetRest()[index - 2].Value
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -258,7 +258,10 @@ namespace Azure.Core
             if (_count > 1 && _second.Key.Equals(key))
                 return 1;
 
-            Kvp[] rest = _rest!; // _rest can't be null when _count >= 2
+            if (_count <= 2)
+                return -1;
+
+            Kvp[] rest = GetRest();
             int max = _count - 2;
             for (var i = 0; i < max; i++)
             {
@@ -289,6 +292,8 @@ namespace Azure.Core
             _rest = default;
             ArrayPool<Kvp>.Shared.Return(rest, true);
         }
+
+        private Kvp[] GetRest() => _rest ?? throw new InvalidOperationException($"{nameof(_rest)} field is null while {nameof(_count)} == {_count}");
 
 #pragma warning disable CA1822
         [Conditional("DEBUG")]

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -513,7 +513,12 @@ namespace Azure.Core.Pipeline
             public override void Dispose()
             {
                 _headers.Dispose();
-                Content?.Dispose();
+                var content = Content;
+                if (content != null)
+                {
+                    Content = null;
+                    content.Dispose();
+                }
             }
 
             public override string ToString() => BuildRequestMessage(default).ToString();

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -342,19 +342,19 @@ namespace Azure.Core.Pipeline
             private string? _clientRequestId;
             private readonly DictionaryHeaders _headers = new();
 
-        protected internal override void SetHeader(string name, string value) => _headers.SetHeader(name, value);
+            protected internal override void SetHeader(string name, string value) => _headers.SetHeader(name, value);
 
-        protected internal override void AddHeader(string name, string value) => _headers.AddHeader(name, value);
+            protected internal override void AddHeader(string name, string value) => _headers.AddHeader(name, value);
 
-        protected internal override bool TryGetHeader(string name, out string value) => _headers.TryGetHeader(name, out value);
+            protected internal override bool TryGetHeader(string name, out string value) => _headers.TryGetHeader(name, out value);
 
-        protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => _headers.TryGetHeaderValues(name, out values);
+            protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => _headers.TryGetHeaderValues(name, out values);
 
-        protected internal override bool ContainsHeader(string name) => _headers.TryGetHeaderValues(name, out _);
+            protected internal override bool ContainsHeader(string name) => _headers.TryGetHeaderValues(name, out _);
 
-        protected internal override bool RemoveHeader(string name) => _headers.RemoveHeader(name);
+            protected internal override bool RemoveHeader(string name) => _headers.RemoveHeader(name);
 
-        protected internal override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.EnumerateHeaders();
+            protected internal override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.EnumerateHeaders();
 
             public override string ClientRequestId
             {
@@ -370,7 +370,12 @@ namespace Azure.Core.Pipeline
 
             public override void Dispose()
             {
-                Content?.Dispose();
+                var content = Content;
+                if (content != null)
+                {
+                    Content = null;
+                    content.Dispose();
+                }
             }
         }
 

--- a/sdk/core/Azure.Core/tests/ArrayBackedPropertyBagTests.cs
+++ b/sdk/core/Azure.Core/tests/ArrayBackedPropertyBagTests.cs
@@ -192,30 +192,27 @@ namespace Azure.Core.Tests
         [TestCase(10)]
         public void DisposeCreateDispose(int count)
         {
-            var target = new ArrayBackedPropertyBag<int, int>();
+            var first = new ArrayBackedPropertyBag<int, int>();
             for (var key = 0; key < count; key++)
             {
-                target.Set(key, key);
+                first.Set(key, key);
             }
-            target.Dispose();
+            first.Dispose();
 
-            var target2 = new ArrayBackedPropertyBag<int, int>();
+            var second = new ArrayBackedPropertyBag<int, int>();
             for (var key = 0; key < count; key++)
             {
-                target2.Set(key, key);
+                second.Set(key, key);
             }
-#if DEBUG
-            Assert.Throws<InvalidOperationException>(() => target.Dispose());
-#else
-            target.Dispose();
 
-            Assert.AreEqual(count, target2.Count);
+            first.Dispose();
+
+            Assert.AreEqual(count, second.Count);
             for (var key = 0; key < count; key++)
             {
-                Assert.IsTrue(target2.TryGetValue(key, out var value));
+                Assert.IsTrue(second.TryGetValue(key, out var value));
                 Assert.AreEqual(key, value);
             }
-#endif
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/ArrayBackedPropertyBagTests.cs
+++ b/sdk/core/Azure.Core/tests/ArrayBackedPropertyBagTests.cs
@@ -168,11 +168,11 @@ namespace Azure.Core.Tests
 
             target.Dispose();
 #if DEBUG
-            Assert.Throws<InvalidOperationException>(() => { _ = target.Count; });
-            Assert.Throws<InvalidOperationException>(() => { _ = target.IsEmpty; });
+            Assert.Throws<ObjectDisposedException>(() => { _ = target.Count; });
+            Assert.Throws<ObjectDisposedException>(() => { _ = target.IsEmpty; });
             for (var key = 0; key < count; key++)
             {
-                Assert.Throws<InvalidOperationException>(() => { _ = target.TryGetValue(key, out _); });
+                Assert.Throws<ObjectDisposedException>(() => { _ = target.TryGetValue(key, out _); });
             }
 #else
             Assert.IsTrue(target.IsEmpty);


### PR DESCRIPTION
The issue has been caused by multiple dispose of `ArrayBackedPropertyBag`. 

`ArrayBackedPropertyBag` is used to store headers in `PipelineRequest`. It uses array from the array pool to store items, which is returned back to the pool when `ArrayBackedPropertyBag` is disposed and [content of array is cleared](https://github.com/Azure/azure-sdk-for-net/blob/b0d465ffa8541b86c4ef7ae499e86f905a1ec26c/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs#L280). However, since array is still referenced, second call of the `Dispose` will clear array again in case it is used by another instance of `ArrayBackedPropertyBag`. 

Double dispose of `ArrayBackedPropertyBag` has been caused by double dispose of `PipelineRequest` in [ManagedIdentitySource](https://github.com/Azure/azure-sdk-for-net/commit/b0d465ffa8541b86c4ef7ae499e86f905a1ec26c#diff-72571e3cca761ecd73c5855b39621f8883c8ee115319a0ecbb629deb5b8c0513L30-L31). New version of `Azure.Identity` has not been released yet, so `Azure.Messaging.ServiceBus` still uses the version where request is disposed twice.