### PR TITLE
Enable support for MessagePack

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -135,9 +135,9 @@
     <PackageReference Update="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0" />
     <PackageReference Update="MessagePack" Version="1.9.11" />
     <PackageReference Update="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="1.1.5" />
-    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.19.2" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.19.2" />
-    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.19.2" />
+    <PackageReference Update="Microsoft.Azure.SignalR" Version="1.21.2" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.21.2" />
+    <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.21.2" />
     <PackageReference Update="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.9.0" />
     <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.36" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.36" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.10.0 (2023-04-05)
+## 1.10.0 (2023-04-11)
 
 ### Features Added
 * Support MessagePack hub protocol for both persistent mode and transient mode.

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 1.10.0-beta.1 (Unreleased)
+## 1.10.0 (2023-04-05)
 
 ### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+* Support MessagePack hub protocol for both persistent mode and transient mode.
 
 ### Other Changes
+* Upgraded `Microsoft.Azure.SignalR`, `Microsoft.Azure.SignalR.Management`, `Microsoft.Azure.SignalR.Protocols` from 1.19.2 to 1.21.2
 
 ## 1.9.0 (2023-01-12)
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/api/Microsoft.Azure.WebJobs.Extensions.SignalRService.netstandard2.0.cs
@@ -237,6 +237,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         public SignalROptions() { }
         public Azure.Core.Serialization.ObjectSerializer JsonObjectSerializer { get { throw null; } set { } }
+        public Microsoft.AspNetCore.SignalR.Protocol.IHubProtocol MessagePackHubProtocol { get { throw null; } set { } }
         public System.Collections.Generic.IList<Microsoft.Azure.SignalR.ServiceEndpoint> ServiceEndpoints { get { throw null; } }
         public Microsoft.Azure.SignalR.Management.ServiceTransportType ServiceTransportType { get { throw null; } set { } }
         string Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter.Format() { throw null; }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/samples/Sample02_CustomizingJsonSerialization.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/samples/Sample02_CustomizingJsonSerialization.md
@@ -5,8 +5,8 @@ The messages sent to SignalR clients are serialized into JSON. By default, the J
 ## Use `System.Text.Json` library
 
 The following sample specifies `System.Text.Json` library as the JSON serialization library and also uses CamelCase as the property naming policy.
-```cs
-public class Startup : FunctionsStartup
+```C# Snippet:SystemTextJsonCustomization
+public class SystemTextJsonStartup : FunctionsStartup
 {
     public override void Configure(IFunctionsHostBuilder builder)
     {
@@ -22,8 +22,8 @@ public class Startup : FunctionsStartup
 ## Use `Newtonsoft.Json` library
 
 The following sample specifies `Newtonsoft.Json` library as the JSON serialization library and also uses CamelCase as the property naming policy.
-```cs
-public class Startup : FunctionsStartup
+```C# Snippet:NewtonsoftJsonCustomization
+public class NewtonsoftJsonStartup : FunctionsStartup
 {
     public override void Configure(IFunctionsHostBuilder builder)
     {
@@ -31,7 +31,8 @@ public class Startup : FunctionsStartup
             new JsonSerializerSettings()
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver()
-            }));
+            }
+        ));
     }
 }
 ```

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/samples/Sample03_IntegrationWithAppGateway.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/samples/Sample03_IntegrationWithAppGateway.md
@@ -28,8 +28,8 @@ Related docs:
 ## Option 3: Dependency injection (In-Process Model Runtime Only)
 This is the most flexible way for C# in-process model functions. Configure `SignalROptions.ServiceEndpoints` in your startup class as follows:
 
-```cs
-public class Startup : FunctionsStartup
+```C# Snippet:AppGatewayIntegration
+public class AppGatewayStartup : FunctionsStartup
 {
     public override void Configure(IFunctionsHostBuilder builder)
     {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/samples/Sample04_MessagePack.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/samples/Sample04_MessagePack.md
@@ -1,0 +1,40 @@
+# MessagePack Hub Protocol
+[MessagePack hub protocol](https://learn.microsoft.com/aspnet/core/signalr/messagepackhubprotocol?view=aspnetcore-7.0) is a built-in SignalR hub protocol which is faster and compacter than JSON hub protocol. You can enable MessagePack hub protocol in SignalR extensions to support MessagePack clients. MessagePack hub protocol works for both persistent mode and transient mode.
+
+> For transient mode, by default the service side converts JSON payload to MessagePack payload and it's the legacy way to support MessagePack. However, we recommend you to add a MessagePack hub protocol explicitly as the behavior of legacy way is not exactly the same as self-hosted SignalR.
+
+You have two options to enable MessagePack hub protocol.
+1. Update application settings
+2. Update .NET code
+
+# Option 1: Update application settings
+
+For your Azure functions app, add the following app setting to your Azure functions:
+```
+Azure__SignalR__HubProtocol__MessagePack__Enabled = true
+```
+
+If you run the app locally, you should add the setting to your `local.settings.json` file and replace the `__` with `:` in the key name.
+```json
+{
+    "Values": {
+        "Azure:SignalR:HubProtocol:MessagePack:Enabled": "true",
+    }
+}
+
+```
+
+# Option 2: Update .NET code
+
+Use the following code to enable MessagePack hub protocol:
+```C# Snippet:MessagePackCustomization
+public class MessagePackStartup : FunctionsStartup
+{
+    public override void Configure(IFunctionsHostBuilder builder)
+    {
+        builder.Services.Configure<SignalROptions>(o => o.MessagePackHubProtocol = new MessagePackHubProtocol());
+    }
+}
+```
+
+

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 serviceManagerBuilder.AddHubProtocol(_options.MessagePackHubProtocol);
             }
             // Allow isolated-process runtimes such as JS, C#-isolated to enable MessagePack hub protocol
-            else if (string.Equals(_configuration[Constants.AzureSignalRMessagePackHubProtocol], Constants.Enabled, StringComparison.InvariantCultureIgnoreCase))
+            else if (string.Equals(_configuration[Constants.AzureSignalRMessagePackHubProtocolEnabled], bool.TrueString, StringComparison.OrdinalIgnoreCase))
             {
                 serviceManagerBuilder.AddHubProtocol(new MessagePackHubProtocol());
             }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 serviceManagerBuilder.AddHubProtocol(_options.MessagePackHubProtocol);
             }
             // Allow isolated-process runtimes such as JS, C#-isolated to enable MessagePack hub protocol
-            else if (string.Equals(_configuration[Constants.AzureSignalRMessagePackHubProtocolEnabled], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            else if (bool.TryParse(_configuration[Constants.AzureSignalRMessagePackHubProtocolEnabled], out var messagePackEnabled) && messagePackEnabled)
             {
                 serviceManagerBuilder.AddHubProtocol(new MessagePackHubProtocol());
             }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceManagerStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.Azure;
@@ -57,6 +58,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 // Serves as a reload token provider only
                 .WithConfiguration(new EmptyConfiguration(_configuration))
                 .WithCallingAssembly();
+
+            if (_options.MessagePackHubProtocol != null)
+            {
+                serviceManagerBuilder.AddHubProtocol(_options.MessagePackHubProtocol);
+            }
+            // Allow isolated-process runtimes such as JS, C#-isolated to enable MessagePack hub protocol
+            else if (string.Equals(_configuration[Constants.AzureSignalRMessagePackHubProtocol], Constants.Enabled, StringComparison.InvariantCultureIgnoreCase))
+            {
+                serviceManagerBuilder.AddHubProtocol(new MessagePackHubProtocol());
+            }
+
             AddWorkingInfo(serviceManagerBuilder, _configuration);
             if (_router != null)
             {

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Constants.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Constants.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public const string AzureSignalREndpoints = "Azure:SignalR:Endpoints";
         public const string AzureSignalRHubProtocol = "Azure:SignalR:HubProtocol";
         public static string AzureSignalRNewtonsoftCamelCase = $"{AzureSignalRHubProtocol}:NewtonsoftJson:CamelCase";
+        public static string AzureSignalRMessagePackHubProtocol = $"{AzureSignalRHubProtocol}:MessagePack";
+        public const string Enabled = "enabled";
         public const string ServiceTransportTypeName = "AzureSignalRServiceTransportType";
         public const string AsrsHeaderPrefix = "X-ASRS-";
         public const string AsrsConnectionIdHeader = AsrsHeaderPrefix + "Connection-Id";

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Constants.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Constants.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public const string AzureSignalREndpoints = "Azure:SignalR:Endpoints";
         public const string AzureSignalRHubProtocol = "Azure:SignalR:HubProtocol";
         public static string AzureSignalRNewtonsoftCamelCase = $"{AzureSignalRHubProtocol}:NewtonsoftJson:CamelCase";
-        public static string AzureSignalRMessagePackHubProtocol = $"{AzureSignalRHubProtocol}:MessagePack";
-        public const string Enabled = "enabled";
+        public static string AzureSignalRMessagePackHubProtocolEnabled = $"{AzureSignalRHubProtocol}:MessagePack:Enabled";
         public const string ServiceTransportTypeName = "AzureSignalRServiceTransportType";
         public const string AsrsHeaderPrefix = "X-ASRS-";
         public const string AsrsConnectionIdHeader = AsrsHeaderPrefix + "Connection-Id";

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
-    <Version>1.10.0-beta.1</Version>
+    <Version>1.10.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.9.0</ApiCompatVersion>
     <SignAssembly>true</SignAssembly>

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalROptions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalROptions.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         {
             get => _messagePackHubProtocol; set
             {
-                if (value != null && value.Name.ToLowerInvariant() != "messagepack")
+                if (value != null && !string.Equals(value.Name, "messagepack", StringComparison.OrdinalIgnoreCase))
                 {
-                    throw new ArgumentException("Only protocol named \"messagepack\"(case-insensitive) is allowed");
+                    throw new ArgumentException("Only protocol named \"messagepack\"(case-insensitive) is allowed.");
                 }
                 _messagePackHubProtocol = value;
             }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalROptions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/SignalROptions.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Azure.Core.Serialization;
+using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.WebJobs.Hosting;
@@ -20,6 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     /// </remarks>
     public class SignalROptions : IOptionsFormatter
     {
+        private IHubProtocol _messagePackHubProtocol;
+
         /// <summary>
         /// Gets the list of SignalR service.
         /// </summary>
@@ -34,6 +38,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         /// Gets or sets the JSON object serializer.
         /// </summary>
         public ObjectSerializer JsonObjectSerializer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MessagePack hub <see cref="IHubProtocol"/>. Defaults to null and MessagePack hub protocol is not used.
+        /// </summary>
+        public IHubProtocol MessagePackHubProtocol
+        {
+            get => _messagePackHubProtocol; set
+            {
+                if (value != null && value.Name.ToLowerInvariant() != "messagepack")
+                {
+                    throw new ArgumentException("Only protocol named \"messagepack\"(case-insensitive) is allowed");
+                }
+                _messagePackHubProtocol = value;
+            }
+        }
 
         /// <summary>
         /// Returns a string representation of this <see cref="SignalROptions"/> instance.

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/ServiceManagerStoreTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/ServiceManagerStoreTests.cs
@@ -146,7 +146,7 @@ namespace SignalRServiceExtension.Tests
         public async void TestAddMessagePackHubProtocolViaConfiguration(ServiceTransportType serviceTransportType)
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
-            configuration["Azure:SignalR:HubProtocol:MessagePack"] = "enabled";
+            configuration["Azure:SignalR:HubProtocol:MessagePack:Enabled"] = "true";
             configuration["AzureSignalRConnectionString"] = FakeEndpointUtils.GetFakeConnectionString();
             configuration["AzureSignalRServiceTransportType"] = serviceTransportType.ToString();
             var managerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, Options.Create(new SignalROptions()));

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/ServiceManagerStoreTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/ServiceManagerStoreTests.cs
@@ -158,5 +158,39 @@ namespace SignalRServiceExtension.Tests
             Assert.Contains(hubProtocolResolver.AllProtocols, h => h.Name.Equals("messagepack", System.StringComparison.OrdinalIgnoreCase));
             Assert.Contains(hubProtocolResolver.AllProtocols, h => h.Name.Equals("json", System.StringComparison.OrdinalIgnoreCase));
         }
+
+        [Fact]
+        public async void TestTransientModeDefaultHubProtocl()
+        {
+            var emptyConfiguration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var signalROptions = new SignalROptions
+            {
+                ServiceTransportType = ServiceTransportType.Transient,
+            };
+            signalROptions.ServiceEndpoints.Add(FakeEndpointUtils.GetFakeEndpoint(1).Single());
+            var managerStore = new ServiceManagerStore(emptyConfiguration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, Options.Create(signalROptions));
+            var hubContextStore = managerStore.GetOrAddByConnectionStringKey("doesn't matter");
+            var hubContext = await hubContextStore.GetAsync("hub") as ServiceHubContextImpl;
+            var serviceProvider = hubContext.ServiceProvider;
+            var hubProtocolResolver = serviceProvider.GetRequiredService<IHubProtocolResolver>();
+            Assert.IsType<JsonObjectSerializerHubProtocol>(hubProtocolResolver.AllProtocols.Single());
+        }
+
+        [Fact]
+        public async void TestHubProtocolDefaultSettings()
+        {
+            var emptyConfiguration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var signalROptions = new SignalROptions
+            {
+                ServiceTransportType = ServiceTransportType.Persistent,
+            };
+            signalROptions.ServiceEndpoints.Add(FakeEndpointUtils.GetFakeEndpoint(1).Single());
+            var managerStore = new ServiceManagerStore(emptyConfiguration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, Options.Create(signalROptions));
+            var hubContextStore = managerStore.GetOrAddByConnectionStringKey("doesn't matter");
+            var hubContext = await hubContextStore.GetAsync("hub") as ServiceHubContextImpl;
+            var serviceProvider = hubContext.ServiceProvider;
+            var hubProtocolResolver = serviceProvider.GetRequiredService<IHubProtocolResolver>();
+            Assert.IsType<JsonHubProtocol>(hubProtocolResolver.AllProtocols.Single());
+        }
     }
 }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/AppGatewayIntegration.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/AppGatewayIntegration.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Azure.Identity;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.Samples
+{
+    public class AppGatewayIntegration
+    {
+        #region Snippet:AppGatewayIntegration
+        public class AppGatewayStartup : FunctionsStartup
+        {
+            public override void Configure(IFunctionsHostBuilder builder)
+            {
+                builder.Services.Configure<SignalROptions>(o => o.ServiceEndpoints.Add(
+                    new ServiceEndpoint(new Uri(""),
+                                            new DefaultAzureCredential(),
+                                            serverEndpoint: new Uri("https://<url-to-app-gateway>"),
+                                            clientEndpoint: new Uri("https://<url-to-app-gateway>"))));
+            }
+        }
+        #endregion
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/AppGatewayIntegration.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/AppGatewayIntegration.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using Azure.Identity;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Azure.SignalR;

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/JsonCustomization.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/JsonCustomization.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Azure.Core.Serialization;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.Samples
+{
+    public static class JsonCustomization
+    {
+        #region Snippet:SystemTextJsonCustomization
+        public class SystemTextJsonStartup : FunctionsStartup
+        {
+            public override void Configure(IFunctionsHostBuilder builder)
+            {
+                builder.Services.Configure<SignalROptions>(o => o.JsonObjectSerializer = new JsonObjectSerializer(
+                    new JsonSerializerOptions()
+                    {
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                    }));
+            }
+        }
+        #endregion
+
+        #region Snippet:NewtonsoftJsonCustomization
+        public class NewtonsoftJsonStartup : FunctionsStartup
+        {
+            public override void Configure(IFunctionsHostBuilder builder)
+            {
+                builder.Services.Configure<SignalROptions>(o => o.JsonObjectSerializer = new NewtonsoftJsonObjectSerializer(
+                    new JsonSerializerSettings()
+                    {
+                        ContractResolver = new CamelCasePropertyNamesContractResolver()
+                    }
+                ));
+            }
+        }
+        #endregion
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/MessagePack.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/MessagePack.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.SignalR.Protocol;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/MessagePack.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Samples/MessagePack.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.Samples
+{
+    public class MessagePack
+    {
+        #region Snippet:MessagePackCustomization
+        public class MessagePackStartup : FunctionsStartup
+        {
+            public override void Configure(IFunctionsHostBuilder builder)
+            {
+                builder.Services.Configure<SignalROptions>(o => o.MessagePackHubProtocol = new MessagePackHubProtocol());
+            }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

Enable support for MessagePack hub protocol.

Usage:
* Option 1: Enable MessagePack in the `Startup` class:
    ```cs
        public override void Configure(IFunctionsHostBuilder builder)
	    {
	        builder.Services.Configure<SignalROptions>(o =>
	        {
	            // o.ServiceTransportType = ServiceTransportType.Persistent;
	            o.MessagePackHubProtocol = new MessagePackHubProtocol();
	        });
	    }
    ```
* Option 2: Add a setting in the application settings
    ```
    Azure:SignalR:HubProtocol:MessagePack:Enabled=true
    ```
---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
