### PR TITLE
[Storage] [DataMovement] Fixing flakey test of StartTransfer_*_Skipped

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -118,22 +118,24 @@ namespace Azure.Storage.DataMovement
                     this,
                     _destinationResource.TransferType);
 
-                await CreateDestinationResource(blockSize, length, false).ConfigureAwait(false);
-
-                // If we cannot upload in one shot, initiate the parallel block uploader
-                List<(long Offset, long Length)> rangeList = GetRangeList(blockSize, length);
-                if (_destinationResource.TransferType == TransferType.Concurrent)
+                bool destinationCreated = await CreateDestinationResource(blockSize, length, false).ConfigureAwait(false);
+                if (destinationCreated)
                 {
-                    await QueueStageBlockRequests(rangeList, length).ConfigureAwait(false);
-                }
-                else // Sequential
-                {
-                    // Queue paritioned block task
-                    await QueueChunk(async () =>
-                    await StageBlockInternal(
-                        rangeList[0].Offset,
-                        rangeList[0].Length,
-                        length).ConfigureAwait(false)).ConfigureAwait(false);
+                    // If we cannot upload in one shot, initiate the parallel block uploader
+                    List<(long Offset, long Length)> rangeList = GetRangeList(blockSize, length);
+                    if (_destinationResource.TransferType == TransferType.Concurrent)
+                    {
+                        await QueueStageBlockRequests(rangeList, length).ConfigureAwait(false);
+                    }
+                    else // Sequential
+                    {
+                        // Queue paritioned block task
+                        await QueueChunk(async () =>
+                        await StageBlockInternal(
+                            rangeList[0].Offset,
+                            rangeList[0].Length,
+                            length).ConfigureAwait(false)).ConfigureAwait(false);
+                    }
                 }
             }
             else

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -153,57 +153,63 @@ namespace Azure.Storage.DataMovement
             if (initialResult == default || initialLength == 0)
             {
                 // We just need to at minimum create the file
-                await CopyToStreamInternal(
+                bool succesfulCreation = await CopyToStreamInternal(
                     offset: 0,
                     sourceLength: 0,
                     source: default,
                     expectedLength: 0).ConfigureAwait(false);
-                // Queue the work to end the download
-                await QueueChunk(
-                    async () =>
-                    await CompleteFileDownload().ConfigureAwait(false))
-                    .ConfigureAwait(false);
+                if (succesfulCreation)
+                {
+                    // Queue the work to end the download
+                    await QueueChunk(
+                        async () =>
+                        await CompleteFileDownload().ConfigureAwait(false))
+                        .ConfigureAwait(false);
+                }
                 return;
             }
 
             // TODO: Change to use buffer instead of converting to stream
             long totalLength = ParseRangeTotalLength(initialResult.ContentRange);
-            await CopyToStreamInternal(
+            bool succesfulInitialCopy = await CopyToStreamInternal(
                 offset: 0,
                 sourceLength: initialLength,
                 source: initialResult.Content,
                 expectedLength: totalLength).ConfigureAwait(false);
-            ReportBytesWritten(initialLength);
-            if (totalLength == initialLength)
+            if (succesfulInitialCopy)
             {
-                // Complete download since it was done in one go
-                await QueueChunk(
-                    async () =>
-                    await CompleteFileDownload().ConfigureAwait(false))
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                // Set rangeSize
-                long rangeSize = CalculateBlockSize(totalLength);
-
-                // Get list of ranges of the blob
-                IList<HttpRange> ranges = GetRangesList(initialLength, totalLength, rangeSize);
-                // Create Download Chunk event handler to manage when the ranges finish downloading
-                _downloadChunkHandler = GetDownloadChunkHandler(
-                    currentTranferred: initialLength,
-                    expectedLength: totalLength,
-                    ranges: ranges,
-                    jobPart: this);
-
-                // Fill the queue with tasks to download each of the remaining
-                // ranges in the blob
-                foreach (HttpRange httpRange in ranges)
+                ReportBytesWritten(initialLength);
+                if (totalLength == initialLength)
                 {
-                    // Add the next Task (which will start the download but
-                    // return before it's completed downloading)
-                    await QueueChunk(async () =>
-                        await DownloadStreamingInternal(range: httpRange).ConfigureAwait(false)).ConfigureAwait(false);
+                    // Complete download since it was done in one go
+                    await QueueChunk(
+                        async () =>
+                        await CompleteFileDownload().ConfigureAwait(false))
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    // Set rangeSize
+                    long rangeSize = CalculateBlockSize(totalLength);
+
+                    // Get list of ranges of the blob
+                    IList<HttpRange> ranges = GetRangesList(initialLength, totalLength, rangeSize);
+                    // Create Download Chunk event handler to manage when the ranges finish downloading
+                    _downloadChunkHandler = GetDownloadChunkHandler(
+                        currentTranferred: initialLength,
+                        expectedLength: totalLength,
+                        ranges: ranges,
+                        jobPart: this);
+
+                    // Fill the queue with tasks to download each of the remaining
+                    // ranges in the blob
+                    foreach (HttpRange httpRange in ranges)
+                    {
+                        // Add the next Task (which will start the download but
+                        // return before it's completed downloading)
+                        await QueueChunk(async () =>
+                            await DownloadStreamingInternal(range: httpRange).ConfigureAwait(false)).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -225,16 +231,19 @@ namespace Azure.Storage.DataMovement
                 if (result == default || initialLength == 0)
                 {
                     // We just need to at minimum create the file
-                    await CopyToStreamInternal(
+                    bool successfulCopy = await CopyToStreamInternal(
                         offset: 0,
                         sourceLength: 0,
                         source: default,
                         expectedLength: 0).ConfigureAwait(false);
-                    // Queue the work to end the download
-                    await QueueChunk(
-                        async () =>
-                        await CompleteFileDownload().ConfigureAwait(false))
-                        .ConfigureAwait(false);
+                    if (successfulCopy)
+                    {
+                        // Queue the work to end the download
+                        await QueueChunk(
+                            async () =>
+                            await CompleteFileDownload().ConfigureAwait(false))
+                            .ConfigureAwait(false);
+                    }
                     return;
                 }
             }
@@ -315,7 +324,7 @@ namespace Azure.Storage.DataMovement
             }
         }
 
-        public async Task CopyToStreamInternal(
+        public async Task<bool> CopyToStreamInternal(
             long offset,
             long sourceLength,
             Stream source,
@@ -334,6 +343,7 @@ namespace Azure.Storage.DataMovement
                     completeLength: expectedLength,
                     options: default,
                     cancellationToken: _cancellationTokenSource.Token).ConfigureAwait(false);
+                return true;
             }
             catch (IOException ex)
             when (_createMode == StorageResourceCreateMode.Skip &&
@@ -351,6 +361,7 @@ namespace Azure.Storage.DataMovement
             {
                 await InvokeFailedArg(ex).ConfigureAwait(false);
             }
+            return false;
         }
 
         public async Task WriteChunkToTempFile(string chunkFilePath, Stream source)


### PR DESCRIPTION
StartTransfer_AwaitCompletion_Skipped
StartTransfer_EnsureCompleted_EnsureCompleted

Are really flakey. This should fix the concurrency issue where CompletedWithSkipped and Completed are both attempting to set the transfer status. Also it was incorrect to try to set to Completed with the Skipped event was raised. The Skipped event should always override the completed status.