### PR TITLE
Revert change from FxCopAnalyzers to NetAnalyzers

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -38,7 +38,7 @@
     -->
     <NoWarn>$(NoWarn);CA1812</NoWarn>
     <!--
-      Disable some NetAnalyzers rules
+      Disable some FxCop rules
      -->
     <NoWarn>
       $(NoWarn);
@@ -78,7 +78,7 @@
 
   <PropertyGroup>
     <EnableClientSdkAnalyzers Condition="'$(IsShippingClientLibrary)' == 'true'">true</EnableClientSdkAnalyzers>
-    <EnableNetAnalyzers Condition="'$(IsShippingClientLibrary)' == 'true'">true</EnableNetAnalyzers>
+    <EnableFxCopAnalyzers Condition="'$(IsShippingClientLibrary)' == 'true'">true</EnableFxCopAnalyzers>
     <EnableStyleCopAnalyzers Condition="'$(EnableStyleCopAnalyzers)' == '' and '$(IsClientLibrary)' == 'true'">true</EnableStyleCopAnalyzers>
     <EnableBannedApiAnalyzers Condition="'$(IsShippingClientLibrary)' == 'true'">true</EnableBannedApiAnalyzers>
     <GenerateAPIListing Condition="'$(IsShippingClientLibrary)' == 'true'">true</GenerateAPIListing>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="Versioning.targets" />
 
@@ -87,7 +87,7 @@
 
     <PackageReference Condition="'$(EnableClientSdkAnalyzers)' == 'true'" Include="Azure.ClientSdk.Analyzers" PrivateAssets="All" />
 
-    <PackageReference Condition="'$(EnableNetAnalyzers)' == 'true'" Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="All" />
+    <PackageReference Condition="'$(EnableFxCopAnalyzers)' == 'true'" Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" />
 
     <PackageReference Condition="'$(EnableBannedApiAnalyzers)' == 'true'" Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="All" />
 

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -168,7 +168,7 @@
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230321.1" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20230131.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20467.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" PrivateAssets="All" />

--- a/sdk/batch/Microsoft.Azure.Batch/src/Microsoft.Azure.Batch.csproj
+++ b/sdk/batch/Microsoft.Azure.Batch/src/Microsoft.Azure.Batch.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; reliability</IncludeAssets>
     </PackageReference>

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineTransportOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineTransportOptions.cs
@@ -17,10 +17,7 @@ namespace Azure.Core.Pipeline
         /// </summary>
         public HttpPipelineTransportOptions()
         {
-            // suppress false postive of NetAnalyzers: error CA1416: This call site is reachable on all platforms. 'X509Certificate2' is unsupported on: 'browser'.
-#pragma warning disable CA1416
             ClientCertificates = new List<X509Certificate2>();
-#pragma warning restore CA1416
         }
 
         /// <summary>
@@ -32,6 +29,6 @@ namespace Azure.Core.Pipeline
         /// The client certificate collection that will be configured for the transport.
         /// </summary>
         /// <value></value>
-        public IList<X509Certificate2> ClientCertificates { get; }
+        public IList<X509Certificate2> ClientCertificates {get;}
     }
 }


### PR DESCRIPTION
This reverts commit 6bf7b23898b8e17b6576a99fe0e2548d586b1a69. I've
opened #35107 to track reverting this reversion after the problem is
fixed and working with internal teams to identify where that issue needs
to be opened.

This is causing Visual Studio to constantly run expensive background
operations and slows it to a near-halt.
