### PR TITLE
Add dummy basic auth header to credscan suppressions

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -4,6 +4,7 @@
         {
             "placeholder": [
                 "Sanitized",
+                "Basic 000000000000000000000000000000000000000000000000000",
                 "%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D",
                 "fake",
                 "Test12345",


### PR DESCRIPTION
The dummy value triggers credscan errors when building in the containerregistry service directory.