### PR TITLE
Include shared delay strategies

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -200,6 +200,8 @@
     <Compile Include="$(AzureCoreSharedSources)ConstantDelayStrategy.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)ExponentialDelayStrategy.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)RetryAfterDelayStrategy.cs" LinkBase="Shared/Core" />
+    <Compile Include="$(AzureCoreSharedSources)SequentialDelayStrategy.cs" LinkBase="Shared/Core" />
+    <Compile Include="$(AzureCoreSharedSources)FixedDelayWithNoJitterStrategy.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)OperationPoller.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared/Core" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared/Core" />

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -56,12 +56,14 @@
     <Compile Include="Shared\DictionaryHeaders.cs" />
     <Compile Include="Shared\EventSourceEventFormatting.cs" />
     <Compile Include="Shared\ExponentialDelayStrategy.cs" />
+    <Compile Include="Shared\FixedDelayWithNoJitterStrategy.cs" />
     <Compile Include="Shared\HashCodeBuilder.cs" />
     <Compile Include="Shared\HttpMessageSanitizer.cs" />
     <Compile Include="Shared\InitializationConstructorAttribute.cs" />
     <Compile Include="Shared\Multipart\MemoryResponse.cs" />
     <Compile Include="Shared\NullableAttributes.cs" />
     <Compile Include="Shared\OperationInternalBase.cs" />
+    <Compile Include="Shared\SequentialDelayStrategy.cs" />
     <Compile Include="Shared\VoidValue.cs" />
     <Compile Include="Shared\OperationInternal.cs" />
     <Compile Include="Shared\OperationInternalOfT.cs" />

--- a/sdk/core/Azure.Core/src/Shared/FixedDelayWithNoJitterStrategy.cs
+++ b/sdk/core/Azure.Core/src/Shared/FixedDelayWithNoJitterStrategy.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+#nullable enable
+
+namespace Azure.Core
+{
+    internal class FixedDelayWithNoJitterStrategy : DelayStrategy
+    {
+        private static readonly TimeSpan DefaultDelay = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan _delay;
+
+        public FixedDelayWithNoJitterStrategy(TimeSpan? suggestedDelay = default) : base(suggestedDelay.HasValue ? Max(suggestedDelay.Value, DefaultDelay) : DefaultDelay, 0)
+        {
+            _delay = suggestedDelay.HasValue ? Max(suggestedDelay.Value, DefaultDelay) : DefaultDelay;
+        }
+
+        protected override TimeSpan GetNextDelayCore(Response? response, int retryNumber) =>
+            _delay;
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/SequentialDelayStrategy.cs
+++ b/sdk/core/Azure.Core/src/Shared/SequentialDelayStrategy.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+#nullable enable
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// Implementation of a <see cref="DelayStrategy"/>. Polling interval is based on the specified sequence.
+    /// Defaults to {1s, 1s, 1s, 2s, 4s, 8s, 16s, 32s}.
+    /// </summary>
+    /// <remarks>Polling interval always follows the given sequence.</remarks>
+    internal class SequentialDelayStrategy : DelayStrategy
+    {
+        private static readonly TimeSpan[] _pollingSequence = new TimeSpan[]
+        {
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(4),
+            TimeSpan.FromSeconds(8),
+            TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32)
+        };
+        private static readonly TimeSpan _maxDelay = _pollingSequence[_pollingSequence.Length - 1];
+
+        public SequentialDelayStrategy() : base(_maxDelay, 0)
+        {
+        }
+
+        protected override TimeSpan GetNextDelayCore(Response? response, int retryNumber)
+        {
+            int index = retryNumber - 1;
+            return index >= _pollingSequence.Length ? _maxDelay : _pollingSequence[index];
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/SequentialDelayStrategy.cs
+++ b/sdk/core/Azure.Core/src/Shared/SequentialDelayStrategy.cs
@@ -7,10 +7,6 @@ using System;
 
 namespace Azure.Core
 {
-    /// <summary>
-    /// Implementation of a delay strategy. Polling interval is hard-coded to {1s, 1s, 1s, 2s, 4s, 8s, 16s, 32s}.
-    /// </summary>
-    /// <remarks>Polling interval always follows the above sequence.</remarks>
     internal class SequentialDelayStrategy : DelayStrategy
     {
         private static readonly TimeSpan[] _pollingSequence = new TimeSpan[]

--- a/sdk/core/Azure.Core/src/Shared/SequentialDelayStrategy.cs
+++ b/sdk/core/Azure.Core/src/Shared/SequentialDelayStrategy.cs
@@ -8,10 +8,9 @@ using System;
 namespace Azure.Core
 {
     /// <summary>
-    /// Implementation of a <see cref="DelayStrategy"/>. Polling interval is based on the specified sequence.
-    /// Defaults to {1s, 1s, 1s, 2s, 4s, 8s, 16s, 32s}.
+    /// Implementation of a delay strategy. Polling interval is hard-coded to {1s, 1s, 1s, 2s, 4s, 8s, 16s, 32s}.
     /// </summary>
-    /// <remarks>Polling interval always follows the given sequence.</remarks>
+    /// <remarks>Polling interval always follows the above sequence.</remarks>
     internal class SequentialDelayStrategy : DelayStrategy
     {
         private static readonly TimeSpan[] _pollingSequence = new TimeSpan[]


### PR DESCRIPTION
These strategies need to exist in shared source in main before autorest can be updated to consume them.

Pulling these types off of https://github.com/Azure/azure-sdk-for-net/pull/33040
Autorest PR - https://github.com/Azure/autorest.csharp/pull/3281