### PR TITLE
Sparse checkout required files for event processor

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -29,7 +29,14 @@ jobs:
     name: Handle ${{ github.event_name }} ${{ github.event.action }} event
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: 'Sparse Checkout'
+        run: |
+          set -ex
+          git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
+          git sparse-checkout init
+          git sparse-checkout set '.github'
+          # head_ref will be empty outside of pull request events, which will choose the repository default branch
+          git checkout ${{ github.head_ref }}
 
       - name: 'Az CLI login'
         if: ${{ github.event_name == 'issues' && github.event.action == 'opened' }}
@@ -59,7 +66,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230324.4
+          --version 1.0.0-dev.20230328.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -26,7 +26,14 @@ jobs:
     name: Handle ${{ github.event.schedule }} ${{ github.event.action }} event
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: 'Sparse Checkout'
+        run: |
+          set -ex
+          git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
+          git sparse-checkout init
+          git sparse-checkout set '.github'
+          # head_ref will be empty outside of pull request events, which will choose the repository default branch
+          git checkout ${{ github.head_ref }}
 
       # To run github-event-processor built from source, for testing purposes, uncomment everything
       # in between the Start/End-Build From Source comments and comment everything in between the
@@ -36,7 +43,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230324.4
+          --version 1.0.0-dev.20230328.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash


### PR DESCRIPTION
Right now the event processor only needs a couple files in `.github/` but we are doing a full checkout of the repository which can take over a minute. Using a sparse checkout here reduces this step to a couple seconds.

Fixes https://github.com/Azure/azure-sdk-tools/issues/5844

Also updating to version 1.0.0-dev.20230328.3