### PR TITLE
[Event Hubs] Change stress references

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -14,7 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
+    <!--TEMP: Unblock release
+        <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
+    -->
+    <!-- TEMP --> <PackageReference Include="Azure.Messaging.EventHubs" /><!--END TEMP -->
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -17,7 +17,6 @@
     <!--TEMP: Unblock release
         <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
     -->
-    <!-- TEMP --> <PackageReference Include="Azure.Messaging.EventHubs" /><!--END TEMP -->
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary

The focus of these changes is to temporarily change the stress project reference to a package reference for the Event Hubs core package, so that the processor and stress project both hold the same reference.  I believe this is needed to resolve temporary restore conflicts.

# References and Resources

- [Build failures with restore](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2623155&view=results) _(Microsoft Internal)_