### PR TITLE
[Event Hubs Processor] Patch Release Prep

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -88,7 +88,7 @@
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.25" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.5.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.8.0" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.8.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.12.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.11.1" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.2.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the referenced version of the Event Hubs core package to prepare the processor package for a patch release.