### PR TITLE
Update event processor version and remove the sparse-checkout

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -74,7 +74,7 @@ jobs:
       #   with:
       #     repository: Azure/azure-sdk-tools
       #     path: azure-sdk-tools
-      #     ref: refs/pull/6030/merge
+      #     ref: <refs/pull/<PRNumber>/merge> or <sha>
 
       # - name: Build and install GitHubEventProcessor from sources
       #   run: |

--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -29,14 +29,6 @@ jobs:
     name: Handle ${{ github.event_name }} ${{ github.event.action }} event
     runs-on: ubuntu-latest
     steps:
-      - name: 'Sparse Checkout'
-        run: |
-          set -ex
-          git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
-          git sparse-checkout init
-          git sparse-checkout set '.github'
-          git checkout main
-
       - name: 'Az CLI login'
         if: ${{ github.event_name == 'issues' && github.event.action == 'opened' }}
         uses: azure/login@v1
@@ -65,11 +57,10 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230328.3
+          --version 1.0.0-dev.20230422.1
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash
-        working-directory: .github/workflows
       # End-Install
 
       # Testing checkout of sources from the Azure/azure-sdk-tools repository
@@ -83,7 +74,7 @@ jobs:
       #   with:
       #     repository: Azure/azure-sdk-tools
       #     path: azure-sdk-tools
-      #     ref: <refs/pull/<PRNumber>/merge> or <sha>
+      #     ref: refs/pull/6030/merge
 
       # - name: Build and install GitHubEventProcessor from sources
       #   run: |

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -51,7 +51,7 @@ jobs:
       #   with:
       #     repository: Azure/azure-sdk-tools
       #     path: azure-sdk-tools
-      #     ref: refs/pull/6030/merge
+      #     ref: <refs/pull/<PRNumber>/merge> or <sha>
 
       # - name: Build and install GitHubEventProcessor from sources
       #   run: |

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -26,14 +26,6 @@ jobs:
     name: Handle ${{ github.event.schedule }} ${{ github.event.action }} event
     runs-on: ubuntu-latest
     steps:
-      - name: 'Sparse Checkout'
-        run: |
-          set -ex
-          git clone --no-checkout --filter=tree:0 https://github.com/${{ github.repository }} .
-          git sparse-checkout init
-          git sparse-checkout set '.github'
-          git checkout main
-
       # To run github-event-processor built from source, for testing purposes, uncomment everything
       # in between the Start/End-Build From Source comments and comment everything in between the
       # Start/End-Install comments
@@ -42,11 +34,10 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230328.3
+          --version 1.0.0-dev.20230422.1
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash
-        working-directory: .github/workflows
       # End-Install
 
       # Testing checkout of sources from the Azure/azure-sdk-tools repository
@@ -60,7 +51,7 @@ jobs:
       #   with:
       #     repository: Azure/azure-sdk-tools
       #     path: azure-sdk-tools
-      #     ref: <refs/pull/<PRNumber>/merge> or <sha>
+      #     ref: refs/pull/6030/merge
 
       # - name: Build and install GitHubEventProcessor from sources
       #   run: |


### PR DESCRIPTION
There are a few changes here:
1. Update the github-event-processor version to 1.0.0-dev.20230422.1. The changes for which are in this [tools PR](https://github.com/Azure/azure-sdk-tools/pull/6030). We now pull the codeowners and event-processor.config from the raw.githubusercontent.com for the repository and no longer require the sparse-checkout.
2. Remove the sparse-checkout from the yml files.
3. The Install GitHub Event Processor step no longer needs to set the working directory.
