### PR TITLE
[ACR] Updates to Upload/Download large blob tests

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Content/ContainerRegistryContentClient.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Content/ContainerRegistryContentClient.cs
@@ -954,16 +954,18 @@ namespace Azure.Containers.ContainerRegistry
                     chunkSize = (int)chunkResult.Headers.ContentLength.Value;
 
                     int offset = 0;
+                    int remaining = chunkSize;
                     int length = async ?
-                        await chunkResult.Value.ReadAsync(buffer, offset, chunkSize, cancellationToken).ConfigureAwait(false) :
-                        chunkResult.Value.Read(buffer, offset, chunkSize);
+                        await chunkResult.Value.ReadAsync(buffer, offset, remaining, cancellationToken).ConfigureAwait(false) :
+                        chunkResult.Value.Read(buffer, offset, remaining);
 
                     while (offset < chunkSize)
                     {
                         offset += length;
+                        remaining -= length;
                         length = async ?
-                            await chunkResult.Value.ReadAsync(buffer, offset, chunkSize, cancellationToken).ConfigureAwait(false) :
-                            chunkResult.Value.Read(buffer, offset, chunkSize);
+                            await chunkResult.Value.ReadAsync(buffer, offset, remaining, cancellationToken).ConfigureAwait(false) :
+                            chunkResult.Value.Read(buffer, offset, remaining);
                     }
 
                     sha256.TransformBlock(buffer, 0, chunkSize, buffer, 0);

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Azure.Containers.ContainerRegistry.Tests.csproj
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/Azure.Containers.ContainerRegistry.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\src\Azure.Containers.ContainerRegistry.csproj" />
+    <ProjectReference Include="..\perf\Azure.Containers.ContainerRegistry.Perf\Azure.Containers.ContainerRegistry.Perf.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTargetingNetFx)' == 'true'">

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryContentClientLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryContentClientLiveTests.cs
@@ -702,6 +702,11 @@ namespace Azure.Containers.ContainerRegistry.Tests
             string downloadFileName = "blob_downloaded.bin";
             string filePath = Path.Combine(path, downloadFileName);
 
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryContentClientLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryContentClientLiveTests.cs
@@ -715,6 +715,7 @@ namespace Azure.Containers.ContainerRegistry.Tests
             using FileStream downloadFs = File.OpenWrite(filePath);
             await client.DownloadBlobToAsync(uploadResult.Digest, downloadFs);
 
+            // Content is validated by the client, so we only need to check length.
             Assert.IsTrue(File.Exists(filePath));
             Assert.AreEqual(size, new FileInfo(filePath).Length);
         }

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryContentClientLiveTests.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/tests/ContainerRegistryContentClientLiveTests.cs
@@ -562,8 +562,8 @@ namespace Azure.Containers.ContainerRegistry.Tests
             await client.DeleteBlobAsync(digest);
         }
 
-        [RecordedTest]
-        public async Task CanDownloadBlobToStream_Large()
+        [LiveOnly]
+        public async Task CanDownloadBlobToStream_MultipleChunks()
         {
             // Download a blob that is larger than the max chunk size.
             int blobSize = 6 * 1024 * 1024;


### PR DESCRIPTION
This PR addresses the following:
- Fix a bug in blob upload when Read() source content stream doesn't read the full content chunk length on the first call
- Fix a bug in blob download when downloading a blob larger than max chunk size
- Change `CanUploadAndDownloadLargeBlob` test to upload different content from different test pipelines

Contributes to https://github.com/Azure/azure-sdk-for-net/issues/32948

Live tests succeed on [this PR branch](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2658932&view=results)