### PR TITLE
[Event Hubs] Restore stress references

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -14,9 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--TEMP: Unblock release
-        <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
-    -->
+    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary

The focus of these changes is to restore the project reference to the core Event Hubs project.