### PR TITLE
Set test in parallel to false for Service Bus tests

### DIFF
--- a/sdk/servicebus/service.projects
+++ b/sdk/servicebus/service.projects
@@ -21,6 +21,9 @@
   <ItemGroup Condition="'$(SDKType)' == 'client'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Messaging.*\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.WebJobs.Extensions.ServiceBus\**\*.csproj" />
+    <ProjectReference Update="$(MSBuildThisFileDirectory)Azure.Messaging.*\tests\*.csproj">
+      <TestInParallel>false</TestInParallel>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(SDKType)' == 'mgmtclient'">


### PR DESCRIPTION
This should help avoid flakiness in tests that depend on a singleton diagnostic listener.