### PR TITLE
[OpenAI] Fix readonly property for Messages

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.OpenAI
         ///     Typical usage begins with a chat message for the System role that provides instructions for the
         ///     behavior of the assistant followed by alternating messages between the User role and Assistant role.
         /// </remarks>
-        public IList<ChatMessage> Messages { get; }
+        public IList<ChatMessage> Messages { get; set; }
 
         /// <inheritdoc cref="CompletionsOptions.NucleusSamplingFactor"/>
         [CodeGenMember("TopP")]


### PR DESCRIPTION
Messages in ChatCompletionsOptions shouldn't be readonly property.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
