### PR TITLE
[AzureMonitorExporter] Rename/Refactor TagEnumerationState

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RequestData.cs
@@ -10,37 +10,37 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class RequestData
     {
-        public RequestData(int version, Activity activity, ref TagEnumerationState monitorTags) : base(version)
+        public RequestData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor) : base(version)
         {
             string? url = null;
 
-            switch (monitorTags.activityType)
+            switch (activityTagsProcessor.activityType)
             {
                 case OperationType.Http:
-                    url = monitorTags.MappedTags.GetRequestUrl();
+                    url = activityTagsProcessor.MappedTags.GetRequestUrl();
                     break;
                 case OperationType.Messaging:
-                    url = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeMessagingUrl)?.ToString();
+                    url = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeMessagingUrl)?.ToString();
                     break;
             }
 
             Id = activity.Context.SpanId.ToHexString();
-            Name = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags).Truncate(SchemaConstants.RequestData_Name_MaxLength);
+            Name = TraceHelper.GetOperationName(activity, ref activityTagsProcessor.MappedTags).Truncate(SchemaConstants.RequestData_Name_MaxLength);
             Duration = activity.Duration < SchemaConstants.RequestData_Duration_LessThanDays
                 ? activity.Duration.ToString("c", CultureInfo.InvariantCulture)
                 : SchemaConstants.Duration_MaxValue;
-            ResponseCode = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpStatusCode)
+            ResponseCode = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpStatusCode)
                 ?.ToString().Truncate(SchemaConstants.RequestData_ResponseCode_MaxLength)
                 ?? "0";
 
-            Success = IsSuccess(activity, ResponseCode, monitorTags.activityType);
+            Success = IsSuccess(activity, ResponseCode, activityTagsProcessor.activityType);
 
             Url = url.Truncate(SchemaConstants.RequestData_Url_MaxLength);
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
 
-            TraceHelper.AddActivityLinksToProperties(activity, ref monitorTags.UnMappedTags);
-            TraceHelper.AddPropertiesToTelemetry(Properties, ref monitorTags.UnMappedTags);
+            TraceHelper.AddActivityLinksToProperties(activity, ref activityTagsProcessor.UnMappedTags);
+            TraceHelper.AddPropertiesToTelemetry(Properties, ref activityTagsProcessor.UnMappedTags);
         }
 
         internal static bool IsSuccess(Activity activity, string? responseCode, OperationType operationType)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -13,7 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class TelemetryItem
     {
-        public TelemetryItem(Activity activity, ref TagEnumerationState monitorTags, AzureMonitorResource? resource, string instrumentationKey) :
+        public TelemetryItem(Activity activity, ref ActivityTagsProcessor activityTagsProcessor, AzureMonitorResource? resource, string instrumentationKey) :
             this(activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency", FormatUtcTimestamp(activity.StartTimeUtc))
         {
             if (activity.ParentSpanId != default)
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
             Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
 
-            var userAgent = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpUserAgent)?.ToString();
+            var userAgent = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpUserAgent)?.ToString();
 
             if (userAgent != null)
             {
@@ -35,12 +35,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             // todo: non-server spans
             if (activity.Kind == ActivityKind.Server)
             {
-                Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationName(activity, ref monitorTags.MappedTags);
-                Tags[ContextTagKeys.AiLocationIp.ToString()] = TraceHelper.GetLocationIp(ref monitorTags.MappedTags);
+                Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationName(activity, ref activityTagsProcessor.MappedTags);
+                Tags[ContextTagKeys.AiLocationIp.ToString()] = TraceHelper.GetLocationIp(ref activityTagsProcessor.MappedTags);
             }
 
             SetResourceSdkVersionAndIkey(resource, instrumentationKey);
-            if (AzMonList.GetTagValue(ref monitorTags.MappedTags, "sampleRate") is float sampleRate)
+            if (AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, "sampleRate") is float sampleRate)
             {
                 SampleRate = sampleRate;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
@@ -81,13 +81,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private void ReportDependencyDurationMetric(Activity activity)
         {
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var dependencyTarget = monitorTags.MappedTags.GetDependencyTarget(monitorTags.activityType);
+            var dependencyTarget = activityTagsProcessor.MappedTags.GetDependencyTarget(activityTagsProcessor.activityType);
 
-            var statusCode = AzMonList.GetTagValue(ref monitorTags.MappedTags, SemanticConventions.AttributeHttpStatusCode);
+            var statusCode = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeHttpStatusCode);
 
-            var dependencyType = monitorTags.MappedTags.GetDependencyType(monitorTags.activityType);
+            var dependencyType = activityTagsProcessor.MappedTags.GetDependencyType(activityTagsProcessor.activityType);
 
             TagList tags = default;
             tags.Add(new KeyValuePair<string, object?>(StandardMetricConstants.DependencyTargetKey, dependencyTarget));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsBenchmarks.cs
@@ -99,29 +99,29 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         [Benchmark]
         public void Enumerate_TagObjects_NoItem()
         {
-            var monitorTags = TraceHelper.EnumerateActivityTags(_noItemActivity);
-            monitorTags.Return();
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(_noItemActivity);
+            activityTagsProcessor.Return();
         }
 
         [Benchmark]
         public void Enumerate_TagObjects_PartB()
         {
-            var monitorTags = TraceHelper.EnumerateActivityTags(_partBActivity);
-            monitorTags.Return();
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(_partBActivity);
+            activityTagsProcessor.Return();
         }
 
         [Benchmark]
         public void Enumerate_TagObjects_PartC()
         {
-            var monitorTags = TraceHelper.EnumerateActivityTags(_partCActivity);
-            monitorTags.Return();
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(_partCActivity);
+            activityTagsProcessor.Return();
         }
 
         [Benchmark]
         public void Enumerate_TagObjects_PartB_And_C()
         {
-            var monitorTags = TraceHelper.EnumerateActivityTags(_partBAndCActivity);
-            monitorTags.Return();
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(_partBAndCActivity);
+            activityTagsProcessor.Return();
         }
 
         private static Activity CreateTestActivity(IEnumerable<KeyValuePair<string, object>> additionalAttributes = null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -270,8 +270,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
         private static TelemetryItem CreateTelemetryItem(Activity activity)
         {
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            return new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            return new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
         }
 
         private class MockFileProvider : PersistentBlobProvider

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -48,9 +48,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             activity.SetTag(SemanticConventions.AttributeDbSystem, dbSystem);
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var remoteDependencyDataType = new RemoteDependencyData(2, activity, ref monitorTags).Type;
+            var remoteDependencyDataType = new RemoteDependencyData(2, activity, ref activityTagsProcessor).Type;
             var expectedType = RemoteDependencyData.s_sqlDbs.Contains(dbSystem) ? "SQL" : dbSystem;
 
             Assert.Equal(expectedType, remoteDependencyDataType);
@@ -64,16 +64,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             using var childActivity = activitySource.StartActivity("ChildActivity", ActivityKind.Internal);
 
             Assert.NotNull(parentActivity);
-            var monitorTagsParent = TraceHelper.EnumerateActivityTags(parentActivity);
+            var activityTagsProcessorParent = TraceHelper.EnumerateActivityTags(parentActivity);
 
-            var remoteDependencyDataTypeForParent = new RemoteDependencyData(2, parentActivity, ref monitorTagsParent).Type;
+            var remoteDependencyDataTypeForParent = new RemoteDependencyData(2, parentActivity, ref activityTagsProcessorParent).Type;
 
             Assert.Null(remoteDependencyDataTypeForParent);
 
             Assert.NotNull(childActivity);
-            var monitorTagsChild = TraceHelper.EnumerateActivityTags(childActivity);
+            var activityTagsProcessorChild = TraceHelper.EnumerateActivityTags(childActivity);
 
-            var remoteDependencyDataTypeForChild = new RemoteDependencyData(2, childActivity, ref monitorTagsChild).Type;
+            var remoteDependencyDataTypeForChild = new RemoteDependencyData(2, childActivity, ref activityTagsProcessorChild).Type;
 
             Assert.Equal("InProc", remoteDependencyDataTypeForChild);
         }
@@ -96,9 +96,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, httpUrl); // only adding test via http.url. all possible combinations are covered in AzMonListExtensionsTests.
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, null);
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var remoteDependencyData = new RemoteDependencyData(2, activity, ref monitorTags);
+            var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
 
             Assert.Equal("GET /search", remoteDependencyData.Name);
             Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
@@ -127,9 +127,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via peer.service. all possible combinations are covered in AzMonListExtensionsTests.
             activity.SetTag(SemanticConventions.AttributeDbStatement, "Select * from table");
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var remoteDependencyData = new RemoteDependencyData(2, activity, ref monitorTags);
+            var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
 
             Assert.Equal(ActivityName, remoteDependencyData.Name);
             Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
@@ -156,9 +156,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             activity.DisplayName = "HTTP GET";
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var remoteDependencyDataName = new RemoteDependencyData(2, activity, ref monitorTags).Name;
+            var remoteDependencyDataName = new RemoteDependencyData(2, activity, ref activityTagsProcessor).Name;
 
             Assert.Equal(activity.DisplayName, remoteDependencyDataName);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RequestDataTests.cs
@@ -52,9 +52,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, httpUrl); // only adding test via http.url. all possible combinations are covered in AzMonListExtensionsTests.
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, null);
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var requestData = new RequestData(2, activity, ref monitorTags);
+            var requestData = new RequestData(2, activity, ref activityTagsProcessor);
 
             Assert.Equal("GET /search", requestData.Name);
             Assert.Equal(activity.Context.SpanId.ToHexString(), requestData.Id);
@@ -84,9 +84,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, httpStatusCode);
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var requestData = new RequestData(2, activity, ref monitorTags);
+            var requestData = new RequestData(2, activity, ref activityTagsProcessor);
 
             Assert.Equal(httpResponseCode, requestData.ResponseCode);
         }
@@ -110,9 +110,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/search");
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, httpStatusCode);
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var requestData = new RequestData(2, activity, ref monitorTags);
+            var requestData = new RequestData(2, activity, ref activityTagsProcessor);
 
             Assert.Equal(httpResponseCode, requestData.ResponseCode);
             Assert.Equal(isSuccess, requestData.Success);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
@@ -53,8 +53,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 tags: new Dictionary<string, object?>() { ["sampleRate"] = SampleRate });
 
             Assert.NotNull(activity);
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, "00000000-0000-0000-0000-000000000000");
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, "00000000-0000-0000-0000-000000000000");
             var expTelemetryItem = new TelemetryItem("Exception", telemetryItem, default, default, default);
 
             if (SampleRate is float)
@@ -85,8 +85,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 tags: new Dictionary<string, object?>() { ["sampleRate"] = SampleRate });
 
             Assert.NotNull(activity);
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, "00000000-0000-0000-0000-000000000000");
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, "00000000-0000-0000-0000-000000000000");
 
             if (SampleRate is float)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -44,9 +44,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var resource = CreateTestResource();
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
             var traceResource = resource.UpdateRoleNameAndInstance();
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -70,10 +70,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
             var traceResource = resource.UpdateRoleNameAndInstance();
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -97,9 +97,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             var resource = CreateTestResource();
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
             var traceResource = resource.UpdateRoleNameAndInstance();
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryItem.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
@@ -140,8 +140,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 expectedOperationName = $"GET {route}";
             }
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.Equal(expectedOperationName, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -162,8 +162,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
             activity.SetTag(SemanticConventions.AttributeHttpUrl, "https://www.foo.bar/path?id=1");
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.Equal("GET /path", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -181,8 +181,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             activity.DisplayName = "displayname";
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.Equal("displayname", telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }
@@ -200,8 +200,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             activity.SetTag(SemanticConventions.AttributeHttpClientIP, "127.0.0.1");
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -219,8 +219,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             activity.SetTag(SemanticConventions.AttributeNetPeerIp, "127.0.0.1");
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.Equal("127.0.0.1", telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -239,8 +239,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var userAgent = "Mozilla / 5.0(Windows NT 10.0;WOW64) AppleWebKit / 537.36(KHTML, like Gecko) Chrome / 91.0.4472.101 Safari / 537.36";
             activity.SetTag(SemanticConventions.AttributeHttpUserAgent, userAgent);
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.Equal(userAgent, telemetryItem.Tags["ai.user.userAgent"]);
         }
@@ -256,8 +256,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.Null(telemetryItem.Tags[ContextTagKeys.AiLocationIp.ToString()]);
         }
@@ -273,8 +273,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
 
             Assert.False(telemetryItem.Tags.TryGetValue("ai.user.userAgent", out var userAgent));
         }
@@ -292,9 +292,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             var resource = CreateTestResource();
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
             var traceResource = resource.UpdateRoleNameAndInstance();
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(Dns.GetHostName(), telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
         }
@@ -312,9 +312,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotNull(activity);
             var resource = CreateTestResource(null, null, "serviceinstance");
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
             var traceResource = resource.UpdateRoleNameAndInstance();
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, traceResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("serviceinstance", telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
         }
@@ -337,9 +337,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             {
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, httpMethod);
             }
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
-            var telemetryItem = new TelemetryItem(activity, ref monitorTags, null, string.Empty);
-            var requestData = new RequestData(2, activity, ref monitorTags);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, null, string.Empty);
+            var requestData = new RequestData(2, activity, ref activityTagsProcessor);
 
             Assert.Equal(requestData.Name, telemetryItem.Tags[ContextTagKeys.AiOperationName.ToString()]);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
@@ -51,16 +51,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
             if (telemetryType == "RequestData")
             {
-                var requestData = new RequestData(2, activity, ref monitorTags);
+                var requestData = new RequestData(2, activity, ref activityTagsProcessor);
                 Assert.False(requestData.Properties.TryGetValue(msLinks, out _));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var remoteDependencyData = new RemoteDependencyData(2, activity, ref monitorTags);
+                var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
 
                 Assert.False(remoteDependencyData.Properties.TryGetValue(msLinks, out _));
             }
@@ -92,16 +92,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             string? expectedMSlinks = GetExpectedMSlinks(links);
             string? actualMSlinks = null;
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
             if (telemetryType == "RequestData")
             {
-                var requestData = new RequestData(2, activity, ref monitorTags);
+                var requestData = new RequestData(2, activity, ref activityTagsProcessor);
                 Assert.True(requestData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var remoteDependencyData = new RemoteDependencyData(2, activity, ref monitorTags);
+                var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
                 Assert.True(remoteDependencyData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
 
@@ -140,16 +140,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 startTime: DateTime.UtcNow);
 
             Assert.NotNull(activity);
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
             if (telemetryType == "RequestData")
             {
-                var requestData = new RequestData(2, activity, ref monitorTags);
+                var requestData = new RequestData(2, activity, ref activityTagsProcessor);
                 Assert.True(requestData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var remoteDependencyData = new RemoteDependencyData(2, activity, ref monitorTags);
+                var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
                 Assert.True(remoteDependencyData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
 
@@ -196,16 +196,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             string? expectedMslinks = GetExpectedMSlinks(links);
             string? actualMSlinks = null;
 
-            var monitorTags = TraceHelper.EnumerateActivityTags(activity);
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
             if (telemetryType == "RequestData")
             {
-                var requestData = new RequestData(2, activity, ref monitorTags);
+                var requestData = new RequestData(2, activity, ref activityTagsProcessor);
                 Assert.True(requestData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
             if (telemetryType == "RemoteDependencyData")
             {
-                var remoteDependencyData = new RemoteDependencyData(2, activity, ref monitorTags);
+                var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
                 Assert.True(remoteDependencyData.Properties.TryGetValue(msLinks, out actualMSlinks));
             }
 


### PR DESCRIPTION
* Rename `TagEnumerationState` to `ActivityTagsProcessor` to read the code easier.
* Performed small customization in  `CategorizeTags` which was `Foreach`.