### PR TITLE
Storage queue trigger binding support for ParameterBindingData reference type

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Constants.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
     {
         public const string DateTimeFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffK";
         public const string WebJobsBlobExtensionName = "AzureStorageBlobs";
+        public const string WebJobsQueueExtensionName = "AzureStorageQueues";
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.2.0-beta.1 (Unreleased)
 
 ### Features Added
+- Trigger binding support for ParameterBindingData reference type
 
 ### Breaking Changes
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                 new ConverterArgumentBindingProvider<string>(new StorageQueueMessageToStringConverter(), loggerFactory),
                 new ConverterArgumentBindingProvider<byte[]>(new StorageQueueMessageToByteArrayConverter(), loggerFactory),
                 new ConverterArgumentBindingProvider<BinaryData>(new StorageQueueMessageToBinaryDataConverter(), loggerFactory),
+                new ConverterArgumentBindingProvider<ParameterBindingData>(new StorageQueueMessageToParameterBindingDataConverter(), loggerFactory),
                 new UserTypeArgumentBindingProvider(loggerFactory)); // Must come last, because it will attempt to bind all types.
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToParameterBindingDataConverter.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToParameterBindingDataConverter.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
+{
+    internal class StorageQueueMessageToParameterBindingDataConverter : IConverter<QueueMessage, ParameterBindingData>
+    {
+        public ParameterBindingData Convert(QueueMessage input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var content = new BinaryData(input);
+            return new ParameterBindingData("1.0", Constants.WebJobsQueueExtensionName, content, "application/json");
+        }
+    }
+}


### PR DESCRIPTION
The Azure Functions team is working on enabling SDK-type bindings for out-of-proc language workers. To enable this, we are introducing a reference type that contains all the information the worker would require to hydrate the SDK-type on the worker side, instead of passing the payload through the host. You can read internal design document [here](https://eng.ms/docs/cloud-ai-platform/devdiv/serverless-paas-balam/serverless-paas-benbyrd/app-service-web-apps/app-service-team-documents/functionteamdocs/design/oopworkers/sdktypebindings/sdktypebindings).

This PR adds a converter for `ParameterBindingData` which is the reference type mentioned above ^ 

- You can learn more about how this is used on the Functions host in this [PR description](https://github.com/Azure/azure-functions-host/pull/8815)

Related issue: https://github.com/Azure/azure-functions-dotnet-worker/issues/1445
