### PR TITLE
typespec renaming for unified pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,5 +174,5 @@ BenchmarkDotNet.Artifacts
 artifacts
 .assets
 
-# Temporary cadl folders for cadl generation
-TempCadlFiles/
+# Temporary typespec folders for typespec generation
+TempTypeSpecFiles/

--- a/eng/scripts/Invoke-GenerateAndBuildV2.ps1
+++ b/eng/scripts/Invoke-GenerateAndBuildV2.ps1
@@ -41,7 +41,7 @@ $commitid = $inputJson.headSha
 $repoHttpsUrl = $inputJson.repoHttpsUrl
 $downloadUrlPrefix = $inputJson.installInstructionInput.downloadUrlPrefix
 $autorestConfig = $inputJson.autorestConfig
-$relatedCadlProjectFolder = $inputJson.relatedCadlProjectFolder
+$relatedTypeSpecProjectFolder = $inputJson.relatedTypeSpecProjectFolder
 
 $autorestConfigYaml = ""
 if ($autorestConfig) {
@@ -109,10 +109,10 @@ if ($inputFileToGen) {
     UpdateExistingSDKByInputFiles -inputFilePaths $inputFileToGen -sdkRootPath $sdkPath -headSha $commitid -repoHttpsUrl $repoHttpsUrl -downloadUrlPrefix "$downloadUrlPrefix" -generatedSDKPackages $generatedSDKPackages
 }
 
-# generate sdk from cadl file
-if ($relatedCadlProjectFolder) {
-    foreach ($cadlRelativeFolder in $relatedCadlProjectFolder) {
-        $typespecFolder = Resolve-Path (Join-Path $swaggerDir $cadlRelativeFolder)
+# generate sdk from typespec file
+if ($relatedTypeSpecProjectFolder) {
+    foreach ($typespecRelativeFolder in $relatedTypeSpecProjectFolder) {
+        $typespecFolder = Resolve-Path (Join-Path $swaggerDir $typespecRelativeFolder)
         $newPackageOutput = "newPackageOutput.json"
 
         $tspConfigYaml = Get-Content -Path (Join-Path "$typespecFolder" "tspconfig.yaml") -Raw
@@ -137,7 +137,7 @@ if ($relatedCadlProjectFolder) {
             -service $service `
             -namespace $namespace `
             -sdkPath $sdkPath `
-            -relatedTypeSpecProjectFolder $cadlRelativeFolder `
+            -relatedTypeSpecProjectFolder $typespecRelativeFolder `
             -specRoot $swaggerDir `
             -outputJsonFile $newpackageoutput
         $newPackageOutputJson = Get-Content $newPackageOutput -Raw | ConvertFrom-Json

--- a/eng/scripts/automation/Invoke-GenerateAndBuild.ps1
+++ b/eng/scripts/automation/Invoke-GenerateAndBuild.ps1
@@ -22,7 +22,7 @@ $downloadUrlPrefix = $inputJson.installInstructionInput.downloadUrlPrefix
 $autorestConfig = $inputJson.autorestConfig
 
 $autorestConfig = $inputJson.autorestConfig
-$relatedCadlProjectFolder = $inputJson.relatedCadlProjectFolder
+$relatedTypeSpecProjectFolder = $inputJson.relatedTypeSpecProjectFolder
 
 $autorestConfigYaml = ""
 if ($autorestConfig) {
@@ -69,8 +69,8 @@ if ($readmeFile) {
   Invoke-GenerateAndBuildSDK -readmeAbsolutePath $readme -sdkRootPath $sdkPath -autorestConfigYaml "$autorestConfigYaml" -downloadUrlPrefix "$downloadUrlPrefix" -generatedSDKPackages $generatedSDKPackages
 }
 
-if ($relatedCadlProjectFolder) {
-  $typespecFolder = Resolve-Path (Join-Path $swaggerDir $relatedCadlProjectFolder)
+if ($relatedTypeSpecProjectFolder) {
+  $typespecFolder = Resolve-Path (Join-Path $swaggerDir $relatedTypeSpecProjectFolder)
   $newPackageOutput = "newPackageOutput.json"
 
   $tspConfigYaml = Get-Content -Path (Join-Path "$typespecFolder" "tspconfig.yaml") -Raw
@@ -92,16 +92,16 @@ if ($relatedCadlProjectFolder) {
   }
   $projectFolder = (Join-Path $sdkPath "sdk" $service $namespace)
   $specRoot = $swaggerDir
-  if ((-Not $relatedCadlProjectFolder.Contains("specification")) -And $swaggerDir.Contains("specification"))
+  if ((-Not $relatedTypeSpecProjectFolder.Contains("specification")) -And $swaggerDir.Contains("specification"))
   {
-    $relatedCadlProjectFolder = "specification/$relatedCadlProjectFolder"
+    $relatedTypeSpecProjectFolder = "specification/$relatedTypeSpecProjectFolder"
     $specRoot = Split-Path $specRoot
   }
   New-TypeSpecPackageFolder `
       -service $service `
       -namespace $namespace `
       -sdkPath $sdkPath `
-      -relatedTypeSpecProjectFolder $relatedCadlProjectFolder `
+      -relatedTypeSpecProjectFolder $relatedTypeSpecProjectFolder `
       -specRoot $specRoot `
       -outputJsonFile $newpackageoutput
   $newPackageOutputJson = Get-Content $newPackageOutput -Raw | ConvertFrom-Json


### PR DESCRIPTION
# Contributing to the Azure SDK

- rename cadl to typespec in scripts for unified pipeline automation

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
