### PR TITLE
Changelog updates for 1.1.0-beta.8

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/CHANGELOG.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 1.1.0-beta.8 (Unreleased)
+## 1.1.0-beta.8 (2023-03-13)
 
 ### Features Added
 
+- Added `SizeInBytes` to `UploadBlobResult` to prevent the need to check stream length on a possibly non-seekable stream.
+
 ### Breaking Changes
 
-### Bugs Fixed
-
-### Other Changes
+- Renamed `OciBlobDescriptor` to `OciDescriptor`.
 
 ## 1.1.0-beta.7 (2023-03-07)
 


### PR DESCRIPTION
Azure.Core 1.29.0 is being deprecated and dependent libraries are being re-released.

Update CHANGELOG to reflect recent changes prior to release of next ACR beta.