### PR TITLE
[AzureMonitorExporter] introduce platform abstraction

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -27,7 +27,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal PersistentBlobProvider? _fileBlobProvider;
         private readonly AzureMonitorStatsbeat? _statsbeat;
         private readonly ConnectionVars _connectionVars;
-        private readonly IPlatform _platform;
         internal readonly TransmissionStateManager _transmissionStateManager;
         internal readonly TransmitFromStorageHandler? _transmitFromStorageHandler;
         private bool _disposed;
@@ -40,8 +39,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
 
             options.Retry.MaxRetries = 0;
-
-            _platform = platform;
 
             _connectionVars = InitializeConnectionVars(options, platform);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Runtime.InteropServices;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
 {
@@ -12,7 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
     {
         private static string? s_defaultStorageDirectory;
 
-        internal static string? GetDefaultStorageDirectory()
+        internal static string? GetDefaultStorageDirectory(IPlatform platform)
         {
             if (s_defaultStorageDirectory != null)
             {
@@ -21,9 +22,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
             else
             {
                 string? dirPath;
-                IDictionary environmentVars = Environment.GetEnvironmentVariables();
+                IDictionary environmentVars = platform.GetEnvironmentVariables();
 
-                if (IsWindowsOS())
+                if (platform.IsOSPlatform(OSPlatform.Windows))
                 {
                     if (TryCreateTelemetryDirectory(path: environmentVars["LOCALAPPDATA"]?.ToString(), createdDirectoryPath: out dirPath)
                         || TryCreateTelemetryDirectory(path: environmentVars["TEMP"]?.ToString(), createdDirectoryPath: out dirPath))
@@ -73,7 +74,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
                 return false;
             }
         }
-
-        internal static bool IsWindowsOS() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
+{
+    internal class DefaultPlatform : IPlatform
+    {
+        public string GetEnvironmentVariable(string name) => Environment.GetEnvironmentVariable(name);
+
+        public IDictionary GetEnvironmentVariables() => Environment.GetEnvironmentVariables();
+
+        public string GetOSPlatformName()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "windows";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "linux";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "osx";
+            }
+
+            return "unknown";
+        }
+
+        public bool IsOSPlatform(OSPlatform osPlatform) => RuntimeInformation.IsOSPlatform(osPlatform);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
@@ -9,7 +9,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
 {
     internal class DefaultPlatform : IPlatform
     {
-        public string GetEnvironmentVariable(string name) => Environment.GetEnvironmentVariable(name);
+        public string? GetEnvironmentVariable(string name) => Environment.GetEnvironmentVariable(name);
 
         public IDictionary GetEnvironmentVariables() => Environment.GetEnvironmentVariables();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
@@ -8,7 +8,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
 {
     internal interface IPlatform
     {
-        public string GetEnvironmentVariable(string name);
+        /// <summary>
+        /// Returns null if the key is not found.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public string? GetEnvironmentVariable(string name);
 
         public IDictionary GetEnvironmentVariables();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
+{
+    internal interface IPlatform
+    {
+        public string GetEnvironmentVariable(string name);
+
+        public IDictionary GetEnvironmentVariables();
+
+        public bool IsOSPlatform(OSPlatform osPlatform);
+
+        public string GetOSPlatformName();
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -175,7 +175,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                 _resourceProviderId = _resourceProviderId = vmMetadata.vmId + "/" + vmMetadata.subscriptionId;
 
                 // osType takes precedence.
-                // TODO: If we get an OS Name from the Platform, should we override with a null?
                 s_operatingSystem = vmMetadata.osType?.ToLower(CultureInfo.InvariantCulture);
 
                 return;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Azure.Core;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
@@ -29,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 {
                     if (!_transmitters.TryGetValue(key, out transmitter))
                     {
-                        transmitter = new AzureMonitorTransmitter(azureMonitorExporterOptions);
+                        transmitter = new AzureMonitorTransmitter(azureMonitorExporterOptions, new DefaultPlatform());
 
                         _transmitters.Add(key, transmitter);
                     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
@@ -14,8 +14,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     /// </summary>
     internal class TransmitterFactory
     {
-        public static TransmitterFactory Instance = new();
-        public static IPlatform platform = new DefaultPlatform();
+        public static readonly TransmitterFactory Instance = new();
+        public static readonly IPlatform platform = new DefaultPlatform();
 
         internal readonly Dictionary<string, AzureMonitorTransmitter> _transmitters = new();
         private readonly object _lockObj = new();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitterFactory.cs
@@ -15,6 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     internal class TransmitterFactory
     {
         public static TransmitterFactory Instance = new();
+        public static IPlatform platform = new DefaultPlatform();
 
         internal readonly Dictionary<string, AzureMonitorTransmitter> _transmitters = new();
         private readonly object _lockObj = new();
@@ -29,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 {
                     if (!_transmitters.TryGetValue(key, out transmitter))
                     {
-                        transmitter = new AzureMonitorTransmitter(azureMonitorExporterOptions, new DefaultPlatform());
+                        transmitter = new AzureMonitorTransmitter(azureMonitorExporterOptions, platform);
 
                         _transmitters.Add(key, transmitter);
                     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
+{
+    internal class MockPlatform : IPlatform
+    {
+        public string OSPlatformName { get; set; } = "UnitTest";
+        public Func<OSPlatform, bool> IsOsPlatformFunc { get; set; } = (OSPlatform) => false;
+
+        public string GetEnvironmentVariable(string name) => string.Empty;
+
+        public IDictionary GetEnvironmentVariables() => new Dictionary<string, string>();
+
+        public string GetOSPlatformName() => OSPlatformName;
+
+        public bool IsOSPlatform(OSPlatform osPlatform) => IsOsPlatformFunc(osPlatform);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
@@ -11,12 +11,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 {
     internal class MockPlatform : IPlatform
     {
+        private readonly Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
+
         public string OSPlatformName { get; set; } = "UnitTest";
         public Func<OSPlatform, bool> IsOsPlatformFunc { get; set; } = (OSPlatform) => false;
+        public void SetEnvironmentVariable(string key, string value) => environmentVariables.Add(key, value);
 
-        public string GetEnvironmentVariable(string name) => string.Empty;
+        public string? GetEnvironmentVariable(string name) => environmentVariables.TryGetValue(name, out var value) ? value : null;
 
-        public IDictionary GetEnvironmentVariables() => new Dictionary<string, string>();
+        public IDictionary GetEnvironmentVariables() => environmentVariables;
 
         public string GetOSPlatformName() => OSPlatformName;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -13,7 +13,7 @@ using Azure.Core.TestFramework;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
-
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using OpenTelemetry.Extensions.PersistentStorage.Abstractions;
 
 using Xunit;
@@ -239,11 +239,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AzureMonitorExporterOptions options = new AzureMonitorExporterOptions
             {
                 ConnectionString = $"InstrumentationKey={testIkey};IngestionEndpoint={testEndpoint}",
-                StorageDirectory = StorageHelper.GetDefaultStorageDirectory() + "\\test",
+                StorageDirectory = "C:\\test",
                 Transport = mockTransport,
                 EnableStatsbeat = false, // disabled in tests.
             };
-            AzureMonitorTransmitter transmitter = new AzureMonitorTransmitter(options);
+            AzureMonitorTransmitter transmitter = new AzureMonitorTransmitter(options, new MockPlatform());
 
             // Overwrite storage with mock
             transmitter._fileBlobProvider = new MockFileProvider();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StatsbeatTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StatsbeatTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Xunit;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
@@ -43,7 +44,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var customer_ConnectionString = $"InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://{euEndpoint}.in.applicationinsights.azure.com/";
             var connectionStringVars = ConnectionStringParser.GetValues(customer_ConnectionString);
-            var statsBeatInstance = new AzureMonitorStatsbeat(connectionStringVars);
+            var statsBeatInstance = new AzureMonitorStatsbeat(connectionStringVars, new MockPlatform());
 
             Assert.Equal(StatsbeatConstants.Statsbeat_ConnectionString_EU, statsBeatInstance._statsbeat_ConnectionString);
         }
@@ -54,7 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var customer_ConnectionString = $"InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://{nonEUEndpoint}.in.applicationinsights.azure.com/";
             var connectionStringVars = ConnectionStringParser.GetValues(customer_ConnectionString);
-            var statsBeatInstance = new AzureMonitorStatsbeat(connectionStringVars);
+            var statsBeatInstance = new AzureMonitorStatsbeat(connectionStringVars, new MockPlatform());
 
             Assert.Equal(StatsbeatConstants.Statsbeat_ConnectionString_NonEU, statsBeatInstance._statsbeat_ConnectionString);
         }
@@ -65,7 +66,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var customer_ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://foo.in.applicationinsights.azure.com/";
 
             var connectionStringVars = ConnectionStringParser.GetValues(customer_ConnectionString);
-            Assert.Throws<InvalidOperationException>(() => new AzureMonitorStatsbeat(connectionStringVars));
+            Assert.Throws<InvalidOperationException>(() => new AzureMonitorStatsbeat(connectionStringVars, new MockPlatform()));
         }
     }
 }


### PR DESCRIPTION
## Background
Our exporter has a few instances where reading an Environment Variable or OS Name is necessary to make internal decisions.
We cannot reliably unit test these codeblocks as-is.

I want to introduce a platform abstraction to facilitate better unit testing. This is inspired by Application Insights' [IPlatform](https://github.com/microsoft/ApplicationInsights-dotnet/blob/main/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/IPlatform.cs) and [PlatformImplementation](https://github.com/microsoft/ApplicationInsights-dotnet/blob/main/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs)

## Changes

- New Interface `IPlatform`. 
  This abstracts EnvironmentVars and OS Name and facilitates more control over unit tests.
- New class `DefaultPlatform : IPlatform` which will be used at runtime. 
  This is initialized in the `TransmitterFactory`.
- New test class `MockPlatform : IPlatform` which will be used in unit tests. 
  Will add new tests in follow up PRs.