### PR TITLE
[FormRecognizer] 4.1.0-beta.1: added query fields suppport and misc properties

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release History
 
-## 4.1.0-beta.1 (Unreleased)
+## 4.1.0-beta.1 (2023-04-13)
 
 ### Features Added
-- Added property `Features` in `AnalyzeDocumentOptions` to support add-on capabilities.
+- Added property `QueryFields` to `AnalyzeDocumentOptions` to support field extraction without the need for added training.
+- Added property `Features` to `AnalyzeDocumentOptions` to support add-on capabilities.
 - Added properties `SimilarFontFamily`, `FontStyle`, `FontWeight`, `Color`, and `BackgroundColor` to `DocumentStyle`. These properties can only be populated when `DocumentAnalysisFeature.OcrFont` is enabled.
 - Added properties `Annotations`, `Barcodes`, `Formulas`, `Images`, and `Kind` to `DocumentPage`. `Formulas` can only be populated when `DocumentAnalysisFeature.OcrFormula` is enabled.
 - Added member `FormulaBlock` to `ParagraphRole`.
@@ -13,11 +14,11 @@
 - Added member `DocumentClassifierBuild` to `DocumentOperationKind`.
 - Added member `Boolean` to `DocumentFieldType`.
 - Added method `AsBoolean` to `DocumentFieldValue` to support extracting values of boolean fields.
+- Added property `Code` to the `CurrencyValue` class.
 - Added properties `Unit`, `CityDistrict`, `StateDistrict`, `Suburb`, `House`, and `Level` to the `AddressValue` class.
-
-### Breaking Changes
-
-### Bugs Fixed
+- Added property `CommonName` to the `DocumentKeyValuePair` class.
+- Added property `ExpiresOn` to the `DocumentModelDetails` and `DocumentModelSummary` classes.
+- Added property `CustomNeuralDocumentModelBuilds` to the `ResourceDetails` class.
 
 ### Other Changes
 - `DocumentAnalysisClient` and `DocumentModelAdministrationClient` now target service API version `2023-02-28-preview` by default. Version `2022-08-31` can still be targeted if specified in the `DocumentAnalysisClientOptions`.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -25,6 +25,7 @@ This table shows the relationship between SDK versions and supported API version
 
 |SDK version|Supported API version of service
 |-|-
+|4.1.0-beta.1 | 2.0, 2.1, 2022-08-31, 2023-02-28-preview
 |4.0.0 | 2.0, 2.1, 2022-08-31
 |3.1.X | 2.0, 2.1
 |3.0.X | 2.0
@@ -33,6 +34,7 @@ This table shows the relationship between SDK versions and supported API version
 
 |API version|Supported clients
 |-|-
+|2023-02-28-preview|DocumentAnalysisClient and DocumentModelAdministrationClient
 |2022-08-31|DocumentAnalysisClient and DocumentModelAdministrationClient
 |2.1|FormRecognizerClient and FormTrainingClient
 |2.0|FormRecognizerClient and FormTrainingClient

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
@@ -293,6 +293,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public System.Collections.Generic.IList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnalysisFeature> Features { get { throw null; } }
         public string Locale { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> Pages { get { throw null; } }
+        public System.Collections.Generic.IList<string> QueryFields { get { throw null; } }
     }
     public partial class AnalyzeResult
     {
@@ -426,6 +427,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public double Amount { get { throw null; } }
+        public string Code { get { throw null; } }
         public string Symbol { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -502,7 +504,9 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public static Azure.AI.FormRecognizer.DocumentAnalysis.AnalyzedDocument AnalyzedDocument(string documentType = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.BoundingRegion> boundingRegions = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> spans = null, System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentField> fields = null, float confidence = 0f) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.AnalyzeResult AnalyzeResult(string modelId = null, string content = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPage> pages = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentTable> tables = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValuePair> keyValuePairs = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentStyle> styles = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentLanguage> languages = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.AnalyzedDocument> documents = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.BoundingRegion BoundingRegion(int pageNumber = 0, System.Collections.Generic.IReadOnlyList<System.Drawing.PointF> boundingPolygon = null) { throw null; }
-        public static Azure.AI.FormRecognizer.DocumentAnalysis.CurrencyValue CurrencyValue(double amount = 0, string symbol = null) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.CurrencyValue CurrencyValue(double amount, string symbol) { throw null; }
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.CurrencyValue CurrencyValue(double amount = 0, string symbol = null, string code = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnnotation DocumentAnnotation(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnnotationKind kind = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnnotationKind), System.Collections.Generic.IReadOnlyList<System.Drawing.PointF> boundingPolygon = null, float confidence = 0f) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentBarcode DocumentBarcode(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentBarcodeKind kind = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentBarcodeKind), string value = null, System.Collections.Generic.IReadOnlyList<System.Drawing.PointF> boundingPolygon = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan span = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan), float confidence = 0f) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentClassifierBuildOperationDetails DocumentClassifierBuildOperationDetails(string operationId = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus status = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus.NotStarted, int? percentCompleted = default(int?), System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.DateTimeOffset lastUpdatedOn = default(System.DateTimeOffset), System.Uri resourceLocation = null, System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, Azure.ResponseError error = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentClassifierDetails result = null) { throw null; }
@@ -527,14 +531,20 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFormula DocumentFormula(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFormulaKind kind = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFormulaKind), string value = null, System.Collections.Generic.IReadOnlyList<System.Drawing.PointF> boundingPolygon = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan span = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan), float confidence = 0f) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentImage DocumentImage(System.Collections.Generic.IReadOnlyList<System.Drawing.PointF> boundingPolygon = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan span = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan), int pageNumber = 0, float confidence = 0f) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement DocumentKeyValueElement(string content = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.BoundingRegion> boundingRegions = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> spans = null) { throw null; }
-        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValuePair DocumentKeyValuePair(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement key = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement value = null, float confidence = 0f) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValuePair DocumentKeyValuePair(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement key, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement value, float confidence) { throw null; }
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValuePair DocumentKeyValuePair(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement key = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement value = null, float confidence = 0f, string commonName = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentLanguage DocumentLanguage(string locale = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> spans = null, float confidence = 0f) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentLine DocumentLine(string content = null, System.Collections.Generic.IReadOnlyList<System.Drawing.PointF> boundingPolygon = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> spans = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> words = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelBuildOperationDetails DocumentModelBuildOperationDetails(string operationId = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus status = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus.NotStarted, int? percentCompleted = default(int?), System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.DateTimeOffset lastUpdatedOn = default(System.DateTimeOffset), System.Uri resourceLocation = null, System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, Azure.ResponseError error = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails result = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelComposeOperationDetails DocumentModelComposeOperationDetails(string operationId = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus status = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus.NotStarted, int? percentCompleted = default(int?), System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.DateTimeOffset lastUpdatedOn = default(System.DateTimeOffset), System.Uri resourceLocation = null, System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, Azure.ResponseError error = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails result = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelCopyToOperationDetails DocumentModelCopyToOperationDetails(string operationId = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus status = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus.NotStarted, int? percentCompleted = default(int?), System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.DateTimeOffset lastUpdatedOn = default(System.DateTimeOffset), System.Uri resourceLocation = null, System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, Azure.ResponseError error = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails result = null) { throw null; }
-        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails DocumentModelDetails(string modelId = null, string description = null, System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentTypeDetails> documentTypes = null) { throw null; }
-        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelSummary DocumentModelSummary(string modelId = null, string description = null, System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails DocumentModelDetails(string modelId, string description, System.DateTimeOffset createdOn, System.Collections.Generic.IReadOnlyDictionary<string, string> tags, System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentTypeDetails> documentTypes) { throw null; }
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelDetails DocumentModelDetails(string modelId = null, string description = null, System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentTypeDetails> documentTypes = null, System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelSummary DocumentModelSummary(string modelId, string description, System.DateTimeOffset createdOn, System.Collections.Generic.IReadOnlyDictionary<string, string> tags) { throw null; }
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelSummary DocumentModelSummary(string modelId = null, string description = null, System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPage DocumentPage(int pageNumber, float? angle, float? width, float? height, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPageLengthUnit? unit, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> spans, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> words, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSelectionMark> selectionMarks, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentLine> lines) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPage DocumentPage(int pageNumber = 0, float? angle = default(float?), float? width = default(float?), float? height = default(float?), Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPageLengthUnit? unit = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPageLengthUnit?), System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> spans = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> words = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSelectionMark> selectionMarks = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentLine> lines = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPageKind kind = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentPageKind), System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentAnnotation> annotations = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentBarcode> barcodes = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFormula> formulas = null, System.Collections.Generic.IEnumerable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentImage> images = null) { throw null; }
@@ -550,7 +560,10 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public static Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord DocumentWord(string content = null, System.Collections.Generic.IReadOnlyList<System.Drawing.PointF> boundingPolygon = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan span = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan), float confidence = 0f) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.OperationDetails OperationDetails(string operationId = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus status = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus.NotStarted, int? percentCompleted = default(int?), System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.DateTimeOffset lastUpdatedOn = default(System.DateTimeOffset), Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationKind kind = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationKind), System.Uri resourceLocation = null, System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null, Azure.ResponseError error = null) { throw null; }
         public static Azure.AI.FormRecognizer.DocumentAnalysis.OperationSummary OperationSummary(string operationId = null, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus status = Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationStatus.NotStarted, int? percentCompleted = default(int?), System.DateTimeOffset createdOn = default(System.DateTimeOffset), System.DateTimeOffset lastUpdatedOn = default(System.DateTimeOffset), Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationKind kind = default(Azure.AI.FormRecognizer.DocumentAnalysis.DocumentOperationKind), System.Uri resourceLocation = null, System.Collections.Generic.IReadOnlyDictionary<string, string> tags = null) { throw null; }
-        public static Azure.AI.FormRecognizer.DocumentAnalysis.ResourceDetails ResourceDetails(int customDocumentModelCount = 0, int customDocumentModelLimit = 0) { throw null; }
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.QuotaDetails QuotaDetails(int used = 0, int quota = 0, System.DateTimeOffset quotaResetsOn = default(System.DateTimeOffset)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.ResourceDetails ResourceDetails(int customDocumentModelCount, int customDocumentModelLimit) { throw null; }
+        public static Azure.AI.FormRecognizer.DocumentAnalysis.ResourceDetails ResourceDetails(int customDocumentModelCount = 0, int customDocumentModelLimit = 0, Azure.AI.FormRecognizer.DocumentAnalysis.QuotaDetails customNeuralDocumentModelBuilds = null) { throw null; }
     }
     public partial class DocumentAnnotation
     {
@@ -754,6 +767,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     public partial class DocumentKeyValuePair
     {
         internal DocumentKeyValuePair() { }
+        public string CommonName { get { throw null; } }
         public float Confidence { get { throw null; } }
         public Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement Key { get { throw null; } }
         public Azure.AI.FormRecognizer.DocumentAnalysis.DocumentKeyValueElement Value { get { throw null; } }
@@ -840,6 +854,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public System.DateTimeOffset CreatedOn { get { throw null; } }
         public string Description { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentTypeDetails> DocumentTypes { get { throw null; } }
+        public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public string ModelId { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
     }
@@ -848,6 +863,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         internal DocumentModelSummary() { }
         public System.DateTimeOffset CreatedOn { get { throw null; } }
         public string Description { get { throw null; } }
+        public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public string ModelId { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Tags { get { throw null; } }
     }
@@ -1128,11 +1144,19 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public static bool operator !=(Azure.AI.FormRecognizer.DocumentAnalysis.ParagraphRole left, Azure.AI.FormRecognizer.DocumentAnalysis.ParagraphRole right) { throw null; }
         public override string ToString() { throw null; }
     }
+    public partial class QuotaDetails
+    {
+        internal QuotaDetails() { }
+        public int Quota { get { throw null; } }
+        public System.DateTimeOffset QuotaResetsOn { get { throw null; } }
+        public int Used { get { throw null; } }
+    }
     public partial class ResourceDetails
     {
         internal ResourceDetails() { }
         public int CustomDocumentModelCount { get { throw null; } }
         public int CustomDocumentModelLimit { get { throw null; } }
+        public Azure.AI.FormRecognizer.DocumentAnalysis.QuotaDetails CustomNeuralDocumentModelBuilds { get { throw null; } }
     }
 }
 namespace Azure.AI.FormRecognizer.Models

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOptions.cs
@@ -46,5 +46,11 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// For more information, see <see href="https://aka.ms/azsdk/formrecognizer/features">Azure Form Recognizer add-on capabilities</see>.
         /// </summary>
         public IList<DocumentAnalysisFeature> Features { get; } = new List<DocumentAnalysisFeature>();
+
+        /// <summary>
+        /// A list of fields to extract without the need of added training.
+        /// For more information, see <see href="https://aka.ms/azsdk/formrecognizer/queryfields">Azure Form Recognizer query field extraction</see>.
+        /// </summary>
+        public IList<string> QueryFields { get; } = new List<string>();
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BoundingRegion.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BoundingRegion.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         internal BoundingRegion(int pageNumber, IReadOnlyList<float> polygon)
         {
             PageNumber = pageNumber;
-            BoundingPolygon = ClientCommon.CovertToListOfPointF(polygon);
+            BoundingPolygon = ClientCommon.ConvertToListOfPointF(polygon);
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CurrencyValue.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CurrencyValue.cs
@@ -10,12 +10,12 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <summary> Initializes a new instance of CurrencyValue. </summary>
         /// <param name="amount"> Currency amount. </param>
         /// <param name="symbol"> Currency symbol label, if any. </param>
-        /// <param name="currencyCode"> Resolved currency code (ISO 4217), if any. </param>
-        internal CurrencyValue(double amount, string symbol, string currencyCode)
+        /// <param name="code"> Resolved currency code (ISO 4217), if any. </param>
+        internal CurrencyValue(double amount, string symbol, string code)
         {
             Amount = amount;
             Symbol = symbol;
-            CurrencyCode = currencyCode;
+            Code = code;
         }
 
         /// <summary>
@@ -32,6 +32,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <summary>
         /// Resolved currency code (ISO 4217), if any.
         /// </summary>
-        internal string CurrencyCode { get; }
+        [CodeGenMember("CurrencyCode")]
+        public string Code { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClient.cs
@@ -17,8 +17,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// documents with models built on custom document types.
     /// </summary>
     /// <remarks>
-    /// Client is only available for <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_08_31"/> and higher.
-    /// If you want to use a lower version, please use the <see cref="FormRecognizer.FormRecognizerClient"/>.
+    /// This client only supports <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_08_31"/> and newer.
+    /// To use an older service version, see <see cref="FormRecognizerClient"/>.
     /// </remarks>
     public class DocumentAnalysisClient
     {
@@ -154,7 +154,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     options.Locale,
                     Constants.DefaultStringIndexType,
                     options.Features.Count == 0 ? null : options.Features,
-                    queryFields: null,
+                    options.QueryFields.Count == 0 ? null : options.QueryFields,
                     document,
                     cancellationToken).ConfigureAwait(false);
 
@@ -217,7 +217,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     options.Locale,
                     Constants.DefaultStringIndexType,
                     options.Features.Count == 0 ? null : options.Features,
-                    queryFields: null,
+                    options.QueryFields.Count == 0 ? null : options.QueryFields,
                     document,
                     cancellationToken);
 
@@ -280,7 +280,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     options.Locale,
                     Constants.DefaultStringIndexType,
                     options.Features.Count == 0 ? null : options.Features,
-                    queryFields: null,
+                    options.QueryFields.Count == 0 ? null : options.QueryFields,
                     request,
                     cancellationToken).ConfigureAwait(false);
 
@@ -343,7 +343,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     options.Locale,
                     Constants.DefaultStringIndexType,
                     options.Features.Count == 0 ? null : options.Features,
-                    queryFields: null,
+                    options.QueryFields.Count == 0 ? null : options.QueryFields,
                     request,
                     cancellationToken);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisModelFactory.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisModelFactory.cs
@@ -102,9 +102,20 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="amount"> Currency amount. </param>
         /// <param name="symbol"> Currency symbol label, if any. </param>
         /// <returns> A new <see cref="DocumentAnalysis.CurrencyValue"/> instance for mocking. </returns>
-        public static CurrencyValue CurrencyValue(double amount = default, string symbol = null)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static CurrencyValue CurrencyValue(double amount, string symbol)
         {
-            return new CurrencyValue(amount, symbol, currencyCode: null);
+            return new CurrencyValue(amount, symbol, code: null);
+        }
+
+        /// <summary> Initializes a new instance of CurrencyValue. </summary>
+        /// <param name="amount"> Currency amount. </param>
+        /// <param name="symbol"> Currency symbol label, if any. </param>
+        /// <param name="code"> Resolved currency code (ISO 4217), if any. </param>
+        /// <returns> A new <see cref="DocumentAnalysis.CurrencyValue"/> instance for mocking. </returns>
+        public static CurrencyValue CurrencyValue(double amount = default, string symbol = null, string code = null)
+        {
+            return new CurrencyValue(amount, symbol, code);
         }
 
         /// <summary> Initializes a new instance of DocumentTypeDetails. </summary>
@@ -366,9 +377,21 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="value"> Field value of the key-value pair. </param>
         /// <param name="confidence"> Confidence of correctly extracting the key-value pair. </param>
         /// <returns> A new <see cref="DocumentAnalysis.DocumentKeyValuePair"/> instance for mocking. </returns>
-        public static DocumentKeyValuePair DocumentKeyValuePair(DocumentKeyValueElement key = null, DocumentKeyValueElement value = null, float confidence = default)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static DocumentKeyValuePair DocumentKeyValuePair(DocumentKeyValueElement key, DocumentKeyValueElement value, float confidence)
         {
             return new DocumentKeyValuePair(key, value, commonName: null, confidence);
+        }
+
+        /// <summary> Initializes a new instance of DocumentKeyValuePair. </summary>
+        /// <param name="key"> Field label of the key-value pair. </param>
+        /// <param name="value"> Field value of the key-value pair. </param>
+        /// <param name="confidence"> Confidence of correctly extracting the key-value pair. </param>
+        /// <param name="commonName"> Common name of the key-value pair. </param>
+        /// <returns> A new <see cref="DocumentAnalysis.DocumentKeyValuePair"/> instance for mocking. </returns>
+        public static DocumentKeyValuePair DocumentKeyValuePair(DocumentKeyValueElement key = null, DocumentKeyValueElement value = null, float confidence = default, string commonName = null)
+        {
+            return new DocumentKeyValuePair(key, value, commonName, confidence);
         }
 
         /// <summary> Initializes a new instance of DocumentLanguage. </summary>
@@ -458,12 +481,29 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="tags"> List of key-value tag attributes associated with the model. </param>
         /// <param name="documentTypes"> Supported document types. </param>
         /// <returns> A new <see cref="DocumentAnalysis.DocumentModelDetails"/> instance for mocking. </returns>
-        public static DocumentModelDetails DocumentModelDetails(string modelId = null, string description = null, DateTimeOffset createdOn = default, IReadOnlyDictionary<string, string> tags = null, IReadOnlyDictionary<string, DocumentTypeDetails> documentTypes = null)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static DocumentModelDetails DocumentModelDetails(string modelId, string description, DateTimeOffset createdOn, IReadOnlyDictionary<string, string> tags, IReadOnlyDictionary<string, DocumentTypeDetails> documentTypes)
         {
             tags ??= new Dictionary<string, string>();
             documentTypes ??= new Dictionary<string, DocumentTypeDetails>();
 
-            return new DocumentModelDetails(modelId, description, createdOn, expirationDateTime: null, apiVersion: null, tags, documentTypes);
+            return new DocumentModelDetails(modelId, description, createdOn, expiresOn: null, apiVersion: null, tags, documentTypes);
+        }
+
+        /// <summary> Initializes a new instance of DocumentModelDetails. </summary>
+        /// <param name="modelId"> Unique model name. </param>
+        /// <param name="description"> Model description. </param>
+        /// <param name="createdOn"> Date and time (UTC) when the model was created. </param>
+        /// <param name="tags"> List of key-value tag attributes associated with the model. </param>
+        /// <param name="documentTypes"> Supported document types. </param>
+        /// <param name="expiresOn"> Date and time (UTC) when the model expires. </param>
+        /// <returns> A new <see cref="DocumentAnalysis.DocumentModelDetails"/> instance for mocking. </returns>
+        public static DocumentModelDetails DocumentModelDetails(string modelId = null, string description = null, DateTimeOffset createdOn = default, IReadOnlyDictionary<string, string> tags = null, IReadOnlyDictionary<string, DocumentTypeDetails> documentTypes = null, DateTimeOffset? expiresOn = null)
+        {
+            tags ??= new Dictionary<string, string>();
+            documentTypes ??= new Dictionary<string, DocumentTypeDetails>();
+
+            return new DocumentModelDetails(modelId, description, createdOn, expiresOn, apiVersion: null, tags, documentTypes);
         }
 
         /// <summary> Initializes a new instance of DocumentModelSummary. </summary>
@@ -472,11 +512,26 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="createdOn"> Date and time (UTC) when the model was created. </param>
         /// <param name="tags"> List of key-value tag attributes associated with the model. </param>
         /// <returns> A new <see cref="DocumentAnalysis.DocumentModelSummary"/> instance for mocking. </returns>
-        public static DocumentModelSummary DocumentModelSummary(string modelId = null, string description = null, DateTimeOffset createdOn = default, IReadOnlyDictionary<string, string> tags = null)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static DocumentModelSummary DocumentModelSummary(string modelId, string description, DateTimeOffset createdOn, IReadOnlyDictionary<string, string> tags)
         {
             tags ??= new Dictionary<string, string>();
 
-            return new DocumentModelSummary(modelId, description, createdOn, expirationDateTime: null, apiVersion: null, tags);
+            return new DocumentModelSummary(modelId, description, createdOn, expiresOn: null, apiVersion: null, tags);
+        }
+
+        /// <summary> Initializes a new instance of DocumentModelSummary. </summary>
+        /// <param name="modelId"> Unique model name. </param>
+        /// <param name="description"> Model description. </param>
+        /// <param name="createdOn"> Date and time (UTC) when the model was created. </param>
+        /// <param name="tags"> List of key-value tag attributes associated with the model. </param>
+        /// <param name="expiresOn"> Date and time (UTC) when the model expires. </param>
+        /// <returns> A new <see cref="DocumentAnalysis.DocumentModelSummary"/> instance for mocking. </returns>
+        public static DocumentModelSummary DocumentModelSummary(string modelId = null, string description = null, DateTimeOffset createdOn = default, IReadOnlyDictionary<string, string> tags = null, DateTimeOffset? expiresOn = null)
+        {
+            tags ??= new Dictionary<string, string>();
+
+            return new DocumentModelSummary(modelId, description, createdOn, expiresOn, apiVersion: null, tags);
         }
 
         /// <summary> Initializes a new instance of DocumentPage. </summary>
@@ -680,13 +735,36 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             return new OperationSummary(operationId, status, percentCompleted, createdOn, lastUpdatedOn, kind, resourceLocation, apiVersion: null, tags);
         }
 
+        /// <summary>
+        /// Initializes a new instance of QuotaDetails.
+        /// </summary>
+        /// <param name="used"> Amount of the resource quota used. </param>
+        /// <param name="quota"> Resource quota limit. </param>
+        /// <param name="quotaResetsOn"> Date/time when the resource quota usage will be reset. </param>
+        /// <returns> A new <see cref="DocumentAnalysis.QuotaDetails"/> instance for mocking. </returns>
+        public static QuotaDetails QuotaDetails(int used = default, int quota = default, DateTimeOffset quotaResetsOn = default)
+        {
+            return new QuotaDetails(used, quota, quotaResetsOn);
+        }
+
         /// <summary> Initializes a new instance of ResourceDetails. </summary>
         /// <param name="customDocumentModelCount"> Number of custom models in the current resource. </param>
         /// <param name="customDocumentModelLimit"> Maximum number of custom models supported in the current resource. </param>
         /// <returns> A new <see cref="DocumentAnalysis.ResourceDetails"/> instance for mocking. </returns>
-        public static ResourceDetails ResourceDetails(int customDocumentModelCount = default, int customDocumentModelLimit = default)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ResourceDetails ResourceDetails(int customDocumentModelCount, int customDocumentModelLimit)
         {
-            return new ResourceDetails(customDocumentModelCount, customDocumentModelLimit);
+            return new ResourceDetails(customDocumentModelCount, customDocumentModelLimit, customNeuralDocumentModelBuilds: null);
+        }
+
+        /// <summary> Initializes a new instance of ResourceDetails. </summary>
+        /// <param name="customDocumentModelCount"> Number of custom models in the current resource. </param>
+        /// <param name="customDocumentModelLimit"> Maximum number of custom models supported in the current resource. </param>
+        /// <param name="customNeuralDocumentModelBuilds"> Quota used, limit, and next reset date/time. </param>
+        /// <returns> A new <see cref="DocumentAnalysis.ResourceDetails"/> instance for mocking. </returns>
+        public static ResourceDetails ResourceDetails(int customDocumentModelCount = default, int customDocumentModelLimit = default, QuotaDetails customNeuralDocumentModelBuilds = null)
+        {
+            return new ResourceDetails(customDocumentModelCount, customDocumentModelLimit, customNeuralDocumentModelBuilds);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnnotation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnnotation.cs
@@ -34,7 +34,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             get => throw new InvalidOperationException();
             set
             {
-                BoundingPolygon = ClientCommon.CovertToListOfPointF(value);
+                BoundingPolygon = ClientCommon.ConvertToListOfPointF(value);
             }
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentBarcode.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentBarcode.cs
@@ -36,7 +36,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             get => throw new InvalidOperationException();
             set
             {
-                BoundingPolygon = ClientCommon.CovertToListOfPointF(value);
+                BoundingPolygon = ClientCommon.ConvertToListOfPointF(value);
             }
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentFormula.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentFormula.cs
@@ -36,7 +36,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             get => throw new InvalidOperationException();
             set
             {
-                BoundingPolygon = ClientCommon.CovertToListOfPointF(value);
+                BoundingPolygon = ClientCommon.ConvertToListOfPointF(value);
             }
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentImage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentImage.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             get => throw new InvalidOperationException();
             set
             {
-                BoundingPolygon = ClientCommon.CovertToListOfPointF(value);
+                BoundingPolygon = ClientCommon.ConvertToListOfPointF(value);
             }
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentLine.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentLine.cs
@@ -40,7 +40,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             get => throw new InvalidOperationException();
             set
             {
-                BoundingPolygon = ClientCommon.CovertToListOfPointF(value);
+                BoundingPolygon = ClientCommon.ConvertToListOfPointF(value);
             }
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
@@ -17,8 +17,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     /// properties.
     /// </summary>
     /// <remarks>
-    /// This client only works with <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_08_31"/> and newer.
-    /// If you want to use a lower version, please use the <see cref="Training.FormTrainingClient"/>.
+    /// This client only supports <see cref="DocumentAnalysisClientOptions.ServiceVersion.V2022_08_31"/> and newer.
+    /// To use an older service version, see <see cref="Training.FormTrainingClient"/>.
     /// </remarks>
     public class DocumentModelAdministrationClient
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelDetails.cs
@@ -18,7 +18,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <summary>
         /// Date and time (UTC) when the document model will expire.
         /// </summary>
-        internal DateTimeOffset? ExpirationDateTime { get; }
+        [CodeGenMember("ExpirationDateTime")]
+        public DateTimeOffset? ExpiresOn { get; }
 
         /// <summary>
         /// Supported document types.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelSummary.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelSummary.cs
@@ -18,7 +18,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <summary>
         /// Date and time (UTC) when the document model will expire.
         /// </summary>
-        internal DateTimeOffset? ExpirationDateTime { get; }
+        [CodeGenMember("ExpirationDateTime")]
+        public DateTimeOffset? ExpiresOn { get; }
 
         /// <summary> API version used to create this model. </summary>
         internal string ApiVersion { get; }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentSelectionMark.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentSelectionMark.cs
@@ -41,7 +41,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             get => throw new InvalidOperationException();
             set
             {
-                BoundingPolygon = ClientCommon.CovertToListOfPointF(value);
+                BoundingPolygon = ClientCommon.ConvertToListOfPointF(value);
             }
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentWord.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentWord.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             get => throw new InvalidOperationException();
             set
             {
-                BoundingPolygon = ClientCommon.CovertToListOfPointF(value);
+                BoundingPolygon = ClientCommon.ConvertToListOfPointF(value);
             }
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient/FormRecognizerClient.cs
@@ -19,7 +19,8 @@ namespace Azure.AI.FormRecognizer
     /// In order to use later versions and their new features, see <see cref="DocumentAnalysis.DocumentAnalysisClient"/>.
     /// </summary>
     /// <remarks>
-    /// Client is only available for <see cref="FormRecognizerClientOptions.ServiceVersion.V2_1"/> and older.
+    /// This client only supports <see cref="FormRecognizerClientOptions.ServiceVersion.V2_1"/> and older.
+    /// To use a newer service version, see <see cref="DocumentAnalysis.DocumentAnalysisClient"/>.
     /// </remarks>
     public class FormRecognizerClient
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient/FormTrainingClient.cs
@@ -18,8 +18,8 @@ namespace Azure.AI.FormRecognizer.Training
     /// properties.
     /// </summary>
     /// <remarks>
-    /// This client only works with <see cref="FormRecognizerClientOptions.ServiceVersion.V2_1"/> and older.
-    /// If you want to use a newer version, please use the <see cref="DocumentAnalysis.DocumentModelAdministrationClient"/>.
+    /// This client only supports <see cref="FormRecognizerClientOptions.ServiceVersion.V2_1"/> and older.
+    /// To use a newer service version, see <see cref="DocumentAnalysis.DocumentModelAdministrationClient"/>.
     /// </remarks>
     public class FormTrainingClient
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentKeyValuePair.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentKeyValuePair.cs
@@ -42,6 +42,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public DocumentKeyValueElement Key { get; }
         /// <summary> Field value of the key-value pair. </summary>
         public DocumentKeyValueElement Value { get; }
+        /// <summary> Common name of the key-value pair. </summary>
+        public string CommonName { get; }
         /// <summary> Confidence of correctly extracting the key-value pair. </summary>
         public float Confidence { get; }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModelDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModelDetails.cs
@@ -32,16 +32,16 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="modelId"> Unique document model name. </param>
         /// <param name="description"> Document model description. </param>
         /// <param name="createdOn"> Date and time (UTC) when the document model was created. </param>
-        /// <param name="expirationDateTime"> Date and time (UTC) when the document model will expire. </param>
+        /// <param name="expiresOn"> Date and time (UTC) when the document model will expire. </param>
         /// <param name="apiVersion"> API version used to create this document model. </param>
         /// <param name="tags"> List of key-value tag attributes associated with the document model. </param>
         /// <param name="documentTypes"> Supported document types. </param>
-        internal DocumentModelDetails(string modelId, string description, DateTimeOffset createdOn, DateTimeOffset? expirationDateTime, string apiVersion, IReadOnlyDictionary<string, string> tags, IReadOnlyDictionary<string, DocumentTypeDetails> documentTypes)
+        internal DocumentModelDetails(string modelId, string description, DateTimeOffset createdOn, DateTimeOffset? expiresOn, string apiVersion, IReadOnlyDictionary<string, string> tags, IReadOnlyDictionary<string, DocumentTypeDetails> documentTypes)
         {
             ModelId = modelId;
             Description = description;
             CreatedOn = createdOn;
-            ExpirationDateTime = expirationDateTime;
+            ExpiresOn = expiresOn;
             ApiVersion = apiVersion;
             Tags = tags;
             DocumentTypes = documentTypes;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModelSummary.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentModelSummary.cs
@@ -31,15 +31,15 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="modelId"> Unique document model name. </param>
         /// <param name="description"> Document model description. </param>
         /// <param name="createdOn"> Date and time (UTC) when the document model was created. </param>
-        /// <param name="expirationDateTime"> Date and time (UTC) when the document model will expire. </param>
+        /// <param name="expiresOn"> Date and time (UTC) when the document model will expire. </param>
         /// <param name="apiVersion"> API version used to create this document model. </param>
         /// <param name="tags"> List of key-value tag attributes associated with the document model. </param>
-        internal DocumentModelSummary(string modelId, string description, DateTimeOffset createdOn, DateTimeOffset? expirationDateTime, string apiVersion, IReadOnlyDictionary<string, string> tags)
+        internal DocumentModelSummary(string modelId, string description, DateTimeOffset createdOn, DateTimeOffset? expiresOn, string apiVersion, IReadOnlyDictionary<string, string> tags)
         {
             ModelId = modelId;
             Description = description;
             CreatedOn = createdOn;
-            ExpirationDateTime = expirationDateTime;
+            ExpiresOn = expiresOn;
             ApiVersion = apiVersion;
             Tags = tags;
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/QuotaDetails.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/QuotaDetails.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
 {
-    internal partial class QuotaDetails
+    public partial class QuotaDetails
     {
         internal static QuotaDetails DeserializeQuotaDetails(JsonElement element)
         {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/QuotaDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/QuotaDetails.cs
@@ -10,24 +10,22 @@ using System;
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
 {
     /// <summary> Quota used, limit, and next reset date/time. </summary>
-    internal partial class QuotaDetails
+    public partial class QuotaDetails
     {
         /// <summary> Initializes a new instance of QuotaDetails. </summary>
         /// <param name="used"> Amount of the resource quota used. </param>
         /// <param name="quota"> Resource quota limit. </param>
-        /// <param name="quotaResetDateTime"> Date/time when the resource quota usage will be reset. </param>
-        internal QuotaDetails(int used, int quota, DateTimeOffset quotaResetDateTime)
+        /// <param name="quotaResetsOn"> Date/time when the resource quota usage will be reset. </param>
+        internal QuotaDetails(int used, int quota, DateTimeOffset quotaResetsOn)
         {
             Used = used;
             Quota = quota;
-            QuotaResetDateTime = quotaResetDateTime;
+            QuotaResetsOn = quotaResetsOn;
         }
 
         /// <summary> Amount of the resource quota used. </summary>
         public int Used { get; }
         /// <summary> Resource quota limit. </summary>
         public int Quota { get; }
-        /// <summary> Date/time when the resource quota usage will be reset. </summary>
-        public DateTimeOffset QuotaResetDateTime { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/GeneratorStubs/InternalTypes.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/GeneratorStubs/InternalTypes.cs
@@ -38,8 +38,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
     internal partial class InnerError { }
 
-    internal partial class QuotaDetails { }
-
     [CodeGenModel("ResourceDetails")]
     internal partial class ServiceResourceDetails { }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Internal/ClientCommon.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Internal/ClientCommon.cs
@@ -91,7 +91,7 @@ namespace Azure.AI.FormRecognizer
             return new RecognizedFormCollection(forms);
         }
 
-        public static IReadOnlyList<PointF> CovertToListOfPointF(IReadOnlyList<float> coordinates)
+        public static IReadOnlyList<PointF> ConvertToListOfPointF(IReadOnlyList<float> coordinates)
         {
             if (coordinates == null || coordinates.Count == 0)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/QuotaDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/QuotaDetails.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
 {
-    public partial class DocumentKeyValuePair
+    public partial class QuotaDetails
     {
         /// <summary>
-        /// Common name of the key-value pair.
+        /// Date/time when the resource quota usage will be reset.
         /// </summary>
-        internal string CommonName { get; }
+        [CodeGenMember("QuotaResetDateTime")]
+        public DateTimeOffset QuotaResetsOn { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ResourceDetails.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ResourceDetails.cs
@@ -9,14 +9,15 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     public class ResourceDetails
     {
         internal ResourceDetails(ServiceResourceDetails details)
-            : this(details.CustomDocumentModels.Count, details.CustomDocumentModels.Limit)
+            : this(details.CustomDocumentModels.Count, details.CustomDocumentModels.Limit, details.CustomNeuralDocumentModelBuilds)
         {
         }
 
-        internal ResourceDetails(int customDocumentModelCount, int customDocumentModelLimit)
+        internal ResourceDetails(int customDocumentModelCount, int customDocumentModelLimit, QuotaDetails customNeuralDocumentModelBuilds)
         {
             CustomDocumentModelCount = customDocumentModelCount;
             CustomDocumentModelLimit = customDocumentModelLimit;
+            CustomNeuralDocumentModelBuilds = customNeuralDocumentModelBuilds;
         }
 
         /// <summary>
@@ -28,5 +29,10 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// Maximum number of custom models supported in the current resource.
         /// </summary>
         public int CustomDocumentModelLimit { get; }
+
+        /// <summary>
+        /// Quota used, limit, and next reset date/time.
+        /// </summary>
+        public QuotaDetails CustomNeuralDocumentModelBuilds { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/ClientCommonTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/ClientCommonTests.cs
@@ -16,20 +16,20 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         [Test]
         public void CovertToListOfPointFReturnsEmptyWhenCoordinatesIsNull()
         {
-            Assert.IsEmpty(ClientCommon.CovertToListOfPointF(null));
+            Assert.IsEmpty(ClientCommon.ConvertToListOfPointF(null));
         }
 
         [Test]
         public void CovertToListOfPointFReturnsEmptyWhenCoordinatesIsEmpty()
         {
-            Assert.IsEmpty(ClientCommon.CovertToListOfPointF(Array.Empty<float>()));
+            Assert.IsEmpty(ClientCommon.ConvertToListOfPointF(Array.Empty<float>()));
         }
 
         [Test]
         public void CovertToListOfPointFConvertsFloatsToPointF()
         {
             var floatPoints = new List<float>() { 1.0f, 1.5f, 2.0f, 2.5f, 3.0f, 3.5f, 4.0f, 4.5f };
-            IReadOnlyList<PointF> points = ClientCommon.CovertToListOfPointF(floatPoints);
+            IReadOnlyList<PointF> points = ClientCommon.ConvertToListOfPointF(floatPoints);
 
             Assert.AreEqual(4, points.Count);
             Assert.AreEqual(1.0f, points[0].X);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientMockTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientMockTests.cs
@@ -284,6 +284,86 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         }
 
         [Test]
+        public async Task AnalyzeDocumentSendsSingleQueryField()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader(Constants.OperationLocationHeader, OperationId));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var options = new DocumentAnalysisClientOptions() { Transport = mockTransport };
+            var client = CreateInstrumentedClient(options);
+
+            using var stream = DocumentAnalysisTestEnvironment.CreateStream(TestFile.ReceiptJpg);
+            var analyzeOptions = new AnalyzeDocumentOptions { QueryFields = { "field1" } };
+            await client.AnalyzeDocumentAsync(WaitUntil.Started, FakeGuid, stream, analyzeOptions);
+
+            var requestUriQuery = mockTransport.Requests.Single().Uri.Query;
+            var expectedSubstring = $"queryFields=field1";
+
+            Assert.True(requestUriQuery.Contains(expectedSubstring));
+        }
+
+        [Test]
+        public async Task AnalyzeDocumentFromUriSendsSingleQueryField()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader(Constants.OperationLocationHeader, OperationId));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var options = new DocumentAnalysisClientOptions() { Transport = mockTransport };
+            var client = CreateInstrumentedClient(options);
+
+            var uri = new Uri("https://fakeuri.com/");
+            var analyzeOptions = new AnalyzeDocumentOptions { QueryFields = { "field1" } };
+            await client.AnalyzeDocumentFromUriAsync(WaitUntil.Started, FakeGuid, uri, analyzeOptions);
+
+            var requestUriQuery = mockTransport.Requests.Single().Uri.Query;
+            var expectedSubstring = $"queryFields=field1";
+
+            Assert.True(requestUriQuery.Contains(expectedSubstring));
+        }
+
+        [Test]
+        public async Task AnalyzeDocumentSendsMultipleQueryFields()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader(Constants.OperationLocationHeader, OperationId));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var options = new DocumentAnalysisClientOptions() { Transport = mockTransport };
+            var client = CreateInstrumentedClient(options);
+
+            using var stream = DocumentAnalysisTestEnvironment.CreateStream(TestFile.ReceiptJpg);
+            var analyzeOptions = new AnalyzeDocumentOptions { QueryFields = { "field1", "field2" } };
+            await client.AnalyzeDocumentAsync(WaitUntil.Started, FakeGuid, stream, analyzeOptions);
+
+            var requestUriQuery = mockTransport.Requests.Single().Uri.Query;
+            var expectedSubstring = $"queryFields=field1%2Cfield2";
+
+            Assert.True(requestUriQuery.Contains(expectedSubstring));
+        }
+
+        [Test]
+        public async Task AnalyzeDocumentFromUriSendsMultipleQueryFields()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader(Constants.OperationLocationHeader, OperationId));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var options = new DocumentAnalysisClientOptions() { Transport = mockTransport };
+            var client = CreateInstrumentedClient(options);
+
+            var uri = new Uri("https://fakeuri.com/");
+            var analyzeOptions = new AnalyzeDocumentOptions { QueryFields = { "field1", "field2" } };
+            await client.AnalyzeDocumentFromUriAsync(WaitUntil.Started, FakeGuid, uri, analyzeOptions);
+
+            var requestUriQuery = mockTransport.Requests.Single().Uri.Query;
+            var expectedSubstring = $"queryFields=field1%2Cfield2";
+
+            Assert.True(requestUriQuery.Contains(expectedSubstring));
+        }
+
+        [Test]
         public async Task AnalyzeDocumentFromUriEncodesBlankSpaces()
         {
             var mockResponse = new MockResponse(202);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
@@ -529,6 +529,18 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             Assert.IsNotNull(model.ModelId);
             Assert.AreNotEqual(default(DateTimeOffset), model.CreatedOn);
 
+            if (_serviceVersion >= DocumentAnalysisClientOptions.ServiceVersion.V2023_02_28_Preview)
+            {
+                if (model.ExpiresOn.HasValue)
+                {
+                    Assert.Greater(model.ExpiresOn, model.CreatedOn);
+                }
+            }
+            else
+            {
+                Assert.Null(model.ExpiresOn);
+            }
+
             // TODO add validation for Doctypes https://github.com/Azure/azure-sdk-for-net-pr/issues/1432
         }
 
@@ -546,6 +558,18 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             Assert.IsNotNull(model.ModelId);
             Assert.AreNotEqual(default(DateTimeOffset), model.CreatedOn);
+
+            if (_serviceVersion >= DocumentAnalysisClientOptions.ServiceVersion.V2023_02_28_Preview)
+            {
+                if (model.ExpiresOn.HasValue)
+                {
+                    Assert.Greater(model.ExpiresOn, model.CreatedOn);
+                }
+            }
+            else
+            {
+                Assert.Null(model.ExpiresOn);
+            }
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DocumentAnalysisLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DocumentAnalysisLiveTestBase.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         /// The version of the REST API to test against.  This will be passed
         /// to the .ctor via ClientTestFixture's values.
         /// </summary>
-        private readonly DocumentAnalysisClientOptions.ServiceVersion _serviceVersion;
+        protected readonly DocumentAnalysisClientOptions.ServiceVersion _serviceVersion;
 
         public DocumentAnalysisLiveTestBase(bool isAsync, DocumentAnalysisClientOptions.ServiceVersion serviceVersion)
             : base(isAsync)


### PR DESCRIPTION
- Added property `QueryFields` to `AnalyzeDocumentOptions` to support field extraction without the need for added training.
- Exposed property `Code` to the `CurrencyValue` class.
- Exposed property `CommonName` to the `DocumentKeyValuePair` class.
- Exposed property `ExpiresOn` to the `DocumentModelDetails` and `DocumentModelSummary` classes.
- Exposed property `CustomNeuralDocumentModelBuilds` to the `ResourceDetails` class.
- Exposed class `QuotaDetails`.

Part of https://github.com/Azure/azure-sdk-for-net/issues/35243.