### PR TITLE
Enable PS module caching

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -162,6 +162,8 @@ jobs:
                 - "/*"
                 - "!SessionRecords"
 
+      - template: /eng/common/pipelines/templates/steps/cache-ps-modules.yml
+
       - template: /eng/common/pipelines/templates/steps/verify-samples.yml
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}


### PR DESCRIPTION
To help with the PS module loading issue we are going to try to cache the modules.

This is a test to see if it can help with https://github.com/Azure/azure-sdk-for-net/issues/35310. 