### PR TITLE
fix(appplatform): failed to parse different formats of guid value

### DIFF
--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/CHANGELOG.md
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2 (2023-03-28)
 
 ### Bugs Fixed
 

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/CHANGELOG.md
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.2 (Unreleased)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix failure to parse different format of GUID value for `AppPlatformServiceProperties.ServiceId`. Add a new string type property `AppPlatformServiceProperties.ServiceInstanceId` to replace `AppPlatformServiceProperties.ServiceId` which is now marked as obsolete.
 
 ## 1.0.1 (2023-02-17)
 

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/api/Azure.ResourceManager.AppPlatform.netstandard2.0.cs
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/api/Azure.ResourceManager.AppPlatform.netstandard2.0.cs
@@ -1843,7 +1843,10 @@ namespace Azure.ResourceManager.AppPlatform.Models
         public Azure.ResourceManager.AppPlatform.Models.AppPlatformServiceNetworkProfile NetworkProfile { get { throw null; } set { } }
         public Azure.ResourceManager.AppPlatform.Models.AppPlatformServicePowerState? PowerState { get { throw null; } }
         public Azure.ResourceManager.AppPlatform.Models.AppPlatformServiceProvisioningState? ProvisioningState { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("'ServiceId' is deprecated. Use 'ServiceInstanceId' instead.")]
         public System.Guid? ServiceId { get { throw null; } }
+        public string ServiceInstanceId { get { throw null; } }
         public int? Version { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Azure.ResourceManager.AppPlatform.csproj
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Azure.ResourceManager.AppPlatform.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.AppPlatform</PackageId>

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Customize/Models/AppPlatformServiceProperties.cs
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Customize/Models/AppPlatformServiceProperties.cs
@@ -10,7 +10,8 @@ namespace Azure.ResourceManager.AppPlatform.Models
 {
     public partial class AppPlatformServiceProperties
     {
-        /// <summary> DEPRECATED: ServiceInstanceEntity GUID which uniquely identifies a created resource. </summary>
+        /// <summary> DEPRECATED: ServiceInstanceEntity GUID which uniquely identifies a created resource.</summary>
+        /// <remarks><see cref="FormatException">FormatException</see> will be thrown if response is not a GUID format.</remarks>
         [Obsolete("'ServiceId' is deprecated. Use 'ServiceInstanceId' instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Guid? ServiceId => ServiceInstanceId != null ? Guid.Parse(ServiceInstanceId) : null;

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Customize/Models/AppPlatformServiceProperties.cs
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Customize/Models/AppPlatformServiceProperties.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using System.ComponentModel;
+
+namespace Azure.ResourceManager.AppPlatform.Models
+{
+    public partial class AppPlatformServiceProperties
+    {
+        /// <summary> DEPRECATED: ServiceInstanceEntity GUID which uniquely identifies a created resource. </summary>
+        [Obsolete("'ServiceId' is deprecated. Use 'ServiceInstanceId' instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Guid? ServiceId => ServiceInstanceId != null ? Guid.Parse(ServiceInstanceId) : null;
+    }
+}

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Generated/Models/AppPlatformServiceProperties.Serialization.cs
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Generated/Models/AppPlatformServiceProperties.Serialization.cs
@@ -5,7 +5,6 @@
 
 #nullable disable
 
-using System;
 using System.Text.Json;
 using Azure.Core;
 
@@ -44,7 +43,7 @@ namespace Azure.ResourceManager.AppPlatform.Models
             Optional<AppPlatformServiceNetworkProfile> networkProfile = default;
             Optional<ServiceVnetAddons> vnetAddons = default;
             Optional<int> version = default;
-            Optional<Guid> serviceId = default;
+            Optional<string> serviceId = default;
             Optional<AppPlatformServicePowerState> powerState = default;
             Optional<bool> zoneRedundant = default;
             Optional<string> fqdn = default;
@@ -92,12 +91,7 @@ namespace Azure.ResourceManager.AppPlatform.Models
                 }
                 if (property.NameEquals("serviceId"u8))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    serviceId = property.Value.GetGuid();
+                    serviceId = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("powerState"u8))
@@ -126,7 +120,7 @@ namespace Azure.ResourceManager.AppPlatform.Models
                     continue;
                 }
             }
-            return new AppPlatformServiceProperties(Optional.ToNullable(provisioningState), networkProfile.Value, vnetAddons.Value, Optional.ToNullable(version), Optional.ToNullable(serviceId), Optional.ToNullable(powerState), Optional.ToNullable(zoneRedundant), fqdn.Value);
+            return new AppPlatformServiceProperties(Optional.ToNullable(provisioningState), networkProfile.Value, vnetAddons.Value, Optional.ToNullable(version), serviceId.Value, Optional.ToNullable(powerState), Optional.ToNullable(zoneRedundant), fqdn.Value);
         }
     }
 }

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Generated/Models/AppPlatformServiceProperties.cs
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/Generated/Models/AppPlatformServiceProperties.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.ResourceManager.AppPlatform.Models
 {
     /// <summary> Service properties payload. </summary>
@@ -22,17 +20,17 @@ namespace Azure.ResourceManager.AppPlatform.Models
         /// <param name="networkProfile"> Network profile of the Service. </param>
         /// <param name="vnetAddons"> Additional Service settings in vnet injection instance. </param>
         /// <param name="version"> Version of the Service. </param>
-        /// <param name="serviceId"> ServiceInstanceEntity GUID which uniquely identifies a created resource. </param>
+        /// <param name="serviceInstanceId"> ServiceInstanceEntity GUID which uniquely identifies a created resource. </param>
         /// <param name="powerState"> Power state of the Service. </param>
         /// <param name="isZoneRedundant"></param>
         /// <param name="fqdn"> Fully qualified dns name of the service instance. </param>
-        internal AppPlatformServiceProperties(AppPlatformServiceProvisioningState? provisioningState, AppPlatformServiceNetworkProfile networkProfile, ServiceVnetAddons vnetAddons, int? version, Guid? serviceId, AppPlatformServicePowerState? powerState, bool? isZoneRedundant, string fqdn)
+        internal AppPlatformServiceProperties(AppPlatformServiceProvisioningState? provisioningState, AppPlatformServiceNetworkProfile networkProfile, ServiceVnetAddons vnetAddons, int? version, string serviceInstanceId, AppPlatformServicePowerState? powerState, bool? isZoneRedundant, string fqdn)
         {
             ProvisioningState = provisioningState;
             NetworkProfile = networkProfile;
             VnetAddons = vnetAddons;
             Version = version;
-            ServiceId = serviceId;
+            ServiceInstanceId = serviceInstanceId;
             PowerState = powerState;
             IsZoneRedundant = isZoneRedundant;
             Fqdn = fqdn;
@@ -59,7 +57,7 @@ namespace Azure.ResourceManager.AppPlatform.Models
         /// <summary> Version of the Service. </summary>
         public int? Version { get; }
         /// <summary> ServiceInstanceEntity GUID which uniquely identifies a created resource. </summary>
-        public Guid? ServiceId { get; }
+        public string ServiceInstanceId { get; }
         /// <summary> Power state of the Service. </summary>
         public AppPlatformServicePowerState? PowerState { get; }
         /// <summary> Gets or sets the is zone redundant. </summary>

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/autorest.md
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/src/autorest.md
@@ -131,7 +131,7 @@ rename-mapping:
   CustomDomainResourceProvisioningState: AppPlatformCustomDomainProvisioningState
   ServiceResource: AppPlatformService
   ClusterResourceProperties: AppPlatformServiceProperties
-  ClusterResourceProperties.serviceId: -|uuid
+  ClusterResourceProperties.serviceId: ServiceInstanceId
   ClusterResourceProperties.zoneRedundant: IsZoneRedundant
   NetworkProfile: AppPlatformServiceNetworkProfile
   PowerState: AppPlatformServicePowerState

--- a/sdk/appplatform/Azure.ResourceManager.AppPlatform/tests/AppPlatformModelTests.cs
+++ b/sdk/appplatform/Azure.ResourceManager.AppPlatform/tests/AppPlatformModelTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.ResourceManager.AppPlatform.Models;
+using NUnit.Framework;
+using System;
+using System.Text.Json;
+
+namespace Azure.ResourceManager.AppPlatform.Tests
+{
+    public class AppPlatformModelTests
+    {
+        [TestCase("79d502c7359c4afc99095965f28ca37f", "79d502c7-359c-4afc-9909-5965f28ca37f")]
+        [TestCase("77af734a-f643-467d-a31f-f873b15cc869", "77af734a-f643-467d-a31f-f873b15cc869")]
+        [Obsolete]
+        public void AppPlatformServicePropertiesServiceId(string rawId, string guid)
+        {
+            var jsonElement = JsonDocument.Parse($"{{\"serviceId\":\"{rawId}\"}}").RootElement;
+            var properties = AppPlatformServiceProperties.DeserializeAppPlatformServiceProperties(jsonElement);
+
+            Assert.AreEqual(new Guid(guid), properties.ServiceId);
+            Assert.AreEqual(rawId, properties.ServiceInstanceId);
+        }
+
+        [Test]
+        [Obsolete]
+        public void AppPlatformServicePropertiesUndefinedServiceId()
+        {
+            var jsonElement = JsonDocument.Parse("{}").RootElement;
+            var properties = AppPlatformServiceProperties.DeserializeAppPlatformServiceProperties(jsonElement);
+
+            Assert.IsNull(properties.ServiceId);
+            Assert.IsNull(properties.ServiceInstanceId);
+        }
+
+        [Test]
+        [Obsolete]
+        public void AppPlatformServicePropertiesNullServiceId()
+        {
+            var jsonElement = JsonDocument.Parse("{\"serviceId\":null}").RootElement;
+            var properties = AppPlatformServiceProperties.DeserializeAppPlatformServiceProperties(jsonElement);
+
+            Assert.IsNull(properties.ServiceId);
+            Assert.IsNull(properties.ServiceInstanceId);
+        }
+
+        [Test]
+        [Obsolete]
+        public void AppPlatformServicePropertiesUnknownServiceId()
+        {
+            var jsonElement = JsonDocument.Parse("{\"serviceId\":\"1232dcf\"}").RootElement;
+            var properties = AppPlatformServiceProperties.DeserializeAppPlatformServiceProperties(jsonElement);
+
+            try
+            {
+                var serviceId = properties.ServiceId;
+                Assert.Fail("Should throw exception");
+            }
+            catch (FormatException) { }
+            Assert.AreEqual("1232dcf", properties.ServiceInstanceId);
+        }
+    }
+}


### PR DESCRIPTION
`AppPlatformServiceProperties` could have GUID values with different foramts. One format doesn't follow the RFC UUID spec, so there will be exception when parsing the value.

This commit will fix the issue by:
- add a new property `ServiceInstanceId` with string type so that various formats can be accepted
- use customization codes to keep `ServiceId` property for backward compatibility
  - its value is from parsing `ServiceInstanceId` as UUID
  - mark it as obsolete and editor visiblity to never
- add unit tests
- update api signature
- bump version to `1.0.2`

fix #35061

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
