### PR TITLE
Fix scan logic

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             containerScanInfo.ContinuationToken = page.ContinuationToken;
 
             // if ending a cycle then copy currentSweepCycleStartTime to lastSweepCycleStartTime, if changed
-            if (page.ContinuationToken == null &&
+            if (string.IsNullOrEmpty(page.ContinuationToken) &&
                 containerScanInfo.CurrentSweepCycleLatestModified > containerScanInfo.LastSweepCycleLatestModified)
             {
                 containerScanInfo.LastSweepCycleLatestModified = containerScanInfo.CurrentSweepCycleLatestModified;


### PR DESCRIPTION
The scan logic for blob trigger is broken - scan blob with the latest scan time is never created and scan logic try to scan the same blobs again and again.

Help for the `ContinuationToken` says:
```
        /// <summary>
        /// Gets the continuation token used to request the next
        /// <see cref="Page{T}"/>.  The continuation token may be null or
        /// empty when there are no more pages.
        /// </summary>
        public abstract string? ContinuationToken { get; }
```

Current code only checks for `null`