### PR TITLE
Fix TableClient.Uri Property when Targeting Azurite

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed the URL returned by `TableClient.Uri` when connecting to Azurite
 
 ### Other Changes
 

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -236,7 +236,7 @@ namespace Azure.Data.Tables
             _tableOperations = new TableRestClient(_diagnostics, _pipeline, _endpoint.AbsoluteUri, _version);
             _batchOperations = new TableRestClient(_diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             Name = tableName;
-            Uri = new Uri(_endpoint, Name);
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
         }
 
         /// <summary>
@@ -288,7 +288,7 @@ namespace Azure.Data.Tables
             _tableOperations = new TableRestClient(_diagnostics, _pipeline, _endpoint.AbsoluteUri, _version);
             _batchOperations = new TableRestClient(_diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             Name = tableName;
-            Uri = new Uri(_endpoint, Name);
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
         }
 
         internal TableClient(Uri endpoint, string tableName, TableSharedKeyPipelinePolicy policy, AzureSasCredential sasCredential, TableClientOptions options)
@@ -339,7 +339,7 @@ namespace Azure.Data.Tables
             _tableOperations = new TableRestClient(_diagnostics, _pipeline, _endpoint.AbsoluteUri, _version);
             _batchOperations = new TableRestClient(_diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             Name = tableName;
-            Uri = new Uri(_endpoint, Name);
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
         }
 
         internal TableClient(
@@ -366,7 +366,7 @@ namespace Azure.Data.Tables
             _batchOperations = new TableRestClient(diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             _version = version;
             Name = table;
-            Uri = new Uri(_endpoint, Name);
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
             _accountName = accountName;
             _diagnostics = diagnostics;
             _isCosmosEndpoint = isPremiumEndpoint;

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -236,7 +236,7 @@ namespace Azure.Data.Tables
             _tableOperations = new TableRestClient(_diagnostics, _pipeline, _endpoint.AbsoluteUri, _version);
             _batchOperations = new TableRestClient(_diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             Name = tableName;
-            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name }.ToUri();
         }
 
         /// <summary>
@@ -288,7 +288,7 @@ namespace Azure.Data.Tables
             _tableOperations = new TableRestClient(_diagnostics, _pipeline, _endpoint.AbsoluteUri, _version);
             _batchOperations = new TableRestClient(_diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             Name = tableName;
-            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name }.ToUri();
         }
 
         internal TableClient(Uri endpoint, string tableName, TableSharedKeyPipelinePolicy policy, AzureSasCredential sasCredential, TableClientOptions options)
@@ -339,7 +339,7 @@ namespace Azure.Data.Tables
             _tableOperations = new TableRestClient(_diagnostics, _pipeline, _endpoint.AbsoluteUri, _version);
             _batchOperations = new TableRestClient(_diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             Name = tableName;
-            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name }.ToUri();
         }
 
         internal TableClient(
@@ -366,7 +366,7 @@ namespace Azure.Data.Tables
             _batchOperations = new TableRestClient(diagnostics, CreateBatchPipeline(), _tableOperations.endpoint, _tableOperations.clientVersion);
             _version = version;
             Name = table;
-            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name, }.ToUri();
+            Uri = new TableUriBuilder(_endpoint) { Query = null, Sas = null, Tablename = Name }.ToUri();
             _accountName = accountName;
             _diagnostics = diagnostics;
             _isCosmosEndpoint = isPremiumEndpoint;


### PR DESCRIPTION
The `TableClient.Uri` property incorrectly generates values for the `Uri` property if it is targeting the Azurite storage emulator. For example, the generated `Uri` for a table like `"someTableName"` would be `http://127.0.0.1:10002/someTableName` when instead it should be `http://127.0.0.1:10002/devstoreaccount1/someTableName`. This change corrects the behavior by leveraging the `TableUriBuilder` and adds new tests.