### PR TITLE
[Communication][Email] Adding PPE Only Parameter to Email Live Tests

### DIFF
--- a/sdk/communication/Azure.Communication.Email/tests.yml
+++ b/sdk/communication/Azure.Communication.Email/tests.yml
@@ -1,5 +1,11 @@
 trigger: none
 
+parameters:
+- name: runOnlyPPE
+  displayName: "Run only the PPE stage"
+  type: boolean
+  default: false
+
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
@@ -19,6 +25,9 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-ppe-test-resources-common)
           - $(sub-config-communication-ppe-test-resources-net)
-    Clouds: 'Public,PPE,Int'
+    ${{ if eq(parameters.runOnlyPPE, true) }}:
+      Clouds: PPE
+    ${{ if eq(parameters.runOnlyPPE, false) }}:
+      Clouds: Public,PPE,Int
     TestResourceDirectories:
       - communication/Azure.Communication.Email/


### PR DESCRIPTION
I've added a parameter to the email live test pipelines that allows only the PPE stage to be run. This allows us to start a build on this pipeline from our service deployment pipeline.