### PR TITLE
Add credscan suppression for blob recording

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -62,9 +62,10 @@
                 "sdk/identity/Azure.Identity/tests/Data/mock-arc-mi-key.key",
                 "sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.Keys.cs",
                 "sdk/storage/Azure.Storage.Common/tests/Shared/azurite_cert.pem",
-                "sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/cert.pem"
+                "sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/cert.pem",
+                "sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientOpenReadTests/OpenReadAsync_CopyReadStreamToAnotherStream.json"
             ],
-            "_justification": "Files contain private keys used by test code."
+            "_justification": "Files contain private keys used by test code or credscan false positives."
         },
         {
             "file":[


### PR DESCRIPTION
The blob recording is getting marked as a credscan false positive for rule CSCAN-AZURE0041 (redis secret).

This may not be necessary, as a re-generation of the recording in https://github.com/Azure/azure-sdk-for-net/pull/35380 fixes the issue as well.