### PR TITLE
Diagnostic Scope improvements

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -260,6 +260,7 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Update="OpenTelemetry" Version="1.4.0" />
     <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0" />
     <PackageReference Update="OpenTelemetry.Extensions.AzureMonitor" Version="1.0.0-beta.3" />
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -180,7 +180,7 @@ namespace Azure.Core.Pipeline
             private string? _traceparent;
             private string? _tracestate;
 
-            private bool _isAllDataRequested;
+            private bool _isAllDataRequested = true;
 
             public ActivityAdapter(object? activitySource, DiagnosticSource diagnosticSource, string activityName, ActivityKind kind, object? diagnosticSourceArgs)
             {
@@ -267,7 +267,7 @@ namespace Azure.Core.Pipeline
                 _currentActivity = StartActivitySourceActivity();
                 if (_currentActivity != null)
                 {
-                    _currentActivity?.AddTag(OpenTelemetrySchemaAttribute, OpenTelemetrySchemaVersion);
+                    _currentActivity.AddTag(OpenTelemetrySchemaAttribute, OpenTelemetrySchemaVersion);
                 }
                 else
                 {

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -17,6 +19,8 @@ namespace Azure.Core.Pipeline
         private readonly string? _resourceProviderNamespace;
         private readonly DiagnosticListener? _source;
         private readonly bool _suppressNestedClientActivities;
+
+        private static readonly ConcurrentDictionary<string, object?> ActivitySources = new();
 
         public DiagnosticScopeFactory(string clientNamespace, string? resourceProviderNamespace, bool isActivityEnabled, bool suppressNestedClientActivities)
         {
@@ -47,13 +51,43 @@ namespace Azure.Core.Pipeline
             {
                 return default;
             }
-            var scope = new DiagnosticScope(_source.Name, name, _source, kind, _suppressNestedClientActivities);
+
+            var scope = new DiagnosticScope(
+                                scopeName: name,
+                                source: _source,
+                                diagnosticSourceArgs: null,
+                                activitySource: GetActivitySource(_source.Name, name),
+                                kind: kind,
+                                suppressNestedClientActivities: _suppressNestedClientActivities);
 
             if (_resourceProviderNamespace != null)
             {
                 scope.AddAttribute("az.namespace", _resourceProviderNamespace);
             }
             return scope;
+        }
+
+        /// <summary>
+        /// This method combines client namespace and operation name into an ActivitySource name and creates the activity source.
+        /// For example:
+        ///     ns: Azure.Storage.Blobs
+        ///     name: BlobClient.DownloadTo
+        ///     result Azure.Storage.Blobs.BlobClient
+        /// </summary>
+        private static object? GetActivitySource(string ns, string name)
+        {
+            if (!ActivityExtensions.SupportsActivitySource())
+            {
+                return null;
+            }
+
+            string clientName = ns;
+            int indexOfDot = name.IndexOf(".", StringComparison.OrdinalIgnoreCase);
+            if (indexOfDot != -1)
+            {
+                clientName += "." + name.Substring(0, indexOfDot);
+            }
+            return ActivitySources.GetOrAdd(clientName, static n => ActivityExtensions.CreateActivitySource(n));
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="OpenTelemetry" VersionOverride="1.4.0" />
+    <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Polly" />  
   </ItemGroup>

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="OpenTelemetry" VersionOverride="1.4.0" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Polly" />  
   </ItemGroup>

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -490,7 +490,7 @@ namespace Azure.Core.Tests
             {
                 DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
                 scope.Start();
-                if (Activity.Current != null)
+                if (Activity.Current.IsAllDataRequested)
                 {
                     activeActivityCounts++;
                 }
@@ -522,7 +522,7 @@ namespace Azure.Core.Tests
                 scope.AddLink($"00-6e76af18746bae4eadc3581338bbe8b{i}-2899ebfdbdce904b-00", "foo=bar");
 
                 scope.Start();
-                if (Activity.Current != null)
+                if (Activity.Current.IsAllDataRequested)
                 {
                     activeActivityCounts++;
                 }

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Azure.Core.Tests
 {
@@ -18,13 +20,13 @@ namespace Azure.Core.Tests
         [TearDown]
         public void ResetFeatureSwitch()
         {
-            ActivityExtensions.ResetFeatureSwitch();
+            Pipeline.ActivityExtensions.ResetFeatureSwitch();
         }
 
         private static TestAppContextSwitch SetAppConfigSwitch()
         {
             var s = new TestAppContextSwitch("Azure.Experimental.EnableActivitySource", "true");
-            ActivityExtensions.ResetFeatureSwitch();
+            Pipeline.ActivityExtensions.ResetFeatureSwitch();
             return s;
         }
 
@@ -467,6 +469,38 @@ namespace Azure.Core.Tests
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("Attribute1", "Value1"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("Attribute2", "2"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("az.namespace", "Microsoft.Azure.Core.Cool.Tests"));
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void OpenTelemetryCompatibilityWithParentBasedSampling()
+        {
+            using var _ = SetAppConfigSwitch();
+
+            // Open Telemetry Listener
+            using TracerProvider OTelTracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource($"Azure.*")
+                .SetSampler(new TraceIdRatioBasedSampler(0.1))
+                .Build();
+
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, true);
+
+            int activeActivityCounts = 0;
+            for (int i = 0; i < 100; i++)
+            {
+                DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
+                scope.Start();
+                if (scope.IsEnabled)
+                {
+                    activeActivityCounts++;
+                }
+                scope.Dispose();
+            }
+
+            Assert.IsTrue(activeActivityCounts > 0, "No activities created");
+            Assert.IsTrue(activeActivityCounts < 20, "More than expected activities created");
+
+            Assert.IsNull(Activity.Current);
         }
     }
 #endif

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -490,7 +490,7 @@ namespace Azure.Core.Tests
             {
                 DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
                 scope.Start();
-                if (Activity.Current != null) activeActivityCounts++;
+                if (Activity.Current.IsAllDataRequested) activeActivityCounts++;
                 scope.Dispose();
             }
 
@@ -519,7 +519,7 @@ namespace Azure.Core.Tests
             {
                 DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
                 scope.Start();
-                if (Activity.Current != null)
+                if (Activity.Current.IsAllDataRequested)
                     activeActivityCounts++;
                 scope.Dispose();
             }
@@ -551,7 +551,7 @@ namespace Azure.Core.Tests
 
                 scope.Start();
 
-                if (Activity.Current != null)
+                if (Activity.Current.IsAllDataRequested)
                     activeActivityCounts++;
                 scope.Dispose();
             }

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -10,10 +10,8 @@ using System.Threading;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using NUnit.Framework;
-using OpenTelemetry;
-using OpenTelemetry.Trace;
 
-[assembly:AzureResourceProviderNamespace("Microsoft.Azure.Core.Cool.Tests")]
+[assembly: AzureResourceProviderNamespace("Microsoft.Azure.Core.Cool.Tests")]
 
 namespace Azure.Core.Tests
 {
@@ -410,42 +408,6 @@ namespace Azure.Core.Tests
             nextScope.Dispose();
 
             Assert.IsNull(Activity.Current);
-        }
-
-        [Test]
-        [NonParallelizable]
-        public void OpenTelemetryCompatibilityWithParentBasedSampling()
-        {
-            AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
-            Pipeline.ActivityExtensions.ResetFeatureSwitch();
-
-            // Open Telemetry Listener
-            using TracerProvider OTelTracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddSource($"Azure.*")
-                .SetSampler(new TraceIdRatioBasedSampler(0.1))
-                .Build();
-
-            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, true);
-
-            int activeActivityCounts = 0;
-            for (int i = 0; i < 100; i++)
-            {
-                DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
-                scope.Start();
-                if (scope.IsEnabled)
-                {
-                    activeActivityCounts++;
-                }
-                scope.Dispose();
-            }
-
-            Assert.IsTrue(activeActivityCounts > 0, "No activities created");
-            Assert.IsTrue(activeActivityCounts < 20, "More than expected activities created");
-
-            Assert.IsNull(Activity.Current);
-
-            AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", false);
-            Pipeline.ActivityExtensions.ResetFeatureSwitch();
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -417,11 +417,10 @@ namespace Azure.Core.Tests
         public void OpenTelemetryCompatibilityWithParentBasedSampling()
         {
             AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
-
             Pipeline.ActivityExtensions.ResetFeatureSwitch();
 
             // Open Telemetry Listener
-            TracerProvider OTelTracerProvider = Sdk.CreateTracerProviderBuilder()
+            using TracerProvider OTelTracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource($"Azure.*")
                 .SetSampler(new TraceIdRatioBasedSampler(0.1))
                 .Build();
@@ -440,10 +439,13 @@ namespace Azure.Core.Tests
                 scope.Dispose();
             }
 
-            Assert.IsTrue(activeActivityCounts < 20);
+            Assert.IsTrue(activeActivityCounts > 0, "No activities created");
+            Assert.IsTrue(activeActivityCounts < 20, "More than expected activities created");
 
-            OTelTracerProvider.Dispose();
-            OTelTracerProvider.ForceFlush();
+            Assert.IsNull(Activity.Current);
+
+            AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", false);
+            Pipeline.ActivityExtensions.ResetFeatureSwitch();
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -443,6 +443,7 @@ namespace Azure.Core.Tests
             Assert.IsTrue(activeActivityCounts < 20);
 
             OTelTracerProvider.Dispose();
+            OTelTracerProvider.ForceFlush();
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -36,6 +36,8 @@ namespace Azure.Storage.Tests
         private readonly UploadTransferValidationOptions s_validationOptions = new UploadTransferValidationOptions();
         private readonly CancellationToken s_cancellation = new CancellationToken();
 
+        private static readonly object s_activitySource = ActivityExtensions.CreateActivitySource("Azure.Storage.Tests");
+
         public PartitionedUploaderTests(bool async)
         {
             IsAsync = async;
@@ -45,7 +47,7 @@ namespace Azure.Storage.Tests
         {
             var mock = new Mock<PartitionedUploader<object, object>.CreateScope>(MockBehavior.Strict);
             mock.Setup(del => del(s_operationName))
-                .Returns(new Core.Pipeline.DiagnosticScope("Azure.Storage.Tests", s_operationName, new DiagnosticListener("Azure.Storage.Tests"), DiagnosticScope.ActivityKind.Client, false));
+                .Returns(new Core.Pipeline.DiagnosticScope("Azure.Storage.Tests", new DiagnosticListener("Azure.Storage.Tests"), null, s_activitySource, DiagnosticScope.ActivityKind.Client, false));
             return mock;
         }
 


### PR DESCRIPTION
Making following improvements:

- Use of ConcurrentDict in DiagScope - Can be improved by passing the ActivitySource from DiagScopeFactory and giving ownership of ActivitySource to it.

- Change Scope state on the basis of activity state, to support parent-based sampling

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
