### PR TITLE
[Text Analytics] Implement `IsEnvironmentReadyAsync`

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/RetryOnInternalServerErrorAttribute.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/RetryOnInternalServerErrorAttribute.cs
@@ -40,14 +40,21 @@ namespace Azure.AI.TextAnalytics.Tests.Infrastructure
                     && message.Contains("Status: 200 (OK)")
                     && message.Contains("ErrorCode: InternalServerError");
 
-            // A known transient issue where the server appears to be unable to process a valid task.
+            // A known transient issue where the server appears to be unable to process a valid text analysis task.
             bool invalidTaskTypeTransientError =
                 message.Contains("Azure.RequestFailedException")
                     && message.Contains("Invalid Task Type")
                     && message.Contains("Status: 500 (Internal Server Error)")
                     && message.Contains("ErrorCode: InternalServerError");
 
-            return failedToProcessTaskTransientError || invalidTaskTypeTransientError;
+            // A known transient issue where the server fails to process a request and does not provide more context.
+            bool internalServerTransientError =
+                message.Contains("Azure.RequestFailedException")
+                    && message.Contains("Internal Server Error.")
+                    && message.Contains("Status: 200 (OK)")
+                    && message.Contains("ErrorCode: InternalServerError");
+
+            return failedToProcessTaskTransientError || invalidTaskTypeTransientError || internalServerTransientError;
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsTestEnvironment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsTestEnvironment.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 
 namespace Azure.AI.TextAnalytics.Tests
@@ -20,5 +22,24 @@ namespace Azure.AI.TextAnalytics.Tests
         public string MultiClassificationDeploymentName => GetRecordedVariable("TEXTANALYTICS_MULTI_CATEGORY_CLASSIFY_DEPLOYMENT_NAME");
         public string RecognizeCustomEntitiesProjectName => GetRecordedVariable("TEXTANALYTICS_CUSTOM_ENTITIES_PROJECT_NAME");
         public string RecognizeCustomEntitiesDeploymentName => GetRecordedVariable("TEXTANALYTICS_CUSTOM_ENTITIES_DEPLOYMENT_NAME");
+
+        protected override async ValueTask<bool> IsEnvironmentReadyAsync()
+        {
+            // Check that the dynamic resource is ready.
+            Uri endpoint = new(Endpoint);
+            AzureKeyCredential credential = new(ApiKey);
+            TextAnalyticsClient client = new(endpoint, credential);
+
+            try
+            {
+                await client.DetectLanguageAsync("The dynamic resource is ready.");
+            }
+            catch (RequestFailedException e) when (e.Status == 401)
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RetryOnInternalServerErrorAttributeTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RetryOnInternalServerErrorAttributeTests.cs
@@ -14,18 +14,24 @@ namespace Azure.AI.TextAnalytics.Tests
     public class RetryOnInternalServerErrorAttributeTests
     {
         private const string FailedToProcessTaskExceptionMessage =
-            "Failed to process task after several retry,"
-            + " Status: 200 (OK),"
-            + " ErrorCode: InternalServerError";
+            "Failed to process task after several retry"
+            + ", Status: 200 (OK)"
+            + ", ErrorCode: InternalServerError";
 
         private const string InvalidTaskTypeExceptionMessage =
-            "Invalid Task Type,"
-            + " Status: 500 (Internal Server Error),"
-            + " ErrorCode: InternalServerError";
+            "Invalid Task Type"
+            + ", Status: 500 (Internal Server Error)"
+            + ", ErrorCode: InternalServerError";
+
+        private const string InternalServerErrorExceptionMessage =
+            "Internal Server Error."
+            + ", Status: 200 (OK)"
+            + ", ErrorCode: InternalServerError";
 
         [Test]
         [TestCase(FailedToProcessTaskExceptionMessage)]
         [TestCase(InvalidTaskTypeExceptionMessage)]
+        [TestCase(InternalServerErrorExceptionMessage)]
         public void FailingTestIsRetried(string exceptionMessage)
         {
             RequestFailedException exception = new(200, exceptionMessage, "InternalServerError", null);


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-sdk-for-net/issues/35452.

Implemented `IsEnvironmentReadyAsync` with a simple request to the dynamic resource to confirm that permissions have propagated successfully, because otherwise we're at risk of having a bunch of test failures like this one:

```text
Azure.RequestFailedException : Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.
Status: 401 (PermissionDenied)
ErrorCode: 401
```

Additionally, while testing, I found another instance of the transient Internal Server Error. The difference is that the message is simply "Internal Server Error." while the previous known case said "Failed to process task after several retry":

```text
Azure.RequestFailedException : Internal Server Error.
Status: 200 (OK)
ErrorCode: InternalServerError

Additional Information:
Target: #/tasks/items/1
error-0: InternalServerError: Internal Server Error.
```

I added this one to the `ShouldRetry` method of `RetryOnInternalServerErrorAttribute`.