### PR TITLE
ContentHasher BinaryData support + tests

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
+++ b/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Shared\UriExtensions.cs" />
     <Compile Include="Shared\UriQueryParamsCollection.cs" />
     <Compile Include="Shared\StorageBearerTokenChallengeAuthorizationPolicy.cs" />
+    <Compile Include="Shared\TransferValidationOptionsExtensions.cs" LinkBase="Shared" />
     <Compile Include="Shared\ISupportsTenantIdChallenges.cs" />
   </ItemGroup>
 </Project>

--- a/sdk/storage/Azure.Storage.Common/src/Shared/TransferValidationOptionsExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/TransferValidationOptionsExtensions.cs
@@ -9,7 +9,7 @@ namespace Azure.Storage
         {
             if (checksumAlgorithm == StorageChecksumAlgorithm.Auto)
             {
-#if BlobSDK || DataLakeSDK
+#if BlobSDK || DataLakeSDK || CommonSDK
                 return StorageChecksumAlgorithm.StorageCrc64;
 #elif FileSDK // file shares don't support crc64
                 return StorageChecksumAlgorithm.MD5;

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -42,7 +42,6 @@
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageWriteStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StreamExtensions.cs" LinkBase="Shared" />
-    <Compile Include="$(AzureStorageSharedSources)TransferValidationOptionsExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" LinkBase="Shared" />
   </ItemGroup>
   <!-- Ensure an empty TestConfigurations.xml is always present so the build can copy it -->

--- a/sdk/storage/Azure.Storage.Common/tests/ContentHasherTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ContentHasherTests.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Storage.Tests
+{
+    public class ContentHasherTests
+    {
+        public enum DataType
+        {
+            Stream,
+            BinaryData
+        }
+
+        public static IEnumerable<DataType> GetDataTypes()
+            => new HashSet<DataType>(Enum.GetValues(typeof(DataType)).Cast<DataType>());
+
+        public static IEnumerable<StorageChecksumAlgorithm> GetValidationAlgorithms()
+        {
+            var values = new HashSet<StorageChecksumAlgorithm>(Enum.GetValues(typeof(StorageChecksumAlgorithm))
+                .Cast<StorageChecksumAlgorithm>());
+            values.Remove(StorageChecksumAlgorithm.None);
+            return values;
+        }
+
+        [Test]
+        [Combinatorial]
+        public void GetHashOrDefaultChecksOptions(
+            [ValueSource(nameof(GetValidationAlgorithms))] StorageChecksumAlgorithm algorithm,
+            [ValueSource(nameof(GetDataTypes))] DataType dataType)
+        {
+            // Given data and options with precalculated checksum
+            var stream = new Mock<Stream>();
+            var binaryData = new Mock<BinaryData>("hello world");
+
+            var precalculatedChecksum = new byte[8];
+            new Random().NextBytes(precalculatedChecksum);
+
+            var options = new UploadTransferValidationOptions()
+            {
+                ChecksumAlgorithm = algorithm,
+                PrecalculatedChecksum = precalculatedChecksum
+            };
+
+            // Get hash
+            var result = dataType switch
+            {
+                DataType.Stream => ContentHasher.GetHashOrDefault(stream.Object, options),
+                DataType.BinaryData => ContentHasher.GetHashOrDefault(binaryData.Object, options),
+                _ => throw new NotImplementedException(),
+            };
+
+            // Assert
+            stream.VerifyNoOtherCalls();
+            binaryData.VerifyNoOtherCalls();
+            CollectionAssert.AreEqual(precalculatedChecksum, result.Checksum.ToArray());
+        }
+
+        [Test]
+        [Combinatorial]
+        public void GetHashOrDefaultCalculatesChecksum(
+            [ValueSource(nameof(GetValidationAlgorithms))] StorageChecksumAlgorithm algorithm,
+            [ValueSource(nameof(GetDataTypes))] DataType dataType)
+        {
+            // Given data and an independently calculated checksum
+            var data = new byte[1024];
+            new Random().NextBytes(data);
+
+            var dataChecksum = algorithm.ResolveAuto() switch
+            {
+                StorageChecksumAlgorithm.MD5 => MD5.Create().ComputeHash(data),
+                StorageChecksumAlgorithm.StorageCrc64 => CrcInline(data),
+                _ => throw new NotImplementedException("Test not implemented for given algorithm."),
+            };
+
+            var options = new UploadTransferValidationOptions()
+            {
+                ChecksumAlgorithm = algorithm
+            };
+
+            // Get hash
+            var result = dataType switch
+            {
+                DataType.Stream => ContentHasher.GetHashOrDefault(new MemoryStream(data), options),
+                DataType.BinaryData => ContentHasher.GetHashOrDefault(BinaryData.FromBytes(data), options),
+                _ => throw new NotImplementedException(),
+            };
+
+            // Assert
+            CollectionAssert.AreEqual(dataChecksum, result.Checksum.ToArray());
+        }
+
+        private static byte[] CrcInline(byte[] data)
+        {
+            var crc = StorageCrc64HashAlgorithm.Create();
+            crc.Append(data);
+            return crc.GetCurrentHash();
+        }
+    }
+}


### PR DESCRIPTION
- Adds `BinaryData` overloads to `ContentHasher`
- Refactors `ContentHasher` internals to avoid code duplication between `Stream` vs `BinaryData` implementations
- Adds unit tests for `ContentHasher`