### PR TITLE
Remove Azure OperationType mapping

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TagEnumerationState.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TagEnumerationState.cs
@@ -51,9 +51,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             [SemanticConventions.AttributeFaasCron] = OperationType.FaaS,
             [SemanticConventions.AttributeFaasTime] = OperationType.FaaS,
 
-            [SemanticConventions.AttributeAzureNameSpace] = OperationType.Azure,
-            [SemanticConventions.AttributeMessageBusDestination] = OperationType.Azure,
-
             [SemanticConventions.AttributeEndpointAddress] = OperationType.Messaging,
             [SemanticConventions.AttributeMessagingSystem] = OperationType.Messaging,
             [SemanticConventions.AttributeMessagingDestination] = OperationType.Messaging,


### PR DESCRIPTION
Having `az.namespace` attribute mapped to OperationType.Azure results in missing az.namespace custom property (This would be ok when we use this tag to set some field on TelemetryItem). For now, we should just pass the tag as it is.
