### PR TITLE
[AzureMonitorExporter] fix nullables in AzMonList

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable disable // TODO: remove and fix errors
-
 using System;
 using System.Runtime.CompilerServices;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
@@ -14,7 +12,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///<summary>
         /// Gets http request url from activity tag objects.
         ///</summary>
-        internal static string GetRequestUrl(this AzMonList tagObjects)
+        internal static string? GetRequestUrl(this AzMonList tagObjects)
         {
             // From spec: one of the following combinations is required in case of server spans:
             // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions
@@ -22,7 +20,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             // http.scheme, http.host, http.target
             // http.scheme, http.server_name, net.host.port, http.target
             // http.scheme, net.host.name, net.host.port, http.target
-            string url = null;
+            string? url = null;
             url = tagObjects.GetUrlUsingHttpUrl();
             if (url != null)
             {
@@ -41,14 +39,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
 
                 string defaultPort = GetDefaultHttpPort(httpScheme);
-                url = tagObjects.GetUrlUsingHttpHost(httpScheme, defaultPort, httpTarget);
+                url = tagObjects.GetUrlUsingHttpHost(httpScheme!, defaultPort, httpTarget!);
                 if (url != null)
                 {
                     return url;
                 }
 
                 var httpServerName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpServerName)?.ToString();
-                string host;
+                string? host;
                 if (!string.IsNullOrWhiteSpace(httpServerName))
                 {
                     host = httpServerName;
@@ -62,7 +60,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     var netHostPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetHostPort)?.ToString();
                     if (!string.IsNullOrWhiteSpace(netHostPort))
                     {
-                        url = tagObjects.GetUrlUsingHostAndPort(httpScheme, host, netHostPort, defaultPort, httpTarget);
+                        url = tagObjects.GetUrlUsingHostAndPort(httpScheme!, host!, netHostPort!, defaultPort, httpTarget!);
                         return url;
                     }
                 }
@@ -74,7 +72,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///<summary>
         /// Gets http dependency url from activity tag objects.
         ///</summary>
-        internal static string GetDependencyUrl(this AzMonList tagObjects)
+        internal static string? GetDependencyUrl(this AzMonList tagObjects)
         {
             // From spec: one of the following combinations is required in case of client spans:
             // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client
@@ -82,7 +80,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             // http.scheme, http.host, http.target
             // http.scheme, net.peer.name, net.peer.port, http.target
             // http.scheme, net.peer.ip, net.peer.port, http.target
-            string url = null;
+            string? url = null;
             url = tagObjects.GetUrlUsingHttpUrl();
             if (url != null)
             {
@@ -101,7 +99,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
 
                 string defaultPort = GetDefaultHttpPort(httpScheme);
-                url = tagObjects.GetUrlUsingHttpHost(httpScheme, defaultPort, httpTarget);
+                url = tagObjects.GetUrlUsingHttpHost(httpScheme!, defaultPort, httpTarget!);
                 if (url != null)
                 {
                     return url;
@@ -113,7 +111,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
                     if (!string.IsNullOrWhiteSpace(netPeerPort))
                     {
-                        url = tagObjects.GetUrlUsingHostAndPort(httpScheme, host, netPeerPort, defaultPort, httpTarget);
+                        url = tagObjects.GetUrlUsingHostAndPort(httpScheme!, host!, netPeerPort!, defaultPort, httpTarget!);
                         return url;
                     }
                 }
@@ -123,7 +121,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string GetDefaultHttpPort(string httpScheme)
+        internal static string GetDefaultHttpPort(string? httpScheme)
         {
             if (string.Equals(httpScheme, "http", StringComparison.OrdinalIgnoreCase))
             {
@@ -140,9 +138,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string GetDefaultDbPort(string dbSystem)
+        internal static string GetDefaultDbPort(string? dbSystem)
         {
-            if (string.Equals(dbSystem, "mssql", StringComparison.OrdinalIgnoreCase))
+            if (dbSystem == null)
+            {
+                return "0";
+            }
+            else if (string.Equals(dbSystem, "mssql", StringComparison.OrdinalIgnoreCase))
             {
                 return "1433";
             }
@@ -157,9 +159,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string GetUrlUsingHttpUrl(this AzMonList tagObjects)
+        internal static string? GetUrlUsingHttpUrl(this AzMonList tagObjects)
         {
-            string url = null;
+            string? url = null;
             var httpUrl = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpUrl)?.ToString();
             if (!string.IsNullOrWhiteSpace(httpUrl))
             {
@@ -169,14 +171,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return url;
         }
 
-        internal static string GetUrlUsingHttpHost(this AzMonList tagObjects, string httpScheme, string defaultPort, string httpTarget)
+        internal static string? GetUrlUsingHttpHost(this AzMonList tagObjects, string httpScheme, string defaultPort, string httpTarget)
         {
-            string url = null;
+            string? url = null;
             var httpHost = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpHost)?.ToString();
             if (!string.IsNullOrWhiteSpace(httpHost))
             {
                 string portSection = $":{defaultPort}";
-                if (httpHost.EndsWith(portSection, StringComparison.OrdinalIgnoreCase))
+                if (httpHost!.EndsWith(portSection, StringComparison.OrdinalIgnoreCase))
                 {
                     var truncatedHost = httpHost.Substring(0, httpHost.IndexOf(portSection, StringComparison.OrdinalIgnoreCase));
                     url = $"{httpScheme}://{truncatedHost}{httpTarget}";
@@ -190,9 +192,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return url;
         }
 
-        internal static string GetUrlUsingHostAndPort(this AzMonList tagObjects, string httpScheme, string host, string port, string defaultPort, string httpTarget)
+        internal static string? GetUrlUsingHostAndPort(this AzMonList tagObjects, string httpScheme, string host, string port, string defaultPort, string httpTarget)
         {
-            string url = null;
+            string? url = null;
             if (port == defaultPort)
             {
                 url = $"{httpScheme}://{host}{httpTarget}";
@@ -205,10 +207,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return url;
         }
 
-        internal static string GetHostUsingNetPeerAttributes(this AzMonList tagObjects)
+        internal static string? GetHostUsingNetPeerAttributes(this AzMonList tagObjects)
         {
             var netPeerName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerName)?.ToString();
-            string host;
+            string? host;
             if (!string.IsNullOrWhiteSpace(netPeerName))
             {
                 host = netPeerName;
@@ -222,9 +224,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string GetTargetUsingNetPeerAttributes(this AzMonList tagObjects, string defaultPort)
+        internal static string? GetTargetUsingNetPeerAttributes(this AzMonList tagObjects, string defaultPort)
         {
-            string target = tagObjects.GetHostUsingNetPeerAttributes();
+            string? target = tagObjects.GetHostUsingNetPeerAttributes();
             if (!string.IsNullOrWhiteSpace(target))
             {
                 var netPeerPort = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeNetPeerPort)?.ToString();
@@ -240,9 +242,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///<summary>
         /// Gets Http dependency target from activity tag objects.
         ///</summary>
-        internal static string GetHttpDependencyTarget(this AzMonList tagObjects)
+        internal static string? GetHttpDependencyTarget(this AzMonList tagObjects)
         {
-            string target;
+            string? target;
             string defaultPort = GetDefaultHttpPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpScheme)?.ToString());
             var peerService = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributePeerService)?.ToString();
             if (!string.IsNullOrWhiteSpace(peerService))
@@ -255,7 +257,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             if (!string.IsNullOrWhiteSpace(httpHost))
             {
                 string portSection = $":{defaultPort}";
-                if (httpHost.EndsWith(portSection, StringComparison.OrdinalIgnoreCase))
+                if (httpHost!.EndsWith(portSection, StringComparison.OrdinalIgnoreCase))
                 {
                     var truncatedHost = httpHost.Substring(0, httpHost.IndexOf(portSection, StringComparison.OrdinalIgnoreCase));
                     target = truncatedHost;
@@ -268,7 +270,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
 
             var httpUrl = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpUrl)?.ToString();
-            if (!string.IsNullOrWhiteSpace(httpUrl) && Uri.TryCreate(httpUrl.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
+            if (!string.IsNullOrWhiteSpace(httpUrl)
+                && Uri.TryCreate(httpUrl!.ToString(), UriKind.RelativeOrAbsolute, out var uri)
+                && uri.IsAbsoluteUri)
             {
                 target = uri.Authority;
                 if (!string.IsNullOrWhiteSpace(target))
@@ -285,9 +289,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///<summary>
         /// Gets Database dependency target from activity tag objects.
         ///</summary>
-        internal static string GetDbDependencyTarget(this AzMonList tagObjects)
+        internal static string? GetDbDependencyTarget(this AzMonList tagObjects)
         {
-            string target = null;
+            string? target = null;
             string defaultPort = GetDefaultDbPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString());
             var peerService = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributePeerService)?.ToString();
             if (!string.IsNullOrWhiteSpace(peerService))
@@ -299,7 +303,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 target = tagObjects.GetTargetUsingNetPeerAttributes(defaultPort);
             }
 
-            string dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
+            string? dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
             bool isTargetEmpty = string.IsNullOrWhiteSpace(target);
             bool isDbNameEmpty = string.IsNullOrWhiteSpace(dbName);
             if (!isTargetEmpty && !isDbNameEmpty)
@@ -321,7 +325,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///<summary>
         /// Gets dependency target from activity tag objects.
         ///</summary>
-        internal static string GetDependencyTarget(this AzMonList tagObjects, OperationType type)
+        internal static string? GetDependencyTarget(this AzMonList tagObjects, OperationType type)
         {
             switch (type)
             {
@@ -334,7 +338,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         }
 
-        internal static string GetHttpDependencyName(this AzMonList tagObjects, string httpUrl)
+        internal static string? GetHttpDependencyName(this AzMonList tagObjects, string? httpUrl)
         {
             if (string.IsNullOrWhiteSpace(httpUrl))
             {
@@ -344,7 +348,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             var httpMethod = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpMethod)?.ToString();
             if (!string.IsNullOrWhiteSpace(httpMethod))
             {
-                if (Uri.TryCreate(httpUrl.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
+                if (Uri.TryCreate(httpUrl!.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
                 {
                     return $"{httpMethod} {uri.AbsolutePath}";
                 }
@@ -353,7 +357,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return null;
         }
 
-        internal static string GetDependencyType(this AzMonList tagObjects, OperationType operationType)
+        internal static string? GetDependencyType(this AzMonList tagObjects, OperationType operationType)
         {
             switch (operationType)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TagEnumerationState.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TagEnumerationState.cs
@@ -79,7 +79,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                 if (activityTag.Value is Array array)
                 {
-                    AzMonList.Add(ref UnMappedTags, new KeyValuePair<string, object>(activityTag.Key, array.ToCommaDelimitedString()));
+                    AzMonList.Add(ref UnMappedTags, new KeyValuePair<string, object?>(activityTag.Key, array.ToCommaDelimitedString()));
                     continue;
                 }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -133,7 +133,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                 linksJson.Append(']');
 
-                AzMonList.Add(ref UnMappedTags, new KeyValuePair<string, object>(msLinks, linksJson.ToString()));
+                AzMonList.Add(ref UnMappedTags, new KeyValuePair<string, object?>(msLinks, linksJson.ToString()));
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
@@ -15,9 +15,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpRequestUrlIsSetUsingHttpUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
 
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal("https://www.wiki.com", url);
         }
 
@@ -29,9 +29,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpRequestUrlIsSetUsing_Scheme_Host_Target(string httpScheme, string port)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:{port}"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:{port}"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl;
             if (port == "80" || port == "443")
             {
@@ -41,7 +41,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedUrl = $"{httpScheme}://www.httphost.org:{port}/path";
             }
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -62,10 +62,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 httpScheme = "https";
             }
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpServerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostPort, port));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, port));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl;
             if (port == "80" || port == "443")
             {
@@ -75,7 +75,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedUrl = $"{httpScheme}://servername.com:{port}/path";
             }
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -96,10 +96,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 httpScheme = "https";
             }
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, "localhost"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostPort, port));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, port));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl;
             if (port == "80" || port == "443")
             {
@@ -109,7 +109,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedUrl = $"{httpScheme}://localhost:{port}/path";
             }
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -117,15 +117,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpUrlAttributeTakesPrecedenceSettingHttpRequestUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, "localhost"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpServerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "https://www.wiki.com";
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -133,14 +133,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpHostAttributeTakesPrecedenceSettingHttpRequestUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, "localhost"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpServerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "http://www.httphost.org/path";
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -148,13 +148,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpServerNameAttributeTakesPrecedenceSettingHttpRequestUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, "localhost"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpServerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpServerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "http://servername.com:8888/path";
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -162,12 +162,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void NetHostNameAttributeTakesPrecedenceSettingHttpRequestUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, "localhost"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostName, "localhost"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetHostPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "http://localhost:8888/path";
-            string url = mappedTags.GetRequestUrl();
+            string? url = mappedTags.GetRequestUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -175,9 +175,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpDependencyUrlIsSetUsingHttpUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
 
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal("https://www.wiki.com", url);
         }
 
@@ -189,9 +189,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpDependencyUrlIsSetUsing_Scheme_Host_Target(string httpScheme, string port)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:{port}"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:{port}"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl;
             if (port == "80" || port == "443")
             {
@@ -201,7 +201,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedUrl = $"{httpScheme}://www.httphost.org:{port}/path";
             }
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -222,10 +222,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 httpScheme = "https";
             }
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, port));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, port));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl;
             if (port == "80" || port == "443")
             {
@@ -235,7 +235,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedUrl = $"{httpScheme}://servername.com:{port}/path";
             }
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -256,10 +256,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 httpScheme = "https";
             }
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, port));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, port));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl;
             if (port == "80" || port == "443")
             {
@@ -269,7 +269,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedUrl = $"{httpScheme}://127.0.0.1:{port}/path";
             }
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -277,15 +277,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpUrlAttributeTakesPrecedenceSettingHttpDependencyUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, "https://www.wiki.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "https://www.wiki.com";
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -293,14 +293,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpHostAttributeTakesPrecedenceSettingHttpDependencyUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, "www.httphost.org"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "http://www.httphost.org/path";
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -308,13 +308,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void NetPeerNameAttributeTakesPrecedenceSettingHttpDependencyUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, "servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, "servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "http://servername.com:8888/path";
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -322,12 +322,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void NetPeerIpAttributeTakesPrecedenceSettingHttpDependencyUrl()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpTarget, "/path"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, "127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpTarget, "/path"));
             string expectedUrl = "http://127.0.0.1:8888/path";
-            string url = mappedTags.GetDependencyUrl();
+            string? url = mappedTags.GetDependencyUrl();
             Assert.Equal(expectedUrl, url);
         }
 
@@ -345,9 +345,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         internal void DependencyTargetIsSetUsingPeerService(OperationType type)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, "servicename"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributePeerService, "servicename"));
             string expectedTarget = "servicename";
-            string target = mappedTags.GetDependencyTarget(type);
+            string? target = mappedTags.GetDependencyTarget(type);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -359,8 +359,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpDependencyTargetIsSetUsingHttpHost(string httpScheme, string port)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:{port}"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:{port}"));
             string expectedTarget;
             if (port == "80" || port == "443")
             {
@@ -370,7 +370,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedTarget = $"www.httphost.org:{port}";
             }
-            string target = mappedTags.GetDependencyTarget(OperationType.Http);
+            string? target = mappedTags.GetDependencyTarget(OperationType.Http);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -383,11 +383,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mappedTags = AzMonList.Initialize();
             if (port == "80")
             {
-                AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:{port}/"));
+                AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:{port}/"));
             }
             else
             {
-                AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, $"https://www.wiki.com:{port}/"));
+                AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, $"https://www.wiki.com:{port}/"));
             }
             string expectedTarget;
             if (port == "80" || port == "443")
@@ -398,7 +398,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedTarget = $"www.wiki.com:{port}";
             }
-            string target = mappedTags.GetDependencyTarget(OperationType.Http);
+            string? target = mappedTags.GetDependencyTarget(OperationType.Http);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -411,10 +411,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         internal void DependencyTargetIsSetUsingNetPeerName(string httpScheme, string port, OperationType type)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, port));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "mssql"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, port));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "mssql"));
             string expectedTarget;
             if (port == "80" || port == "443" || port == "1433")
             {
@@ -424,7 +424,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedTarget = $"servername.com:{port}";
             }
-            string target = mappedTags.GetDependencyTarget(type);
+            string? target = mappedTags.GetDependencyTarget(type);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -437,10 +437,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         internal void DependencyTargetIsSetUsingNetPeerIp(string httpScheme, string port, OperationType type)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "mssql"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, port));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, httpScheme));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "mssql"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, port));
             string expectedTarget;
             if (port == "80" || port == "443" || port == "1433")
             {
@@ -450,7 +450,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 expectedTarget = $"127.0.0.1:{port}";
             }
-            string target = mappedTags.GetDependencyTarget(type);
+            string? target = mappedTags.GetDependencyTarget(type);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -460,17 +460,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         internal void PeerServiceTakesPrecedenceSettingDependencyTarget(OperationType type)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, "servicename"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:8888/"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "mssql"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributePeerService, "servicename"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:8888/"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "mssql"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
 
             string expectedTarget = "servicename";
-            string target = mappedTags.GetDependencyTarget(type);
+            string? target = mappedTags.GetDependencyTarget(type);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -478,15 +478,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpHostTakesPrecedenceSettingHttpDependencyTarget()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:8888"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:8888/"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpHost, $"www.httphost.org:8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:8888/"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
 
             string expectedTarget = "www.httphost.org:8888";
-            string target = mappedTags.GetDependencyTarget(OperationType.Http);
+            string? target = mappedTags.GetDependencyTarget(OperationType.Http);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -494,14 +494,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void HttpUrlTakesPrecedenceSettingHttpDependencyTarget()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:8888/"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpUrl, $"http://www.wiki.com:8888/"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
 
             string expectedTarget = "www.wiki.com:8888";
-            string target = mappedTags.GetDependencyTarget(OperationType.Http);
+            string? target = mappedTags.GetDependencyTarget(OperationType.Http);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -511,14 +511,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         internal void PeerNameTakesPrecedenceSettingDependencyTarget(OperationType type)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "mssql"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "mssql"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, $"servername.com"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
 
             string expectedTarget = "servername.com:8888";
-            string target = mappedTags.GetDependencyTarget(type);
+            string? target = mappedTags.GetDependencyTarget(type);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -528,13 +528,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         internal void PeerIpTakesPrecedenceSettingDependencyTarget(OperationType type)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "mssql"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, "8888"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeHttpScheme, "http"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "mssql"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, $"127.0.0.1"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, "8888"));
 
             string expectedTarget = "127.0.0.1:8888";
-            string target = mappedTags.GetDependencyTarget(type);
+            string? target = mappedTags.GetDependencyTarget(type);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -544,7 +544,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         internal void DependencyTargetIsNullByDefault(OperationType type)
         {
             var mappedTags = AzMonList.Initialize();
-            string target = mappedTags.GetDependencyTarget(type);
+            string? target = mappedTags.GetDependencyTarget(type);
             Assert.Null(target);
         }
 
@@ -555,11 +555,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DbNameIsAppendedToTargetDerivedFromNetAttributesforDBDependencyTarget(string peerService, string netPeerName, string netPeerIp, string netPeerPort)
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, peerService));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, netPeerName));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, netPeerIp));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, netPeerPort));
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbName, "DbName"));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributePeerService, peerService));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerName, netPeerName));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerIp, netPeerIp));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeNetPeerPort, netPeerPort));
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
             string? hostName = null;
             if (peerService != null)
             {
@@ -574,7 +574,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 hostName = $"{netPeerIp}:{netPeerPort}";
             }
             string expectedTarget = $"{hostName} | DbName";
-            string target = mappedTags.GetDbDependencyTarget();
+            string? target = mappedTags.GetDbDependencyTarget();
             Assert.Equal(expectedTarget, target);
         }
 
@@ -582,8 +582,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DbDependencyTargetIsSetToDbNameWhenNetAttributesAreNotPresent()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbName, "DbName"));
-            string target = mappedTags.GetDbDependencyTarget();
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
+            string? target = mappedTags.GetDbDependencyTarget();
             Assert.Equal("DbName", target);
         }
 
@@ -591,8 +591,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DbDependencyTargetIsSetToDbSystemWhenNetAndDbNameAttributesAreNotPresent()
         {
             var mappedTags = AzMonList.Initialize();
-            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "DbSystem"));
-            string target = mappedTags.GetDbDependencyTarget();
+            AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "DbSystem"));
+            string? target = mappedTags.GetDbDependencyTarget();
             Assert.Equal("DbSystem", target);
         }
 
@@ -600,7 +600,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DbDependencyTargetIsSetToNullByDefault()
         {
             var mappedTags = AzMonList.Initialize();
-            string target = mappedTags.GetDbDependencyTarget();
+            string? target = mappedTags.GetDbDependencyTarget();
             Assert.Null(target);
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -318,7 +318,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal(1.1, AzMonList.GetTagValue(ref monitorTags.UnMappedTags, "doubleKey"));
             Assert.Equal("test", AzMonList.GetTagValue(ref monitorTags.UnMappedTags, "stringKey"));
             Assert.Equal(true, AzMonList.GetTagValue(ref monitorTags.UnMappedTags, "boolKey"));
-            Assert.Equal("Azure.Monitor.OpenTelemetry.Exporter.Tests.TagsTests+Test", AzMonList.GetTagValue(ref monitorTags.UnMappedTags, "objectKey").ToString());
+            Assert.Equal("Azure.Monitor.OpenTelemetry.Exporter.Tests.TagsTests+Test", AzMonList.GetTagValue(ref monitorTags.UnMappedTags, "objectKey")?.ToString());
             Assert.Equal("1,2,3", AzMonList.GetTagValue(ref monitorTags.UnMappedTags, "arrayKey"));
         }
 


### PR DESCRIPTION
Towards https://github.com/Azure/azure-sdk-for-net/issues/34013

this is the final PR for nullables in our product code! 🎉

The change to `KeyValuePair<string, object?>` is to match `Activity.TagObjects` which is also nullable ([link](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity.tagobjects?view=net-7.0))