### PR TITLE
Update github-event-processor to 1.0.0-dev.20230324.4

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -59,7 +59,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230317.6
+          --version 1.0.0-dev.20230324.4
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -36,7 +36,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230317.6
+          --version 1.0.0-dev.20230324.4
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash


### PR DESCRIPTION
github-event-processor version 1.0.0-dev.20230324.4 has no rules changes but it does update the scheduled event governor based upon the actions rate limit. We'll set the number of updates to 1/10th the core rate limit with a cap at 1000. The 1000 cap is because that's the number of search results that can be pulled within a 60 second time frame before it gets secondary rate limited.    Azure/azure-sdk-for-net is an enterprise repository, as our all of our language repositories, which will benefit from this.