### PR TITLE
[Text Analytics] Mitigate transient test failures due to "InternalServerError" with 200 OK

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RetryOnErrorAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RetryOnErrorAttribute.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+
+namespace Azure.Core.TestFramework
+{
+    /// <summary>
+    /// Attribute used to specify that a test must be retried in the specific case of a known error. If the test
+    /// continues to fail due to this particular issue after reaching the specified limit of tries, the test result is
+    /// marked as inconclusive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class RetryOnErrorAttribute : NUnitAttribute, IRepeatTest
+    {
+        private readonly int _tryCount;
+
+        private readonly Func<TestExecutionContext, bool> _shouldRetry;
+
+        /// <summary>
+        /// Initializes a <see cref="RetryOnErrorAttribute"/> instance.
+        /// </summary>
+        /// <param name="tryCount">The number of times that the test can be executed.</param>
+        /// <param name="shouldRetry">The function that determines whether the test should be retried.</param>
+        public RetryOnErrorAttribute(int tryCount, Func<TestExecutionContext, bool> shouldRetry)
+        {
+            _tryCount = tryCount;
+            _shouldRetry = shouldRetry;
+        }
+
+        #region IRepeatTest Members
+
+        /// <summary>
+        /// Wrap a command and return the result.
+        /// </summary>
+        /// <param name="command">The command to wrap.</param>
+        /// <returns>The wrapped command.</returns>
+        public TestCommand Wrap(TestCommand command)
+        {
+            return new RetryOnErrorCommand(command, _tryCount, _shouldRetry);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The test command for the <see cref="RetryOnErrorAttribute"/>.
+        /// </summary>
+        public class RetryOnErrorCommand : DelegatingTestCommand
+        {
+            private readonly int _tryCount;
+
+            private Func<TestExecutionContext, bool> _shouldRetry;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="RetryOnErrorCommand"/> class.
+            /// </summary>
+            public RetryOnErrorCommand(TestCommand innerCommand, int tryCount, Func<TestExecutionContext, bool> shouldRetry)
+                : base(innerCommand)
+            {
+                _tryCount = tryCount;
+                _shouldRetry = shouldRetry;
+            }
+
+            /// <summary>
+            /// Runs the test, saving a <see cref="TestResult"/> in the supplied <see cref="TestExecutionContext"/>.
+            /// </summary>
+            public override TestResult Execute(TestExecutionContext context)
+            {
+                int count = _tryCount;
+
+                while (count-- > 0)
+                {
+                    try
+                    {
+                        context.CurrentResult = innerCommand.Execute(context);
+                    }
+                    catch (Exception ex)
+                    {
+                        context.CurrentResult ??= context.CurrentTest.MakeTestResult();
+                        context.CurrentResult.RecordException(ex);
+                    }
+
+                    if (!ShouldRetry(context))
+                    {
+                        break;
+                    }
+
+                    if (count > 0)
+                    {
+                        // Clear result for retry.
+                        context.CurrentResult = context.CurrentTest.MakeTestResult();
+                        context.CurrentRepeatCount++;
+                    }
+                    else
+                    {
+                        context.CurrentResult = context.CurrentTest.MakeTestResult();
+                        context.CurrentResult.SetResult(ResultState.Inconclusive);
+                    }
+                }
+
+                return context.CurrentResult;
+            }
+
+            private bool ShouldRetry(TestExecutionContext context)
+            {
+                return
+                    context.CurrentResult.ResultState.Status == TestStatus.Failed
+                    && context.CurrentResult.ResultState.Label == "Error"
+                    && _shouldRetry(context);
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core.TestFramework/src/RetryOnErrorAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RetryOnErrorAttribute.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.TestFramework
     /// marked as inconclusive.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-    public class RetryOnErrorAttribute : NUnitAttribute, IRepeatTest
+    public abstract class RetryOnErrorAttribute : NUnitAttribute, IRepeatTest
     {
         private readonly int _tryCount;
 
@@ -26,7 +26,7 @@ namespace Azure.Core.TestFramework
         /// </summary>
         /// <param name="tryCount">The number of times that the test can be executed.</param>
         /// <param name="shouldRetry">The function that determines whether the test should be retried.</param>
-        public RetryOnErrorAttribute(int tryCount, Func<TestExecutionContext, bool> shouldRetry)
+        protected RetryOnErrorAttribute(int tryCount, Func<TestExecutionContext, bool> shouldRetry)
         {
             _tryCount = tryCount;
             _shouldRetry = shouldRetry;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractSummaryTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractSummaryTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -76,6 +77,7 @@ namespace Azure.AI.TextAnalytics.Tests
         private const int AbstractiveSummarizationSentenceCount = 3;
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AbstractSummaryWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);
@@ -93,6 +95,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AbstractSummaryBatchWithErrorTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -118,6 +121,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AbstractSummaryBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -135,6 +139,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AbstractSummaryBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -158,6 +163,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AbstractSummaryBatchTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -175,6 +181,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AbstractSummaryBatchWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -198,6 +205,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/32614")]
         public async Task AbstractSummaryBatchConvenienceWithAutoDetectedLanguageTest()
         {
@@ -216,6 +224,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/32614")]
         public async Task AnalyzeOperationAbstractSummaryWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeHealthcareEntitiesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -60,6 +61,7 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);
@@ -79,6 +81,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -142,6 +145,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeHealthcareEntitiesWithConfidenceScoreTest()
         {
@@ -168,6 +172,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesTestWithAssertions()
         {
             TextAnalyticsClient client = GetClient();
@@ -233,6 +238,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesWithLanguageTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -249,6 +255,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesBatchWithErrorTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -279,6 +286,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -295,6 +303,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -319,6 +328,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesBatchTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -342,6 +352,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesBatchWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -373,6 +384,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task AnalyzeHealthcareEntitiesBatchWithNameTest()
         {
@@ -401,6 +413,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V3_1)]
         public void AnalyzeHealthcareEntitiesBatchWithNameThrows()
         {
@@ -417,6 +430,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeHealthcareEntitiesPagination()
         {
             TextAnalyticsClient client = GetClient();
@@ -454,6 +468,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeHealthcareEntitiesBatchWithFhirVersionTest()
         {
@@ -481,6 +496,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public void AnalyzeHealthcareEntitiesBatchWithFhirVersionThrows()
         {
@@ -497,6 +513,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public void AnalyzeHealthcareEntitiesBatchWithDocumentTypeThrows()
         {
@@ -513,6 +530,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeHealthcareEntitiesBatchConvenienceWithAutoDetectedLanguageTest()
         {
@@ -529,6 +547,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationAnalyzeHealthcareEntitiesWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -37,6 +38,7 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);
@@ -60,6 +62,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task AnalyzeOperationTest()
         {
@@ -117,6 +120,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithLanguageTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -170,6 +174,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithMultipleActions()
         {
             TextAnalyticsClient client = GetClient();
@@ -303,6 +308,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [Ignore("issue: results in an internal server error | bug link: https://dev.azure.com/msazure/Cognitive%20Services/_workitems/edit/12413250")]
         public async Task AnalyzeOperationWithMultipleActionsOfSameType()
@@ -423,6 +429,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithPagination()
         {
             TextAnalyticsClient client = GetClient();
@@ -477,6 +484,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public void AnalyzeOperationWithErrorTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -503,6 +511,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithErrorsInDocumentTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -538,6 +547,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithPHIDomain()
         {
             TextAnalyticsClient client = GetClient();
@@ -574,6 +584,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithPiiCategories()
         {
             TextAnalyticsClient client = GetClient();
@@ -610,6 +621,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -664,6 +676,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationAllActionsAndDisableServiceLogs()
         {
             TextAnalyticsClient client = GetClient();
@@ -707,6 +720,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationAnalyzeSentimentWithOpinionMining()
         {
             TextAnalyticsClient client = GetClient();
@@ -740,6 +754,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public async Task AnalyzeOperationAnalyzeHealthcareEntities()
         {
@@ -779,6 +794,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationAnalyzeHealthcareEntitiesWithFhirVersion()
         {
@@ -817,6 +833,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationExtractSummary()
         {
@@ -849,6 +866,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationAbstractSummary()
         {
@@ -889,6 +907,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V3_1)]
         public void AnalyzeOperationAnalyzeHealthcareEntitiesActionNotSupported()
         {
@@ -909,6 +928,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V3_1)]
         public void AnalyzeOperationMultiLabelClassifyActionNotSupported()
         {
@@ -929,6 +949,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V3_1)]
         public void AnalyzeOperationRecognizeCustomEntitiesActionNotSupported()
         {
@@ -949,6 +970,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V3_1)]
         public void AnalyzeOperationSingleLabelClassifyActionNotSupported()
         {
@@ -969,6 +991,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         public void AnalyzeOperationExtractSummaryActionNotSupported()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -437,8 +438,9 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(exceptionMessage, ex.Message);
         }
 
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [RecordedTest]
+        [RetryOnInternalServerError]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [Ignore("LRO not implemented")]
         public async Task AnalyzeSentimentWithMultipleActions()
         {
@@ -530,6 +532,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationAnalyzeSentimentWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractKeyPhrasesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -197,8 +198,9 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(exceptionMessage, ex.Message);
         }
 
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [RecordedTest]
+        [RetryOnInternalServerError]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [Ignore("LRO not implemented")]
         public async Task ExtractKeyPhrasesWithMultipleActions()
         {
@@ -257,6 +259,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationExtractKeyPhrasesWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractSummaryTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractSummaryTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -78,6 +79,7 @@ namespace Azure.AI.TextAnalytics.Tests
         private const int ExtractSummaryMaxSentenceCount = 5;
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true);
@@ -95,6 +97,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryBatchWithRankOrderTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -118,6 +121,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryBatchWithErrorTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -143,6 +147,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -160,6 +165,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -183,6 +189,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryBatchTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -200,6 +207,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryBatchWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -223,6 +231,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task ExtractSummaryBatchConvenienceWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient();
@@ -240,6 +249,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationExtractSummaryWithAutoDetectedLanguageTest()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/RetryOnInternalServerErrorAttribute.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/RetryOnInternalServerErrorAttribute.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+
+namespace Azure.AI.TextAnalytics.Tests.Infrastructure
+{
+    /// <summary>
+    /// Attribute used to specify that a test must be retried in the specific case of a known transient issue where the
+    /// server returns a successful 200 OK response status but reports an internal server error in the response body
+    /// for one or more text analysis tasks. If the test continues to fail due to this particular issue after reaching
+    /// the retry limit, the test result is marked as inconclusive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class RetryOnInternalServerErrorAttribute : NUnitAttribute, IRepeatTest
+    {
+        /// <summary>
+        /// The maximum number of times that the test will be retried.
+        /// </summary>
+        internal const int TryCount = 3;
+
+        #region IRepeatTest Members
+
+        /// <summary>
+        /// Wrap a command and return the result.
+        /// </summary>
+        public TestCommand Wrap(TestCommand command)
+        {
+            return new RetryOnInternalServerErrorCommand(command, TryCount);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The test command for the <see cref="RetryOnInternalServerErrorAttribute"/>.
+        /// </summary>
+        public class RetryOnInternalServerErrorCommand : DelegatingTestCommand
+        {
+            private readonly int _tryCount;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="RetryOnInternalServerErrorCommand"/> class.
+            /// </summary>
+            public RetryOnInternalServerErrorCommand(TestCommand innerCommand, int tryCount)
+                : base(innerCommand)
+            {
+                _tryCount = tryCount;
+            }
+
+            /// <summary>
+            /// Runs the test, saving a  <see cref="TestResult"/> in the supplied <see cref="TestExecutionContext"/>.
+            /// </summary>
+            public override TestResult Execute(TestExecutionContext context)
+            {
+                int count = _tryCount;
+
+                while (count-- > 0)
+                {
+                    try
+                    {
+                        context.CurrentResult = innerCommand.Execute(context);
+                    }
+                    catch (Exception ex)
+                    {
+                        context.CurrentResult ??= context.CurrentTest.MakeTestResult();
+                        context.CurrentResult.RecordException(ex);
+                    }
+
+                    if (!ShouldRetry(context))
+                        break;
+
+                    if (count > 0)
+                    {
+                        // Clear result for retry.
+                        context.CurrentResult = context.CurrentTest.MakeTestResult();
+                        context.CurrentRepeatCount++;
+                    }
+                    else
+                    {
+                        context.CurrentResult = context.CurrentTest.MakeTestResult();
+                        context.CurrentResult.SetResult(ResultState.Inconclusive);
+                    }
+                }
+
+                return context.CurrentResult;
+            }
+
+            /// <summary>
+            /// Indicates whether the encountered exception corresponds to the issue in question.
+            /// </summary>
+            private bool ShouldRetry(TestExecutionContext context)
+            {
+                return
+                    context.CurrentResult.ResultState.Status == TestStatus.Failed
+                    && context.CurrentResult.ResultState.Label == "Error"
+                    && context.CurrentResult.Message.Contains("Azure.RequestFailedException")
+                    && context.CurrentResult.Message.Contains("Status: 200 (OK)")
+                    && context.CurrentResult.Message.Contains("ErrorCode: InternalServerError");
+            }
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/RetryOnInternalServerErrorAttribute.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/RetryOnInternalServerErrorAttribute.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using NUnit.Framework;
-using NUnit.Framework.Interfaces;
+using Azure.Core.TestFramework;
 using NUnit.Framework.Internal;
-using NUnit.Framework.Internal.Commands;
 
 namespace Azure.AI.TextAnalytics.Tests.Infrastructure
 {
@@ -13,94 +10,26 @@ namespace Azure.AI.TextAnalytics.Tests.Infrastructure
     /// Attribute used to specify that a test must be retried in the specific case of a known transient issue where the
     /// server returns a successful 200 OK response status but reports an internal server error in the response body
     /// for one or more text analysis tasks. If the test continues to fail due to this particular issue after reaching
-    /// the retry limit, the test result is marked as inconclusive.
+    /// the limit of tries, the test result is marked as inconclusive.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-    public class RetryOnInternalServerErrorAttribute : NUnitAttribute, IRepeatTest
+    public class RetryOnInternalServerErrorAttribute : RetryOnErrorAttribute
     {
-        /// <summary>
-        /// The maximum number of times that the test will be retried.
-        /// </summary>
         internal const int TryCount = 3;
 
-        #region IRepeatTest Members
-
-        /// <summary>
-        /// Wrap a command and return the result.
-        /// </summary>
-        public TestCommand Wrap(TestCommand command)
+        public RetryOnInternalServerErrorAttribute()
+            : base(TryCount, ShouldRetry)
         {
-            return new RetryOnInternalServerErrorCommand(command, TryCount);
         }
 
-        #endregion
-
         /// <summary>
-        /// The test command for the <see cref="RetryOnInternalServerErrorAttribute"/>.
+        /// Indicates whether the encountered exception corresponds to the issue in question.
         /// </summary>
-        public class RetryOnInternalServerErrorCommand : DelegatingTestCommand
+        private static bool ShouldRetry(TestExecutionContext context)
         {
-            private readonly int _tryCount;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="RetryOnInternalServerErrorCommand"/> class.
-            /// </summary>
-            public RetryOnInternalServerErrorCommand(TestCommand innerCommand, int tryCount)
-                : base(innerCommand)
-            {
-                _tryCount = tryCount;
-            }
-
-            /// <summary>
-            /// Runs the test, saving a  <see cref="TestResult"/> in the supplied <see cref="TestExecutionContext"/>.
-            /// </summary>
-            public override TestResult Execute(TestExecutionContext context)
-            {
-                int count = _tryCount;
-
-                while (count-- > 0)
-                {
-                    try
-                    {
-                        context.CurrentResult = innerCommand.Execute(context);
-                    }
-                    catch (Exception ex)
-                    {
-                        context.CurrentResult ??= context.CurrentTest.MakeTestResult();
-                        context.CurrentResult.RecordException(ex);
-                    }
-
-                    if (!ShouldRetry(context))
-                        break;
-
-                    if (count > 0)
-                    {
-                        // Clear result for retry.
-                        context.CurrentResult = context.CurrentTest.MakeTestResult();
-                        context.CurrentRepeatCount++;
-                    }
-                    else
-                    {
-                        context.CurrentResult = context.CurrentTest.MakeTestResult();
-                        context.CurrentResult.SetResult(ResultState.Inconclusive);
-                    }
-                }
-
-                return context.CurrentResult;
-            }
-
-            /// <summary>
-            /// Indicates whether the encountered exception corresponds to the issue in question.
-            /// </summary>
-            private bool ShouldRetry(TestExecutionContext context)
-            {
-                return
-                    context.CurrentResult.ResultState.Status == TestStatus.Failed
-                    && context.CurrentResult.ResultState.Label == "Error"
-                    && context.CurrentResult.Message.Contains("Azure.RequestFailedException")
-                    && context.CurrentResult.Message.Contains("Status: 200 (OK)")
-                    && context.CurrentResult.Message.Contains("ErrorCode: InternalServerError");
-            }
+            return
+                context.CurrentResult.Message.Contains("Azure.RequestFailedException")
+                && context.CurrentResult.Message.Contains("Status: 200 (OK)")
+                && context.CurrentResult.Message.Contains("ErrorCode: InternalServerError");
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MultiLabelClassifyTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/MultiLabelClassifyTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -43,6 +44,7 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task MultiLabelClassifyWithDisableServiceLogs()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -67,6 +69,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task MultiLabelClassifyBatchWithErrorTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -102,6 +105,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task MultiLabelClassifyBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -129,6 +133,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task MultiLabelClassifyBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -161,6 +166,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task MultiLabelClassifyBatchTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -188,6 +194,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task MultiLabelClassifyBatchWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -220,6 +227,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [Ignore("Issue https://github.com/Azure/azure-sdk-for-net/issues/25152")]
         public async Task MultiLabelClassifyWithMultipleActions()
         {
@@ -258,6 +266,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task StartMultiLabelClassify()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -272,6 +281,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task StartMultiLabelClassifyWithName()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -290,6 +300,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task MultiLabelClassifyBatchConvenienceWithAutoDetectedLanguageTest()
         {
@@ -308,6 +319,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationMultiLabelClassifyWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/OperationLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/OperationLiveTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -19,6 +20,7 @@ namespace Azure.AI.TextAnalytics.Tests
         #region Analyze
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationCanPollFromNewObject()
         {
             TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);
@@ -48,6 +50,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task AnalyzeOperationConvenienceCanPollFromNewObject()
         {
             TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);
@@ -75,6 +78,7 @@ namespace Azure.AI.TextAnalytics.Tests
         #region Healthcare
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task HealthcareOperationCanPollFromNewObject()
         {
             TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);
@@ -99,6 +103,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task HealthcareOperationConvenienceCanPollFromNewObject()
         {
             TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeCustomEntitiesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -71,6 +72,7 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task RecognizeCustomEntitiesWithAADTest()
         {
             TextAnalyticsClient client = GetClient(useTokenCredential: true, useStaticResource: true);
@@ -95,6 +97,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task RecognizeCustomEntitiesTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -119,6 +122,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task RecognizeCustomEntitiesWithLanguageTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -148,6 +152,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task RecognizeCustomEntitiesBatchWithErrorTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -183,6 +188,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task RecognizeCustomEntitiesBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -206,6 +212,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task RecognizeCustomEntitiesBatchTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -234,6 +241,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public void RecognizeCustomEntitiesBatchWithNullIdTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -252,6 +260,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [Ignore("Issue https://github.com/Azure/azure-sdk-for-net/issues/25152")]
         public async Task RecognizeCustomEntitiesWithMultipleActions()
         {
@@ -290,6 +299,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task StartRecognizeCustomEntities()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -311,6 +321,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task StartRecognizeCustomEntitiesWithName()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -336,6 +347,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task RecognizeCustomEntitiesBatchConvenienceWithAutoDetectedLanguageTest()
         {
@@ -354,6 +366,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationRecognizeCustomEntitiesWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -229,8 +230,9 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(exceptionMessage, ex.Message);
         }
 
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [RecordedTest]
+        [RetryOnInternalServerError]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [Ignore("LRO not implemented")]
         public async Task RecognizeEntitiesWithMultipleActions()
         {
@@ -464,6 +466,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationRecognizeEntitiesWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -211,8 +212,9 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(exceptionMessage, ex.Message);
         }
 
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [RecordedTest]
+        [RetryOnInternalServerError]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [Ignore("LRO not implemented")]
         public async Task RecognizeLinkedEntitiesWithMultipleActions()
         {
@@ -272,6 +274,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationRecognizeLinkedEntitiesWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -233,8 +234,9 @@ namespace Azure.AI.TextAnalytics.Tests
             ValidateBatchDocumentsResult(results, expectedOutput);
         }
 
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [RecordedTest]
+        [RetryOnInternalServerError]
+        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
         [Ignore("LRO not implemented")]
         public async Task RecognizePiiEntitiesWithMultipleActions()
         {
@@ -272,6 +274,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationRecognizePiiEntitiesWithAutoDetectedLanguageTest()
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RetryOnInternalServerErrorAttributeTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RetryOnInternalServerErrorAttributeTests.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
+using Moq;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+
+namespace Azure.AI.TextAnalytics.Tests
+{
+    public class RetryOnInternalServerErrorAttributeTests
+    {
+        private const string ExceptionMessage =
+            "Failed to process task after several retry"
+            + "\r\nStatus: 200 (OK)"
+            + "\r\nErrorCode: InternalServerError";
+
+        [Test]
+        public void PassingTestIsNotRetried()
+        {
+            FakeTest test = new();
+            TestExecutionContext context = new() { CurrentTest = test };
+            Mock<TestCommand> mockTestCommand = new(test);
+            Mock<TestResult> mockResult = new(test);
+
+            mockResult
+                .Setup(res => res.PassCount)
+                .Returns(1);
+
+            mockTestCommand
+                .Setup(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()))
+                .Returns(mockResult.Object);
+
+            RetryOnInternalServerErrorAttribute retryAttribute = new();
+            retryAttribute.Wrap(mockTestCommand.Object).Execute(context);
+
+            mockTestCommand
+                .Verify(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()), Times.Once);
+        }
+
+        [Test]
+        public void FailingTestWithUnexpectedMessageIsNotRetried()
+        {
+            const string differentMessage =
+                "A different error occurred"
+                + "\r\nStatus: 400 (Bad Request)"
+                + "\r\nErrorCode: BadRequest";
+
+            RequestFailedException exception = new(400, differentMessage, "BadRequest", null);
+            FakeTest test = new();
+            TestExecutionContext context = new() { CurrentTest = test };
+            Mock<TestCommand> mockTestCommand = new(test);
+
+            mockTestCommand
+                .Setup(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()))
+                .Throws(exception);
+
+            RetryOnInternalServerErrorAttribute retryAttribute = new();
+            retryAttribute.Wrap(mockTestCommand.Object).Execute(context);
+
+            mockTestCommand
+                .Verify(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()), Times.Once);
+        }
+
+        [Test]
+        public void FailingTestIsRetried()
+        {
+            RequestFailedException exception = new(200, ExceptionMessage, "InternalServerError", null);
+            FakeTest test = new();
+            TestExecutionContext context = new() { CurrentTest = test };
+            Mock<TestCommand> mockTestCommand = new(test);
+            Mock<TestResult> mockTestResult = new(test);
+
+            mockTestResult
+                .Setup(res => res.PassCount)
+                .Returns(1);
+
+            mockTestCommand
+                .SetupSequence(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()))
+                .Throws(exception)
+                .Returns(mockTestResult.Object);
+
+            RetryOnInternalServerErrorAttribute retryAttribute = new();
+            retryAttribute.Wrap(mockTestCommand.Object).Execute(context);
+
+            mockTestCommand
+                .Verify(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public void FailingTestObeysRetryLimits()
+        {
+            RequestFailedException exception = new(200, ExceptionMessage, "InternalServerError", null);
+            FakeTest test = new();
+            TestExecutionContext context = new() { CurrentTest = test };
+            Mock<TestCommand> mockTestCommand = new(test);
+
+            mockTestCommand
+                .Setup(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()))
+                .Throws(exception);
+
+            RetryOnInternalServerErrorAttribute retryAttribute = new();
+            retryAttribute.Wrap(mockTestCommand.Object).Execute(context);
+
+            mockTestCommand
+                .Verify(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()), Times.Exactly(RetryOnInternalServerErrorAttribute.TryCount));
+        }
+
+        [Test]
+        public void FailingTestIsInconclusiveWhenRetriesExhausted()
+        {
+            RequestFailedException exception = new(200, ExceptionMessage, "InternalServerError", null);
+            FakeTest test = new();
+            TestExecutionContext context = new() { CurrentTest = test };
+            Mock<TestCommand> mockTestCommand = new(test);
+
+            mockTestCommand
+                .Setup(cmd => cmd.Execute(It.IsAny<TestExecutionContext>()))
+                .Throws(exception);
+
+            RetryOnInternalServerErrorAttribute retryAttribute = new();
+            var result = retryAttribute.Wrap(mockTestCommand.Object).Execute(context);
+
+            Assert.That(result.ResultState, Is.EqualTo(ResultState.Inconclusive), "The result should be inconclusive.");
+        }
+
+        public class FakeTest : Test
+        {
+            public FakeTest() : base("Fake")
+            {
+            }
+
+            public override object[] Arguments { get; }
+            public override string XmlElementName { get; }
+            public override bool HasChildren { get; }
+            public override IList<ITest> Tests { get; }
+            public override TNode AddToXml(TNode parentNode, bool recursive) => throw new System.NotImplementedException();
+            public override TestResult MakeTestResult() => new Mock<TestResult>(this).Object;
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SingleLabelClassifyTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SingleLabelClassifyTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.AI.TextAnalytics.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -43,6 +44,7 @@ namespace Azure.AI.TextAnalytics.Tests
         };
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task SingleLabelClassifyWithDisableServiceLogs()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -67,6 +69,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task SingleLabelClassifyBatchWithErrorTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -102,6 +105,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task SingleLabelClassifyBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -129,6 +133,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task SingleLabelClassifyBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -161,6 +166,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task SingleLabelClassifyBatchTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -188,6 +194,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task SingleLabelClassifyBatchWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -220,6 +227,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [Ignore("Issue https://github.com/Azure/azure-sdk-for-net/issues/25152")]
         public async Task SingleLabelClassifyWithMultipleActions()
         {
@@ -257,6 +265,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task StartSingleLabelClassify()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -271,6 +280,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         public async Task StartSingleLabelClassifyWithName()
         {
             TextAnalyticsClient client = GetClient(useStaticResource: true);
@@ -289,6 +299,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task SingleLabelClassifyBatchConvenienceWithAutoDetectedLanguageTest()
         {
@@ -307,6 +318,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [RecordedTest]
+        [RetryOnInternalServerError]
         [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationSingleLabelClassifyWithAutoDetectedLanguageTest()
         {


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-sdk-for-net/issues/34970

I'm adding a custom `NUnitAttribute` that I'm calling `RetryOnInternalServerErrorAttribute` and which is basically a simple modification of the [`RetryAttribute`](https://github.com/nunit/nunit/blob/30e1255feb2c7108e6b7b168126360ac3689d4bb/src/NUnitFramework/framework/Attributes/RetryAttribute.cs) in the NUnit framework. Its purpose is to specify that a test must be retried in the specific case of a known transient issue where the server returns a successful 200 OK response status but reports an internal server error in the response body for one or more text analysis tasks. If the test continues to fail due to this particular issue after reaching the max try count, the test result is marked as inconclusive.