### PR TITLE
[AzureMonitorExporter] add platform tests for StorageHelper

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -106,11 +106,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             {
                 try
                 {
-                    var storageDirectory = options.StorageDirectory
-                        ?? StorageHelper.GetDefaultStorageDirectory(platform)
-                        ?? throw new InvalidOperationException("Unable to determine offline storage directory.");
+                    var storageDirectory = StorageHelper.GetStorageDirectory(
+                        platform: platform,
+                        configuredStorageDirectory: options.StorageDirectory);
 
-                    // TODO: Fallback to default location if location provided via options does not work.
                     AzureMonitorExporterEventSource.Log.WriteInformational("InitializedPersistentStorage", storageDirectory);
 
                     return new FileBlobProvider(storageDirectory);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
@@ -13,6 +13,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
     {
         private static string? s_defaultStorageDirectory;
 
+        internal static string GetStorageDirectory(IPlatform platform, string? configuredStorageDirectory)
+        {
+            // get root directory
+            var rootDirectory = configuredStorageDirectory
+                ?? GetDefaultStorageDirectory(platform)
+                ?? throw new InvalidOperationException("Unable to determine offline storage directory.");
+
+            return rootDirectory;
+        }
+
         internal static string? GetDefaultStorageDirectory(IPlatform platform)
         {
             if (s_defaultStorageDirectory != null)
@@ -64,7 +74,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
 
             try
             {
-                createdDirectoryPath = Path.Combine(path, "Microsoft\\AzureMonitor");
+                // these names need to be separate to use the correct OS specific DirectorySeparatorChar.
+                createdDirectoryPath = Path.Combine(path, "Microsoft", "AzureMonitor");
                 Directory.CreateDirectory(createdDirectoryPath);
                 return true;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
@@ -17,7 +17,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
         {
             // get root directory
             var rootDirectory = configuredStorageDirectory
-                ?? GetDefaultStorageDirectory(platform)
+                ?? (s_defaultStorageDirectory ??= GetDefaultStorageDirectory(platform))
                 ?? throw new InvalidOperationException("Unable to determine offline storage directory.");
 
             return rootDirectory;
@@ -25,46 +25,40 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
 
         internal static string? GetDefaultStorageDirectory(IPlatform platform)
         {
-            if (s_defaultStorageDirectory != null)
+            string? dirPath;
+            IDictionary environmentVars = platform.GetEnvironmentVariables();
+
+            if (platform.IsOSPlatform(OSPlatform.Windows))
             {
-                return s_defaultStorageDirectory;
+                if (TryCreateTelemetryDirectory(platform: platform, path: environmentVars["LOCALAPPDATA"]?.ToString(), createdDirectoryPath: out dirPath)
+                    || TryCreateTelemetryDirectory(platform: platform, path: environmentVars["TEMP"]?.ToString(), createdDirectoryPath: out dirPath))
+                {
+                    s_defaultStorageDirectory = dirPath;
+                    return s_defaultStorageDirectory;
+                }
             }
             else
             {
-                string? dirPath;
-                IDictionary environmentVars = platform.GetEnvironmentVariables();
-
-                if (platform.IsOSPlatform(OSPlatform.Windows))
+                if (TryCreateTelemetryDirectory(platform: platform, path: environmentVars["TMPDIR"]?.ToString(), createdDirectoryPath: out dirPath)
+                    || TryCreateTelemetryDirectory(platform: platform, path: "/var/tmp/", createdDirectoryPath: out dirPath)
+                    || TryCreateTelemetryDirectory(platform: platform, path: "/tmp/", createdDirectoryPath: out dirPath))
                 {
-                    if (TryCreateTelemetryDirectory(path: environmentVars["LOCALAPPDATA"]?.ToString(), createdDirectoryPath: out dirPath)
-                        || TryCreateTelemetryDirectory(path: environmentVars["TEMP"]?.ToString(), createdDirectoryPath: out dirPath))
-                    {
-                        s_defaultStorageDirectory = dirPath;
-                        return s_defaultStorageDirectory;
-                    }
+                    s_defaultStorageDirectory = dirPath;
+                    return s_defaultStorageDirectory;
                 }
-                else
-                {
-                    if (TryCreateTelemetryDirectory(path: environmentVars["TMPDIR"]?.ToString(), createdDirectoryPath: out dirPath)
-                        || TryCreateTelemetryDirectory(path: "/var/tmp/", createdDirectoryPath: out dirPath)
-                        || TryCreateTelemetryDirectory(path: "/tmp/", createdDirectoryPath: out dirPath))
-                    {
-                        s_defaultStorageDirectory = dirPath;
-                        return s_defaultStorageDirectory;
-                    }
-                }
-
-                return s_defaultStorageDirectory;
             }
+
+            return s_defaultStorageDirectory;
         }
 
         /// <summary>
         /// Creates directory for storing telemetry.
         /// </summary>
+        /// <param name="platform">Platform abstraction.</param>
         /// <param name="path">Base directory.</param>
         /// <param name="createdDirectoryPath">Full directory.</param>
         /// <returns><see langword= "true"/> if directory is created.</returns>
-        private static bool TryCreateTelemetryDirectory(string? path, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? createdDirectoryPath)
+        private static bool TryCreateTelemetryDirectory(IPlatform platform, string? path, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? createdDirectoryPath)
         {
             createdDirectoryPath = null;
             if (path == null)
@@ -72,18 +66,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
                 return false;
             }
 
-            try
-            {
-                // these names need to be separate to use the correct OS specific DirectorySeparatorChar.
-                createdDirectoryPath = Path.Combine(path, "Microsoft", "AzureMonitor");
-                Directory.CreateDirectory(createdDirectoryPath);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                AzureMonitorExporterEventSource.Log.WriteError("ErrorCreatingDefaultStorageFolder", ex);
-                return false;
-            }
+            // these names need to be separate to use the correct OS specific DirectorySeparatorChar.
+            createdDirectoryPath = Path.Combine(path, "Microsoft", "AzureMonitor");
+            return platform.CreateDirectory(createdDirectoryPath);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
@@ -32,5 +33,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         }
 
         public bool IsOSPlatform(OSPlatform osPlatform) => RuntimeInformation.IsOSPlatform(osPlatform);
+
+        public bool CreateDirectory(string path)
+        {
+            try
+            {
+                Directory.CreateDirectory(path);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorExporterEventSource.Log.WriteError("ErrorCreatingStorageFolder", ex);
+                return false;
+            }
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
@@ -20,5 +20,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         public bool IsOSPlatform(OSPlatform osPlatform);
 
         public string GetOSPlatformName();
+
+        public bool CreateDirectory(string path);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
@@ -15,6 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
         public string OSPlatformName { get; set; } = "UnitTest";
         public Func<OSPlatform, bool> IsOsPlatformFunc { get; set; } = (OSPlatform) => false;
+        public Func<string, bool> CreateDirectoryFunc { get; set; } = (path) => true;
         public void SetEnvironmentVariable(string key, string value) => environmentVariables.Add(key, value);
 
         public string? GetEnvironmentVariable(string name) => environmentVariables.TryGetValue(name, out var value) ? value : null;
@@ -24,5 +25,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
         public string GetOSPlatformName() => OSPlatformName;
 
         public bool IsOSPlatform(OSPlatform osPlatform) => IsOsPlatformFunc(osPlatform);
+
+        public bool CreateDirectory(string path) => CreateDirectoryFunc(path);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StorageHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StorageHelperTests.cs
@@ -5,11 +5,19 @@ using System.IO;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 {
     public class StorageHelperTests
     {
+        internal readonly ITestOutputHelper output;
+
+        public StorageHelperTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
         // The directory separator is either '/' or '\' depending on the Platform, making unit testing tricky.
         private static readonly char ds = Path.DirectorySeparatorChar;
 
@@ -20,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 platform: new MockPlatform(),
                 configuredStorageDirectory: $"C:{ds}Temp");
 
-            Assert.Equal(directoryPath, $"C:{ds}Temp");
+            Assert.Equal($"C:{ds}Temp", directoryPath);
         }
 
         [Theory]
@@ -37,7 +45,22 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 platform: platform,
                 configuredStorageDirectory: null);
 
-            Assert.Equal(directoryPath, $"C:{ds}Temp{ds}Microsoft{ds}AzureMonitor");
+            Assert.Equal($"C:{ds}Temp{ds}Microsoft{ds}AzureMonitor", directoryPath);
+        }
+
+        [Fact]
+        public void INVESTIGATE_TEST_FAILURE()
+        {
+            var input = $"C:{ds}Temp";
+            this.output.WriteLine($"Input: {input}");
+
+            var path = Path.Combine(input, "Microsoft");
+            this.output.WriteLine($"Path: {path}");
+
+            var directory = Directory.CreateDirectory(path);
+            this.output.WriteLine($"Directory: {directory.FullName}");
+
+            Assert.Fail("investigating test");
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StorageHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StorageHelperTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class StorageHelperTests
+    {
+        // The directory separator is either '/' or '\' depending on the Platform, making unit testing tricky.
+        private static readonly char ds = Path.DirectorySeparatorChar;
+
+        [Fact]
+        public void VerifyConfiguredDirectory()
+        {
+            var directoryPath = StorageHelper.GetStorageDirectory(
+                platform: new MockPlatform(),
+                configuredStorageDirectory: $"C:{ds}Temp");
+
+            Assert.Equal(directoryPath, $"C:{ds}Temp");
+        }
+
+        [Theory]
+        [InlineData("WINDOWS", "LOCALAPPDATA")]
+        [InlineData("WINDOWS", "TEMP")]
+        [InlineData("LINUX", "TMPDIR")]
+        public void VerifyDefaultDirectory(string osName, string environmentVarName)
+        {
+            var platform = new MockPlatform();
+            platform.IsOsPlatformFunc = (os) => os.ToString() == osName;
+            platform.SetEnvironmentVariable(environmentVarName, $"C:{ds}Temp");
+
+            var directoryPath = StorageHelper.GetStorageDirectory(
+                platform: platform,
+                configuredStorageDirectory: null);
+
+            Assert.Equal(directoryPath, $"C:{ds}Temp{ds}Microsoft{ds}AzureMonitor");
+        }
+    }
+}


### PR DESCRIPTION
## Background
Our exporter has a few instances where reading an Environment Variable or OS Name is necessary to make internal decisions.
I introduced a platform abstraction in https://github.com/Azure/azure-sdk-for-net/pull/35287 to facilitate better unit testing.

## Changes
- new test class `StorageHelperTests` which validates storage directory.
- update `IPlatform` to abstract `Directory.CreateDirectory`
  This method has side effects and was causing tests to fail.
  Specifically, if a directory is not available, it will try to create within the process directory.