### PR TITLE
[Azure.Core] Add Public Model Serialization

### DIFF
--- a/sdk/core/Azure.Core/src/IJsonSerializable.cs
+++ b/sdk/core/Azure.Core/src/IJsonSerializable.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+
+namespace Azure
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public interface IJsonSerializable
+    {
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="bytesWritten"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        bool TrySerialize(Stream stream, out long bytesWritten, SerializableOptions? options = default);
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="bytesConsumed"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        bool TryDeserialize(Stream stream, out long bytesConsumed, SerializableOptions? options = default);
+    }
+}

--- a/sdk/core/Azure.Core/src/SerializableOptions.cs
+++ b/sdk/core/Azure.Core/src/SerializableOptions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public class SerializableOptions
+    {
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public bool IncludeReadOnlyProperties { get; set; } = true;
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public bool HandleAdditionalProperties { get; set; } = true;
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public bool PrettyPrint { get; set; } = false;
+    }
+}

--- a/sdk/core/Azure.Core/tests/ModelSerializationTests/Animal.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerializationTests/Animal.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Azure.Core.Tests.ModelSerializationTests
+{
+    public class Animal : IJsonSerializable, IUtf8JsonSerializable
+    {
+        private Dictionary<string, BinaryData> RawData { get; set; } = new Dictionary<string, BinaryData>();
+
+        public bool IsHungry { get; set; } = false;
+        public double Weight { get; set; } = 0;
+        public string LatinName { get; private set; } = "Animalia";
+        public string Name { get; set; } = "Animal";
+
+        public Animal()
+        {
+        }
+
+        public Animal(double weight, string latinName, string name, bool isHungry)
+        {
+            Weight = weight;
+            LatinName = latinName;
+            Name = name;
+            IsHungry = isHungry;
+        }
+
+        internal Animal(double weight, string latinName, string name, bool isHungry, Dictionary<string, BinaryData> rawData)
+        {
+            Weight = weight;
+            LatinName = latinName;
+            Name = name;
+            IsHungry = isHungry;
+            RawData = rawData;
+        }
+
+        #region Serialization
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer, SerializableOptions options)
+        {
+            writer.WriteStartObject();
+            if (options.IncludeReadOnlyProperties)
+            {
+                writer.WritePropertyName("latinName"u8);
+                writer.WriteStringValue(LatinName);
+            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name);
+            writer.WritePropertyName("isHungry"u8);
+            writer.WriteBooleanValue(IsHungry);
+            writer.WritePropertyName("weight"u8);
+            writer.WriteNumberValue(Weight);
+
+            if (options.HandleAdditionalProperties)
+            {
+                //write out the raw data
+                foreach (var property in RawData)
+                {
+                    writer.WritePropertyName(property.Key);
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(property.Value);
+#else
+                    JsonSerializer.Serialize(writer, JsonDocument.Parse(property.Value.ToString()).RootElement);
+#endif
+                }
+            }
+            writer.WriteEndObject();
+        }
+
+        internal static Animal DeserializeAnimal(JsonElement element, SerializableOptions options)
+        {
+            double weight = default;
+            string name = "";
+            string latinName = "";
+            bool isHungry = default;
+
+            Dictionary<string, BinaryData> rawData = new Dictionary<string, BinaryData>();
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("weight"u8))
+                {
+                    weight = property.Value.GetDouble();
+                    continue;
+                }
+                if (property.NameEquals("name"u8))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("latinName"u8))
+                {
+                    latinName = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("isHungry"u8))
+                {
+                    isHungry = property.Value.GetBoolean();
+                    continue;
+                }
+
+                if (options.HandleAdditionalProperties)
+                {
+                    //this means it's an unknown property we got
+                    rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
+                }
+            }
+            return new Animal(weight, latinName, name, isHungry, rawData);
+        }
+        #endregion
+
+        #region InterfaceImplementation
+        public bool TryDeserialize(Stream stream, out long bytesConsumed, SerializableOptions options = default)
+        {
+            bytesConsumed = 0;
+            try
+            {
+                JsonDocument jsonDocument = JsonDocument.Parse(stream);
+                var model = DeserializeAnimal(jsonDocument.RootElement, options ?? new SerializableOptions());
+                this.LatinName = model.LatinName;
+                this.Weight = model.Weight;
+                this.IsHungry = model.IsHungry;
+                this.Name = model.Name;
+                this.RawData = model.RawData;
+                bytesConsumed = stream.Length;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool TrySerialize(Stream stream, out long bytesWritten, SerializableOptions options = default)
+        {
+            bytesWritten = 0;
+            try
+            {
+                JsonWriterOptions jsonWriterOptions = new JsonWriterOptions();
+                if (options.PrettyPrint)
+                {
+                    jsonWriterOptions.Indented = true;
+                }
+                Utf8JsonWriter writer = new Utf8JsonWriter(stream, jsonWriterOptions);
+                ((IUtf8JsonSerializable)this).Write(writer, options ?? new SerializableOptions());
+                writer.Flush();
+                bytesWritten = stream.Length;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        #endregion
+    }
+}

--- a/sdk/core/Azure.Core/tests/ModelSerializationTests/CatReadOnlyProperty.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerializationTests/CatReadOnlyProperty.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Azure.Core.Tests.ModelSerializationTests
+{
+    public class CatReadOnlyProperty : Animal, IJsonSerializable, IUtf8JsonSerializable
+    {
+        private Dictionary<string, BinaryData> RawData { get; set; } = new Dictionary<string, BinaryData>();
+
+        public CatReadOnlyProperty(double weight, string latinName, string name, bool isHungry, bool hasWhiskers) : base(weight, "Felis catus", name, isHungry)
+        {
+            CatLatinName = LatinName;
+            CatIsHungry = IsHungry;
+            CatWeight = Weight;
+            CatName = Name;
+            HasWhiskers = hasWhiskers;
+        }
+
+        internal CatReadOnlyProperty(double weight, string latinName, string name, bool isHungry, bool hasWhiskers, Dictionary<string, BinaryData> rawData) : this(weight, latinName, name, isHungry, hasWhiskers)
+        {
+            RawData = rawData;
+        }
+
+        public bool HasWhiskers { get; set; } = true;
+
+        private string CatLatinName;
+        private bool CatIsHungry;
+        private double CatWeight;
+        private string CatName;
+
+        #region Serialization
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer, SerializableOptions options)
+        {
+            writer.WriteStartObject();
+            if (options.IncludeReadOnlyProperties)
+            {
+                writer.WritePropertyName("latinName"u8);
+                writer.WriteStringValue(LatinName);
+            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(CatName);
+            writer.WritePropertyName("isHungry"u8);
+            writer.WriteBooleanValue(CatIsHungry);
+            writer.WritePropertyName("weight"u8);
+            writer.WriteNumberValue(CatWeight);
+            writer.WritePropertyName("hasWhiskers"u8);
+            writer.WriteBooleanValue(HasWhiskers);
+
+            if (options.HandleAdditionalProperties)
+            {
+                //write out the raw data
+                foreach (var property in RawData)
+                {
+                    writer.WritePropertyName(property.Key);
+#if NET6_0_OR_GREATER
+				writer.WriteRawValue(property.Value);
+#else
+                    JsonSerializer.Serialize(writer, JsonDocument.Parse(property.Value.ToString()).RootElement);
+#endif
+                }
+            }
+            writer.WriteEndObject();
+        }
+
+        internal static CatReadOnlyProperty DeserializeCatReadOnlyProperty(JsonElement element, SerializableOptions options)
+        {
+            double weight = default;
+            string name = "";
+            string latinName = "";
+            bool isHungry = default;
+            bool hasWhiskers = default;
+
+            Dictionary<string, BinaryData> rawData = new Dictionary<string, BinaryData>();
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("weight"u8))
+                {
+                    weight = property.Value.GetDouble();
+                    continue;
+                }
+                if (property.NameEquals("name"u8))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("latinName"u8))
+                {
+                    latinName = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("hasWhiskers"u8))
+                {
+                    hasWhiskers = property.Value.GetBoolean();
+                    continue;
+                }
+                if (property.NameEquals("isHungry"u8))
+                {
+                    isHungry = property.Value.GetBoolean();
+                    continue;
+                }
+
+                if (options.HandleAdditionalProperties)
+                {
+                    //this means its an unknown property we got
+                    rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
+                }
+            }
+            return new CatReadOnlyProperty(weight, latinName, name, isHungry, hasWhiskers, rawData);
+        }
+        #endregion
+
+        #region InterfaceImplementation
+        public new bool TryDeserialize(Stream stream, out long bytesConsumed, SerializableOptions options = default)
+        {
+            bytesConsumed = 0;
+            try
+            {
+                JsonDocument jsonDocument = JsonDocument.Parse(stream);
+                var model = DeserializeCatReadOnlyProperty(jsonDocument.RootElement, options ?? new SerializableOptions());
+                this.CatLatinName = model.LatinName;
+                this.CatWeight = model.Weight;
+                this.CatIsHungry = model.IsHungry;
+                this.HasWhiskers = model.HasWhiskers;
+                this.CatIsHungry = model.CatIsHungry;
+                bytesConsumed = stream.Length;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public new bool TrySerialize(Stream stream, out long bytesWritten, SerializableOptions options = default)
+        {
+            bytesWritten = 0;
+            try
+            {
+                JsonWriterOptions jsonWriterOptions = new JsonWriterOptions();
+                if (options.PrettyPrint)
+                {
+                    jsonWriterOptions.Indented = true;
+                }
+                Utf8JsonWriter writer = new Utf8JsonWriter(stream, jsonWriterOptions);
+                ((IUtf8JsonSerializable)this).Write(writer, options ?? new SerializableOptions());
+                writer.Flush();
+                bytesWritten = (int)stream.Length;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        #endregion
+    }
+}

--- a/sdk/core/Azure.Core/tests/ModelSerializationTests/IUtf8JsonSerializable.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerializationTests/IUtf8JsonSerializable.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace Azure.Core.Tests.ModelSerializationTests
+{
+    internal interface IUtf8JsonSerializable
+    {
+        void Write(Utf8JsonWriter writer, SerializableOptions options);
+    }
+}

--- a/sdk/core/Azure.Core/tests/ModelSerializationTests/SerializableTests.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerializationTests/SerializableTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -25,10 +25,6 @@ namespace Azure.Core.Tests.ModelSerializationTests
         {
             Stream stream = new MemoryStream();
             string serviceResponse = "{\"latinName\":\"Canis lupus familiaris\",\"weight\":5.5,\"name\":\"Doggo\",\"numberOfLegs\":4}";
-            //if (handleUnknown)
-            //    serviceResponse =
-            //else
-            //    serviceResponse = "{\"latinName\":\"Canis lupus familiaris\",\"weight\":5.5,\"name\":\"Doggo\"}";
 
             StringBuilder expectedSerialized = new StringBuilder("{");
             if (includeReadonly)
@@ -62,14 +58,11 @@ namespace Azure.Core.Tests.ModelSerializationTests
             {
                 var additionalProperties = typeof(Animal).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(model) as Dictionary<string, BinaryData>;
                 Assert.AreEqual(1, additionalProperties.Count);
-                foreach (var entry in additionalProperties)
-                {
-                    Assert.AreEqual("numberOfLegs", entry.Key);
-                    Assert.AreEqual(4.ToString(), entry.Value.ToString());
-                }
+                Assert.IsTrue(additionalProperties.ContainsKey("numberOfLegs"));
+                Assert.IsTrue(additionalProperties["numberOfLegs"].ToString() == "4");
             }
             Assert.That(serviceResponse.Length, Is.EqualTo(bytesConsumed));
-            model.TrySerialize(stream, out var bytesWritten, options: options); // consider resetting stream in TrySerialize
+            model.TrySerialize(stream, out var bytesWritten, options: options);
             stream.Position = 0;
             string roundTrip = new StreamReader(stream).ReadToEnd();
             Assert.That(roundTrip, Is.EqualTo(expectedSerializedString));
@@ -83,8 +76,18 @@ namespace Azure.Core.Tests.ModelSerializationTests
             Assert.That(model.Name, Is.EqualTo(model2.Name));
             Assert.That(model.Weight, Is.EqualTo(model2.Weight));
             Assert.That(roundTrip.Length, Is.EqualTo(bytesConsumed));
-            //validate add properties
-            //consider adding generic model checker that verifies all model properties
+            if (handleUnknown)
+            {
+                var additionalProperties1 = typeof(Animal).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(model) as Dictionary<string, BinaryData>;
+                var additionalProperties2 = typeof(Animal).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(model2) as Dictionary<string, BinaryData>;
+
+                Assert.AreEqual(1, additionalProperties1.Count);
+                Assert.IsTrue(additionalProperties1.ContainsKey("numberOfLegs"));
+                Assert.IsTrue(additionalProperties1["numberOfLegs"].ToString() == "4");
+                Assert.AreEqual(1, additionalProperties2.Count);
+                Assert.IsTrue(additionalProperties2.ContainsKey("numberOfLegs"));
+                Assert.IsTrue(additionalProperties2["numberOfLegs"].ToString() == "4");
+            }
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/ModelSerializationTests/SerializableTests.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerializationTests/SerializableTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Azure;
+using Azure.Core.Tests;
+using Azure.Core.Tests.ModelSerializationTests;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests.ModelSerializationTests
+{
+    public class SerializableTests
+    {
+        private readonly SerializableOptions _wireOptions = new SerializableOptions { IncludeReadOnlyProperties = false };
+        private readonly SerializableOptions _objectOptions = new SerializableOptions();
+
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(false, false)]
+        public void CanRoundTripFutureVersionWithoutLoss(bool includeReadonly, bool handleUnknown)
+        {
+            Stream stream = new MemoryStream();
+            string serviceResponse = "{\"latinName\":\"Canis lupus familiaris\",\"weight\":5.5,\"name\":\"Doggo\",\"numberOfLegs\":4}";
+            //if (handleUnknown)
+            //    serviceResponse =
+            //else
+            //    serviceResponse = "{\"latinName\":\"Canis lupus familiaris\",\"weight\":5.5,\"name\":\"Doggo\"}";
+
+            StringBuilder expectedSerialized = new StringBuilder("{");
+            if (includeReadonly)
+            {
+                expectedSerialized.Append("\"latinName\":\"Canis lupus familiaris\",");
+            }
+            expectedSerialized.Append("\"name\":\"Doggo\",");
+            expectedSerialized.Append("\"isHungry\":false,");
+            expectedSerialized.Append("\"weight\":5.5");
+            if (handleUnknown)
+            {
+                expectedSerialized.Append(",\"numberOfLegs\":4");
+            }
+            expectedSerialized.Append("}");
+            var expectedSerializedString = expectedSerialized.ToString();
+
+            SerializableOptions options = new SerializableOptions() { IncludeReadOnlyProperties = includeReadonly, HandleAdditionalProperties = handleUnknown };
+
+            var model = new Animal();
+            model.TryDeserialize(new MemoryStream(Encoding.UTF8.GetBytes(serviceResponse)), out long bytesConsumed, options: options);
+
+            if (includeReadonly)
+            {
+                Assert.That(model.LatinName, Is.EqualTo("Canis lupus familiaris"));
+            }
+            Assert.That(model.Name, Is.EqualTo("Doggo"));
+            Assert.IsFalse(model.IsHungry);
+            Assert.That(model.Weight, Is.EqualTo(5.5));
+
+            if (handleUnknown)
+            {
+                var additionalProperties = typeof(Animal).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(model) as Dictionary<string, BinaryData>;
+                Assert.AreEqual(1, additionalProperties.Count);
+                foreach (var entry in additionalProperties)
+                {
+                    Assert.AreEqual("numberOfLegs", entry.Key);
+                    Assert.AreEqual(4.ToString(), entry.Value.ToString());
+                }
+            }
+            Assert.That(serviceResponse.Length, Is.EqualTo(bytesConsumed));
+            model.TrySerialize(stream, out var bytesWritten, options: options); // consider resetting stream in TrySerialize
+            stream.Position = 0;
+            string roundTrip = new StreamReader(stream).ReadToEnd();
+            Assert.That(roundTrip, Is.EqualTo(expectedSerializedString));
+            Assert.That(expectedSerialized.Length, Is.EqualTo(bytesWritten));
+
+            var model2 = new Animal();
+            model2.TryDeserialize(new MemoryStream(Encoding.UTF8.GetBytes(roundTrip)), out bytesConsumed, options: options);
+
+            if (includeReadonly)
+                Assert.That(model.LatinName, Is.EqualTo(model2.LatinName));
+            Assert.That(model.Name, Is.EqualTo(model2.Name));
+            Assert.That(model.Weight, Is.EqualTo(model2.Weight));
+            Assert.That(roundTrip.Length, Is.EqualTo(bytesConsumed));
+            //validate add properties
+            //consider adding generic model checker that verifies all model properties
+        }
+
+        [Test]
+        public void PrettyPrint()
+        {
+            CatReadOnlyProperty model = new CatReadOnlyProperty(3.2, "Felis catus", "Catto", true, false);
+
+            Stream stream = new MemoryStream();
+            model.TrySerialize(stream, out long bytesWritten, options: new SerializableOptions() { PrettyPrint = true });
+            stream.Position = 0;
+            var actualJson = new StreamReader(stream).ReadToEnd();
+
+            var expectedJson = """
+                {
+                  "latinName": "Felis catus",
+                  "name": "Catto",
+                  "isHungry": true,
+                  "weight": 3.2,
+                  "hasWhiskers": false
+                }
+                """;
+
+            Assert.AreEqual(expectedJson, actualJson);
+        }
+    }
+}


### PR DESCRIPTION
The goal of this PR is to provide a public interface that exposes the currently internal serialization code so customers can access it without needing to use reflection or write their own translation.  This interface would be applied to all models in all of our libraries today.  The implementation simply uses the existing internal serialization logic since that code already knows all of the property name changes / structure changes that exist.  We can at a future date change the underlying implementation as long as we maintain functional compatibility.

The SerializationOptions class introduces a couple concepts that are common across the other languages serialization implementations which are:

- IncludeReadonlyProperties:  This flag tells the serializer to include the readonly properties when making the payload.  This is always off during client calls since the service would error out if we tried to change a readonly property, however if a customer wants to save the state of the model this can be included by setting this property to true.
- HandleAdditionalProperties:  This flag tells the serializer to keep any properties it didn't recognize during deserialization as an internal dictionary.  If the same model instance is then serialized with the same property set to true these values will be echoed and not lost.  This is useful for dealing with a large enterprise where various micro-services could be on different versions of the azure sdk library.

We should consider what defaults we want for the above properties.  I would imagine most customers would want true for both in most cases and we can simply have false for both in our client invocations.

Currently the interface only takes in `Stream` as the input and output object we should consider other convenience overloads such as `string`.

We should also consider explicit / implict cast operators Model -> RequestContent and Response -> Model.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
