### PR TITLE
TransferValidation Improvements: OpenWrite

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -2041,7 +2041,7 @@ namespace Azure.Storage.Blobs.Specialized
                     position: position,
                     conditions: conditions,
                     progressHandler: options?.ProgressHandler,
-                    options?.TransferValidation
+                    options?.TransferValidation ?? ClientConfiguration.TransferValidation.Upload
                     );
             }
             catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobWriteStream.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobWriteStream.cs
@@ -35,6 +35,7 @@ namespace Azure.Storage.Blobs
         }
 
         protected override async Task AppendInternal(
+            UploadTransferValidationOptions validationOptions,
             bool async,
             CancellationToken cancellationToken)
         {
@@ -44,7 +45,7 @@ namespace Azure.Storage.Blobs
 
                 Response<BlobAppendInfo> response = await _appendBlobClient.AppendBlockInternal(
                     content: _buffer,
-                    _validationOptions,
+                    validationOptions,
                     _conditions,
                     _progressHandler,
                     async: async,
@@ -57,8 +58,11 @@ namespace Azure.Storage.Blobs
             }
         }
 
-        protected override async Task FlushInternal(bool async, CancellationToken cancellationToken)
-            => await AppendInternal(async, cancellationToken).ConfigureAwait(false);
+        protected override async Task FlushInternal(
+            UploadTransferValidationOptions validationOptions,
+            bool async,
+            CancellationToken cancellationToken)
+            => await AppendInternal(validationOptions, async, cancellationToken).ConfigureAwait(false);
 
         protected override void ValidateBufferSize(long bufferSize)
         {

--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -58,6 +58,7 @@
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IDownloadedContent.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)IHasherExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)LoggingExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonDisposingStream.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -2783,7 +2783,7 @@ namespace Azure.Storage.Blobs.Specialized
                     blobHttpHeaders: options?.HttpHeaders,
                     metadata: options?.Metadata,
                     tags: options?.Tags,
-                    options?.TransferValidation
+                    options?.TransferValidation ?? ClientConfiguration.TransferValidation.Upload
                     );
             }
             catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobWriteStream.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobWriteStream.cs
@@ -47,7 +47,10 @@ namespace Azure.Storage.Blobs
             _tags = tags;
         }
 
-        protected override async Task AppendInternal(bool async, CancellationToken cancellationToken)
+        protected override async Task AppendInternal(
+            UploadTransferValidationOptions validationOptions,
+            bool async,
+            CancellationToken cancellationToken)
         {
             if (_buffer.Length > 0)
             {
@@ -68,7 +71,7 @@ namespace Azure.Storage.Blobs
                 await _blockBlobClient.StageBlockInternal(
                     base64BlockId: blockId,
                     content: _buffer,
-                    _validationOptions,
+                    validationOptions,
                     conditions: conditions,
                     progressHandler: _progressHandler,
                     async: async,
@@ -80,9 +83,12 @@ namespace Azure.Storage.Blobs
             }
         }
 
-        protected override async Task FlushInternal(bool async, CancellationToken cancellationToken)
+        protected override async Task FlushInternal(
+            UploadTransferValidationOptions validationOptions,
+            bool async,
+            CancellationToken cancellationToken)
         {
-            await AppendInternal(async, cancellationToken).ConfigureAwait(false);
+            await AppendInternal(validationOptions, async, cancellationToken).ConfigureAwait(false);
 
             Response<BlobContentInfo> response = await _blockBlobClient.CommitBlockListInternal(
                 base64BlockIds: _blockIds,

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -4225,7 +4225,7 @@ namespace Azure.Storage.Blobs.Specialized
                     position: position,
                     conditions: conditions,
                     progressHandler: options?.ProgressHandler,
-                    options?.TransferValidation
+                    options?.TransferValidation ?? ClientConfiguration.TransferValidation.Upload
                     );
             }
             catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ContentHasher.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ContentHasher.cs
@@ -266,7 +266,7 @@ namespace Azure.Storage
             return (
                 ChecksumCalculatingStream.GetReadStream(stream, hasher.AppendHash),
                 hasher.GetFinalHash,
-                hasher.HashSize,
+                hasher.HashSizeInBytes,
                 hasher
             );
         }
@@ -293,6 +293,18 @@ namespace Azure.Storage
             byte[] hash = hasher.ComputeHash(content);
             content.Position = startPosition;
             return hash;
+        }
+
+        public static IHasher GetHasherFromAlgorithmId(StorageChecksumAlgorithm algorithm)
+        {
+            return algorithm.ResolveAuto() switch
+            {
+                StorageChecksumAlgorithm.None => null,
+                StorageChecksumAlgorithm.MD5 => new HashAlgorithmHasher(MD5.Create()),
+                StorageChecksumAlgorithm.StorageCrc64
+                    => new NonCryptographicHashAlgorithmHasher(StorageCrc64HashAlgorithm.Create()),
+                _ => throw Errors.InvalidArgument(nameof(algorithm))
+            };
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
@@ -59,6 +59,9 @@ namespace Azure.Storage
         public static ArgumentException CannotDeferTransactionalHashVerification()
             => new ArgumentException("Cannot defer transactional hash verification. Returned hash is unavailable to caller.");
 
+        public static ArgumentException CannotInitializeWriteStreamWithData()
+            => new ArgumentException("Initialized buffer for StorageWriteStream must be empty.");
+
         internal static void VerifyStreamPosition(Stream stream, string streamName)
         {
             if (stream != null && stream.CanSeek && stream.Length > 0 && stream.Position >= stream.Length)

--- a/sdk/storage/Azure.Storage.Common/src/Shared/HashAlgorithmHasher.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/HashAlgorithmHasher.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.IO.Hashing;
 using System.Security.Cryptography;
 
 namespace Azure.Storage
@@ -15,7 +14,7 @@ namespace Azure.Storage
     {
         private readonly HashAlgorithm _hashAlgorithm;
 
-        public int HashSize => _hashAlgorithm.HashSize;
+        public int HashSizeInBytes => _hashAlgorithm.HashSize >> 3;
 
         public HashAlgorithmHasher(HashAlgorithm hashAlgorithm)
         {
@@ -31,9 +30,9 @@ namespace Azure.Storage
 
         public int GetFinalHash(Span<byte> hashDestination)
         {
-            byte[] hash = _hashAlgorithm.TransformFinalBlock(new byte[0], 0, 0);
-            hash.CopyTo(hashDestination);
-            return hash.Length;
+            _hashAlgorithm.TransformFinalBlock(new byte[0], 0, 0);
+            _hashAlgorithm.Hash.CopyTo(hashDestination);
+            return _hashAlgorithm.Hash.Length;
         }
 
         public void Dispose()

--- a/sdk/storage/Azure.Storage.Common/src/Shared/HashAlgorithmHasher.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/HashAlgorithmHasher.cs
@@ -14,7 +14,7 @@ namespace Azure.Storage
     {
         private readonly HashAlgorithm _hashAlgorithm;
 
-        public int HashSizeInBytes => _hashAlgorithm.HashSize >> 3;
+        public int HashSizeInBytes => BitsToBytes(_hashAlgorithm.HashSize);
 
         public HashAlgorithmHasher(HashAlgorithm hashAlgorithm)
         {
@@ -39,5 +39,7 @@ namespace Azure.Storage
         {
             _hashAlgorithm.Dispose();
         }
+
+        private static int BitsToBytes(int bits) => bits >> 3;
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/IHasher.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/IHasher.cs
@@ -15,7 +15,7 @@ namespace Azure.Storage
         /// <summary>
         /// Hash length in bytes.
         /// </summary>
-        int HashSize { get; }
+        int HashSizeInBytes { get; }
 
         /// <summary>
         /// Hashes the contents of the stream.
@@ -31,6 +31,8 @@ namespace Azure.Storage
 
         /// <summary>
         /// Writes the current hash calculation to the given buffer.
+        /// Note that some implementations have an explicit hash finalization step.
+        /// Therefore this method should NOT be called to observe a partial calculation.
         /// </summary>
         /// <param name="hashDestination">Buffer to write hash value to.</param>
         /// <returns>Number of bytes written to buffer.</returns>

--- a/sdk/storage/Azure.Storage.Common/src/Shared/IHasherExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/IHasherExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+
+namespace Azure.Storage
+{
+    internal static partial class IHasherExtensions
+    {
+        /// <summary>
+        /// Creates a new buffer with the current hash calculation and returns it.
+        /// Note that some implementations have an explicit hash finalization step.
+        /// Therefore this method should NOT be called to observe a partial calculation.
+        /// </summary>
+        public static Memory<byte> GetFinalHash(this IHasher hasher)
+        {
+            var checksum = new Memory<byte>(new byte[hasher.HashSizeInBytes]);
+            hasher.GetFinalHash(checksum.Span);
+            return checksum;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/NonCryptographicHashAlgorithmHasher.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/NonCryptographicHashAlgorithmHasher.cs
@@ -17,7 +17,7 @@ namespace Azure.Storage
 
         private readonly NonCryptographicHashAlgorithm _nonCryptographicHashAlgorithm;
 
-        public int HashSize => _nonCryptographicHashAlgorithm.HashLengthInBytes;
+        public int HashSizeInBytes => _nonCryptographicHashAlgorithm.HashLengthInBytes;
 
         public NonCryptographicHashAlgorithmHasher(NonCryptographicHashAlgorithm nonCryptographicHashAlgorithm)
         {

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageWriteStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageWriteStream.cs
@@ -48,7 +48,7 @@ namespace Azure.Storage.Shared
             {
                 if (buffer.Position != 0)
                 {
-                    throw new ArgumentException("Buffer must be empty if provided.", nameof(buffer));
+                    throw Errors.CannotInitializeWriteStreamWithData();
                 }
                 _buffer = buffer;
                 _shouldDisposeBuffer = false;

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IDownloadedContent.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)IHasherExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)LazyLoadingReadOnlyStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PartitionedUploader.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Common/tests/StorageWriteStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageWriteStreamTests.cs
@@ -257,13 +257,19 @@ namespace Azure.Storage.Tests
                 ApiCalls = new List<string>();
             }
 
-            protected override Task AppendInternal(bool async, CancellationToken cancellationToken)
+            protected override Task AppendInternal(
+                UploadTransferValidationOptions validationOptions,
+                bool async,
+                CancellationToken cancellationToken)
             {
                 ApiCalls.Add(s_append);
                 return Task.CompletedTask;
             }
 
-            protected override Task FlushInternal(bool async, CancellationToken cancellationToken)
+            protected override Task FlushInternal(
+                UploadTransferValidationOptions validationOptions,
+                bool async,
+                CancellationToken cancellationToken)
             {
                 ApiCalls.Add(s_flush);
                 return Task.CompletedTask;

--- a/sdk/storage/Azure.Storage.Common/tests/StorageWriteStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageWriteStreamTests.cs
@@ -33,11 +33,6 @@ namespace Azure.Storage.Tests
             int writeCount = 9;
 
             Mock<PooledMemoryStream> mockBuffer = new Mock<PooledMemoryStream>(MockBehavior.Strict);
-            StorageWriteStreamImplementation stream = new StorageWriteStreamImplementation(
-                position: 0,
-                bufferSize: bufferSize,
-                progressHandler: null,
-                buffer: mockBuffer.Object);
 
             mockBuffer.SetupSequence(r => r.WriteAsync(
                 It.IsAny<byte[]>(),
@@ -58,6 +53,7 @@ namespace Azure.Storage.Tests
 
             mockBuffer.SetupSequence(r => r.Position)
                 .Returns(0)
+                .Returns(0)
                 .Returns(256)
                 .Returns(512)
                 .Returns(768)
@@ -68,6 +64,14 @@ namespace Azure.Storage.Tests
                 .Returns(512)
                 .Returns(1024)
                 .Returns(1024);
+
+            mockBuffer.Setup(r => r.Length).Returns(1024); // just need a value > 0
+
+            StorageWriteStreamImplementation stream = new StorageWriteStreamImplementation(
+                position: 0,
+                bufferSize: bufferSize,
+                progressHandler: null,
+                buffer: mockBuffer.Object);
 
             List<byte[]> data = new List<byte[]>();
             for (int i = 0; i < writeCount; i++)
@@ -89,7 +93,7 @@ namespace Azure.Storage.Tests
             Assert.AreEqual(s_append, stream.ApiCalls[1]);
             Assert.AreEqual(s_flush, stream.ApiCalls[2]);
 
-            mockBuffer.Verify(r => r.Position, Times.Exactly(11));
+            mockBuffer.Verify(r => r.Position, Times.Exactly(12));
             for (int i = 0; i < writeCount; i++)
             {
                 mockBuffer.Verify(r => r.WriteAsync(
@@ -114,11 +118,6 @@ namespace Azure.Storage.Tests
             int writeCount = 5;
 
             Mock<PooledMemoryStream> mockBuffer = new Mock<PooledMemoryStream>(MockBehavior.Strict);
-            StorageWriteStreamImplementation stream = new StorageWriteStreamImplementation(
-                position: 0,
-                bufferSize: bufferSize,
-                progressHandler: null,
-                buffer: mockBuffer.Object);
 
             mockBuffer.SetupSequence(r => r.WriteAsync(
                 It.IsAny<byte[]>(),
@@ -135,12 +134,21 @@ namespace Azure.Storage.Tests
 
             mockBuffer.SetupSequence(r => r.Position)
                 .Returns(0)
+                .Returns(0)
                 .Returns(500)
                 .Returns(1000)
                 .Returns(1000)
                 .Returns(476)
                 .Returns(976)
                 .Returns(976);
+
+            mockBuffer.Setup(r => r.Length).Returns(1024); // just need a value > 0
+
+            StorageWriteStreamImplementation stream = new StorageWriteStreamImplementation(
+                position: 0,
+                bufferSize: bufferSize,
+                progressHandler: null,
+                buffer: mockBuffer.Object);
 
             List<byte[]> data = new List<byte[]>();
             for (int i = 0; i < writeCount; i++)
@@ -161,7 +169,7 @@ namespace Azure.Storage.Tests
             Assert.AreEqual(s_append, stream.ApiCalls[1]);
             Assert.AreEqual(s_flush, stream.ApiCalls[2]);
 
-            mockBuffer.Verify(r => r.Position, Times.Exactly(7));
+            mockBuffer.Verify(r => r.Position, Times.Exactly(8));
 
             mockBuffer.Verify(r => r.WriteAsync(data[0], 0, writeSize, default));
             mockBuffer.Verify(r => r.WriteAsync(data[1], 0, writeSize, default));
@@ -185,11 +193,6 @@ namespace Azure.Storage.Tests
             int writeCount = 2;
 
             Mock<PooledMemoryStream> mockBuffer = new Mock<PooledMemoryStream>(MockBehavior.Strict);
-            StorageWriteStreamImplementation stream = new StorageWriteStreamImplementation(
-                position: 0,
-                bufferSize: bufferSize,
-                progressHandler: null,
-                buffer: mockBuffer.Object);
 
             mockBuffer.SetupSequence(r => r.WriteAsync(
                 It.IsAny<byte[]>(),
@@ -205,8 +208,17 @@ namespace Azure.Storage.Tests
             mockBuffer.SetupSequence(r => r.Position)
                 .Returns(0)
                 .Returns(0)
+                .Returns(0)
                 .Returns(976)
                 .Returns(976);
+
+            mockBuffer.Setup(r => r.Length).Returns(1024); // just need a value > 0
+
+            StorageWriteStreamImplementation stream = new StorageWriteStreamImplementation(
+                position: 0,
+                bufferSize: bufferSize,
+                progressHandler: null,
+                buffer: mockBuffer.Object);
 
             List<byte[]> data = new List<byte[]>();
             for (int i = 0; i < writeCount; i++)
@@ -228,7 +240,7 @@ namespace Azure.Storage.Tests
             Assert.AreEqual(s_append, stream.ApiCalls[2]);
             Assert.AreEqual(s_flush, stream.ApiCalls[3]);
 
-            mockBuffer.Verify(r => r.Position, Times.Exactly(4));
+            mockBuffer.Verify(r => r.Position, Times.Exactly(5));
 
             mockBuffer.Verify(r => r.WriteAsync(data[0], 0, bufferSize, default));
             mockBuffer.Verify(r => r.WriteAsync(data[0], bufferSize, 976, default));
@@ -251,7 +263,10 @@ namespace Azure.Storage.Tests
                       position,
                       bufferSize,
                       progressHandler,
-                      transferValidation: default,
+                      transferValidation: new UploadTransferValidationOptions
+                      {
+                          ChecksumAlgorithm = StorageChecksumAlgorithm.Auto
+                      },
                       buffer)
             {
                 ApiCalls = new List<string>();

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -86,7 +86,6 @@
     <Compile Include="$(AzureStorageSharedSources)UserDelegationKeyProperties.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)LazyLoadingReadOnlyStream.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" LinkBase="Shared\Storage" />
-    <Compile Include="$(AzureStorageSharedSources)StorageWriteStream.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)StorageBearerTokenChallengeAuthorizationPolicy.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)StreamExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)TransferValidationOptionsExtensions.cs" LinkBase="Shared\Storage" />

--- a/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
@@ -80,7 +80,6 @@
     <Compile Include="$(AzureStorageSharedSources)UriQueryParamsCollection.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)UserDelegationKeyProperties.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" LinkBase="Shared\Storage" />
-    <Compile Include="$(AzureStorageSharedSources)StorageWriteStream.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)\StorageBearerTokenChallengeAuthorizationPolicy.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)ISupportsTenantIdChallenges.cs" LinkBase="Shared\Storage" />
   </ItemGroup>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
@@ -48,6 +48,7 @@
     <Compile Include="$(AzureStorageSharedSources)GeoRedundantReadPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)IHasherExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)LoggingExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonDisposingStream.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -5169,7 +5169,7 @@ namespace Azure.Storage.Files.DataLake
                     position: position,
                     conditions: conditions,
                     progressHandler: options?.ProgressHandler,
-                    validationOptions: options?.TransferValidation,
+                    validationOptions: options?.TransferValidation ?? ClientConfiguration.TransferValidation.Upload,
                     closeEvent: options?.Close);
             }
             catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileWriteStream.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileWriteStream.cs
@@ -37,7 +37,10 @@ namespace Azure.Storage.Files.DataLake
             _closeEvent = closeEvent;
         }
 
-        protected override async Task AppendInternal(bool async, CancellationToken cancellationToken)
+        protected override async Task AppendInternal(
+            UploadTransferValidationOptions validationOptions,
+            bool async,
+            CancellationToken cancellationToken)
         {
             if (_buffer.Length > 0)
             {
@@ -46,7 +49,7 @@ namespace Azure.Storage.Files.DataLake
                 await _fileClient.AppendInternal(
                     content: _buffer,
                     offset: _writeIndex,
-                    validationOptionsOverride: _validationOptions,
+                    validationOptionsOverride: validationOptions,
                     leaseId: _conditions.LeaseId,
                     leaseAction: null,
                     leaseDuration: null,
@@ -62,9 +65,12 @@ namespace Azure.Storage.Files.DataLake
             }
         }
 
-        protected override async Task FlushInternal(bool async, CancellationToken cancellationToken)
+        protected override async Task FlushInternal(
+            UploadTransferValidationOptions validationOptions,
+            bool async,
+            CancellationToken cancellationToken)
         {
-            await AppendInternal(async, cancellationToken).ConfigureAwait(false);
+            await AppendInternal(validationOptions, async, cancellationToken).ConfigureAwait(false);
 
             Response<PathInfo> response = await _fileClient.FlushInternal(
                 position: _writeIndex,

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
@@ -50,6 +50,7 @@
     <Compile Include="$(AzureStorageSharedSources)LoggingExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IDownloadedContent.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)IHasherExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonDisposingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PartitionedUploader.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -6550,7 +6550,7 @@ namespace Azure.Storage.Files.Shares
                     position: position,
                     conditions: options?.OpenConditions,
                     progressHandler: options?.ProgressHandler,
-                    options?.TransferValidation
+                    options?.TransferValidation ?? ClientConfiguration.TransferValidation.Upload
                     );
             }
             catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileWriteStream.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileWriteStream.cs
@@ -35,7 +35,10 @@ namespace Azure.Storage.Files.Shares
             _writeIndex = position;
         }
 
-        protected override async Task AppendInternal(bool async, CancellationToken cancellationToken)
+        protected override async Task AppendInternal(
+            UploadTransferValidationOptions validationOptions,
+            bool async,
+            CancellationToken cancellationToken)
         {
             if (_buffer.Length > 0)
             {
@@ -46,7 +49,7 @@ namespace Azure.Storage.Files.Shares
                await _fileClient.UploadRangeInternal(
                     range: httpRange,
                     content: _buffer,
-                    _validationOptions,
+                    validationOptions,
                     _progressHandler,
                     _conditions,
                     fileLastWrittenMode: null,
@@ -59,8 +62,11 @@ namespace Azure.Storage.Files.Shares
             }
         }
 
-        protected override async Task FlushInternal(bool async, CancellationToken cancellationToken)
-            => await AppendInternal(async, cancellationToken).ConfigureAwait(false);
+        protected override async Task FlushInternal(
+            UploadTransferValidationOptions validationOptions,
+            bool async,
+            CancellationToken cancellationToken)
+            => await AppendInternal(validationOptions, async, cancellationToken).ConfigureAwait(false);
 
         protected override void ValidateBufferSize(long bufferSize)
         {


### PR DESCRIPTION
`StorageWriteStream` now keeps a running calculation of the bytes in its buffer as they are copied into the buffer, ensuring earliest possible accounting of data.

Bug fix for keeping a running calculation of an MD5. Was not an issue previously as MD5 was only ever calculated all at once before now.