### PR TITLE
[AzureMonitorExporter] update dependent projects for Exporter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
@@ -29,6 +29,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.Perf", "perf\Azure.Monitor.OpenTelemetry.Exporter.Perf.csproj", "{D18AC472-8802-4F0B-A8A4-E6E3DA12881E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{71F988E7-4896-4DB4-B029-8E5CB197B42C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependent Projects", "Dependent Projects", "{858E33CF-A291-4A61-B662-2776B641205E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,9 +75,17 @@ Global
 		{D18AC472-8802-4F0B-A8A4-E6E3DA12881E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D18AC472-8802-4F0B-A8A4-E6E3DA12881E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D18AC472-8802-4F0B-A8A4-E6E3DA12881E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71F988E7-4896-4DB4-B029-8E5CB197B42C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71F988E7-4896-4DB4-B029-8E5CB197B42C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71F988E7-4896-4DB4-B029-8E5CB197B42C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71F988E7-4896-4DB4-B029-8E5CB197B42C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8052009B-2126-44A3-88CD-4F3B17894C64} = {858E33CF-A291-4A61-B662-2776B641205E}
+		{71F988E7-4896-4DB4-B029-8E5CB197B42C} = {858E33CF-A291-4A61-B662-2776B641205E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A97F4B90-2591-4689-B1F8-5F21FE6D6CAE}


### PR DESCRIPTION
Azure.Monitor.OpenTelemetry.Exporter.Perf has a dependency on Azure.Test.Perf.
I added that project to our solution.

![image](https://user-images.githubusercontent.com/28785781/231258820-b87b4c48-9d43-4a09-b04e-5b89cc40c8c5.png)
