### PR TITLE
Checksum Stream

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
+++ b/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);net6.0</TargetFrameworks>
     <!-- Remove this line when Azure.Core is released for net6.0  -->
@@ -33,6 +33,7 @@
     <Compile Remove="Shared\*.cs" />
     <Compile Remove="Shared\ClientsideEncryption\*.cs;Shared\ClientsideEncryption\Models\*.cs" />
     <Compile Remove="Shared\AesGcm\**\*.cs" />
+    <Compile Include="Shared\ChecksumCalculatingStream.cs" />
     <!--we're defining the Shared Source in Common, but we only want to build in the files that Common names use of-->
     <Compile Include="Shared\Constants.cs" />
     <Compile Include="Shared\Errors.cs" />
@@ -45,6 +46,7 @@
     <Compile Include="Shared\StorageResponseClassifier.cs" />
     <Compile Include="Shared\StorageSharedKeyCredentialInternals.cs" />
     <Compile Include="Shared\StorageSharedKeyPipelinePolicy.cs" />
+    <Compile Include="Shared\StreamExtensions.cs" />
     <Compile Include="Shared\UriExtensions.cs" />
     <Compile Include="Shared\UriQueryParamsCollection.cs" />
     <Compile Include="Shared\StorageBearerTokenChallengeAuthorizationPolicy.cs" />

--- a/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
+++ b/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
@@ -33,7 +33,6 @@
     <Compile Remove="Shared\*.cs" />
     <Compile Remove="Shared\ClientsideEncryption\*.cs;Shared\ClientsideEncryption\Models\*.cs" />
     <Compile Remove="Shared\AesGcm\**\*.cs" />
-    <Compile Include="Shared\ChecksumCalculatingStream.cs" />
     <!--we're defining the Shared Source in Common, but we only want to build in the files that Common names use of-->
     <Compile Include="Shared\Constants.cs" />
     <Compile Include="Shared\Errors.cs" />
@@ -46,7 +45,6 @@
     <Compile Include="Shared\StorageResponseClassifier.cs" />
     <Compile Include="Shared\StorageSharedKeyCredentialInternals.cs" />
     <Compile Include="Shared\StorageSharedKeyPipelinePolicy.cs" />
-    <Compile Include="Shared\StreamExtensions.cs" />
     <Compile Include="Shared\UriExtensions.cs" />
     <Compile Include="Shared\UriQueryParamsCollection.cs" />
     <Compile Include="Shared\StorageBearerTokenChallengeAuthorizationPolicy.cs" />

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ChecksumCalculatingStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ChecksumCalculatingStream.cs
@@ -1,0 +1,233 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Storage
+{
+    /// <summary>
+    /// Checksums stream contents as the stream is progressed through.
+    /// Limited seek support on read. No seek support on write.
+    /// <para/>
+    /// All properties pass through except <see cref="Stream.CanRead"/>,
+    /// <see cref="Stream.CanWrite"/>, <see cref="Stream.CanSeek"/>, and
+    /// <see cref="Stream.Position"/> <c>set</c> (<c>get</c> will pass through).
+    /// <para/>
+    /// Passes thorugh properties traditionally locked behind seeking (e.g.
+    /// <see cref="Stream.Length"/>) regardless of read or write mode, ensuring
+    /// expected stream  checks are not interrupted and that exceptions only
+    /// throw when unsupported behavior is actually attempted. This is done
+    /// to maintain existing stream behavior as closely as possible, as this
+    /// class is meant to only observe the stream contents as they flow.
+    /// </summary>
+    internal class ChecksumCalculatingStream : Stream
+    {
+        public delegate void AppendChecksumCalculation(ReadOnlySpan<byte> checksum);
+
+        private readonly Stream _stream;
+        private readonly AppendChecksumCalculation _appendChecksumCalculation;
+
+        private readonly long _initialPosition;
+        private long _nextToBeChecksummedPosition;
+
+        public override bool CanRead { get; }
+
+        public override bool CanWrite { get; }
+
+        public override bool CanSeek => CanWrite ? false : _stream.CanSeek;
+
+        public override long Length => _stream.Length;
+
+        public override long Position
+        {
+            get => _stream.Position;
+            set => Seek(value, SeekOrigin.Begin);
+        }
+
+        public override bool CanTimeout => _stream.CanTimeout;
+
+        public override int ReadTimeout { get => _stream.ReadTimeout; set => _stream.ReadTimeout = value; }
+
+        public override int WriteTimeout { get => _stream.WriteTimeout; set => _stream.WriteTimeout = value; }
+
+        public static Stream GetReadStream(Stream stream, AppendChecksumCalculation appendChecksumCalculation)
+            => new ChecksumCalculatingStream(stream, appendChecksumCalculation, isReadMode: true);
+
+        public static Stream GetWriteStream(Stream stream, AppendChecksumCalculation appendChecksumCalculation)
+            => new ChecksumCalculatingStream(stream, appendChecksumCalculation, isReadMode: false);
+
+        private ChecksumCalculatingStream(Stream stream, AppendChecksumCalculation appendChecksumCalculation, bool isReadMode)
+        {
+            Argument.AssertNotNull(stream, nameof(stream));
+            Argument.AssertNotNull(appendChecksumCalculation, nameof(appendChecksumCalculation));
+
+            CanRead = isReadMode;
+            CanWrite = !isReadMode;
+            if (CanRead && !stream.CanRead)
+            {
+                throw new ArgumentException("Created stream in read mode but base stream cannot read.");
+            }
+            else if (CanWrite && !stream.CanWrite)
+            {
+                throw new ArgumentException("Created stream in write mode but base stream cannot write.");
+            }
+
+            _stream = stream;
+            _appendChecksumCalculation = appendChecksumCalculation;
+
+            if (_stream.CanSeek)
+            {
+                _initialPosition = _stream.Position;
+                _nextToBeChecksummedPosition = _stream.Position;
+            }
+            else
+            {
+                _initialPosition = -1;
+                _nextToBeChecksummedPosition = -1;
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return CanSeek
+                ? ReadSeekableInternal(buffer, offset, count, async: false, cancellationToken: default).EnsureCompleted()
+                : ReadUnseekableInternal(buffer, offset, count, async: false, cancellationToken: default).EnsureCompleted();
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return CanSeek
+                ? await ReadSeekableInternal(buffer, offset, count, async: true, cancellationToken).ConfigureAwait(false)
+                : await ReadUnseekableInternal(buffer, offset, count, async: true, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<int> ReadSeekableInternal(
+            byte[] buffer,
+            int offset,
+            int count,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            AssertCanRead();
+            Argument.AssertInRange(_stream.Position, _initialPosition, _nextToBeChecksummedPosition, nameof(Stream.Position));
+            long startingPosition = _stream.Position;
+            int read = await _stream.ReadInternal(buffer, offset, count, async, cancellationToken).ConfigureAwait(false);
+
+            if (read > 0 && startingPosition + read >= _nextToBeChecksummedPosition)
+            {
+                int alreadyChecksummedDataLength = (int)(_nextToBeChecksummedPosition - startingPosition);
+                _appendChecksumCalculation(new ReadOnlySpan<byte>(
+                    buffer, offset + alreadyChecksummedDataLength, read - alreadyChecksummedDataLength));
+            }
+
+            _nextToBeChecksummedPosition += read;
+            return read;
+        }
+
+        private async Task<int> ReadUnseekableInternal(
+            byte[] buffer,
+            int offset,
+            int count,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            AssertCanRead();
+            int read = await _stream.ReadInternal(buffer, offset, count, async, cancellationToken).ConfigureAwait(false);
+
+            if (read > 0)
+            {
+                _appendChecksumCalculation(new ReadOnlySpan<byte>(buffer, offset, read));
+            }
+
+            _nextToBeChecksummedPosition += read;
+            return read;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            WriteInternal(buffer, offset, count, async: false, cancellationToken: default).EnsureCompleted();
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await WriteInternal(buffer, offset, count, async: true, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteInternal(
+            byte[] buffer,
+            int offset,
+            int count,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            AssertCanWrite();
+            // if stream is seekable, ensure position wasn't moved out from under us
+            if (CanSeek && _nextToBeChecksummedPosition != _stream.Position)
+            {
+                throw new InvalidOperationException("Stream position was moved, cannot properly checksum contents.");
+            }
+
+            _appendChecksumCalculation(new ReadOnlySpan<byte>(buffer, offset, count));
+            await _stream.WriteInternal(buffer, offset, count, async, cancellationToken).ConfigureAwait(false);
+            _nextToBeChecksummedPosition += count;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (CanWrite)
+            {
+                throw new NotSupportedException("No seek support in write mode.");
+            }
+
+            // Seeking past data that has not yet been added ruins the checksum
+            // Enforce that seeking is only done within bounds of already checksummed data
+            if (_stream.CanSeek)
+            {
+                long absoluteOffset = origin switch
+                {
+                    SeekOrigin.Begin => offset,
+                    SeekOrigin.Current => _stream.Position + offset,
+                    SeekOrigin.End => _stream.Length + offset,
+                    _ => throw new ArgumentException($"SeekOrigin '{origin}' not recognized"),
+                };
+
+                if (absoluteOffset < _initialPosition || _nextToBeChecksummedPosition < absoluteOffset)
+                {
+                    throw new NotSupportedException("Cannot seek past current checksum calculation point.");
+                }
+            }
+
+            return _stream.Seek(offset, origin);
+        }
+
+        public override void Flush() => _stream.Flush();
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+            => await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        public override void Close() => _stream.Close();
+
+        public override void SetLength(long value) => _stream.SetLength(value);
+
+        private void AssertCanRead()
+        {
+            if (!CanRead)
+            {
+                throw new NotSupportedException("Cannot read from stream.");
+            }
+        }
+
+        private void AssertCanWrite()
+        {
+            if (!CanWrite)
+            {
+                throw new NotSupportedException("Cannot write to stream.");
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ChecksumCalculatingStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ChecksumCalculatingStream.cs
@@ -123,9 +123,10 @@ namespace Azure.Storage
                 int alreadyChecksummedDataLength = (int)(_nextToBeChecksummedPosition - startingPosition);
                 _appendChecksumCalculation(new ReadOnlySpan<byte>(
                     buffer, offset + alreadyChecksummedDataLength, read - alreadyChecksummedDataLength));
+
+                _nextToBeChecksummedPosition += read - alreadyChecksummedDataLength;
             }
 
-            _nextToBeChecksummedPosition += read;
             return read;
         }
 

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Storage
+{
+    /// <summary>
+    /// Extension methods for working with Streams.
+    /// </summary>
+    internal static class StreamExtensions
+    {
+        public static async Task<int> ReadInternal(
+            this Stream stream,
+            byte[] buffer,
+            int offset,
+            int count,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            if (async)
+            {
+                return await stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                return stream.Read(buffer, offset, count);
+            }
+        }
+
+        public static async Task WriteInternal(
+            this Stream stream,
+            byte[] buffer,
+            int offset,
+            int count,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            if (async)
+            {
+                await stream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                stream.Write(buffer, offset, count);
+            }
+        }
+
+        public static async Task CopyToInternal(
+            this Stream src,
+            Stream dest,
+            int bufferSize,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            if (async)
+            {
+                await src.CopyToAsync(dest, bufferSize, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                src.CopyTo(dest, bufferSize);
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
@@ -16,7 +16,7 @@ namespace Azure.Storage
     /// <summary>
     /// Extension methods for working with Streams.
     /// </summary>
-    internal static class StreamExtensions
+    internal static partial class StreamExtensions
     {
         public static async Task<int> ReadInternal(
             this Stream stream,

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StreamExtensions.cs
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\IAuthenticatedCryptographicTransform.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ClientsideEncryption\Models\TransformMode.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)AggregatingProgressIncrementer.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ChecksumCalculatingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ContentHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IDownloadedContent.cs" LinkBase="Shared" />
@@ -40,6 +41,7 @@
     <Compile Include="$(AzureStorageSharedSources)StorageArgument.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageWriteStream.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StreamExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)TransferValidationOptionsExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" LinkBase="Shared" />
   </ItemGroup>

--- a/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
@@ -34,27 +34,27 @@ namespace Azure.Storage.Tests
             innerStream.BasicSetup(canRead: true, innerStreamCanWrite, innerStreamCanSeek);
 
             // Create the checksum stream
-            Stream checksumStream = null;
-            Assert.DoesNotThrow(() => checksumStream = ChecksumCalculatingStream.GetReadStream(
-                innerStream.Object, new Mock<ChecksumCallback>().Object));
-            Assert.IsNotNull(checksumStream);
+            Stream stream = null;
+            Assert.DoesNotThrow(() => stream = ChecksumCalculatingStream.GetReadStream(
+                innerStream.Object, buf => { }));
+            Assert.IsNotNull(stream);
 
             // Assert read-only
-            Assert.IsTrue(checksumStream.CanRead);
-            Assert.IsFalse(checksumStream.CanWrite);
+            Assert.IsTrue(stream.CanRead);
+            Assert.IsFalse(stream.CanWrite);
             Assert.DoesNotThrowAsync(
-                async () => await checksumStream.ReadInternal(new byte[1], 0, 1, IsAsync, default));
+                async () => await stream.ReadInternal(new byte[1], 0, 1, IsAsync, default));
             Assert.ThrowsAsync<NotSupportedException>(
-                async () => await checksumStream.WriteInternal(new byte[1], 0, 1, IsAsync, default));
+                async () => await stream.WriteInternal(new byte[1], 0, 1, IsAsync, default));
 
             // Assert maintain seekability
-            Assert.AreEqual(innerStreamCanSeek, checksumStream.CanSeek);
+            Assert.AreEqual(innerStreamCanSeek, stream.CanSeek);
             foreach (TestDelegate del in new List<TestDelegate>()
             {
-                () => checksumStream.Seek(0, SeekOrigin.Begin),
-                () => _ = checksumStream.Position,
-                () => checksumStream.Position = 0,
-                () => _ = checksumStream.Length
+                () => stream.Seek(0, SeekOrigin.Begin),
+                () => _ = stream.Position,
+                () => stream.Position = 0,
+                () => _ = stream.Length
             })
             {
                 if (innerStreamCanSeek)
@@ -71,7 +71,7 @@ namespace Azure.Storage.Tests
             innerStream.BasicSetup(canRead: false, canWrite: true, canSeek: true);
 
             Assert.Throws<ArgumentException>(() => ChecksumCalculatingStream.GetReadStream(
-                innerStream.Object, new Mock<ChecksumCallback>().Object));
+                innerStream.Object, buf => { }));
         }
 
         [Test]
@@ -84,31 +84,31 @@ namespace Azure.Storage.Tests
             innerStream.BasicSetup(innerStreamCanRead, canWrite: true, innerStreamCanSeek);
 
             // Create the checksum stream
-            Stream checksumStream = null;
-            Assert.DoesNotThrow(() => checksumStream = ChecksumCalculatingStream.GetWriteStream(
-                innerStream.Object, new Mock<ChecksumCallback>().Object));
-            Assert.IsNotNull(checksumStream);
+            Stream stream = null;
+            Assert.DoesNotThrow(() => stream = ChecksumCalculatingStream.GetWriteStream(
+                innerStream.Object, buf => { }));
+            Assert.IsNotNull(stream);
 
             // Assert write-only
-            Assert.IsFalse(checksumStream.CanRead);
-            Assert.IsTrue(checksumStream.CanWrite);
+            Assert.IsFalse(stream.CanRead);
+            Assert.IsTrue(stream.CanWrite);
             Assert.ThrowsAsync<NotSupportedException>(
-                async () => await checksumStream.ReadInternal(new byte[1], 0, 1, IsAsync, default));
+                async () => await stream.ReadInternal(new byte[1], 0, 1, IsAsync, default));
             Assert.DoesNotThrowAsync(
-                async () => await checksumStream.WriteInternal(new byte[1], 0, 1, IsAsync, default));
+                async () => await stream.WriteInternal(new byte[1], 0, 1, IsAsync, default));
 
             // Assert seeking not supported
-            Assert.IsFalse(checksumStream.CanSeek);
+            Assert.IsFalse(stream.CanSeek);
             Assert.Throws<NotSupportedException>(
-                () => checksumStream.Seek(0, SeekOrigin.Begin));
+                () => stream.Seek(0, SeekOrigin.Begin));
             Assert.Throws<NotSupportedException>(
-                () => checksumStream.Position = 0);
+                () => stream.Position = 0);
 
             // Assert maintains existing info traditionally locked behind seeking
             foreach (TestDelegate del in new List<TestDelegate>()
             {
-                () => _ = checksumStream.Position,
-                () => _ = checksumStream.Length
+                () => _ = stream.Position,
+                () => _ = stream.Length
             })
             {
                 if (innerStreamCanSeek)
@@ -125,7 +125,7 @@ namespace Azure.Storage.Tests
             innerStream.BasicSetup(canRead: true, canWrite: false, canSeek: true);
 
             Assert.Throws<ArgumentException>(() => ChecksumCalculatingStream.GetWriteStream(
-                innerStream.Object, new Mock<ChecksumCallback>().Object));
+                innerStream.Object, buf => { }));
         }
 
         [TestCase(Constants.KB, 16, default)]
@@ -140,7 +140,7 @@ namespace Azure.Storage.Tests
 
             // and a checksumming stream
             var streamChecksumCalculator = StorageCrc64HashAlgorithm.Create();
-            var checksumStream = ChecksumCalculatingStream.GetReadStream(
+            var stream = ChecksumCalculatingStream.GetReadStream(
                 readReturnLimit.HasValue
                     ? ReadCountLimitingStream.Create(new MemoryStream(data), readReturnLimit.Value)
                     : new MemoryStream(data),
@@ -148,7 +148,7 @@ namespace Azure.Storage.Tests
 
             // Read the data through the checksumming stream and get the checksum
             var destStream = new MemoryStream();
-            await checksumStream.CopyToInternal(destStream, copyBuffer, IsAsync, cancellationToken: default);
+            await stream.CopyToInternal(destStream, copyBuffer, IsAsync, cancellationToken: default);
             var streamChecksum = streamChecksumCalculator.GetCurrentHash();
 
             // Assert output data and checksum are expected
@@ -158,7 +158,6 @@ namespace Azure.Storage.Tests
 
         [TestCase(Constants.KB, 16)]
         [TestCase(Constants.KB, 10)]
-        [TestCase(Constants.KB, 16)]
         public async Task CalculateOnSequentialWrite(int dataSize, int copyBuffer)
         {
             // Given data and it's checksum
@@ -169,15 +168,176 @@ namespace Azure.Storage.Tests
             // and a checksumming stream
             var streamChecksumCalculator = StorageCrc64HashAlgorithm.Create();
             var destStream = new MemoryStream();
-            var checksumStream = ChecksumCalculatingStream.GetWriteStream(destStream, streamChecksumCalculator.Append);
+            var stream = ChecksumCalculatingStream.GetWriteStream(destStream, streamChecksumCalculator.Append);
 
             // Write the data through the checksumming stream and get the checksum
-            await new MemoryStream(data).CopyToInternal(checksumStream, copyBuffer, IsAsync, cancellationToken: default);
+            await new MemoryStream(data).CopyToInternal(stream, copyBuffer, IsAsync, cancellationToken: default);
             var streamChecksum = streamChecksumCalculator.GetCurrentHash();
 
             // Assert output data and checksum are expected
             CollectionAssert.AreEqual(data, destStream.ToArray());
             CollectionAssert.AreEqual(dataChecksum, streamChecksum);
+        }
+
+        [Test]
+        [Combinatorial]
+        public async Task ReadModeCanSeekWithinChecksummedBounds(
+            [Values(0, 20)] int startOffset,
+            [Values(true, false)] bool seekViaMethod)
+        {
+            // given a stream at a given position wrapped in the checksumming read stream
+            var data = new byte[Constants.KB];
+            new Random().NextBytes(data);
+            var stream = ChecksumCalculatingStream.GetReadStream(
+                new MemoryStream(data) { Position = startOffset },
+                buf => { });
+
+            // and an upper bound of what has been checksummed so far
+            int upperOffset = 800;
+            await stream.ReadInternal(
+                new byte[upperOffset - startOffset], 0, upperOffset - startOffset, IsAsync, default);
+
+            // Assert the following target seek positions are successful and lead to a successful read
+            var b = new byte[10];
+            foreach (int l in new List<int> {
+                512,
+                600,
+                upperOffset - b.Length,
+                startOffset,
+                startOffset + 1,
+                upperOffset
+            })
+            {
+                if (seekViaMethod)
+                    Assert.DoesNotThrow(() => stream.Seek(l, SeekOrigin.Begin));
+                else
+                    Assert.DoesNotThrow(() => stream.Position = l);
+
+                Assert.AreEqual(l, stream.Position);
+
+                await stream.ReadInternal(b, 0, b.Length, IsAsync, default);
+                CollectionAssert.AreEqual(new Span<byte>(data, l, b.Length).ToArray(), b);
+            }
+        }
+
+        [Test]
+        public async Task ReadModeCannotSeekChecksummedBounds([Values(true, false)] bool seekViaMethod)
+        {
+            // given a stream at a given position wrapped in the checksumming read stream
+            int startOffset = 20;
+            var data = new byte[Constants.KB];
+            new Random().NextBytes(data);
+            var stream = ChecksumCalculatingStream.GetReadStream(
+                new MemoryStream(data) { Position = startOffset },
+                buf => { });
+
+            // and an upper bound of what has been checksummed so far
+            int upperOffset = 800;
+            await stream.ReadInternal(
+                new byte[upperOffset - startOffset], 0, upperOffset - startOffset, IsAsync, default);
+
+            // Assert the following target seek positions throw and stream position is unchanged
+            long position = stream.Position;
+            foreach (long l in new List<long> {
+                0,
+                startOffset - 1,
+                upperOffset + 1,
+                stream.Length
+            })
+            {
+                if (seekViaMethod)
+                    Assert.Throws<NotSupportedException>(() => stream.Seek(l, SeekOrigin.Begin));
+                else
+                    Assert.Throws<NotSupportedException>(() => stream.Position = l);
+
+                Assert.AreEqual(position, stream.Position);
+            }
+        }
+
+        [Test]
+        public async Task ReadModeDoesNotDoubleCalculateChecksum()
+        {
+            // Given data and it's checksum
+            var data = new byte[4 * Constants.KB];
+            new Random().NextBytes(data);
+            var dataChecksum = ChecksumInlineStorageCrc64(data, StorageCrc64HashAlgorithm.Create());
+
+            // and a checksumming stream
+            var streamChecksumCalculator = StorageCrc64HashAlgorithm.Create();
+            var stream = ChecksumCalculatingStream.GetReadStream(
+                new MemoryStream(data),
+                streamChecksumCalculator.Append);
+
+            // Read the data through the checksumming stream
+            var destStream = new MemoryStream();
+            await stream.CopyToInternal(destStream, bufferSize: 1000, IsAsync, cancellationToken: default);
+
+            // Assert output data and checksum are expected
+            CollectionAssert.AreEqual(data, destStream.ToArray());
+            CollectionAssert.AreEqual(dataChecksum, streamChecksumCalculator.GetCurrentHash());
+
+            // Rewind and reread the checksumming stream
+            stream.Position = 0;
+            destStream = new MemoryStream();
+            await stream.CopyToInternal(destStream, bufferSize: 900, IsAsync, cancellationToken: default);
+
+            // Assert output data as expected and checksum unaltered
+            CollectionAssert.AreEqual(data, destStream.ToArray());
+            CollectionAssert.AreEqual(dataChecksum, streamChecksumCalculator.GetCurrentHash());
+        }
+
+        [Test]
+        public async Task ReadModeCanCalculateReadOverlapOnChecksumBoundary()
+        {
+            // Given data and it's checksum
+            var data = new byte[4 * Constants.KB];
+            new Random().NextBytes(data);
+            var dataChecksum = ChecksumInlineStorageCrc64(data, StorageCrc64HashAlgorithm.Create());
+
+            // and a checksumming stream that records its actions
+            var callbacks = new List<byte[]>();
+            var streamChecksumCalculator = StorageCrc64HashAlgorithm.Create();
+            var stream = ChecksumCalculatingStream.GetReadStream(
+                new MemoryStream(data),
+                buf => {
+                    streamChecksumCalculator.Append(buf);
+                    var copy = new byte[buf.Length];
+                    buf.CopyTo(copy);
+                    callbacks.Add(copy);
+                });
+
+            // Read 2 KB
+            int firstReadLength = 2 * Constants.KB;
+            await stream.ReadInternal(new byte[firstReadLength], 0, firstReadLength, IsAsync, cancellationToken: default);
+
+            // Assert expected checksum call on the whole read
+            Assert.AreEqual(1, callbacks.Count);
+            CollectionAssert.AreEqual(new Span<byte>(data, 0, firstReadLength).ToArray(), callbacks[0]);
+
+            // Rewind to 1 KB and read another 2 KB, reading half checksummed contents and half unchecksummed
+            int secondReadStartOffset = Constants.KB;
+            int secondReadLength = 2 * Constants.KB;
+            stream.Position = secondReadStartOffset;
+            await stream.ReadInternal(new byte[secondReadLength], 0, secondReadLength, IsAsync, cancellationToken: default);
+
+            // Assert expected checksum call on latter half of the read
+            Assert.AreEqual(2, callbacks.Count);
+            CollectionAssert.AreEqual(
+                new Span<byte>(
+                    data,
+                    firstReadLength, // where the first checksum ended
+                    secondReadStartOffset + secondReadLength - firstReadLength // amount of new data checksummed
+                    ).ToArray(),
+                callbacks[1]);
+
+            // Finish consuming stream
+            await stream.CopyToInternal(Stream.Null, 1000, IsAsync, cancellationToken: default);
+
+            // Assert callback invocations and final checksum are as expected
+            Assert.AreEqual(4, callbacks.Count);
+            Assert.AreEqual(1000, callbacks[2].Length);
+            Assert.AreEqual(24, callbacks[3].Length);
+            CollectionAssert.AreEqual(dataChecksum, streamChecksumCalculator.GetCurrentHash());
         }
 
         private static byte[] ChecksumInlineStorageCrc64(Span<byte> data, NonCryptographicHashAlgorithm algorithm)

--- a/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 
-using ChecksumCallback = Azure.Storage.ChecksumCalculatingStream.AppendChecksumCalculation;
-
 namespace Azure.Storage.Tests
 {
     [TestFixture(true)]

--- a/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Hashing;
+using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
@@ -332,9 +333,9 @@ namespace Azure.Storage.Tests
             await stream.CopyToInternal(Stream.Null, 1000, IsAsync, cancellationToken: default);
 
             // Assert callback invocations and final checksum are as expected
-            Assert.AreEqual(4, callbacks.Count);
-            Assert.AreEqual(1000, callbacks[2].Length);
-            Assert.AreEqual(24, callbacks[3].Length);
+            // some targets don't strictly obey CopyTo bufferSize, so just check remaining KB of data made it
+            Assert.GreaterOrEqual(callbacks.Count, 3);
+            Assert.AreEqual(Constants.KB, callbacks.Skip(2).Sum(arr => arr.Length));
             CollectionAssert.AreEqual(dataChecksum, streamChecksumCalculator.GetCurrentHash());
         }
 

--- a/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Hashing;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+
+using ChecksumCallback = Azure.Storage.ChecksumCalculatingStream.AppendChecksumCalculation;
+
+namespace Azure.Storage.Tests
+{
+    [TestFixture(true)]
+    [TestFixture(false)]
+    internal class ChecksumCalculatingStreamTests
+    {
+        private readonly bool IsAsync;
+
+        public ChecksumCalculatingStreamTests(bool async)
+        {
+            IsAsync = async;
+        }
+
+        [Test]
+        public void MakeReadStream(
+            [Values(true, false)] bool innerStreamCanWrite,
+            [Values(true, false)] bool innerStreamCanSeek)
+        {
+            // Given a mock stream with various write/seek capabilities
+            var innerStream = new Mock<Stream>();
+            innerStream.BasicSetup(canRead: true, innerStreamCanWrite, innerStreamCanSeek);
+
+            // Create the checksum stream
+            Stream checksumStream = null;
+            Assert.DoesNotThrow(() => checksumStream = ChecksumCalculatingStream.GetReadStream(
+                innerStream.Object, new Mock<ChecksumCallback>().Object));
+            Assert.IsNotNull(checksumStream);
+
+            // Assert read-only
+            Assert.IsTrue(checksumStream.CanRead);
+            Assert.IsFalse(checksumStream.CanWrite);
+            Assert.DoesNotThrowAsync(
+                async () => await checksumStream.ReadInternal(new byte[1], 0, 1, IsAsync, default));
+            Assert.ThrowsAsync<NotSupportedException>(
+                async () => await checksumStream.WriteInternal(new byte[1], 0, 1, IsAsync, default));
+
+            // Assert maintain seekability
+            Assert.AreEqual(innerStreamCanSeek, checksumStream.CanSeek);
+            foreach (TestDelegate del in new List<TestDelegate>()
+            {
+                () => checksumStream.Seek(0, SeekOrigin.Begin),
+                () => _ = checksumStream.Position,
+                () => checksumStream.Position = 0,
+                () => _ = checksumStream.Length
+            })
+            {
+                if (innerStreamCanSeek)
+                    Assert.DoesNotThrow(del);
+                else
+                    Assert.Throws<NotSupportedException>(del);
+            }
+        }
+
+        [Test]
+        public void MakeReadStream_Fail()
+        {
+            var innerStream = new Mock<Stream>();
+            innerStream.BasicSetup(canRead: false, canWrite: true, canSeek: true);
+
+            Assert.Throws<ArgumentException>(() => ChecksumCalculatingStream.GetReadStream(
+                innerStream.Object, new Mock<ChecksumCallback>().Object));
+        }
+
+        [Test]
+        public void MakeWriteStream(
+            [Values(true, false)] bool innerStreamCanRead,
+            [Values(true, false)] bool innerStreamCanSeek)
+        {
+            // Given a mock stream with various read/seek capabilities
+            var innerStream = new Mock<Stream>();
+            innerStream.BasicSetup(innerStreamCanRead, canWrite: true, innerStreamCanSeek);
+
+            // Create the checksum stream
+            Stream checksumStream = null;
+            Assert.DoesNotThrow(() => checksumStream = ChecksumCalculatingStream.GetWriteStream(
+                innerStream.Object, new Mock<ChecksumCallback>().Object));
+            Assert.IsNotNull(checksumStream);
+
+            // Assert write-only
+            Assert.IsFalse(checksumStream.CanRead);
+            Assert.IsTrue(checksumStream.CanWrite);
+            Assert.ThrowsAsync<NotSupportedException>(
+                async () => await checksumStream.ReadInternal(new byte[1], 0, 1, IsAsync, default));
+            Assert.DoesNotThrowAsync(
+                async () => await checksumStream.WriteInternal(new byte[1], 0, 1, IsAsync, default));
+
+            // Assert seeking not supported
+            Assert.IsFalse(checksumStream.CanSeek);
+            Assert.Throws<NotSupportedException>(
+                () => checksumStream.Seek(0, SeekOrigin.Begin));
+            Assert.Throws<NotSupportedException>(
+                () => checksumStream.Position = 0);
+
+            // Assert maintains existing info traditionally locked behind seeking
+            foreach (TestDelegate del in new List<TestDelegate>()
+            {
+                () => _ = checksumStream.Position,
+                () => _ = checksumStream.Length
+            })
+            {
+                if (innerStreamCanSeek)
+                    Assert.DoesNotThrow(del);
+                else
+                    Assert.Throws<NotSupportedException>(del);
+            }
+        }
+
+        [Test]
+        public void MakeWriteStream_Fail()
+        {
+            var innerStream = new Mock<Stream>();
+            innerStream.BasicSetup(canRead: true, canWrite: false, canSeek: true);
+
+            Assert.Throws<ArgumentException>(() => ChecksumCalculatingStream.GetWriteStream(
+                innerStream.Object, new Mock<ChecksumCallback>().Object));
+        }
+
+        [TestCase(Constants.KB, 16, default)]
+        [TestCase(Constants.KB, 10, default)]
+        [TestCase(Constants.KB, 16, 13)]
+        public async Task CalculateOnSequentialRead(int dataSize, int copyBuffer, int? readReturnLimit)
+        {
+            // Given data and it's checksum
+            var data = new byte[dataSize];
+            new Random().NextBytes(data);
+            var dataChecksum = ChecksumInlineStorageCrc64(data, StorageCrc64HashAlgorithm.Create());
+
+            // and a checksumming stream
+            var streamChecksumCalculator = StorageCrc64HashAlgorithm.Create();
+            var checksumStream = ChecksumCalculatingStream.GetReadStream(
+                readReturnLimit.HasValue
+                    ? ReadCountLimitingStream.Create(new MemoryStream(data), readReturnLimit.Value)
+                    : new MemoryStream(data),
+                streamChecksumCalculator.Append);
+
+            // Read the data through the checksumming stream and get the checksum
+            var destStream = new MemoryStream();
+            await checksumStream.CopyToInternal(destStream, copyBuffer, IsAsync, cancellationToken: default);
+            var streamChecksum = streamChecksumCalculator.GetCurrentHash();
+
+            // Assert output data and checksum are expected
+            CollectionAssert.AreEqual(data, destStream.ToArray());
+            CollectionAssert.AreEqual(dataChecksum, streamChecksum);
+        }
+
+        [TestCase(Constants.KB, 16)]
+        [TestCase(Constants.KB, 10)]
+        [TestCase(Constants.KB, 16)]
+        public async Task CalculateOnSequentialWrite(int dataSize, int copyBuffer)
+        {
+            // Given data and it's checksum
+            var data = new byte[dataSize];
+            new Random().NextBytes(data);
+            var dataChecksum = ChecksumInlineStorageCrc64(data, StorageCrc64HashAlgorithm.Create());
+
+            // and a checksumming stream
+            var streamChecksumCalculator = StorageCrc64HashAlgorithm.Create();
+            var destStream = new MemoryStream();
+            var checksumStream = ChecksumCalculatingStream.GetWriteStream(destStream, streamChecksumCalculator.Append);
+
+            // Write the data through the checksumming stream and get the checksum
+            await new MemoryStream(data).CopyToInternal(checksumStream, copyBuffer, IsAsync, cancellationToken: default);
+            var streamChecksum = streamChecksumCalculator.GetCurrentHash();
+
+            // Assert output data and checksum are expected
+            CollectionAssert.AreEqual(data, destStream.ToArray());
+            CollectionAssert.AreEqual(dataChecksum, streamChecksum);
+        }
+
+        private static byte[] ChecksumInlineStorageCrc64(Span<byte> data, NonCryptographicHashAlgorithm algorithm)
+        {
+            algorithm.Append(data);
+            return algorithm.GetCurrentHash();
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ChecksumCalculatingStreamTests.cs
@@ -147,7 +147,7 @@ namespace Azure.Storage.Tests
 
             // Read the data through the checksumming stream and get the checksum
             var destStream = new MemoryStream();
-            await stream.CopyToInternal(destStream, copyBuffer, IsAsync, cancellationToken: default);
+            await stream.CopyToInternalExactBufferSize(destStream, copyBuffer, IsAsync, cancellationToken: default);
             var streamChecksum = streamChecksumCalculator.GetCurrentHash();
 
             // Assert output data and checksum are expected
@@ -170,7 +170,7 @@ namespace Azure.Storage.Tests
             var stream = ChecksumCalculatingStream.GetWriteStream(destStream, streamChecksumCalculator.Append);
 
             // Write the data through the checksumming stream and get the checksum
-            await new MemoryStream(data).CopyToInternal(stream, copyBuffer, IsAsync, cancellationToken: default);
+            await new MemoryStream(data).CopyToInternalExactBufferSize(stream, copyBuffer, IsAsync, cancellationToken: default);
             var streamChecksum = streamChecksumCalculator.GetCurrentHash();
 
             // Assert output data and checksum are expected
@@ -269,7 +269,7 @@ namespace Azure.Storage.Tests
 
             // Read the data through the checksumming stream
             var destStream = new MemoryStream();
-            await stream.CopyToInternal(destStream, bufferSize: 1000, IsAsync, cancellationToken: default);
+            await stream.CopyToInternalExactBufferSize(destStream, bufferSize: 1000, IsAsync, cancellationToken: default);
 
             // Assert output data and checksum are expected
             CollectionAssert.AreEqual(data, destStream.ToArray());
@@ -278,7 +278,7 @@ namespace Azure.Storage.Tests
             // Rewind and reread the checksumming stream
             stream.Position = 0;
             destStream = new MemoryStream();
-            await stream.CopyToInternal(destStream, bufferSize: 900, IsAsync, cancellationToken: default);
+            await stream.CopyToInternalExactBufferSize(destStream, bufferSize: 900, IsAsync, cancellationToken: default);
 
             // Assert output data as expected and checksum unaltered
             CollectionAssert.AreEqual(data, destStream.ToArray());
@@ -330,12 +330,12 @@ namespace Azure.Storage.Tests
                 callbacks[1]);
 
             // Finish consuming stream
-            await stream.CopyToInternal(Stream.Null, 1000, IsAsync, cancellationToken: default);
+            await stream.CopyToInternalExactBufferSize(Stream.Null, 1000, IsAsync, cancellationToken: default);
 
             // Assert callback invocations and final checksum are as expected
-            // some targets don't strictly obey CopyTo bufferSize, so just check remaining KB of data made it
-            Assert.GreaterOrEqual(callbacks.Count, 3);
-            Assert.AreEqual(Constants.KB, callbacks.Skip(2).Sum(arr => arr.Length));
+            Assert.AreEqual(4, callbacks.Count);
+            Assert.AreEqual(1000, callbacks[2].Length);
+            Assert.AreEqual(24, callbacks[3].Length);
             CollectionAssert.AreEqual(dataChecksum, streamChecksumCalculator.GetCurrentHash());
         }
 

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/MockExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/MockExtensions.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+
+using static Moq.It;
+
+namespace Azure.Storage
+{
+    /// <summary>
+    /// Extension methods to make tests easier to author.
+    /// </summary>
+    public static partial class MockExtensions
+    {
+        /// <summary>
+        /// Sets up baseline behavior for mocking a stream. Includes basic descriptor properties
+        /// as well as setting up appropriate throws based on those values.
+        /// </summary>
+        /// <param name="stream">Stream mock to setup.</param>
+        /// <param name="canRead"></param>
+        /// <param name="canWrite"></param>
+        /// <param name="canSeek"></param>
+        public static void BasicSetup(this Mock<Stream> stream, bool canRead, bool canWrite, bool canSeek)
+        {
+            stream.SetupGet(s => s.CanRead).Returns(canRead);
+            stream.SetupGet(s => s.CanWrite).Returns(canWrite);
+            stream.SetupGet(s => s.CanSeek).Returns(canSeek);
+
+            if (!canRead)
+            {
+                stream.Setup(s => s.Read(IsAny<byte[]>(), IsAny<int>(), IsAny<int>()))
+                    .Throws<NotSupportedException>();
+                stream.Setup(s => s.ReadAsync(IsAny<byte[]>(), IsAny<int>(), IsAny<int>(), IsAny<CancellationToken>()))
+                    .Throws<NotSupportedException>();
+            }
+
+            if (!canWrite)
+            {
+                stream.Setup(s => s.Write(IsAny<byte[]>(), IsAny<int>(), IsAny<int>()))
+                    .Throws<NotSupportedException>();
+                stream.Setup(s => s.WriteAsync(IsAny<byte[]>(), IsAny<int>(), IsAny<int>(), IsAny<CancellationToken>()))
+                    .Throws<NotSupportedException>();
+            }
+
+            if (!canSeek)
+            {
+                stream.SetupGet(s => s.Length)
+                    .Throws<NotSupportedException>();
+                stream.SetupGet(s => s.Position)
+                    .Throws<NotSupportedException>();
+                stream.SetupSet<long>(s => s.Position = default)
+                    .Throws<NotSupportedException>();
+                stream.Setup(s => s.Seek(IsAny<long>(), IsAny<SeekOrigin>()))
+                    .Throws<NotSupportedException>();
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ReadCountLimitingStream.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ReadCountLimitingStream.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Tests
+{
+    /// <summary>
+    /// Checksums stream contents as the stream is progressed through.
+    /// Limited seek support on read. No seek support on write.
+    /// </summary>
+    internal class ReadCountLimitingStream : Stream
+    {
+        /// <summary>
+        /// Function to limit the given count parameter based on inputs to Read().
+        /// </summary>
+        /// <returns>A new value for count, no larger than the original.</returns>
+        public delegate int LimitCount(byte[] buffer, int offset, int count);
+
+        private readonly Stream _stream;
+        private readonly LimitCount _limiter;
+
+        public override bool CanRead => _stream.CanRead;
+
+        public override bool CanWrite => _stream.CanWrite;
+
+        public override bool CanSeek => _stream.CanSeek;
+
+        public override long Length => _stream.Length;
+
+        public override long Position { get => _stream.Position; set => _stream.Position = value; }
+
+        public override bool CanTimeout => _stream.CanTimeout;
+
+        public override int ReadTimeout { get => _stream.ReadTimeout; set => _stream.ReadTimeout = value; }
+
+        public override int WriteTimeout { get => _stream.WriteTimeout; set => _stream.WriteTimeout = value; }
+
+        private ReadCountLimitingStream(Stream stream, LimitCount limiter)
+        {
+            _stream = stream;
+            _limiter = limiter;
+        }
+
+        public static Stream Create(Stream innerStream, int limit)
+            => new ReadCountLimitingStream(innerStream, (buf, offset, count) => Math.Min(count, limit));
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int newCount = _limiter(buffer, offset, count);
+            if (newCount > count)
+            {
+                throw new Exception("ReadCountLimitingStream limiter grew count parameter.");
+            }
+            return _stream.Read(buffer, offset, newCount);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            int newCount = _limiter(buffer, offset, count);
+            if (newCount > count)
+            {
+                throw new Exception("ReadCountLimitingStream limiter grew count parameter.");
+            }
+            return await _stream.ReadAsync(buffer, offset, newCount, cancellationToken);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _stream.Write(buffer, offset, count);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await _stream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _stream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _stream.SetLength(value);
+        }
+
+        public override void Flush()
+        {
+            _stream.Flush();
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            await _stream.FlushAsync();
+        }
+
+        public override void Close()
+        {
+            _stream.Close();
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StreamExtensions.Test.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StreamExtensions.Test.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Buffers;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Storage
+{
+    internal static partial class StreamExtensions
+    {
+        public static async Task CopyToInternalExactBufferSize(
+            this Stream src,
+            Stream dest,
+            int bufferSize,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[bufferSize];
+            int bytesRead;
+            while ((bytesRead = async
+                ? await src.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
+                : src.Read(buffer, 0, buffer.Length)) != 0)
+            {
+                if (async)
+                {
+                    await dest.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                }
+                else
+                {
+                    dest.Write(buffer, 0, bytesRead);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
A stream wrapper that keeps a running calculation of a checksum across the stream. Supports:
- Read or write mode
- No seek on write
- Limited seek on read (elaborated in docstrings)

Added to shared source but not yet pulled into any packages.

Misc. additions:
- Stream extensions for calling appropriate sync/async APIs on Stream class
- General purpose test tooling