### PR TITLE
[AzureMonitorExporter] add platform tests for Transmitter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -56,7 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             _statsbeat = InitializeStatsbeat(options, _connectionVars, platform);
         }
 
-        private static ConnectionVars InitializeConnectionVars(AzureMonitorExporterOptions options, IPlatform platform)
+        internal static ConnectionVars InitializeConnectionVars(AzureMonitorExporterOptions options, IPlatform platform)
         {
             if (options.ConnectionString == null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTransmitterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTransmitterTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class AzureMonitorTransmitterTests
+    {
+        [Theory]
+        [InlineData("InstrumentationKey=001", null, "001")] // Options Only
+        [InlineData(null, "InstrumentationKey=002", "002")] // Env Var Only
+        [InlineData("InstrumentationKey=001", "InstrumentationKey=002", "001")] // If both set, Options will be used.
+        public void Verify_InitializeConnectionVars(string? optionsConnStr, string? envVarConnStr, string expectedIkey)
+        {
+            var options = new AzureMonitorExporterOptions();
+            if (optionsConnStr != null)
+            {
+                options.ConnectionString = optionsConnStr;
+            }
+
+            var platform = new MockPlatform();
+            if (envVarConnStr != null)
+            {
+                platform.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", envVarConnStr);
+            }
+
+            var connectionVars = AzureMonitorTransmitter.InitializeConnectionVars(options, platform);
+
+            Assert.Equal(expectedIkey, connectionVars.InstrumentationKey);
+        }
+    }
+}


### PR DESCRIPTION
## Background
Our exporter has a few instances where reading an Environment Variable is necessary to make internal decisions.
I introduced a platform abstraction in #35287 to facilitate better unit testing.

THIS PR pulls changes out of #35384. That PR will instead focus on Statsbeat.

## Changes
- added tests for `AzureMonitorTransmitter` methods `InitializeConnectionVars()`
