### PR TITLE
Integrate TransmissionStateManager and TransmitFromStorageHandler with transmitter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmissionStateManager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmissionStateManager.cs
@@ -86,6 +86,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// </summary>
         internal void ResetConsecutiveErrors()
         {
+            _nextMinTimeToUpdateConsecutiveErrors = DateTimeOffset.MinValue;
             Interlocked.Exchange(ref _consecutiveErrors, 0);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -12,7 +12,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     internal class TransmitFromStorageHandler : IDisposable
     {
         private readonly ApplicationInsightsRestClient _applicationInsightsRestClient;
-        private readonly PersistentBlobProvider _blobProvider;
+        internal PersistentBlobProvider _blobProvider;
         private readonly TransmissionStateManager _transmissionStateManager;
         private readonly System.Timers.Timer _transmitFromStorageTimer;
         private bool _disposed;


### PR DESCRIPTION
This is the final PR, it integrates the changes done in in https://github.com/Azure/azure-sdk-for-net/pull/35017 and https://github.com/Azure/azure-sdk-for-net/pull/34926 with `AzureMonitorTransmitter`.

Summary: With this change, transmission from storage will be handled by `TransmitFromStorageHandler`. It will periodically check for any files available in the storage for retries. In addition to this, `TransmissionStateManager` will manage the transmission state by implementing exponential back-off in case of transient errors.
