### PR TITLE
Upgrade Python to 3.9

### DIFF
--- a/eng/pipelines/templates/jobs/ci.mgmt.yml
+++ b/eng/pipelines/templates/jobs/ci.mgmt.yml
@@ -92,9 +92,9 @@ jobs:
       vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
-        displayName: "Use Python 3.6"
+        displayName: "Use Python 3.9"
         inputs:
-          versionSpec: "3.6"
+          versionSpec: "3.9"
       - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
         parameters:
           SourceDirectory: $(Build.SourcesDirectory)

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -222,9 +222,9 @@ jobs:
         vmImage: windows-2022
       steps:
         - task: UsePythonVersion@0
-          displayName: "Use Python 3.7"
+          displayName: "Use Python 3.9"
           inputs:
-            versionSpec: "3.7"
+            versionSpec: "3.9"
 
         - template: /eng/common/pipelines/templates/steps/validate-filename.yml
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -79,9 +79,9 @@ jobs:
           echo "##vso[task.setvariable variable=VersioningProperties]$versioningProperties"
         displayName: "Setup .NET specific versioning properties"
       - task: UsePythonVersion@0
-        displayName: 'Use Python 3.6'
+        displayName: 'Use Python 3.9'
         inputs:
-          versionSpec: '3.6'
+          versionSpec: '3.9'
       - template: /eng/pipelines/templates/steps/dotnet-diagnostics.yml
         parameters:
           LogFilePath: $(Build.ArtifactStagingDirectory)/pack.binlog
@@ -222,9 +222,9 @@ jobs:
         vmImage: windows-2022
       steps:
         - task: UsePythonVersion@0
-          displayName: "Use Python 3.6"
+          displayName: "Use Python 3.7"
           inputs:
-            versionSpec: "3.6"
+            versionSpec: "3.7"
 
         - template: /eng/common/pipelines/templates/steps/validate-filename.yml
 


### PR DESCRIPTION
- Python 3.6 is EOL
- Python 3.9 is the current "default" version we use across our repos

Failures in `net - mgmt - ci` are a known issue (https://github.com/Azure/azure-sdk-for-net/pull/35151) and unrelated to this PR.