### PR TITLE
[Communication] - PhoneNumbers - Simplify status code assertions

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
@@ -212,7 +211,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(400, ex.Status);
                 Assert.NotNull(ex.Message);
             }
         }
@@ -228,7 +226,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(400, ex.Status);
                 Assert.NotNull(ex.Message);
             }
         }
@@ -239,25 +236,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient();
             try
             {
-                var purchaseOperation = await client.GetPurchasedPhoneNumberAsync(UnauthorizedNumber);
+                var phoneNumbers = await client.GetPurchasedPhoneNumberAsync(UnauthorizedNumber);
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
-            }
-        }
-
-        [Test]
-        public async Task StartPurchasedUnauthorizedNumber()
-        {
-            var client = CreateClient();
-            try
-            {
-                var releaseOperation = await client.StartPurchasePhoneNumbersAsync(UnauthorizedNumber);
-            }
-            catch (RequestFailedException ex)
-            {
-                Assert.AreEqual(404, ex.Status);
                 Assert.NotNull(ex.Message);
             }
         }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
@@ -104,7 +104,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status));
+                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -198,7 +198,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             Assert.IsTrue(updateOperation.HasCompleted);
             Assert.IsNotNull(updateOperation.Value);
             Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status));
+            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status));
+                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 Assert.NotNull(ex.Message);
             }
         }
@@ -227,7 +227,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status));
+                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 Assert.NotNull(ex.Message);
             }
         }
@@ -242,6 +242,21 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
+                Assert.NotNull(ex.Message);
+            }
+        }
+
+        [Test]
+        public async Task StartPurchaseInvalidSearchId()
+        {
+            var client = CreateClient();
+            try
+            {
+                var purchaseOperation = await client.StartPurchasePhoneNumbersAsync("some-invalid-id");
+            }
+            catch (RequestFailedException ex)
+            {
+                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 Assert.NotNull(ex.Message);
             }
         }
@@ -289,7 +304,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             Assert.IsTrue(updateOperation.HasCompleted);
             Assert.IsNotNull(updateOperation.Value);
             Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status));
+            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
@@ -102,9 +102,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 var searchOperation = await client.StartSearchAvailablePhoneNumbersAsync(countryCode, PhoneNumberType.TollFree, PhoneNumberAssignmentType.Person,
                     new PhoneNumberCapabilities(PhoneNumberCapabilityType.Outbound, PhoneNumberCapabilityType.None), new PhoneNumberSearchOptions { AreaCode = "212", Quantity = 1 });
             }
-            catch (Azure.RequestFailedException ex)
+            catch (RequestFailedException ex)
             {
-                Assert.AreEqual(400, ex.Status);
+                Assert.IsTrue(IsClientError(ex.Status));
                 return;
             }
 
@@ -198,7 +198,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             Assert.IsTrue(updateOperation.HasCompleted);
             Assert.IsNotNull(updateOperation.Value);
             Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.AreEqual(200, updateOperation.GetRawResponse().Status);
+            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status));
         }
 
         [Test]
@@ -211,6 +211,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
+                Assert.IsTrue(IsClientError(ex.Status));
                 Assert.NotNull(ex.Message);
             }
         }
@@ -226,6 +227,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
+                Assert.IsTrue(IsClientError(ex.Status));
                 Assert.NotNull(ex.Message);
             }
         }
@@ -287,7 +289,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             Assert.IsTrue(updateOperation.HasCompleted);
             Assert.IsNotNull(updateOperation.Value);
             Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.AreEqual(200, updateOperation.GetRawResponse().Status);
+            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status));
         }
 
         [Test]
@@ -401,6 +403,16 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 Console.WriteLine("Offering " + offering.ToString());
             }
             Assert.IsNotNull(offerings);
+        }
+
+        private static bool IsSuccess(int statusCode)
+        {
+            return statusCode >= 200 && statusCode < 300;
+        }
+
+        private static bool IsClientError(int statusCode)
+        {
+            return statusCode >= 400 && statusCode < 500;
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/PhoneNumbersClientLiveTests/StartPurchaseInvalidSearchId.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/PhoneNumbersClientLiveTests/StartPurchaseInvalidSearchId.json
@@ -8,32 +8,32 @@
         "Authorization": "Sanitized",
         "Content-Length": "30",
         "Content-Type": "application/json",
-        "traceparent": "00-96c3056355bbb4408471863138e00e2d-04ec9f20c2731846-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221207.1 (.NET Core 3.1.31; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "4e7919ae4d3710b0dd8570d41d9c624c",
+        "traceparent": "00-271f901f21983389289b6ca83d8f9a4f-e8c1a8642d91ad22-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20230310.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ef9c12a8de2a3addcfac2568850d3792",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 07 Dec 2022 21:33:58 GMT",
+        "x-ms-date": "Sat, 11 Mar 2023 01:02:13 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "searchId": "\u002BSanitized"
+        "searchId": "some-invalid-id"
       },
       "StatusCode": 404,
       "ResponseHeaders": {
-        "api-supported-versions": "2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01",
+        "api-supported-versions": "2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01, 2022-12-02-preview2",
         "Content-Type": "application/json",
-        "Date": "Wed, 07 Dec 2022 21:33:57 GMT",
-        "MS-CV": "9KTgslHaAkWEdlR527bG9g.0",
+        "Date": "Sat, 11 Mar 2023 01:02:13 GMT",
+        "MS-CV": "FGSEEDAi9Uq0o24mXzp1Ow.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0xgaRYwAAAAAYHhW6DLhMR6sXNruZCqMMTUVYMzFFREdFMDQxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0FdMLZAAAAAChWX2PykE1SIn0VgeNsXKfTEFYMzExMDAwMTA4MDE3ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "419ms"
+        "X-Processing-Time": "189ms"
       },
       "ResponseBody": {
         "error": {
           "code": "NotFound",
-          "message": "Input searchId Sanitized cannot be found.",
+          "message": "Input searchId some-invalid-id cannot be found.",
           "target": "searchid"
         }
       }
@@ -41,6 +41,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://smstestapp.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "479739574"
+    "RandomSeed": "1604679153"
   }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/PhoneNumbersClientLiveTests/StartPurchaseInvalidSearchIdAsync.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SessionRecords/PhoneNumbersClientLiveTests/StartPurchaseInvalidSearchIdAsync.json
@@ -8,32 +8,32 @@
         "Authorization": "Sanitized",
         "Content-Length": "30",
         "Content-Type": "application/json",
-        "traceparent": "00-082d1e3f1a8fb84eb950289d8ef68e78-7a7fdb3dfe5ff849-00",
-        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20221207.1 (.NET Core 3.1.31; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "64738d63983c3ded9a9ec1760d028023",
+        "traceparent": "00-31408d8415a7a8b8574a33ba0069f05f-8ec6c53cb8437669-00",
+        "User-Agent": "azsdk-net-Communication.PhoneNumbers/1.1.0-alpha.20230310.1 (.NET 6.0.14; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3dd0780e68cedcb2b6867e4d8262d81d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 07 Dec 2022 21:35:02 GMT",
+        "x-ms-date": "Sat, 11 Mar 2023 01:00:26 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "searchId": "\u002BSanitized"
+        "searchId": "some-invalid-id"
       },
       "StatusCode": 404,
       "ResponseHeaders": {
-        "api-supported-versions": "2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01",
+        "api-supported-versions": "2021-03-07, 2022-01-11-preview2, 2022-06-01-preview, 2022-12-01, 2022-12-02-preview2",
         "Content-Type": "application/json",
-        "Date": "Wed, 07 Dec 2022 21:35:02 GMT",
-        "MS-CV": "dQ0226OYC0O2sPbaWgThrw.0",
+        "Date": "Sat, 11 Mar 2023 01:00:26 GMT",
+        "MS-CV": "d108iCxc3kSl4LySPxMkuA.0",
         "Strict-Transport-Security": "max-age=2592000",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0BQeRYwAAAACrsR/H/nl0RqjSyHTkPzAHTUVYMzFFREdFMDQxOQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0qtILZAAAAAC/517h7H41SKURjqzZO2ykTEFYMzExMDAwMTA4MDIzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE",
-        "X-Processing-Time": "412ms"
+        "X-Processing-Time": "267ms"
       },
       "ResponseBody": {
         "error": {
           "code": "NotFound",
-          "message": "Input searchId Sanitized cannot be found.",
+          "message": "Input searchId some-invalid-id cannot be found.",
           "target": "searchid"
         }
       }
@@ -41,6 +41,6 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING": "endpoint=https://smstestapp.communication.azure.com/;accesskey=Kg==",
-    "RandomSeed": "1059727615"
+    "RandomSeed": "1982234997"
   }
 }


### PR DESCRIPTION
Due to a small backend change, tests that validate operations on unauthorized or invalid phone numbers now return status code 403, as opposed to 400 or 404 previously. To simplify the code of the test, the assertion now checks that the request has been rejected due to a client error, which is validated by checking if the status code falls under the 4xx bucket.

While it should be enough to validate that the operation itself fails, the check for client error was added to ensure that the request is indeed being rejected by the server instead of it failing due to another unrelated reason, which would usually be represented by a 5XX error.

A similar approach was followed to validate successful requests, instead of checking against a specific status code.