### PR TITLE
[AzureMonitorExporter] fix flaky test

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTraceExporterTests.cs
@@ -5,10 +5,10 @@ using OpenTelemetry.Trace;
 using System;
 using System.Reflection;
 
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 
 using Xunit;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 {
@@ -37,20 +37,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             GetInternalFields(exporter, out string? ikey, out string? endpoint);
             Assert.Equal(testIkey, ikey);
             Assert.Equal(Constants.DefaultIngestionEndpoint, endpoint);
-        }
-
-        [Fact]
-        public void VerifyConnectionString_ThrowsExceptionWhenInvalid()
-        {
-            Assert.Throws<InvalidOperationException>(() => new AzureMonitorTraceExporter(new AzureMonitorExporterOptions { ConnectionString = null }));
-        }
-
-        [Fact]
-        public void VerifyConnectionString_ThrowsExceptionWhenMissingInstrumentationKey()
-        {
-            var testEndpoint = "https://www.bing.com/";
-
-            Assert.Throws<InvalidOperationException>(() => new AzureMonitorTraceExporter(new AzureMonitorExporterOptions { ConnectionString = $"IngestionEndpoint={testEndpoint}" }));
         }
 
         [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTransmitterTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorTransmitterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Xunit;
@@ -30,6 +31,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var connectionVars = AzureMonitorTransmitter.InitializeConnectionVars(options, platform);
 
             Assert.Equal(expectedIkey, connectionVars.InstrumentationKey);
+        }
+
+        [Fact]
+        public void VerifyConnectionString_ThrowsExceptionWhenInvalid()
+        {
+            Assert.Throws<InvalidOperationException>(() => new AzureMonitorTransmitter(new AzureMonitorExporterOptions { ConnectionString = null }, new MockPlatform()));
+        }
+
+        [Fact]
+        public void VerifyConnectionString_ThrowsExceptionWhenMissingInstrumentationKey()
+        {
+            var testEndpoint = "https://www.bing.com/";
+
+            Assert.Throws<InvalidOperationException>(() => new AzureMonitorTransmitter(new AzureMonitorExporterOptions { ConnectionString = $"IngestionEndpoint={testEndpoint}" }, new MockPlatform()));
         }
     }
 }


### PR DESCRIPTION
The test `VerifyConnectionString_ThrowsExceptionWhenInvalid ` can fail if another test sets the ConnectionString EnvironmentVariable.

Currently the TransmitterFactoryTests can set EnvironmentVariables.

https://dev.azure.com/azure-sdk/public/_build/results?buildId=2713276&view=logs&j=c719eb44-067e-5bef-86e8-5af019de2794&t=12631d7d-2900-5e3f-7e38-d888c0588833&l=310

## Changes
- modify test `VerifyConnectionString_ThrowsExceptionWhenInvalid`
  - move from `AzureMonitorTraceExporterTests` class to `AzureMonitorTransmitterTests` class.
  - modify test to use Platform abstraction to avoid conflicts with Environment Variable.

## Future work
- currently we only have a test class for the `AzureMonitorTraceExporter`. Need to improve test coverage for all three Exporters.