### PR TITLE
update CodeOwners for AzureMonitorExporter and AzureMonitorDistro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -488,7 +488,7 @@
 /sdk/monitor/ci.yml                                                @nisha-bhatia @JoshLove-msft @pallavit
 
 # PRLabel: %Monitor - Query
-/sdk/monitor/Azure.Monitor.Query/                                  @nisha-bhatia @JoshLove-msft @pallavit
+/sdk/monitor/Azure.Monitor.Query/                                  @nisha-bhatia @JoshLove-msft @pallavit 
 /sdk/monitor/ci.yml                                                @nisha-bhatia @JoshLove-msft @pallavit
 
 # PRLabel: %Monitor - ApplicationInsights

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -488,7 +488,7 @@
 /sdk/monitor/ci.yml                                                @nisha-bhatia @JoshLove-msft @pallavit
 
 # PRLabel: %Monitor - Query
-/sdk/monitor/Azure.Monitor.Query/                                  @nisha-bhatia @JoshLove-msft @pallavit 
+/sdk/monitor/Azure.Monitor.Query/                                  @nisha-bhatia @JoshLove-msft @pallavit
 /sdk/monitor/ci.yml                                                @nisha-bhatia @JoshLove-msft @pallavit
 
 # PRLabel: %Monitor - ApplicationInsights
@@ -503,11 +503,11 @@
 
 # PRLabel: %Monitor - Exporter
 # ServiceLabel: %Monitor - Exporter %Service Attention
-/sdk/monitor/Azure.Monitor.OpenTelemetry.*/                        @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar
+/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/                 @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar
 
 # PRLabel: %Monitor - Distro
 # ServiceLabel: %Monitor - Distro %Service Attention
-/sdk/monitor/Azure.Monitor.OpenTelemetry/     @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar
+/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/               @cijothomas @reyang @rajkumar-rangaraj @TimothyMothra @vishweshbankwar
 
 # ServiceLabel: %Monitor - Metrics %Service Attention
 #/<NotInRepo>/                                                     @AzMonEssential


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/34732#issuecomment-1462696993

The monitor directory ([link](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor)) went through some renames.
This PR updates the CODEOWNERS file to reflect the most recent changes.

![image](https://user-images.githubusercontent.com/28785781/231236969-a0abe7ba-dc8f-4b63-a00a-53cbe7a34ff7.png)

cc: @vishweshbankwar @rajkumar-rangaraj 