### PR TITLE
Remove auto-merge label for version increment PRs

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -236,7 +236,6 @@ stages:
                             PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                             CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                             PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
-                            PRLabels: "auto-merge"
                             CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 
             - ${{if ne(artifact.skipSmokeTests, 'true')}}:


### PR DESCRIPTION
We are deprecating the auto-merge label so removing it from the version increment PRs. 

We may add support for the GH auto-merge functionality to our automation at a future point.