### PR TITLE
[Event Hubs Trigger] MinBatch WaitTime Adjustments

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobCheckpointStoreInternal.cs
@@ -315,7 +315,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                         .GetBlobClient(blobName)
                         .GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                    var checkpoint = CreateCheckpoint(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, blob.Value.Metadata);
+                    var checkpoint = CreateCheckpoint(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, blob.Value.Metadata, blob.Value.LastModified);
                     return checkpoint;
                 }
                 catch (RequestFailedException e) when (e.ErrorCode == BlobErrorCode.BlobNotFound)
@@ -423,6 +423,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
         /// <param name="metadata">The metadata of the blob that represents the checkpoint.</param>
+        /// <param name="modifiedDate">The date/time that the blob representing the checkpoint was last modified.</param>
         ///
         /// <returns>A <see cref="EventProcessorCheckpoint"/> initialized with checkpoint properties if the checkpoint exists, otherwise <code>null</code>.</returns>
         ///
@@ -430,7 +431,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                           string eventHubName,
                                                           string consumerGroup,
                                                           string partitionId,
-                                                          IDictionary<string, string> metadata)
+                                                          IDictionary<string, string> metadata,
+                                                          DateTimeOffset modifiedDate)
         {
             var startingPosition = default(EventPosition?);
             var offset = default(long?);
@@ -464,7 +466,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                 PartitionId = partitionId,
                 StartingPosition = startingPosition.Value,
                 Offset = offset,
-                SequenceNumber = sequenceNumber
+                SequenceNumber = sequenceNumber,
+                LastModified = modifiedDate
             };
         }
 
@@ -526,7 +529,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                 PartitionId = partitionId,
                 StartingPosition = startingPosition.Value,
                 Offset = offset,
-                SequenceNumber = sequenceNumber
+                SequenceNumber = sequenceNumber,
             };
         }
 
@@ -864,6 +867,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         {
             public long? Offset { get; set; }
             public long? SequenceNumber { get; set; }
+            public DateTimeOffset? LastModified { get; set; }
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 
+- It is now possible to configure a desired minimum for the number of events included in each batch that the trigger build and how long the trigger should wait while trying to a batch of that size.  This is intended to help control costs by having the trigger invoke the Function fewer times, but with more events in each batch.
+
+  It is important to note that neither the minimum batch size or maximum wait time are guarantees; the trigger will make its best effort to honor them but you may see partial batches or inaccurate timing.  This scenario is common when a Function is scaling.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -141,6 +141,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         /// receive multiple events. This value must be less than <see cref="MaxEventBatchSize"/> and is used in
         /// conjunction with <see cref="MaxWaitTime"/>. Default 1.
         /// </summary>
+        /// <remarks>
+        /// The minimum size is not a strict guarantee, as a partial batch will be dispatched if a full batch cannot be
+        /// prepared before the <see cref="MaxWaitTime"/> has elapsed.  Partial batches are also likely for the first invocation
+        /// of the function after scaling takes place.
+        /// </remarks>
         public int MinEventBatchSize
         {
             get => _minEventBatchSize;
@@ -163,6 +168,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         /// If less than <see cref="MinEventBatchSize" /> events were available before the wait time elapses, the function
         /// will be invoked with a partial batch.  Default is 60 seconds.  The longest allowed wait time is 10 minutes.
         /// </summary>
+        /// <remarks>
+        /// This interval is not a strict guarantee for the exact timing on which the function will be invoked. There is a small
+        /// margin of error due to timer precision. When scaling takes place, the first invocation with a partial
+        /// batch may take place more quickly or may take up to twice the configured <see cref="MaxWaitTime"/>.
+        /// </remarks>
         public TimeSpan MaxWaitTime
         {
             get => _maxWaitTime;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Azure.Core.Diagnostics;
+using System.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 {
@@ -27,18 +28,20 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
         /// </summary>
         internal class PartitionProcessor : IEventProcessor, IDisposable
         {
+            private readonly CancellationTokenSource _cts = new();
+
             private readonly ITriggeredFunctionExecutor _executor;
             private readonly bool _singleDispatch;
             private readonly ILogger _logger;
-            private readonly CancellationTokenSource _cts = new();
             private readonly int _batchCheckpointFrequency;
             private int _batchCounter;
+            private bool _firstFunctionExecute;
             private bool _minimumBatchesEnabled;
             private bool _disposed;
-            private Task _cachedEventsBackgroundTask;
             private TimeSpan _maxWaitTime;
             private ValueStopwatch _currentCycle;
             private EventProcessorHostPartition _mostRecentPartitionContext;
+            private Task _cachedEventsBackgroundTask;
             private CancellationTokenSource _cachedEventsBackgroundTaskCts;
             private SemaphoreSlim _cachedEventsGuard;
 
@@ -53,17 +56,23 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 _singleDispatch = singleDispatch;
                 _batchCheckpointFrequency = options.BatchCheckpointFrequency;
                 _logger = logger;
-                _minimumBatchesEnabled = options.MinEventBatchSize > 1; // 1 is the default
-                CachedEventsManager = new PartitionProcessorEventsManager(maxBatchSize: options.MaxEventBatchSize, minBatchSize: options.MinEventBatchSize);
+                _firstFunctionExecute = true;
                 _maxWaitTime = options.MaxWaitTime;
-                _cachedEventsGuard = new SemaphoreSlim(1, 1);
+                _minimumBatchesEnabled = options.MinEventBatchSize > 1; // 1 is the default
+
+                // Events are only cached when building a batch of minimum size.
+                if (_minimumBatchesEnabled)
+                {
+                    _cachedEventsGuard = new SemaphoreSlim(1, 1);
+                    CachedEventsManager = new PartitionProcessorEventsManager(maxBatchSize: options.MaxEventBatchSize, minBatchSize: options.MinEventBatchSize);
+                }
             }
 
             public Task CloseAsync(EventProcessorHostPartition context, ProcessingStoppedReason reason)
             {
                 // signal cancellation for any in progress executions and clear the cached events
                 _cts.Cancel();
-                CachedEventsManager.ClearEventCache();
+                CachedEventsManager?.ClearEventCache();
 
                 _logger.LogDebug(GetOperationDetails(context, $"CloseAsync, {reason}"));
                 return Task.CompletedTask;
@@ -127,6 +136,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                         };
 
                         await _executor.TryExecuteAsync(input, linkedCts.Token).ConfigureAwait(false);
+                        _firstFunctionExecute = false;
                         eventToCheckpoint = events[i];
                     }
                 }
@@ -158,6 +168,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 
                                 UpdateCheckpointContext(triggerEvents, context);
                                 await TriggerExecute(triggerEvents, context, linkedCts.Token).ConfigureAwait(false);
+                                _firstFunctionExecute = false;
                                 eventToCheckpoint = triggerEvents.Last();
 
                                 // If there is a background timer task, cancel it and dispose of the cancellation token. If there
@@ -176,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                             {
                                 // If there are events waiting to be processed, and no background task running, start a monitoring cycle.
                                 _cachedEventsBackgroundTaskCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
-                                _cachedEventsBackgroundTask = MonitorCachedEvents(_cachedEventsBackgroundTaskCts);
+                                _cachedEventsBackgroundTask = MonitorCachedEvents(context.ProcessorHost.GetLastReadCheckpoint(context.PartitionId)?.LastModified, _cachedEventsBackgroundTaskCts);
                             }
                         }
                         finally
@@ -191,6 +202,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                     {
                         UpdateCheckpointContext(events, context);
                         await TriggerExecute(events, context, _cts.Token).ConfigureAwait(false);
+                        _firstFunctionExecute = false;
                         eventToCheckpoint = events.LastOrDefault();
                     }
 
@@ -227,19 +239,24 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 };
 
                 await _executor.TryExecuteAsync(input, cancellationToken).ConfigureAwait(false);
+                _firstFunctionExecute = false;
             }
 
-            private async Task MonitorCachedEvents(CancellationTokenSource backgroundCancellationTokenSource)
+            private async Task MonitorCachedEvents(DateTimeOffset? lastCheckpointTime, CancellationTokenSource backgroundCancellationTokenSource)
             {
+                Debug.Assert(_minimumBatchesEnabled, "Monitoring of cached events should only take place when minimum batches are enabled.");
+
                 var acquiredSemaphore = false;
+                var adjustedMaxWaitTime = GetAdjustedMaxWaitTime(_maxWaitTime, lastCheckpointTime, _firstFunctionExecute);
+
                 try
                 {
                     _currentCycle = ValueStopwatch.StartNew();
 
                     // Wait max wait time after starting this task before checking the number of events.
-                    while (_currentCycle.GetElapsedTime() < _maxWaitTime && !backgroundCancellationTokenSource.Token.IsCancellationRequested)
+                    while (_currentCycle.GetElapsedTime() < adjustedMaxWaitTime && !backgroundCancellationTokenSource.Token.IsCancellationRequested)
                     {
-                        var remainingTime = GetRemainingTime(_currentCycle.GetElapsedTime());
+                        var remainingTime = GetRemainingTime(_currentCycle.GetElapsedTime(), adjustedMaxWaitTime);
                         await Task.Delay(remainingTime, backgroundCancellationTokenSource.Token).ConfigureAwait(false);
                     }
 
@@ -287,19 +304,52 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 }
             }
 
-            private TimeSpan GetRemainingTime(TimeSpan elapsed)
+            private TimeSpan GetAdjustedMaxWaitTime(TimeSpan configuredMaxWaitTime, DateTimeOffset? lastCheckpointTime, bool firstInvocation)
             {
-                if ((_maxWaitTime == Timeout.InfiniteTimeSpan) || (_maxWaitTime == TimeSpan.Zero) || (elapsed == TimeSpan.Zero))
+                // If this is not the first invocation of the function for this partition then use the configured wait time.
+                if (!firstInvocation)
                 {
-                    return _maxWaitTime;
+                    return configuredMaxWaitTime;
                 }
 
-                if (elapsed >= _maxWaitTime)
+                // If there was no checkpoint found, then it is safer to dispatch a partial batch for the
+                // first invocation than assume no ownership changes are taking place.
+                if (!lastCheckpointTime.HasValue)
                 {
                     return TimeSpan.Zero;
                 }
 
-                return TimeSpan.FromMilliseconds(_maxWaitTime.TotalMilliseconds - elapsed.TotalMilliseconds);
+                var timeSinceLastCheckpoint = DateTimeOffset.UtcNow.Subtract(lastCheckpointTime.Value);
+
+                // If the checkpoint was last recorded more than the 1.5 times configured wait time ago, ownership
+                // of the partition likely migrated and the function was not invoked on the expected schedule.
+                // Dispatch any available events immediately, as the wait time is presumed to have already elapsed.
+                if (timeSinceLastCheckpoint.TotalMilliseconds >= (configuredMaxWaitTime.TotalMilliseconds * 1.5))
+                {
+                    return TimeSpan.Zero;
+                }
+
+                return configuredMaxWaitTime;
+            }
+
+            private TimeSpan GetRemainingTime(TimeSpan elapsed, TimeSpan maxWaitTime)
+            {
+                if (maxWaitTime == Timeout.InfiniteTimeSpan)
+                {
+                    return TimeSpan.Zero;
+                }
+
+                if ((maxWaitTime == TimeSpan.Zero) || (elapsed == TimeSpan.Zero))
+                {
+                    return maxWaitTime;
+                }
+
+                if (elapsed >= maxWaitTime)
+                {
+                    return TimeSpan.Zero;
+                }
+
+                return TimeSpan.FromMilliseconds(maxWaitTime.TotalMilliseconds - elapsed.TotalMilliseconds);
             }
 
             private void UpdateCheckpointContext(EventData[] events, EventProcessorHostPartition context)
@@ -345,8 +395,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                     if (disposing)
                     {
                         _cts.Dispose();
-                        _cachedEventsBackgroundTaskCts.Dispose();
-                        _cachedEventsGuard.Dispose();
+                        _cachedEventsBackgroundTaskCts?.Dispose();
+                        _cachedEventsGuard?.Dispose();
                     }
 
                     _disposed = true;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -2,29 +2,15 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Primitives;
-using Azure.Messaging.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Azure.Core.Diagnostics;
-using Microsoft.Extensions.Azure;
-using System.Text;
-using Azure.Identity;
-using Azure.Core;
-using System.Diagnostics.Tracing;
 
 namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/CheckpointInfo.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/CheckpointInfo.cs
@@ -1,17 +1,21 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Azure.WebJobs.EventHubs.Processor
 {
     internal struct CheckpointInfo
     {
         public long Offset { get; }
         public long SequenceNumber { get; }
+        public DateTimeOffset? LastModified { get; }
 
-        public CheckpointInfo(long offset, long sequenceNumber)
+        public CheckpointInfo(long offset, long sequenceNumber, DateTimeOffset? lastModified)
         {
             Offset = offset;
             SequenceNumber = sequenceNumber;
+            LastModified = lastModified;
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -18,6 +19,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
         private readonly Action<ExceptionReceivedEventArgs> _exceptionHandler;
         private IEventProcessorFactory _processorFactory;
         private BlobCheckpointStoreInternal _checkpointStore;
+
+        private ConcurrentDictionary<string, CheckpointInfo> _lastReadCheckpoint = new();
 
         /// <summary>
         /// Mocking constructor
@@ -59,7 +62,14 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
 
         protected override async Task<EventProcessorCheckpoint> GetCheckpointAsync(string partitionId, CancellationToken cancellationToken)
         {
-            return await _checkpointStore.GetCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partitionId, cancellationToken).ConfigureAwait(false);
+            var checkpoint = await _checkpointStore.GetCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partitionId, cancellationToken).ConfigureAwait(false);
+
+            if (checkpoint is BlobCheckpointStoreInternal.BlobStorageCheckpoint blobCheckpoint && blobCheckpoint is not null)
+            {
+                _lastReadCheckpoint[partitionId] = new CheckpointInfo(blobCheckpoint.Offset ?? -1, blobCheckpoint.SequenceNumber ?? -1, blobCheckpoint.LastModified);
+            }
+
+            return checkpoint;
         }
 
         internal virtual async Task CheckpointAsync(string partitionId, EventData checkpointEvent, CancellationToken cancellationToken = default)
@@ -73,6 +83,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
                 checkpointEvent.SequenceNumber,
                 cancellationToken).ConfigureAwait(false);
         }
+
+        internal virtual CheckpointInfo? GetLastReadCheckpoint(string partitionId) => _lastReadCheckpoint.TryGetValue(partitionId, out var checkpointInfo) ? checkpointInfo : null;
 
         protected override Task OnProcessingErrorAsync(Exception exception, EventProcessorHostPartition partition, string operationDescription, CancellationToken cancellationToken)
         {
@@ -109,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
             partition.EventProcessor = _processorFactory.CreatePartitionProcessor();
 
             // Since we are re-initializing this partition, any cached information we have about the partition will be incorrect.
-            // Clear it out now, if there is any, we'll refresh it in ListCheckpointsAsync, which EventProcessor will call before starting to pump messages.
+            // Clear it out now, if there is any, we'll refresh it in GetCheckpointAsync, which EventProcessor will call before starting to pump messages.
             partition.Checkpoint = null;
             await partition.EventProcessor.OpenAsync(partition).ConfigureAwait(false);
 
@@ -120,6 +132,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
 
         protected override Task OnPartitionProcessingStoppedAsync(EventProcessorHostPartition partition, ProcessingStoppedReason reason, CancellationToken cancellationToken)
         {
+            _lastReadCheckpoint.TryRemove(partition.PartitionId, out _);
             return partition.EventProcessor.CloseAsync(partition, reason);
         }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -2,14 +2,16 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Processor;
+using Azure.Messaging.EventHubs.Tests;
 using Microsoft.Azure.WebJobs.EventHubs.Listeners;
 using Microsoft.Azure.WebJobs.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -55,6 +57,15 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
             }
 
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
             Assert.AreEqual(expected, checkpoints);
         }
 
@@ -86,27 +97,38 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
             }
 
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
             processor.Verify(
                 p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
                 Times.Exactly(expected));
         }
 
-        [TestCase(1, 30)]
-        [TestCase(5, 6)]
-        [TestCase(10, 3)]
-        [TestCase(30, 1)]
+        [TestCase(1, 29)]
+        [TestCase(5, 5)]
+        [TestCase(10, 2)]
+        [TestCase(30, 0)]
         [TestCase(35, 0)]
-        public async Task ProcessEvents_MultipleDispatch_MinBatch_CheckpointsCorrectly(int batchCheckpointFrequency, int expected)
+        public async Task ProcessEvents_MultipleDispatch_MinBatch_CheckpointsCorrectly_NoCheckpoint(int batchCheckpointFrequency, int expected)
         {
             var partitionContext = EventHubTests.GetPartitionContext();
             var options = new EventHubOptions
             {
                 BatchCheckpointFrequency = batchCheckpointFrequency,
+                MaxWaitTime = TimeSpan.FromSeconds(60),
                 MinEventBatchSize = 10
             };
 
             var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
             processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => null);
             partitionContext.ProcessorHost = processor.Object;
 
             var loggerMock = new Mock<ILogger>();
@@ -121,9 +143,197 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
             }
 
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
+            // Because the first invocation will allow a partial batch due to the old checkpoint,
+            // the last 5 events will remain in the cache after disposing and stopping the background task.
+            Assert.NotNull(eventProcessor.CachedEventsManager);
+            Assert.AreEqual(5, eventProcessor.CachedEventsManager.CachedEvents.Count);
+
             processor.Verify(
                 p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
                 Times.Exactly(expected));
+
+            processor.Verify(
+                p => p.GetLastReadCheckpoint(partitionContext.PartitionId),
+                Times.AtLeastOnce);
+        }
+
+        [TestCase(1, 30)]
+        [TestCase(5, 6)]
+        [TestCase(10, 3)]
+        [TestCase(30, 1)]
+        [TestCase(35, 0)]
+        public async Task ProcessEvents_MultipleDispatch_MinBatch_CheckpointsCorrectly_RecentCheckpoint(int batchCheckpointFrequency, int expected)
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+
+            var options = new EventHubOptions
+            {
+                BatchCheckpointFrequency = batchCheckpointFrequency,
+                MaxWaitTime = TimeSpan.FromSeconds(60),
+                MinEventBatchSize = 10
+            };
+
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo(123, 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(1))));
+            partitionContext.ProcessorHost = processor.Object;
+
+            var loggerMock = new Mock<ILogger>();
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
+
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+
+            for (int i = 0; i < 60; i++)
+            {
+                List<EventData> events = new List<EventData>() { new EventData("event1"), new EventData("event2"), new EventData("event3"), new EventData("event4"), new EventData("event5") };
+                await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
+            }
+
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
+            Assert.NotNull(eventProcessor.CachedEventsManager);
+            Assert.AreEqual(0, eventProcessor.CachedEventsManager.CachedEvents.Count);
+
+            processor.Verify(
+                p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(expected));
+
+            processor.Verify(
+                p => p.GetLastReadCheckpoint(partitionContext.PartitionId),
+                Times.AtLeastOnce);
+        }
+
+        [TestCase(1, 29)]
+        [TestCase(5, 5)]
+        [TestCase(10, 2)]
+        [TestCase(30, 0)]
+        [TestCase(35, 0)]
+        public async Task ProcessEvents_MultipleDispatch_MinBatch_CheckpointsCorrectly_OldCheckpoint(int batchCheckpointFrequency, int expected)
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+
+            var options = new EventHubOptions
+            {
+                BatchCheckpointFrequency = batchCheckpointFrequency,
+                MaxWaitTime = TimeSpan.FromSeconds(60),
+                MinEventBatchSize = 10
+            };
+
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo(123, 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1))));
+            partitionContext.ProcessorHost = processor.Object;
+
+            var loggerMock = new Mock<ILogger>();
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
+
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+
+            for (int i = 0; i < 60; i++)
+            {
+                List<EventData> events = new List<EventData>() { new EventData("event1"), new EventData("event2"), new EventData("event3"), new EventData("event4"), new EventData("event5") };
+                await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
+            }
+
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
+            // Because the first invocation will allow a partial batch due to the old checkpoint,
+            // the last 5 events will remain in the cache after disposing and stopping the background task.
+            Assert.NotNull(eventProcessor.CachedEventsManager);
+            Assert.AreEqual(5, eventProcessor.CachedEventsManager.CachedEvents.Count);
+
+            processor.Verify(
+                p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(expected));
+
+            processor.Verify(
+                p => p.GetLastReadCheckpoint(partitionContext.PartitionId),
+                Times.AtLeastOnce);
+        }
+
+        [Test]
+        public async Task ProcessEvents_MultipleDispatch_MinBatch_BackgroundInvokesPartialBatch()
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+
+            var options = new EventHubOptions
+            {
+                BatchCheckpointFrequency = 1,
+                MaxWaitTime = TimeSpan.FromSeconds(20),
+                MinEventBatchSize = 10
+            };
+
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => new CheckpointInfo(123, 45678, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1))));
+            partitionContext.ProcessorHost = processor.Object;
+
+            // Because the first invocation will allow a partial batch due to the old checkpoint,
+            // the last 5 events will remain in the cache until the background task invokes.  We
+            // expect to see 28 invocations with full batches and 2 partials.
+            var expectedInvocations = 31;
+            var invocations = 0;
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var loggerMock = new Mock<ILogger>();
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+
+            executor
+                .Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() =>
+                {
+                    if (++invocations == expectedInvocations)
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                })
+                .ReturnsAsync(new FunctionResult(true));
+
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+
+            for (int i = 0; i < 60; i++)
+            {
+                List<EventData> events = new List<EventData>() { new EventData("event1"), new EventData("event2"), new EventData("event3"), new EventData("event4"), new EventData("event5") };
+                await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
+            }
+
+            await completionSource.Task.TimeoutAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            try
+            {
+                eventProcessor.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected; ignore.
+            }
+
+            Assert.NotNull(eventProcessor.CachedEventsManager);
+            Assert.AreEqual(eventProcessor.CachedEventsManager.CachedEvents.Count, 0);
         }
 
         /// <summary>
@@ -177,6 +387,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
             processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => null);
             partitionContext.ProcessorHost = processor.Object;
 
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
@@ -194,10 +405,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         public async Task Partition_OwnershipLost_DropsEvents()
         {
             var partitionContext = EventHubTests.GetPartitionContext();
-            var options = new EventHubOptions();
+            var options = new EventHubOptions { MinEventBatchSize = 5 };
 
             var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
             processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            processor.Setup(p => p.GetLastReadCheckpoint(partitionContext.PartitionId)).Returns(() => null);
             partitionContext.ProcessorHost = processor.Object;
 
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);


### PR DESCRIPTION
# Summary

The focus of these changes is to guard against the scenario where partition ownership changes while the trigger is waiting to build a batch of the requested size.  Because the new owner has no insight into how long the previous owner has already waited, the wait time will restart and obey the configured `MaxWaitTime`.  This could result in a batch for the partition not being dispatched in a timely manner.   In the worst case, where ownership of the partition changes multiple times, this could lead to a batch for the partition appearing to be severely delayed or to never be dispatched to the Function.

To guard against this, the trigger will now consider the time that the most recently read checkpoint was created and prefer dispatching a partial batch when the partition reads events for the first time and the checkpoint is older than the configured `MaxWaitTime` or when no checkpoint was found.