### PR TITLE
Fix: use operation.Value to get Response

### DIFF
--- a/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/README.md
+++ b/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/README.md
@@ -71,7 +71,7 @@ OncoPhenotypeResult oncoPhenotypeResult = default;
 try
 {
     Operation<OncoPhenotypeResult> operation = await client.InferCancerProfileAsync(WaitUntil.Completed, oncoPhenotypeData);
-    oncoPhenotypeResult = operation.Value
+    oncoPhenotypeResult = operation.Value;
 }
 catch (Exception ex)
 {

--- a/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/README.md
+++ b/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/README.md
@@ -71,8 +71,7 @@ OncoPhenotypeResult oncoPhenotypeResult = default;
 try
 {
     Operation<OncoPhenotypeResult> operation = await client.InferCancerProfileAsync(WaitUntil.Completed, oncoPhenotypeData);
-    Response resp = operation.GetRawResponse();
-    oncoPhenotypeResult = OncoPhenotypeResult.FromResponse(resp);
+    oncoPhenotypeResult = operation.Value
 }
 catch (Exception ex)
 {

--- a/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/samples/Sample01_InferCancerProfile.md
+++ b/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/samples/Sample01_InferCancerProfile.md
@@ -148,8 +148,7 @@ OncoPhenotypeResult oncoPhenotypeResult = default;
 try
 {
     Operation<OncoPhenotypeResult> operation = client.InferCancerProfile(WaitUntil.Completed, oncoPhenotypeData);
-    Response resp = operation.GetRawResponse();
-    oncoPhenotypeResult = OncoPhenotypeResult.FromResponse(resp);
+    oncoPhenotypeResult = operation.Value;
 }
 catch (Exception ex)
 {

--- a/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/samples/Sample01_InferCancerProfileAsync.md
+++ b/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/samples/Sample01_InferCancerProfileAsync.md
@@ -148,8 +148,7 @@ OncoPhenotypeResult oncoPhenotypeResult = default;
 try
 {
     Operation<OncoPhenotypeResult> operation = await client.InferCancerProfileAsync(WaitUntil.Completed, oncoPhenotypeData);
-    Response resp = operation.GetRawResponse();
-    oncoPhenotypeResult = OncoPhenotypeResult.FromResponse(resp);
+    oncoPhenotypeResult = operation.Value;
 }
 catch (Exception ex)
 {

--- a/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/tests/Samples/Sample01_InferCancerProfile.cs
+++ b/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/tests/Samples/Sample01_InferCancerProfile.cs
@@ -148,8 +148,7 @@ namespace Azure.Health.Insights.CancerProfiling.Tests.Samples
             try
             {
                 Operation<OncoPhenotypeResult> operation = client.InferCancerProfile(WaitUntil.Completed, oncoPhenotypeData);
-                Response resp = operation.GetRawResponse();
-                oncoPhenotypeResult = OncoPhenotypeResult.FromResponse(resp);
+                oncoPhenotypeResult = operation.Value;
             }
             catch (Exception ex)
             {

--- a/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/tests/Samples/Sample01_InferCancerProfileAsync.cs
+++ b/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/tests/Samples/Sample01_InferCancerProfileAsync.cs
@@ -148,8 +148,7 @@ namespace Azure.Health.Insights.CancerProfiling.Tests.Samples
             try
             {
                 Operation<OncoPhenotypeResult> operation = await client.InferCancerProfileAsync(WaitUntil.Completed, oncoPhenotypeData);
-                Response resp = operation.GetRawResponse();
-                oncoPhenotypeResult = OncoPhenotypeResult.FromResponse(resp);
+                oncoPhenotypeResult = operation.Value;
             }
             catch (Exception ex)
             {

--- a/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/README.md
+++ b/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/README.md
@@ -75,8 +75,7 @@ try
 {
     // Using ClinicalMatchingClient + MatchTrialsAsync
     Operation<TrialMatcherResult> operation = await clinicalMatchingClient.MatchTrialsAsync(WaitUntil.Completed, trialMatcherData);
-    Response resp = operation.GetRawResponse();
-    trialMatcherResult = TrialMatcherResult.FromResponse(resp);
+    trialMatcherResult = operation.Value;
 }
 catch (Exception ex)
 {

--- a/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/samples/Sample01_MatchTrials.md
+++ b/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/samples/Sample01_MatchTrials.md
@@ -118,8 +118,7 @@ try
 {
     // Using ClinicalMatchingClient + MatchTrials
     Operation<TrialMatcherResult> operation = clinicalMatchingClient.MatchTrials(WaitUntil.Completed, trialMatcherData);
-    Response resp = operation.GetRawResponse();
-    trialMatcherResult = TrialMatcherResult.FromResponse(resp);
+    trialMatcherResult = operation.Value;
 }
 catch (Exception ex)
 {

--- a/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/samples/Sample01_MatchTrialsAsync.md
+++ b/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/samples/Sample01_MatchTrialsAsync.md
@@ -118,8 +118,7 @@ try
 {
     // Using ClinicalMatchingClient + MatchTrialsAsync
     Operation<TrialMatcherResult> operation = await clinicalMatchingClient.MatchTrialsAsync(WaitUntil.Completed, trialMatcherData);
-    Response resp = operation.GetRawResponse();
-    trialMatcherResult = TrialMatcherResult.FromResponse(resp);
+    trialMatcherResult = operation.Value;
 }
 catch (Exception ex)
 {

--- a/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/tests/Samples/Sample01_MatchTrials.cs
+++ b/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/tests/Samples/Sample01_MatchTrials.cs
@@ -123,8 +123,7 @@ namespace Azure.Health.Insights.ClinicalMatching.Tests.Samples
             {
                 // Using ClinicalMatchingClient + MatchTrials
                 Operation<TrialMatcherResult> operation = clinicalMatchingClient.MatchTrials(WaitUntil.Completed, trialMatcherData);
-                Response resp = operation.GetRawResponse();
-                trialMatcherResult = TrialMatcherResult.FromResponse(resp);
+                trialMatcherResult = operation.Value;
             }
             catch (Exception ex)
             {

--- a/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/tests/Samples/Sample01_MatchTrialsAsync.cs
+++ b/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/tests/Samples/Sample01_MatchTrialsAsync.cs
@@ -123,8 +123,7 @@ namespace Azure.Health.Insights.ClinicalMatching.Tests.Samples
             {
                 // Using ClinicalMatchingClient + MatchTrialsAsync
                 Operation<TrialMatcherResult> operation = await clinicalMatchingClient.MatchTrialsAsync(WaitUntil.Completed, trialMatcherData);
-                Response resp = operation.GetRawResponse();
-                trialMatcherResult = TrialMatcherResult.FromResponse(resp);
+                trialMatcherResult = operation.Value;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fix samples to use operaton.Value instead of the internal  <resultModel>.GetRawResponse()