### PR TITLE
Add retries to actions sparse checkout

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -30,12 +30,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Sparse Checkout'
+        shell: pwsh
         run: |
-          set -ex
-          git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
+          $maxAttempts = 3
+          $attempts = 0
+          while ($attempts -lt $maxAttempts) {
+            Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} ."
+            git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
+            if ($LASTEXITCODE -eq 0) { break }
+            Write-Host "Retrying clone..." && Start-Sleep ([Math]::Pow(2, ++$attempts))
+          }
+          if ($attempts -eq $maxAttempts) { exit 1 } else { $attempts = 0 }
           git sparse-checkout init
           git sparse-checkout set '.github'
-          git checkout main
+          while ($attempts -lt $maxAttempts) {
+            Write-Host "git checkout main"
+            git checkout main
+            if ($LASTEXITCODE -eq 0) { break }
+            Write-Host "Retrying checkout..." && Start-Sleep ([Math]::Pow(2, ++$attempts))
+          }
+          if ($attempts -ge $maxAttempts) { exit 1 }
 
       - name: 'Az CLI login'
         if: ${{ github.event_name == 'issues' && github.event.action == 'opened' }}

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -27,12 +27,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Sparse Checkout'
+        shell: pwsh
         run: |
-          set -ex
-          git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
+          $maxAttempts = 3
+          $attempts = 0
+          while ($attempts -lt $maxAttempts) {
+            Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} ."
+            git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
+            if ($LASTEXITCODE -eq 0) { break }
+            Write-Host "Retrying clone..." && Start-Sleep ([Math]::Pow(2, ++$attempts))
+          }
+          if ($attempts -eq $maxAttempts) { exit 1 } else { $attempts = 0 }
           git sparse-checkout init
           git sparse-checkout set '.github'
-          git checkout main
+          while ($attempts -lt $maxAttempts) {
+            Write-Host "git checkout main"
+            git checkout main
+            if ($LASTEXITCODE -eq 0) { break }
+            Write-Host "Retrying checkout..." && Start-Sleep ([Math]::Pow(2, ++$attempts))
+          }
+          if ($attempts -ge $maxAttempts) { exit 1 }
+
 
       # To run github-event-processor built from source, for testing purposes, uncomment everything
       # in between the Start/End-Build From Source comments and comment everything in between the


### PR DESCRIPTION
Updating the sparse checkout code to retry a few times to help with occasional (0.03%) secondary rate limiting from github.

At the time of updating this we've executed 11,996 total actions workflows and only had 4 fail with the 429 rate limit.