### PR TITLE
Mark NullableResponseOfT.Value as nullable

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -117,7 +117,7 @@ namespace Azure
     {
         protected NullableResponse() { }
         public abstract bool HasValue { get; }
-        public abstract T Value { get; }
+        public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -256,6 +256,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -117,7 +117,7 @@ namespace Azure
     {
         protected NullableResponse() { }
         public abstract bool HasValue { get; }
-        public abstract T Value { get; }
+        public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -256,6 +256,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -117,7 +117,7 @@ namespace Azure
     {
         protected NullableResponse() { }
         public abstract bool HasValue { get; }
-        public abstract T Value { get; }
+        public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -256,6 +256,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -117,7 +117,7 @@ namespace Azure
     {
         protected NullableResponse() { }
         public abstract bool HasValue { get; }
-        public abstract T Value { get; }
+        public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -256,6 +256,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -117,7 +117,7 @@ namespace Azure
     {
         protected NullableResponse() { }
         public abstract bool HasValue { get; }
-        public abstract T Value { get; }
+        public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -256,6 +256,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/src/NullableResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/NullableResponseOfT.cs
@@ -23,7 +23,7 @@ namespace Azure
         /// <summary>
         /// Gets the value returned by the service. Accessing this property will throw if <see cref="HasValue"/> is false.
         /// </summary>
-        public abstract T Value { get; }
+        public abstract T? Value { get; }
 
         /// <summary>
         /// Returns the HTTP response returned by the service.

--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -20,7 +20,10 @@ namespace Azure
     {
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool HasValue => true;
+        public override bool HasValue => Value != null;
+
+        /// <inheritdoc />
+        public override T Value => Value!;
 
         /// <summary>
         /// Returns the value of this <see cref="Response{T}"/> object.
@@ -28,14 +31,14 @@ namespace Azure
         /// <param name="response">The <see cref="Response{T}"/> instance.</param>
         public static implicit operator T(Response<T> response)
         {
-            if (response == null)
+            if (response == null || !response.HasValue)
             {
 #pragma warning disable CA1065 // Don't throw from cast operators
                 throw new ArgumentNullException(nameof(response), $"The implicit cast from Response<{typeof(T)}> to {typeof(T)} failed because the Response<{typeof(T)}> was null.");
 #pragma warning restore CA1065
             }
 
-            return response.Value;
+            return response.Value!;
         }
 
         /// <inheritdoc />

--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -31,7 +31,7 @@ namespace Azure
         /// <param name="response">The <see cref="Response{T}"/> instance.</param>
         public static implicit operator T(Response<T> response)
         {
-            if (response == null || !response.HasValue)
+            if (response == null)
             {
 #pragma warning disable CA1065 // Don't throw from cast operators
                 throw new ArgumentNullException(nameof(response), $"The implicit cast from Response<{typeof(T)}> to {typeof(T)} failed because the Response<{typeof(T)}> was null.");

--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -20,7 +20,7 @@ namespace Azure
     {
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool HasValue => Value != null;
+        public override bool HasValue => true;
 
         /// <inheritdoc />
         public override T Value => Value;

--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -23,7 +23,7 @@ namespace Azure
         public override bool HasValue => Value != null;
 
         /// <inheritdoc />
-        public override T Value => Value!;
+        public override T Value => Value;
 
         /// <summary>
         /// Returns the value of this <see cref="Response{T}"/> object.


### PR DESCRIPTION
related #37171

This PR only addresses the nullability of the Value property and does not change the behavior of HasValue. In a future PR, we will look at fixing up current APIs that return null for the Value in a Response<T>.