### PR TITLE
Add target for collecting codegen projects to service.proj

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -343,6 +343,12 @@
     <Message Condition="'$(IsShippingLibrary)' == 'true'" Text="'$(PackageRootDirectory)' '$(ServiceDirectory)' '$(PackageId)' '$(VersionForProperties)' '$(PackageSdkType)' '$(PackageIsNewSdk)' '$(BaseOutputPath)'" Importance="High" />
   </Target>
 
+  <Target Name="GetCodeGenProjects" Returns="@(ProjectsToInclude)">
+    <ItemGroup Condition="'$(_GenerateCode)' == 'true'">
+      <ProjectsToInclude Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_SetProjectDependsOnInnerTarget">
     <PropertyGroup>
       <InnerTargets>ProjectDependsOnInner</InnerTargets>

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -28,7 +28,7 @@
     <ProjectReference Include="@(SampleApplications)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
     <ProjectReference Include="@(SrcProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSrc)' == 'true'" />
   </ItemGroup>
-  
+
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
   <Import Project="$(RepoRoot)$(ProjectListOverrideFile)" Condition="'$(ProjectListOverrideFile)' != '' " />
 
@@ -79,6 +79,25 @@
             BuildInParallel="$(BuildInParallel)"
             SkipNonexistentProjects="false"
             SkipNonexistentTargets="true" />
+  </Target>
+
+  <Target Name="GetCodeGenProjects">
+    <MSBuild Projects="@(ProjectReference)"
+            Targets="GetCodeGenProjects"
+            BuildInParallel="$(BuildInParallel)"
+            SkipNonexistentProjects="false"
+            SkipNonexistentTargets="true">
+      <Output ItemName="ProjectsToInclude" TaskParameter="TargetOutputs"/>
+    </MSBuild>
+    <RemoveDuplicates Inputs="@(ProjectsToInclude->Replace($(RepoRoot), ''))">
+      <Output TaskParameter="Filtered" ItemName="ProjectsToIncludeFitered"/>
+    </RemoveDuplicates>
+    <Message Text="Write to file $(OutputProjectFilePath)" Importance="high"/>
+    <Message Text="%24%28RepoRoot%29%(ProjectsToIncludeFitered.Identity)" Importance="high"/>
+    <ItemGroup>
+      <_WriteToLines Include="%24%28RepoRoot%29%(ProjectsToIncludeFitered.Identity)" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(OutputProjectFilePath)" Lines="@(_WriteToLines)" />
   </Target>
 
   <Target Name="ProjectDependsOn">


### PR DESCRIPTION
AutoRest.CSharp validation needs a list of all projects that will no skip code gen.  This target outputs project file paths based on the same conditional used in the CodeGen target.