### PR TITLE
update the commit of translate project

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Text/tsp-location.yaml
+++ b/sdk/translation/Azure.AI.Translation.Text/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/translation/Azure.AI.TextTranslation
-commit: 9f3ae9dd908ad3bce8cf00b4a51cfefb07b95e83
+commit: 4637adf8aac277915fad37135dc4d11d34e166b9
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
# Contributing to the Azure SDK

- The commit used for translate SDK is not the latest one and it break the lint rule of connection format in 0.43.0 typespec. Update to the latest commit.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
