### PR TITLE
Fix bad BinaryData conversion in Communication Email attachments

### DIFF
--- a/sdk/communication/Azure.Communication.Email/src/Models/EmailAttachment.cs
+++ b/sdk/communication/Azure.Communication.Email/src/Models/EmailAttachment.cs
@@ -41,7 +41,7 @@ namespace Azure.Communication.Email
         {
             get
             {
-                string valueToReturn = Convert.ToBase64String(Encoding.UTF8.GetBytes(Content.ToString()));
+                string valueToReturn = Convert.ToBase64String(Content.ToArray());
                 if (string.IsNullOrWhiteSpace(valueToReturn))
                 {
                     throw new ArgumentException(ErrorMessages.InvalidAttachmentContent);


### PR DESCRIPTION
BinaryData already has a .ToArray() of byte, and Convert.ToBase64() already accept it.  The conversion to and from string is not needed and mangles binary attachments like images. This happens because the conversion to utf8 is not round-trip safe when there are invalid characters pairs.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
