### PR TITLE
[Experiment] Add Core.Experimental public tests to Core CI

### DIFF
--- a/eng/scripts/splittestdependencies/tests/inputs/projects.txt
+++ b/eng/scripts/splittestdependencies/tests/inputs/projects.txt
@@ -37,6 +37,7 @@ $(RepoRoot)sdk\containerregistry\Azure.ResourceManager.ContainerRegistry\tests\A
 $(RepoRoot)sdk\containerservice\Azure.ResourceManager.ContainerService\tests\Azure.ResourceManager.ContainerService.Tests.csproj
 $(RepoRoot)sdk\core\Azure.Core.Amqp\tests\Azure.Core.Amqp.Tests.csproj
 $(RepoRoot)sdk\core\Azure.Core.Experimental\tests\Azure.Core.Experimental.Tests.csproj
+$(RepoRoot)sdk\core\Azure.Core.Experimental\tests\public\Azure.Core.Experimental.Tests.Public.csproj
 $(RepoRoot)sdk\core\Azure.Core.Experimental\tests\perf\Azure.Core.Experimental.Performance.csproj
 $(RepoRoot)sdk\core\Azure.Core.TestFramework\tests\Azure.Core.TestFramework.Tests.csproj
 $(RepoRoot)sdk\core\Azure.Core\tests\Azure.Core.Tests.csproj

--- a/sdk/core/Azure.Core.Experimental/tests/public/JsonDataObjectTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/public/JsonDataObjectTests.cs
@@ -144,5 +144,11 @@ namespace Azure.Core.Tests.Public
 
             Assert.Throws<RuntimeBinderException>(() => data.Get("first"));
         }
+
+        [Test]
+        public void WillFail()
+        {
+            Assert.Fail("Intentional failure to show tests in this project will block the CI.");
+        }
     }
 }


### PR DESCRIPTION
I would like the Azure.Core.Experimental.Public tests to be able to block CI - they have been failing and because it wasn't blocking, I wasn't aware until recently.

This PR is intended as an experiment to see if the approach I found accomplishes this.