### PR TITLE
[Event Hubs] Companion Package April Release Prep

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -88,7 +88,7 @@
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.25" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.5.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.8.1" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.9.0" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.14.1" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.13.1" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.2.0" />
@@ -186,7 +186,6 @@
     <PackageReference Update="ApprovalTests" Version="3.0.22" />
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Identity" Version="1.7.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.8.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.14.1" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.13.1" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.0.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 5.9.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.9.0 (2023-04-11)
 
 ### Bugs Fixed
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.9.0-beta.1</Version>
+    <Version>5.9.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.8.1</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.3.0-beta.1 (Unreleased)
+## 5.3.0 (2023-04-11)
 
 ### Features Added
 
@@ -8,13 +8,9 @@
 
   It is important to note that neither the minimum batch size or maximum wait time are guarantees; the trigger will make its best effort to honor them but you may see partial batches or inaccurate timing.  This scenario is common when a Function is scaling.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Changed the approach that the trigger uses to validate permissions on startup to ensure that it does not interrupt other triggers already running by temporarily asserting ownership of a partition.
-
-### Other Changes
 
 ## 5.2.0 (2023-02-23)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>5.3.0-beta.1</Version>
+    <Version>5.3.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.2.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>


### PR DESCRIPTION
# Summary

The focus of the changes is to prepare the Event Hubs companion packages for the April 2023 release.