### PR TITLE
Add transmit from storage handler

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -24,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     /// </summary>
     internal class AzureMonitorTransmitter : ITransmitter
     {
-        private readonly ApplicationInsightsRestClient _applicationInsightsRestClient;
+        internal readonly ApplicationInsightsRestClient _applicationInsightsRestClient;
         internal PersistentBlobProvider? _fileBlobProvider;
         private readonly AzureMonitorStatsbeat? _statsbeat;
         private readonly ConnectionVars _connectionVars;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -11,7 +11,6 @@ using Azure.Core;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry;
 using OpenTelemetry.Extensions.PersistentStorage.Abstractions;
-using OpenTelemetry.Extensions.PersistentStorage;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -159,7 +159,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         if (content != null)
                         {
                             blob.TryDelete();
-                            blobProvider?.SaveTelemetry(content);
+                            blobProvider.SaveTelemetry(content);
                         }
                         break;
                     case ResponseStatusCodes.RequestTimeout:

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/PersistentStorageExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/PersistentStorageExtensions.cs
@@ -12,5 +12,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
         {
             return storage.TryCreateBlob(content, leaseTime, out _) ? ExportResult.Success : ExportResult.Failure;
         }
+
+        internal static ExportResult SaveTelemetry(this PersistentBlobProvider storage, byte[] content)
+        {
+            return storage.TryCreateBlob(content, out _) ? ExportResult.Success : ExportResult.Failure;
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -31,7 +31,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal void TransmitFromStorage(object? sender, ElapsedEventArgs? e)
         {
-            while (_transmissionStateManager.State == TransmissionState.Closed && _blobProvider.TryGetBlob(out var blob) && blob.TryLease(1000))
+            while (_transmissionStateManager.State == TransmissionState.Closed && _blobProvider.TryGetBlob(out var blob) && blob.TryLease(120000))
             {
                 try
                 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Timers;
+using OpenTelemetry;
+using OpenTelemetry.Extensions.PersistentStorage.Abstractions;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    internal class TransmitFromStorageHandler : IDisposable
+    {
+        private readonly ApplicationInsightsRestClient _applicationInsightsRestClient;
+        private readonly PersistentBlobProvider _blobProvider;
+        private readonly System.Timers.Timer _transmitFromStorageTimer;
+        private bool _disposed;
+
+        internal TransmitFromStorageHandler(ApplicationInsightsRestClient applicationInsightsRestClient, PersistentBlobProvider blobProvider)
+        {
+            _applicationInsightsRestClient = applicationInsightsRestClient;
+            _blobProvider = blobProvider;
+            _transmitFromStorageTimer = new System.Timers.Timer();
+            _transmitFromStorageTimer.Elapsed += TransmitFromStorage;
+            _transmitFromStorageTimer.AutoReset = true;
+            _transmitFromStorageTimer.Interval = 120000;
+            _transmitFromStorageTimer.Start();
+        }
+
+        internal void TransmitFromStorage(object? sender, ElapsedEventArgs? e)
+        {
+            while (_blobProvider.TryGetBlob(out var blob) && blob.TryLease(1000))
+            {
+                try
+                {
+                    blob.TryRead(out var data);
+
+                    using var httpMessage = _applicationInsightsRestClient.InternalTrackAsync(data, CancellationToken.None).Result;
+                    var result = HttpPipelineHelper.IsSuccess(httpMessage);
+
+                    if (result == ExportResult.Success)
+                    {
+                        AzureMonitorExporterEventSource.Log.WriteInformational("TransmitFromStorageSuccess", "Successfully transmitted a blob from storage.");
+
+                        // In case if the delete fails, there is a possibility
+                        // that the current batch will be transmitted more than once resulting in duplicates.
+                        blob.TryDelete();
+                    }
+                    else
+                    {
+                        HttpPipelineHelper.HandleFailures(httpMessage, blob, _blobProvider);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    AzureMonitorExporterEventSource.Log.WriteError("FailedToTransmitFromStorage", ex);
+                }
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _transmitFromStorageTimer?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -53,7 +53,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             // Transmit
             var mockResponse = new MockResponse(200).SetContent("Ok");
-            using var transmitter = GetTransmitter(new[] { mockResponse });
+            using var transmitter = GetTransmitter(mockResponse);
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
@@ -71,7 +71,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             // Transmit
             var mockResponse = new MockResponse(500).SetContent("Internal Server Error");
-            using var transmitter = GetTransmitter(new[] { mockResponse });
+            using var transmitter = GetTransmitter(mockResponse);
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
@@ -91,7 +91,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mockResponse = new MockResponse(429)
                                     .AddHeader("Retry-After", "6")
                                     .SetContent("Too Many Requests");
-            using var transmitter = GetTransmitter(new[] { mockResponse });
+            using var transmitter = GetTransmitter(mockResponse);
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
@@ -117,7 +117,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mockResponse = new MockResponse(206)
                                     .AddHeader("Retry-After", "6")
                                     .SetContent("{\"itemsReceived\": 3,\"itemsAccepted\": 1,\"errors\":[{\"index\": 0,\"statusCode\": 429,\"message\": \"Throttle\"},{\"index\": 1,\"statusCode\": 429,\"message\": \"Throttle\"}]}");
-            using var transmitter = GetTransmitter(new[] { mockResponse });
+            using var transmitter = GetTransmitter(mockResponse);
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
@@ -150,7 +150,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mockFileProvider = new MockFileProvider();
             // Transmit
             var mockResponse = new MockResponse(500).SetContent("Internal Server Error");
-            var transmitter = GetTransmitter(new[] { mockResponse });
+            var transmitter = GetTransmitter(mockResponse);
             transmitter._fileBlobProvider = mockFileProvider;
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
@@ -181,7 +181,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponseError = new MockResponse(500).SetContent("Internal Server Error");
             var mockResponseSuccess = new MockResponse(200).SetContent("{\"itemsReceived\": 1,\"itemsAccepted\": 1,\"errors\":[]}");
-            var transmitter = GetTransmitter(new[] { mockResponseError, mockResponseSuccess });
+            var transmitter = GetTransmitter(mockResponseError, mockResponseSuccess);
 
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
@@ -210,7 +210,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponseError = new MockResponse(500).SetContent("Internal Server Error");
             var mockResponseSuccess = new MockResponse(200).SetContent("{\"itemsReceived\": 1,\"itemsAccepted\": 1,\"errors\":[]}");
-            var transmitter = GetTransmitter(new[] { mockResponseError, mockResponseSuccess });
+            var transmitter = GetTransmitter(mockResponseError, mockResponseSuccess);
 
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
@@ -248,7 +248,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 ;
             // Transmit
             var mockResponse = new MockResponse(500).SetContent("Internal Server Error");
-            var transmitter = GetTransmitter(new[]{ mockResponse, mockResponse});
+            var transmitter = GetTransmitter(mockResponse, mockResponse);
             transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
@@ -270,7 +270,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             transmitter.Dispose();
         }
 
-        private static AzureMonitorTransmitter GetTransmitter(MockResponse[] mockResponse)
+        private static AzureMonitorTransmitter GetTransmitter(params MockResponse[] mockResponse)
         {
             MockTransport mockTransport = new MockTransport(mockResponse);
             AzureMonitorExporterOptions options = new AzureMonitorExporterOptions


### PR DESCRIPTION
Adding `TransmitFromStorageHandler`. Handler will periodically check for any files in storage and try transmitting it if transmission state is Closed. With this change the current implementation is still not impacted. Will do a follow up to integrate this and `TransmissionStateManager` with `AzureMonitorTransmitter`
