### PR TITLE
[DynamicJson] Change delimiter used by changelist

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.ChangeTracker.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.ChangeTracker.cs
@@ -13,7 +13,7 @@ namespace Azure.Core.Json
         {
             private List<MutableJsonChange>? _changes;
 
-            //private const char Delimiter = (char)1;
+            internal const char Delimiter = (char)1;
 
             internal bool HasChanges => _changes != null && _changes.Count > 0;
 
@@ -55,39 +55,6 @@ namespace Azure.Core.Json
                 }
 
                 return changed;
-            }
-
-            internal bool TryGetChange(ReadOnlySpan<byte> path, out MutableJsonChange change)
-            {
-                if (_changes == null)
-                {
-                    change = default;
-                    return false;
-                }
-
-                // TODO: re-enable optimizations
-                // (System.Text.Unicode.Utf8 isn't available to us here)
-                var pathStr = Encoding.UTF8.GetString(path.ToArray());
-
-                //Span<char> utf16 = stackalloc char[path.Length];
-                //OperationStatus status = System.Text.Unicode.Utf8.ToUtf16(path, utf16, out _, out int written, false, true);
-                //if (status != OperationStatus.Done)
-                //{ throw new NotImplementedException(); } // TODO: needs to allocate from the pool
-                //utf16 = utf16.Slice(0, written);
-
-                for (int i = _changes.Count - 1; i >= 0; i--)
-                {
-                    var c = _changes[i];
-                    if (c.Path == pathStr)
-                    //if (change.Property.AsSpan().SequenceEqual(utf16))
-                    {
-                        change = c;
-                        return true;
-                    }
-                }
-
-                change = default;
-                return false;
             }
 
             internal bool TryGetChange(string path, in int lastAppliedChange, out MutableJsonChange change)
@@ -149,32 +116,30 @@ namespace Azure.Core.Json
                     return value;
                 }
 
-                return $"{path}.{value}";
-
-                //return string.Concat(path, Delimiter, value);
+                return string.Concat(path, Delimiter, value);
             }
 
             internal static string PushProperty(string path, ReadOnlySpan<byte> value)
             {
                 string propertyName = BinaryData.FromBytes(value.ToArray()).ToString();
+
                 if (path.Length == 0)
                 {
                     return propertyName;
                 }
 
-                return $"{path}.{propertyName}";
-
-                //return string.Concat(path, Delimiter, propertyName);
+                return string.Concat(path, Delimiter, propertyName);
             }
 
             internal static string PopProperty(string path)
             {
-                int lastDelimiter = path.LastIndexOf('.');
-                //int lastDelimiter = path.LastIndexOf(Delimiter);
+                int lastDelimiter = path.LastIndexOf(Delimiter);
+
                 if (lastDelimiter == -1)
                 {
                     return string.Empty;
                 }
+
                 return path.Substring(0, lastDelimiter);
             }
         }

--- a/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.ChangeTracker.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MutableJsonDocument.ChangeTracker.cs
@@ -13,6 +13,8 @@ namespace Azure.Core.Json
         {
             private List<MutableJsonChange>? _changes;
 
+            //private const char Delimiter = (char)1;
+
             internal bool HasChanges => _changes != null && _changes.Count > 0;
 
             internal bool AncestorChanged(string path, int highWaterMark)
@@ -146,7 +148,10 @@ namespace Azure.Core.Json
                 {
                     return value;
                 }
+
                 return $"{path}.{value}";
+
+                //return string.Concat(path, Delimiter, value);
             }
 
             internal static string PushProperty(string path, ReadOnlySpan<byte> value)
@@ -156,12 +161,16 @@ namespace Azure.Core.Json
                 {
                     return propertyName;
                 }
+
                 return $"{path}.{propertyName}";
+
+                //return string.Concat(path, Delimiter, propertyName);
             }
 
             internal static string PopProperty(string path)
             {
                 int lastDelimiter = path.LastIndexOf('.');
+                //int lastDelimiter = path.LastIndexOf(Delimiter);
                 if (lastDelimiter == -1)
                 {
                     return string.Empty;

--- a/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/MutableJsonDocumentTests.cs
@@ -118,6 +118,64 @@ namespace Azure.Core.Experimental.Tests
         }
 
         [Test]
+        public void CanSetProperty_JsonWithDotProperty()
+        {
+            string json = """
+                {
+                  "Baz.NotChild" : {
+                     "A" : 3
+                  },
+                  "Foo" : 1,
+                  "Bar" : "Hi!"
+                }
+                """;
+
+            var jd = MutableJsonDocument.Parse(json);
+
+            jd.RootElement.GetProperty("Foo").Set(3);
+
+            Assert.AreEqual(3, jd.RootElement.GetProperty("Foo").GetInt32());
+
+            MutableJsonDocumentWriteToTests.WriteToAndParse(jd, out string jsonString);
+
+            Assert.AreEqual(
+                MutableJsonDocumentWriteToTests.RemoveWhiteSpace("""
+                {
+                  "Baz.NotChild" : {
+                     "A" : 3
+                  },
+                  "Foo" : 3,
+                  "Bar" : "Hi!"
+                }
+                """),
+                jsonString);
+        }
+
+        [Test]
+        public void JsonWithDelimiterIsInvalidJson()
+        {
+            char delimiter = MutableJsonDocument.ChangeTracker.Delimiter;
+            string propertyName = "\"Baz" + delimiter + "NotChild\"";
+            string json = "{" + propertyName + ": {\"A\": 3}, \"Foo\":1}";
+
+            bool parsed = false;
+            bool threwJsonException = false;
+
+            try
+            {
+                MutableJsonDocument.Parse(json);
+                parsed = true;
+            }
+            catch (JsonException)
+            {
+                threwJsonException = true;
+            }
+
+            Assert.IsFalse(parsed);
+            Assert.IsTrue(threwJsonException);
+        }
+
+        [Test]
         public void CanSetPropertyToMutableJsonDocument()
         {
             string json = """


### PR DESCRIPTION
Before this PR, we used a `.` character as a delimiter, however it is a valid character to use in a JSON property name, and as a result, if properties were present that had dots in the name, [it could break serialization](https://github.com/Azure/azure-sdk-for-net/compare/main...annelo-msft:azure-sdk-for-net:dynamicdata-delimiter?expand=1#diff-404b45ffe3711cbf1d5b4229cb6c300ffc0c1088e55ace215b8c2befd902e0f6R121).

By moving to an unescaped unicode control character as a delimiter, we're now keying changes on property names that are [invalid JSON strings](https://www.rfc-editor.org/rfc/rfc8259#section-7) and therefore invalid JSON.  The benefit is that the [BCL JsonReader will validate the JSON for us](https://github.com/Azure/azure-sdk-for-net/compare/main...annelo-msft:azure-sdk-for-net:dynamicdata-delimiter?expand=1#diff-404b45ffe3711cbf1d5b4229cb6c300ffc0c1088e55ace215b8c2befd902e0f6R155) when we call JsonDocument.Parse() to ensure that we can't be working with JSON strings where our delimiter could appear.

Many thanks to @bterlson for the Unicode/JSON consultation!

Contributes to https://github.com/Azure/azure-sdk-for-net/issues/33856