### PR TITLE
[DataMovement] [Storage] Add verification for matching Source, Destination and CreateMode when Resuming

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlanExtensions.cs
@@ -193,18 +193,41 @@ namespace Azure.Storage.DataMovement
                 preserveLastModifiedTime: false, // TODO: update when supported
                 checksumVerificationOption: 0); // TODO: update when supported
 
+            // Create the source Path
+            string sourcePath;
+            if (jobPart._sourceResource.CanProduceUri == ProduceUriType.ProducesUri)
+            {
+                // Remove any query or SAS that could be attach to the Uri
+                UriBuilder uriBuilder = new UriBuilder(jobPart._sourceResource.Uri.AbsoluteUri);
+                uriBuilder.Query = "";
+                sourcePath = uriBuilder.Uri.AbsoluteUri;
+            }
+            else
+            {
+                sourcePath = jobPart._sourceResource.Path;
+            }
+
+            string destinationPath;
+            if (jobPart._destinationResource.CanProduceUri == ProduceUriType.ProducesUri)
+            {
+                // Remove any query or SAS that could be attach to the Uri
+                UriBuilder uriBuilder = new UriBuilder(jobPart._destinationResource.Uri.AbsoluteUri);
+                uriBuilder.Query = "";
+                destinationPath = uriBuilder.Uri.AbsoluteUri;
+            }
+            else
+            {
+                destinationPath = jobPart._destinationResource.Path;
+            }
+
             return new JobPartPlanHeader(
                 version: DataMovementConstants.PlanFile.SchemaVersion,
                 startTime: DateTimeOffset.UtcNow, // TODO: update to job start time
                 transferId: jobPart._dataTransfer.Id,
                 partNumber: (uint)jobPart.PartNumber,
-                sourcePath: jobPart._sourceResource.CanProduceUri == ProduceUriType.ProducesUri ?
-                            jobPart._sourceResource.Uri.AbsoluteUri :
-                            jobPart._sourceResource.Path,
+                sourcePath: sourcePath,
                 sourceExtraQuery: "", // TODO: convert options to string
-                destinationPath: jobPart._destinationResource.CanProduceUri == ProduceUriType.ProducesUri ?
-                            jobPart._destinationResource.Uri.AbsoluteUri :
-                            jobPart._destinationResource.Path,
+                destinationPath: destinationPath,
                 destinationExtraQuery: "", // TODO: convert options to string
                 isFinalPart: isFinalPart,
                 forceWrite: jobPart._createMode == StorageResourceCreateMode.Overwrite, // TODO: change to enum value

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlanExtensions.cs
@@ -20,6 +20,8 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
+            baseJob.VerifyJobPartPlanHeader(header);
+
             // Apply credentials to the saved transfer job path
             StorageTransferStatus jobPartStatus = header.AtomicJobStatus;
             StreamToUriJobPart jobPart = await StreamToUriJobPart.CreateJobPartAsync(
@@ -42,7 +44,9 @@ namespace Azure.Storage.DataMovement
             StorageResource destinationResource)
         {
             // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);;
+            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
+
+            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             StorageTransferStatus jobPartStatus = header.AtomicJobStatus;
@@ -66,7 +70,9 @@ namespace Azure.Storage.DataMovement
             StorageResource destinationResource)
         {
             // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);;
+            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
+
+            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             StorageTransferStatus jobPartStatus = header.AtomicJobStatus;
@@ -91,6 +97,8 @@ namespace Azure.Storage.DataMovement
         {
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
+
+            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
@@ -118,7 +126,9 @@ namespace Azure.Storage.DataMovement
             StorageResourceContainer destinationResource)
         {
             // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);;
+            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
+
+            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
@@ -144,7 +154,9 @@ namespace Azure.Storage.DataMovement
             StorageResourceContainer destinationResource)
         {
             // Convert stream to job plan header
-            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);;
+            JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
+
+            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
@@ -268,6 +280,62 @@ namespace Azure.Storage.DataMovement
                 result = JobPartPlanHeader.Deserialize(stream);
             }
             return result;
+        }
+
+        /// <summary>
+        /// Verifies the contents of the Job Part Plan Header with the
+        /// information passed to resume the transfer.
+        /// </summary>
+        /// <param name="job">The job containing the resume information.</param>
+        /// <param name="header">The header which holds the state of the job when it was stopped/paused.</param>
+        internal static void VerifyJobPartPlanHeader(this TransferJobInternal job, JobPartPlanHeader header)
+        {
+            // Check source path
+            string passedSourcePath;
+            if (job._sourceResource.CanProduceUri == ProduceUriType.ProducesUri)
+            {
+                // Remove any query or SAS that could be attach to the Uri
+                UriBuilder uriBuilder = new UriBuilder(job._sourceResource.Uri.AbsoluteUri);
+                uriBuilder.Query = "";
+                passedSourcePath = uriBuilder.Uri.AbsoluteUri;
+            }
+            else
+            {
+                passedSourcePath = job._sourceResource.Path;
+            }
+            // We only check if it starts with the path because if we're passed a container
+            // then we only need to check if the prefix matches
+            if (!header.SourcePath.StartsWith(passedSourcePath))
+            {
+                throw Errors.MismatchResumeTransferArguments(nameof(header.SourcePath), header.SourcePath, passedSourcePath);
+            }
+
+            // Check destinationPath
+            string passedDestinationPath;
+            if (job._destinationResource.CanProduceUri == ProduceUriType.ProducesUri)
+            {
+                // Remove any query or SAS that could be attach to the Uri
+                UriBuilder uriBuilder = new UriBuilder(job._destinationResource.Uri.AbsoluteUri);
+                uriBuilder.Query = "";
+                passedDestinationPath = uriBuilder.Uri.AbsoluteUri;
+            }
+            else
+            {
+                passedDestinationPath = job._destinationResource.Path;
+            }
+            // We only check if it starts with the path because if we're passed a container
+            // then we only need to check if the prefix matches
+            if (!header.DestinationPath.StartsWith(passedDestinationPath))
+            {
+                throw Errors.MismatchResumeTransferArguments(nameof(header.DestinationPath), header.DestinationPath, passedDestinationPath);
+            }
+
+            // Check CreateMode / Overwrite
+            if ((header.ForceWrite && job._createMode != StorageResourceCreateMode.Overwrite) ||
+                (!header.ForceWrite && job._createMode == StorageResourceCreateMode.Overwrite))
+            {
+                throw Errors.MismatchResumeCreateMode(header.ForceWrite, job._createMode);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
@@ -56,9 +56,6 @@ namespace Azure.Storage
         public static ArgumentException MismatchIdSingleContainer(string transferId)
             => throw new ArgumentException($"Cannot Resume Error: Transfer Id, {transferId} is being attempted as a single transfer when it's a container transfer.");
 
-        public static ArgumentException MismatchIdContainer(string transferId)
-            => throw new ArgumentException($"Cannot Resume Error: Transfer Id, {transferId} is being attempted as a container transfer when it's a single transfer.");
-
         public static ArgumentException CollisionJobPart(string transferId, int jobPart)
             => throw new ArgumentException($"Job Part Collision Checkpointer: The job part {jobPart} for transfer id {transferId}, already exists in the checkpointer.");
 
@@ -83,15 +80,17 @@ namespace Azure.Storage
         public static ArgumentException InvalidStringToDictionary(string elementName, string value)
             => throw new ArgumentException($"Invalid Job Part Plan File: Attempt to set element, \"{elementName}\" failed.\n Expected format stored was invalid, \"{value}\"");
 
-        public static void ThrowIfElementIsNotPositive(string elementName, long actualValue)
-        {
-            if (actualValue <= 0)
-            {
-                throw new ArgumentException($"Invalid Job Part Plan File: Value of {elementName} was expected to be a non-zero positive value but instead was {actualValue}");
-            }
-        }
-
         public static IOException LocalFileAlreadyExists(string pathName)
             => new IOException($"File path `{pathName}` already exists. Cannot overwrite file.");
+
+        public static ArgumentException MismatchResumeTransferArguments(string elementName, string checkpointerValue, string passedValue)
+            => new ArgumentException($"Mismatch Value to Resume Job: The following parameter, {elementName}, does not match the stored value in the transfer checkpointer. Please ensure the value passed to resume the transfer matches the value used when the transfer was started.\n" +
+                $"Checkpointer Value: {checkpointerValue}\n" +
+                $"New Value: {passedValue}");
+
+        public static ArgumentException MismatchResumeCreateMode(bool checkpointerValue, StorageResourceCreateMode passedValue)
+            => new ArgumentException($"Mismatch Value to Resume Job: The value to overwrite / create files when they exist does not match the stored value in the transfer checkpointer. Please ensure the value passed to resume the transfer matches the value in order to prevent overwriting or failing files.\n" +
+                $"Checkpointer Value to overwrite was set to {checkpointerValue.ToString()}.\n" +
+                $"The value passed in was {passedValue.ToString()}");
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_CreateMode_Overwrite.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_CreateMode_Overwrite.json
@@ -1,0 +1,250 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-13b96b37913722b0c932d533d015a0c8-d19dcf1ae3289a64-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5b8fe58a-5e65-d526-1980-e2cb70a1e94b",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:22 GMT",
+        "ETag": "\u00220x8DB42FC73492A22\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5b8fe58a-5e65-d526-1980-e2cb70a1e94b",
+        "x-ms-request-id": "1388b927-301e-0034-80e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631/test-blob-4ee8eb81-76c8-2842-b03f-4435c3d356f6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-5d12ff052a6895898560e91dac86f6bd-7e7ed73df077f99c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "34956528-526b-af7f-4161-43b3238dab56",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "1Z2nIEWLzNN6WOVY313\u002B8c2/O2rQ/S8To2aqJRrwEUUp7PbT\u002BckF9h8V02\u002BR6klTQFJnA5frJddtlH3f4Ka4ikafLvNmK/cEukVLuyq/grgdV\u002BTHiA2tPsYeZWVMJRZ4XEkp8btV7BVbY0lSoGqtrRLEwYnC8QE48vAsSMWSuJQu017hlpH9x2rOayXEWp1ccLhSiGSNtmpH8P7KKaRQyKq0I8wLzBaBxvke84bbdJdSz9cMPzAwoR30maaSMp7FfqJ7DzfRUaSh0cFqbsPkbHtneFrNQ4l6hIGvFzNv7pRbWXTjYGRggX4yam5vxTNaDywrKrpE\u002BDoZAIu1ITpxMuIsDhROAQwWBvbbmtgaCr5OVQcGRMPaF2E5yV/Zq19DwTiLQrYfCw4gFCTDaF1i/vXMZswyau4eUfezFDesPFuXmNigjsgIL0n55S\u002BfF68D18ppDUSSEVdKbfC/a/fWdNfIK9CEwXAtwzeDOYW\u002BfjpHrzxtQi8XBIaBVSHXSMNRInFX1\u002BvffxVaO0kMDtfRi\u002B62d7u6aTGosSZJAmtOVnp0MRYTZqdPaDAnEgflCvWvsMoyINEIl7lAriXElnypDOXOmN3AviRHZw6Kk1cqw6cwmVKhGzWpbJpd07iBitK0fQYhFnEY7vGl67nCfQRiFut\u002Bk/wpCPCvJSxCYupsxdw81hVQCKw1GKpg/DB75u6W\u002B73MA/bWinUVcfBF1YsGOCbdhqbuEQ0\u002BSHtRyQvAND89rGctoMHmZkygO5a88EIeWcMJnl9Ip\u002Bqvjbp6hMBpVT2xBygk2Zhk9yBZTdV2glg5Mm9ItpXf9AV8fhIGa\u002BGLN\u002BVZCugZ\u002BoAqpac/71oUOAtiQVFRIZ\u002Bo0hIjp1uGXYs\u002BzRbwHXdwIDjuHRHtoAWraEUGpCmQOhZGsTjV9VIlpEcbACFDJBqT8iEYYgONujENeD8VgLlirpMAqWw/mirlyXnJ0p/jZ0QqcrEId9cSuPYGx3wTDySNuVKOQ3quVFf2MpmKxOeRKhH66w0HWTa77fB1ONKu0rlVOxhNVCPJfB5ZEUQ9h/QOdZ1rGCQWhl8b0lWKOBuFSGDgNYjPQ9XtMW/urUfxfmb8ZsM1QrmUPrW5MoHOP0MD1MnkXVJsPzHIfee1KNgXKVTvjdJYUAWmS/bSFRFUHvEr69l\u002BDSATjyaRbMTS3xXdoggs37FwqoTDPhJbmSofc1/1iT3\u002BmBw03P6rxuNB02zh9HMJJz9AukBUus8Ot/b8cfll3FXY3gnr\u002BAKzxeOhgmqmeqS2Fkwftc78qt5NJSQIrlTq2/YWCBZqHi48jPVcszhkaD1RRVusRieG2zQrndPeqxaOtqdzj3GOTPge4ijZn/al6L3ntmj5PpXPkC3hP4BbXuHezvyR8dnLwvljjWT\u002BrTw\u002BhbQV9/StlXgSo/9ErA13woNH\u002BtH5FPfkG/RvlbAx0OPxo7nLRWfsMDiDfk3ahxXs68rgt7JqRHC9MdsAPv/I4dMbUglTq30cWsqYdZWpCpPeg6nlUBkwhl9JDhSL7PI5u516vjQMmEBNw13o0c7aFCdIIbpV45C568yqCp1okG3XX7r3Lkxe0uppl427SLSQbvrtQ8s349cNwNJoYY6j5DLvEHIU4uXa6U7P7EwC/qIXGZuie02ioHzi6m159nBcxrJazDhCe4sUElp8Z/eLCsIwUEjyAGnlTW/2Mfh3YfLecyWZqDFp1J0QjmnyJTiEVt\u002BqSKUoacZJdX7JTEmSnLBnnvPR8WKRx3uq4nL/8ig2cdsZzRlMtQpfUDKyoIhTffG5i4ZFsmR8GYEqfoZTSYNWktpuec\u002BXG\u002BjpcqEw3ifzVmWARmeh8b52nLOYIjeDCwevXA2t5QMhIW\u002BdW0DDTDtaNicg0wIctaEc\u002BN0c//ixZmaZgYEZRXFiXyT3A5Z\u002Bsk93PesPYjgFkqdskewlBCJ37PTZKcu5QPG2vnPdJLELnUWOpMEMoQMulO7arbOEPVoCgBahpIiEvv36WKTFJ271YfOnl19hakrxq5Xd3pM9MoEY26Sbafm8CebDEkhfaWyA5Uy/3KX7oBXLsPjzp99qvCYirEzJWff66o15nVgCkUIpXPlGfVXbHTqPz7kByWIHWVUiPLwftotUxfEYgQO8yR61yUrlIz/QR48SOoo\u002B\u002BSEqcUQD31SGCaVt8rhjw5s20gWaS/8YITYVUfUsDHwBFsvQ7RC/uerKL8CkeDGGbIP022eEo64hElAO7Y1fWfwpbNvsk9aKdxgb0Bw/dKkFj\u002BRxODAUfHMdrtrAsMtca9XDewtVmtmtaWNPadOS4p2mCV6p7SHMFPBozuT7ysdMv2VGe/mdr/ULxM/MxRKfi8w8Gadts32092Yb7Mv1sZ6cAqpuS2akCFlpnSlR/07dyEMYvrEf3wznkoSSgsMpFRIwMMNoMUBllxBOBBVUYvgYPSOI3fPtfSKdhrjiEoaWP4gXIc6LdJcCsiag0Nv3kzCMeUSfoTgeQ7Kgy6qHg4WKuMSMPEApjciMhSvMTaxHpvOIVplB9p5Q\u002BN0c6qnsey\u002BhFRgWalbvYux8ExsNUfYFWSS3/y3sSMElPERjDKMenwr8KzeTMTucmPOsxeODQqbnFpGFNXwBtcxX8C0SjFVJXXQQESa\u002BcijpGmY6P4Pdovmde/YRmWmO\u002BnZqO0ANigydY2dvcjGAKaRpnBsVx3VJek40dBFfN8QLghavVDbn25BanNwbbi/IHVJRqP1OeDIAIMHx2Rb6PSujZPAa0NRugcCLuyqZLgsea1e/Do7GvAnjrjN09gF5X1\u002Bwdwo/rUx94yc8w70IZ/K2022\u002BOy\u002Bd3afmNiKh\u002Bou\u002BEVzK6LYA3r4LQStnivlM20dAvSKUuyMwE5pjWXYp3OicfbJgPX48tvSvs/kDNVKtmVvbYDxoKlU4mtUcnYVH4WVCygxH653IBAcu5QcpLN1Htb8bTnusM1JcKKKpIBhuZ9GUwWpFZq29Elw0OUVNDm731OfFLJLqlZe668P7H\u002BTuv301lWpyAU8SXTwfd/oNDhk0sUsxqDo/qSzTi3rpwvN4RnrHF3kDhNKXs85Wyx2drN2qxm2YvBdD9us\u002Bn3XVKJtIpjGARfafMC14mvRs6d4ONt\u002BdP/uG34lihCGOxeVdwoszDSTsHWbmCpVAICIi1w0MMGiWN\u002BigwseoHcHVEWtHG9hpOdu6IRl4tjRlRr9mQK0TgZR9xoqjkktcRP\u002BlEfgq\u002BARKuZ4yUg5OHoCzOnwIQdwUwZDWylRNxqaPXd0Z06U7O026HIcP4S6GLqgJ71jPVAIjkFBoUy6w/fP3ovUxNUvbd/4uTSVUBd9hUJysQ9ZNwAja9UJU0\u002BceCh6UFz85VPhdLXdZoAbdzotwBwOSA7kcquHsVz8IhqQXEEMGwO2gJ/ujTxVf8yAC/Se25MzkjAZleGxdTf25VKfTQo/D1g6dz98I77SjvbbA6lkYUaLYM4M8oEiAQ9r96fpujLGQPiYYGRXt251Swrq2nGKjoQIE\u002Bg8MhjXGHIwECgW5NDEFL6sz/ziM61fl6t6NyqZ4WUf4aZGihLjwUvyJ6NGYmY2JsW22cKHKeA\u002B3JpxXOVLli7C9wcqfYqvzQ607AwKFTVFQAxk5wemmLfGB6l4cmBmqo1wg2tfD6U7Bwyz0j3QNMdhKBjU4rMrGF5PYHndN1qqUkF\u002BlZXN5jRnKd/29sZ59c7iF0ZLjcfeSWcND6svWdO2BX/4UaMxl0XgbbjTMCWX1W6q/xwUYsB5oEguwNaNO8wMQO1GfaAvrIAAZxwPCxlBdTo4gF6znaa/gq1XBtJvVzHsxu80TVfOf06cF/ugbpky6UuYVLttWKdKiv7y2KWtkRPqHkAqDSfmbgUMF4mrGxAUIB2G1v56f25L6cZU26Kk7oLrukxVCNwnteq2YUEZo3Pq3riIJr4Rc6LV4iNhjZJiZykGv2DHvxdBYx0XwB4pMkZSafzmHMfE2katgyq4wihUU/oYEuQTJx\u002BhSsec\u002Ba\u002BAqK/ZDyOReEphQeUaGjvshJzwv3AkER9iQ0bdRNYAJ9yXKNp647cIwtevttD\u002B9QjnsMYmrDo/XJeMes/YtDd0YRoEgvFddaDp6/iYdFpOY0o5\u002BZAT3XuiW8hC6mjnLA6gO1W69nYbhj8hOMQ9puQ5QheBnr6jYIOeZislHos4Arvt9DkEl2zUHnNU7qC3ZLTkCahRZY1T/NbSGJBK9muz5ToIU66rNKqqrXxLTnHi5v1yQRDe5p0qnftmMnrYiSgLoQlmrxUGONUBqrQNBLJg7zWS1LVW1P6c3bG3RQIvziRUQ61oeDvobAQ/3T/lGZlFAUdFRbB2sMgKyc1jUvPS0dyTuMUA\u002BHb5pmitGvfCt8AYbke\u002B6oRz3Y7hXbJqiRkQaQ9fVWDURATMS6NHyZnUSBYJSuSsF\u002BdUH9s2I5rEjx1TmK3oY15jRCo\u002B7p7lKBfxDRGYYUI0YFEkCzWFniBuC7yF9Czv6\u002Bi7qgK\u002BcSlIcvPHQRaJKC3bGzRYxFgk3aYF0OLiYzfrBSEo4Ls/efMr25hFwl0N5OOOqtj0kyOQkshctKBKZg\u002B/3DvxXEt2n6FFMOi/4xtI\u002B\u002B//V7ha8nYBmE3u4sFS3XWIheYhGISYGA87s1420LOxE7y0SxJXYOnB88P5h7jf9ld3N101K99nZzutI0MbysuePc8EmpJjMSD4XyjAnpBSW70Gw5lSe\u002BvdTOPWqkGqqiT4W0nt21vBEAI4PMi2osinWsuCEQsuS8HnJ02uiIrjUbEDyENKZIBhRa\u002BbGj8fKq4bM096JJUdyhOECrAOEod3WOsXstqFXPZHIM9blzGGx/yjl1k/ZSkf4f4zwlnQVzMkI8FQB3fTldJVMwfJxjbeAUKzbn8uO/PB\u002B9DYVZqYdsmYN3NwNryEz/2G5jYlUh/HUcEbHOiz9efNjgum\u002B0A7uLw6LY7DbcqCLp59p1W9nKmxEQPZgVng5D2PoqS04dS9Tyl56yCNA\u002BP2lPJKMlKSE/Fh8eY8XjtiWUVRN88lzUjJvFgoR7GFIA0f4uhrlrHu\u002BY6zUu/ugOzyF5HbP8wU0MulfHX2ZcxD2M3VHH9O\u002BsKTZj5AcnpY2z9rOjAjqeRBCw4gwhY/9JPCc3oiGWBxoxjPR9mN0F5NTKE2jy\u002BcHC7pkBVtLjioU22qggMAOsHa\u002BZcXVGIKszav03V1CWlgIlNLNIlPAHTgIvRr51JfSRHjW5GYhMvI3tzewVrHN0oERl\u002BvuQI0j/keNzFtns/gTIpjkbHXy5mLflWobD8eGOuqZ5z2s5ATqsuYelGWW0AM\u002BnDQZ6WYMH7CIDqoiB\u002B6ABpJxzsy7Zz2T\u002BbmO01L8SMVm3XOTbVGEjMiNI9VZx6v4no3TJQE3gzX2he\u002BtfUxejMbluyp67ZlA7EEELkNoOjENljXEKSLDL1k\u002Bnedh1w98L5cPdAuAfbH0kjnAM1XyjUu\u002Bn\u002BcWmWKjIYzRPFCx3xUyh/\u002BrWQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "\u002BEBaHhD9HJfE15s\u002BEDNqUA==",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "ETag": "\u00220x8DB42FC736473F3\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "34956528-526b-af7f-4161-43b3238dab56",
+        "x-ms-content-crc64": "gJwEsNnuCLE=",
+        "x-ms-request-id": "1388b983-301e-0034-59e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:23.8212083Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631/test-blob-98863446-cd11-c993-ccb9-1e91cdef4015",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-8d8c7dd7967111e929c46e40b0f2d465-c09e387f95b95cf4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0f531da3-c33b-4605-2cc3-3c5a1e757981",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "O90KIml27XKm3tgijeLGdU\u002BtBdsWCiZa0sxosTTt4VEgLXdFg4js0EYT8jP1cDzq86hBIOpl/zG3sFCdDjs\u002BuPyGAl9qgPLGwDSUAhjzZGGQfb6MrMFnuy5GjtI4T8IK1Tk2bm3cgHO1el\u002B10PwYxEvvDJB9sQw7H0cwI/EfjnByii3fvPXzs/1K1jFhseoyLsqHSUIxjCMt\u002B08mrFyBluzuQ0bOOQdV\u002B1mTMtva2W1c/vUnmEUtQP0KscGmzAegyT9Fc26kZPXCMU3pnlpHUiHhyq1nWv6mwAJJw4dGry5S82mblWb\u002Bt5oAZGb4RKKjwl6fxQJZOG9BnrJsW6BtfIIflqvwrL274hITZ/WXrnxgpgEop\u002Bos\u002BLr6Wva0klz5kujk2K73shah4\u002BLvRdF5qfA1DLWfRNSY8p3w9lLHB0\u002B1GdQMs9XOaPPrh8MHPLLogbAFfoanWk4TS\u002BYQBrzD2dySOiz8bPUaZ6PBs70RkLbrB3WhwYnJDr6G\u002BGfvvWI3J63ndAKG7BS76hbi5aaQArovJf5HIhdTySttdnONK6lBiowPKRy0ZBtg5tZy5ygX9fatv5hj8ASVk6vWGHagLb9soFsagdiee8Dj5jxB4OIDVoB94GsQ3pmHeZVx3UulwLgXBUbM/XQdDkTYgAnIVLPI0sL1I01TW8LBkgdCLZ50PSaDKducN1gLYNEnOF2PvyTiqAqJr51rw6qDCmts2uGlY0LjRSrYLJtq6sJ7LCNlMdPiX4ST642IGGYwGCztn4XwgdUarHn6CntuHsXa8JeGHtiYiXpcEne0Wi3EpxRvfEs8iqpOSoVZ6FUJJczIrifOqfpTVRULlG9dZlFMNWNn/qJ6nWXtONRSPqElUu2q7KwF9f0ZHCc2MfY68OQ0DLLxoiYqTRDB4XEmABZz5kGCsnmkR0BmTeJ6RGxvskjwHjLuM7DGgJ6bQxOM8xsRwku1tz5qj8Ryi1RDsAmkUi4pNuLjhbKQuzLaCQMs2lnHaYIguvsJhY5te6hbg8\u002BV9vHlY705LT2YJPwMj4bBRrD6e0eHhJgzH7BUdQkJNDdiRRISR3ecjjtFh5X\u002B/fUHrDX3YAeIDXJZsUMM5bczj/DEqUpzr/45Xu0LQvwCNCK7TMnTEdMv2TeguJUzj6mDEfilOlOrk/02vgIafMt2VnwhUZjuX30clNAS0/ZoBc5EiDEDXfrOD7jMnFPRFV1sKmIZEj4QlbF7iaaDmMAHzbgz1vSacvmCUkHgIsIpSn5ypqiTT/OQNPN/iNNUS3f3xc\u002BanT9o0bhol7/8L3PuUT4nEPIXc37Fo6EBGuolLQfK6Fzzjq0/CtTwK7g0lAR/kTaVLDuF4FFR1fqdZ7fNQmm4MkcW\u002BsOQ5wUdJkfGkQ\u002BdgYm0kADLRQgLormzoaMdI\u002BlOe2K9aZZzBEU1Z7kKikTr/\u002BUtGbJo7Ow\u002BC1cJ3UZiAANedxWt4BfyQYu7lt1PABd1yKG97wk25Y51fl4\u002BaSf\u002B0me1qxMuPR/NO9gnrVYP7gpAlBWkpRD6J5KHOGG5s9dkvMN1mlUERoqC77QxDzg3ZY9U/tQRWi1Xu4OApwW9FIcAw/CTmVS1O06LIbVbyBhaT9LRZbUDUmKVHt7Rg56ExNstMExHpMs7n8OGhjh3\u002B/JrJlgz7K/R/XCO/Xt147evBl3aLpjLEqoGlsXxfMwpHSLsZl1GUdcrWzPbuaZPxbsL13/bnc1anxStLFbp4ICkZd9ZiHxaaLWFrtJk8FkEttAJ5aRNTYBUksdJmCSBQnuyN1PG9jw/sW7JVe779a\u002B6qXWF3/rcVxdfBPa1Ec\u002BQA2xWsrgFPcCTyjQ1g/iRWZ0Yju\u002Bv/GKB1uA8Z/JGiaCfOFGCpEL2tWu18RTGptMfzqpYnYLg4QcK1dzXyNbNTUGTlkqmD7RbIdmD\u002BgpNuzAMHZhI7usdv1dKd89mHuyV6KTTMg\u002BIeL71/XypXOf9vBmsyqs9hF9VdtfzXJfk9QLs7hJleYkghKTaUvBvdGNwTLq2uVRBV2NFfbw4lRwnEQd5vG3Ul0OQi0YGYzJu5QJzgw/cLjuuq5evIPvN6O\u002BIskHo9bf2m7V3Ji4NOvMw1pi5xBENS\u002BLMyxDVJXdHwqJXfbDxhfBKfedaZAgMoHGjfkljEyTde2deHCqmIHU\u002BMGOMtbxDP1Gnb0YpsubavyqfMact469\u002BegJIk2jGo11yHDSkgOu0YD/4vKPes8iBg1z/B\u002B7NEEyzDju6\u002Bqvo4cvpt5ayNT8/69FnNScLn8Y5xw8MxpxupAvn8XKv\u002BWWTD9rX9Pwyzk0dvxsdZtolp251gDKc3BovexKKy0TNkPFr1CZMNKvKB/jB7weBUD4wwUkEOXky9jPAqHnppwMJUC8psZG02HPDqng52\u002BwTrirUWQn6yFZ4ON3yjIsx4WD1t5/XV5\u002Bse\u002BnVQI8A\u002BRtGrPpPFE36DofYsHm0wkvokckXRCNNO1aLJ94gJIfHeD/BrOCR4cwT\u002B6gX/6Yl\u002BLmd7a/F6LT4\u002BHGjxO1v2ur/ETg58hVrV7D9BEl6NjyvZS8kgjbYAY\u002BKybNu7R3epCG\u002BGO1u7AWjMZb\u002ByORrfcI09F\u002B\u002BS1ezJhCorili/GmTHmAnux1OQXgpgFGg2jirH0vxOvm9IFnKC/HdxT3cQTQsa6qDQ8Kk5rPmlMoFEkzX/I/dccJw1f0GXa8scHs7TD4cc26NJ9yJTFNG14yOxPilBcmu/9BxvJWtfOUSeHU3q0iM6Z/dStWyVCVvKv5xeJm2hmuyjE1uq7bZ36r2dtPdDixDAttZx7vz\u002B6qrApKXPARLW/EKhR76Hj3oBGoqvN1RkRvSLXa\u002BXb6wvpCiwqgkQaKmqhrh04gNSOOdccNQyT/NWXB2xQ\u002BNjf4yWseNWFuVw8LIgxHDb76TxOSSIez7X/RR1Wg3rnyTGB0brnjAf/CIB60BiEUuCumy4wAr\u002B2wSN/rTPIPyXRVFNGvzp8FF0kXzChk/\u002BdeuIst/hMt8Zx2xCXZ\u002B7UNslqqXvFPaO2IobRC7N/FS0z0iJBm4c9hKyMxNQZ1KxuUBh3Rvpz2E0\u002BdoVhe7wTAsXjU5W8gptCLRTfOGjfnE3qcqubB94ywAnlExUBzBjwacIeJnEWoc19NRnVlJ/Ubuo3hvkAiArnsJOL1392QFD77s6msWXMw8DuHcK0XStqAKQ6ykUf/\u002BG3JnXtitpd9vS46bXBLb2EarM4Imo4I1N4IdbLS3Yb2/7s/4rv70j2gBbeC3NlmNL2tm\u002BB592HfwMiZWjzgrt\u002BnQ3G5D4ilHt6QZJDWifQAojz1JUWmfQhVXCHzYnf8v1rb25lrqSUxBHkB5Y7RBTbQlLQD74WaAMZpZ7Nqsbxmk6U1/q5amPkXwBzIoJd5hFbrIsnD/M/VPdrW/kV1yla4m1XlmwaIdf\u002B66C9kzVwy899Yf472opbZYMDTh5q3ofXKDAVBk\u002B1MYqzKCRSgbGx6pA5mHU7HxfS/DDZFtPJhB0Y5nr1W8V/yCBjiLJmCNPRQWOOMTYCrAkoMgoe3Cq2\u002BaQHOZs2vJ7aycBUx5ZlfPNc98VwO1LXBkpx3Rm7UPv1vJ8Obs9IqoTEs2d1vdRywsUWsdRVNr5BICNQtO91H2jUXwr3Vw4kFF0wq4frYVhmDwpEpK8XoHXgzU6b5\u002BWlX5P\u002BkW7Ze3vG4q2HFJsmZb7a\u002BrXVIHrJzL6FFpnPmCxnm1vz7M/pnJOejbHxgIvqulePsP0/wC8pNNSwRFTiB1pxH4k/Mnju8V4SRqK4yDwiqlwyP9c/N8s8yrf7OUg\u002BrHZngHDyq4fukM\u002BfHXl8YGyojaoIv8eDQee\u002BAmfA87gV46o8UUfLL/7UQ68HkBpRwGpLQruuNfyu1E6JRJkQLZ0XiSnfQB8U7V2rJGwoi6HdbEINdaEMZ72tjX0JMetltCYB4BbggnBbNmVeAwGAhlicu\u002BhXEqfsCxF8IbKSG6tyRWBGJpuK7OnBsk87rmS8LPcUbIXzDqF\u002BFeUFdFC9uRrJ682RSm/NEc8OhWBosGy8wATLja8lfzbOyAC2hXiJA/kkcbKnGuKXV1q29IkxFWWIWLRb8jt7pHyG0nJfFpxWhXFnND6qFaUSJCZUbnq9jbKrLjzELRHNqN1GEEhgODC\u002BYH8H2dEm3kMPOd4FJzXx2UTPs\u002BhvklhvqYthY/Vssfvllg4LpbPRdF/5tPMzuIGnRDbzoIRYXs4mmCBFxXpNoofiH4En9jOQ/k\u002BYdd1VK\u002BEJyh/OaRFnnUdP5Q2Di77VrAJrUZkAj14DUqI0z9jgwXw/TAtqfzlmeoI56AEmDWKAssnK6cpX\u002BUrByxZvIs1uXxORRE\u002BjezzZBOcG1pdM3UVPtA0fJdeh50LAmLQjB0e0y4j9lMki7Uec8eTjQSKjdP3BH37AXzk7/1z84tJ4pf2vUgseXziMLNa1giPyvqYgLSPGYefI9HxfsaVsJfp1FEv3Q/8nhSW1NPKoCt0FSTC23MW\u002BskQF1l2evq2DL/bcQG3X\u002B3q3CJf\u002BASz1EOmfSmh0tVk0tlIH4W2RiNaIIhT728pvPV21/9QtsLEnEMVz/2Q1Hmqtp5ob0BodJX\u002BxZd8ICUUfIB0azrWFBvWg4NCYHYlyQxOqXiQwU21DmNpUfEriHxeAVN9XKl\u002B1GKCUeu85hQfmTyK7bbsQ7syv1yXbIIqqvsHJF7i6Gyiz5TWDm\u002Bh\u002BChPSfi0oJqFcb2YCp1Mp6fgV6bwtcG1PLCP6B3h1nVLUMc0R\u002BLJtcpggbLhCt3PFmgtNfbI8UJm2k0H5Li845tITLmWWF\u002BE1qGcT/QO0/HSwNH1tOC\u002Bgp9Eja2VgZER454XWP4kOP3IqB8VLGFOF8ZbNSPmxy66ycoaEYrx71TQSqwWN3sz7ofT7QzBaVY\u002BNnWnekytaxyvnI70Cedy1vjKBKH1OCCLZ0ZcEtohuWB0HBsVSnTIYx\u002BPplrsf\u002BSgoRZUN2T0CP4VHBMGERgCjiMuf\u002B3MHUxDwaFCZZHF3ueh\u002B7GDjUH7v9McwG5hwhIHTRh3vf/21EOJ0DWDseNsTz0rZBWmvsChcsAar10eIj9POti5TmDn6yct\u002Bf1MN83v8HExNl38YI4X1gs/nCUmq\u002B32dHbK8sDcA7kueIUDVTryar7r7OvhUtoKYbgVqA7CBw3PVcOW5P2wFPKkzegJFIEQTTFmOv7CFOGcwFFIxltqLHG3M/83G4XBe5f5PITyAU02xVrdXAxOzUEiOiRsJ05XeqG2keCCGTGrpP8nCNgcqr8EUgEATJBlKCa91SGhVRRJYcHje69sdOwpcfdNJ8RoxU9lZ9VNVu3RUWm6BAPQCk\u002Bq3acWeW7P2B1VFxrZF8BiFQ/SO\u002B1\u002B/AsUEeoFsjCoGSdnokodUovgVY\u002B4OH\u002BS\u002BHlpV\u002B80Pg5iK\u002BFbwieEiiXsrP3zcXW2BMJD8aZdhsPLQRmw3BpBtBsYxbaogVBkW4tpy0tBn4cD81LssAxoBGTdkIEN0\u002B3Lazjiw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Pbu3hY8xvW6ycwFQAD0K4A==",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "ETag": "\u00220x8DB42FC7372F0BA\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0f531da3-c33b-4605-2cc3-3c5a1e757981",
+        "x-ms-content-crc64": "hnLRCCHWPYQ=",
+        "x-ms-request-id": "1388b9b4-301e-0034-05e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:23.9161530Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631/test-blob-4ee8eb81-76c8-2842-b03f-4435c3d356f6",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d892ada23c617847bca62b2bb1548ce3-4f5d0ef294aac047-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "10149ced-d358-a650-a9b5-084b8b2339f6",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "\u002BEBaHhD9HJfE15s\u002BEDNqUA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "ETag": "\u00220x8DB42FC736473F3\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "10149ced-d358-a650-a9b5-084b8b2339f6",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1388b9fd-301e-0034-48e5-744629000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:23.8212083Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631/test-blob-98863446-cd11-c993-ccb9-1e91cdef4015",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-a47a4146ac63ae2ca75e936a61b07d46-1ff76fd30edc44fe-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "826cbea8-6961-7628-2a6d-c35d8ff25e1f",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631/test-blob-4ee8eb81-76c8-2842-b03f-4435c3d356f6",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "826cbea8-6961-7628-2a6d-c35d8ff25e1f",
+        "x-ms-error-code": "CannotVerifyCopySource",
+        "x-ms-request-id": "1388ba35-301e-0034-7ee5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ECannotVerifyCopySource\u003C/Code\u003E\u003CMessage\u003EServer failed to authenticate the request. Please refer to the information in the www-authenticate header.\n",
+        "RequestId:1388ba35-301e-0034-7ee5-744629000000\n",
+        "Time:2023-04-22T06:40:24.1430890Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631/test-blob-98863446-cd11-c993-ccb9-1e91cdef4015",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2a4fd388d9c04a3c3fe55f81431663e9-29aaeffa3ae0d626-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cca27015-b7b7-eb94-4320-810418417ced",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cca27015-b7b7-eb94-4320-810418417ced",
+        "x-ms-delete-type-permanent": "false",
+        "x-ms-request-id": "1388ba79-301e-0034-3fe5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-d6aed9eb-ceed-ad91-af20-953106d5e631?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-456862577d6ea60bdcb8bb4d9089ee8a-07167a80eab323f2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1e48dc57-9250-e967-a801-f5dced08f8ba",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1e48dc57-9250-e967-a801-f5dced08f8ba",
+        "x-ms-request-id": "1388bace-301e-0034-0ee5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "463126213",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_CreateMode_OverwriteAsync.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_CreateMode_OverwriteAsync.json
@@ -1,0 +1,250 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-093938ef8b80d143b1256ab7c99b2ccb-e38e7440c7e3d796-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9466f2aa-eea2-ef55-c74b-3ec489781d29",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "ETag": "\u00220x8DB42FC754880E5\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9466f2aa-eea2-ef55-c74b-3ec489781d29",
+        "x-ms-request-id": "1388c206-301e-0034-4ce5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66/test-blob-f32dda5f-5715-8ffc-02eb-dac0367eb5f8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-6ee7eb00f2d026297322e127f203de24-91bf45d30b2c81cc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ba7f56fc-953b-6b80-4d48-3b28524216e6",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "up\u002BL9FlpxPyK5vqVVLqJ3mjqLOzL6SBT9teRtxSVuEiVRgnp7CnQ9RYxaS5cZzpHYftYTFHJLNF/OP2C1wzn9S2xAA6xn/E\u002BGTbWmn/x9o6cSlUZPGz3zBk4arQrTh0JSXQBqmcrlsIKGjIa8pJRjkFv5Y23zrjAujP0eDU8E8sZzVAL70wncLSSDiI53NmH59tzvGmQUXu7QO8zNh2NzQZnASRBRZ71R3TZJL\u002BWht5abZBZyVZiiHvVT65c9DmWBUEb0tq0RaE8fnX0tiy7JboR2MmMNAOwBXipbPbwmVI7Qx99e7QEpSjuHEvhbdJOGSr0ShtwCdA\u002BasxhC9mrTOQjuXMNPaoGDTOhnhi4zpemWlLL/E42yjpOPxDnoplOQs9mvrRfQduA7j3oz2u4hZw1u7GG4FCW7O44vv6ZHmqZUltIURDjRxh2Sw0QTfvOlrl0suboyGJ/z9HGJoPd5s/STnwQcDSLUXSYEJRChp/yaihEJWyEsIn4yIE/HSGVmGU\u002BPf5\u002BviWF6GByULjNPEky07xbmcBjTp3zF6eyTDRSA3cvA0igdKsCvz0LEWDRKos4DElkOf\u002Bk2\u002B5hi6d\u002B0pwrH01BnjkBkl8RWdmDVz09Ie0bej/r7sl3iyhZPugEg\u002Byg3/ETkIxSN3rqU\u002BAlIISxI2m5YlhcQDGDyRMQp1N2DdXt4ndMKZFhyEPFAJroUWqkqBt/SiCTRJ\u002B/j8Z4Qo8nc0YLOD4MZfrXWJoVlz\u002BXm3epbP4498K0WZ7YjJnL6Iazno1T3Rkrl0Mhp/GGfq1fJ/ROz9aR7nyEV96gNNhgDG8UYvmyRL1efdS7F1DRLdvweWSlfBivIq8Rz4Y7i2NrwJqBchyzrOM28FIB1tcssikCr7tzupBXZEBKoXU3IvFxT1a1T7u/PMyBbovGrkvX5RxcONyo9wYKKg3baQtt/s5gkIaBdmNtQ3Lu8kwFkLb0crxZ2ukVyVhQqyWt49PBE2\u002B9ZR3FVW647/VpuQS5BJpX5/ZOFCTkS8ctMco\u002Bv1\u002BfLN7cRyqYLh1NoOv0rA9TlqaKVvvccv9L2BpWlySjei\u002BVyY0m3b1vvrjZAXQ475\u002B42Zoks2ljw7rfkG8PQpf4qSW7XuKBLbjpGpdDAnGLEul7nr2Jf8fGMQbTRkxNYHwh4VdOfJC8NqzhOpjRIMFIVH2Gk6PZbipe9S3brudsm7oaISEZPJZYvmcRqEQu9BBFivHOx8zYSHIt8IZj4IfEdZ/dtv\u002BfLxjnLdU7x8bmLwEcliT1ndPuQdmu7EwP9N3gTDKkUT0RpVrZ55r3nICsRsCFR0piztfM73Ql8ULL2Dn3W3uTQd7DCvHJHLY596VZAqWLiayTfX1a2GLJ7LQYDQ5gAEEFGAXiwjxZmLIhkvfPzO\u002BcQE\u002BMY939OGh7\u002BR48sQ6n2fdjVOmgqMZwOuXLOUZq\u002BR/Fe82/05xkCN\u002BcZsgeHOejebkAbHgF/JeIHCn4Mf8iEQD\u002BdzZB6AVa/0sJA0H9UR3\u002BKL\u002BMaY2nv342Nrdya9bgelXIH6WxYpC0pmws\u002B/hVisoM\u002Bgk/lahzV7i3C7FN6JN1KYnsNTJ4TMUu2MMge8OG4KzsZnHNoOSsVcjs\u002BlffZr3Yt9JuaFWXlK1DELzlUtz0MCoFYIIip4ilP\u002BBqi1JuT3IFR8PwF3dWVdLEio8nxwLr\u002BMks2QU7tg9JySh0LQha1MFK3wsYAxmyrguwXR35fXjdfpKJQXZtyZC0p01O4SfJabXO3ef30/Wweir5i1nyUEywlq510ZJK3RZ6ZFzLZMzk5vRnKqCR5qud2MdMdD43wVYBnkt4U5gjhADRfW\u002BY5BZdFKRliyarH7AD1/jK/mjXQqIGysWBa5JbQ6agv2k8BfSx7l\u002BZ0jYwVX\u002BadXufWIWX\u002BTrMkhlQ26kSCUd/C19Hx9IDGA8JPnBr1XRG5/YWvOsgCcYvb3LaYRO1h8jvsEofU62pmz92jbvJYLylCfOz\u002B01bXwKZGFhgKbf8VLenfCUpJ5RIbSCrqnsLZQ61NVcfAot7k1BIhjpVSXKIeTkDIeSXe\u002BJfa40ssLSGjbJKqvNf3FErK\u002BnU4aBZ8iSuIzBBB0QpHrl1v5b\u002BT\u002BOcwfiIC55\u002BKZzn2PX7wppBBXhpfoyERIZuIIs66Ry6LdwFOB\u002Bo0eeFL/qTWi5OLlwfM7kelNFWF31xGesSRD9/LKsZ9Yl7mTSR406S8OpXIPEvG7ZinJgLryCiNrf7c\u002Bu6Ey2DNTnSpJmFjLGCwyeSGvn54yiJHJASDUZp2WN9lXBj2Ny91Ou4XXcc3Q/miev5Dxy9AY/CMfadcSfyacs1B/dBHutK1UUOQYaxbD\u002BAK4Rbb8lHv5PgoKblIGPDxfOs5tUYpWr/rjrWr8AJEcS3HEWjl/kB7khjYH1FZbTiSnuSBYZpaIYZW8GPcQ/T14/hLQMdIC76qviNtETtukmF82REdgw\u002BTrO/iTs4cnw5kIntYzewxCpMmFqN3LNBK6F4CX6qjmGDo99PXpbzwjh7VCS7/1cS1C46992xsHEAfl2av2j\u002BjgEnar9XYGaTWdYhEoiPhSxJZjVPb5aD0fJtT\u002BA5WQLQfMUjlJWXunPHp54HkJ7pcPkxUFkyrx5qpJjN6RGGWf/UUZXCbPCWsqvCh8j4fEFThN7mBwionc2nuO/9ydBiQU2eMz8JJgQImp6ucCdWcihXeWUyn1L3K7PHG7MBmejaX0Z6WUgCSl3a3mxq\u002Bi2mUUbHplBrMKH7pweLQQtRBwG10xDh2xjfVC8IV8HljDGGIclsOfOYbi\u002BkfrFBdglRiddrtSYcxHUu6FEhY9jgFhvWBR9B5M4OHWTgPF1mnd4lts7petcLaV1UPlChdwtXxGiWanDpD6QJXZjBO4cYx0pz\u002B6wJ9ptEy5vC7aV9bKVZiXj00DJtPKYq4Bw\u002BSS7VPHcFLnxfTs3MUp/UJiL\u002Bi/HyaLIPI/YYBb4F3xZ\u002BBYFt7bEueD0p\u002BjqrJ32TmBWEK1QrTOF7xRiA7Sm9WW\u002B2TU0dZzhx0BOzyG13Y/x5hG2ogbPBU7ig8SiYrYsUbKDL9NkwdTHdE1pBd4NzBGEcB2i7FNi79fqUfXUQ2COHn1zNrG8iSA87y25Zf9s0LO3GfKYiWFjID//enPe8zDo3udgnplfy\u002Bb5ZgEhpYnUfX1GHSlx8ZUcEBJxvQ6wXf/8zIsUCDYWV04PnyNcPX62KvjymNIHeulSQI6K7g7USQQBINkCvHVHL8XfZlZxv9KXv5YVvcUt\u002BVWdxcurj2lDN1IfXxyht2qHq2kIKBSS3IS79y50wotC1yuDYPqtn5xYmC8AVly18gQrjhZYIc1BCuVC75g\u002BynDK3IvxIlJv2gvIs4/lkookBgUqTTR05rFaQlYRaqwEHdG6OXXUwM\u002Bxu7AKk25BW3hbHumXFH08VfnWlt/4WnNfwJG\u002BK1UQT0E1dJGAalNDGObdukvGcQlQfed//invtV1Ars7YgywjSs\u002BoYZ/vv\u002Bumk331HqAnmVOIaa1xlE0XRb8wP7\u002BEapW6um94GhNpZL371Wqv\u002Bpq9GRV7UBmCsbaCkRvgv3wsIijkPmA0r39AIwTvdb7ma08gdyamCRZ8NAi4\u002BYj3iKlBz7dBx7g6iG2aOzEQkz/7mCnMvEhZhhUWaApbe7HySJpfraoHoKOS6e61D9Hla6DIwV1fJshg5EmiL1\u002Bx3wy7p\u002B6atOWV8/uKOdZZoHZHLPxljrpUlyHN\u002BslcZXVD4Q7d/WvjTrK/Ns1l1Oz2B0PTWv5jSFBWYxDMyLocNY6CRlTLf6cOZ\u002BJJplfo8r402/eFjQp24Ji6i5pbEoH4owE\u002B446ULoecxPMcFaH4aXBSl\u002BzGlqSAC2G8DPQIs1FcUQdWqg8voK1z5MgbWsr2wh4qBHqRNghYvtgs1B2TkBGdw8Saob9lIvdDUrHcaLCayUrV4q7Wyx7\u002B\u002Be83AsiP3FS2eZsGWCBewOWDUeNWfFIrkg7WubFmyvSpn6vMMhwus3ZdJfMVlHEqex3FU3U/pH2dD2y9uSajU7KiWLx4jpLFVJ5o\u002BVZfEf2ZrEKTnXeDbfcqMyavbPpTudZAdzuwseiO//7a0qsnPflvIAzgD7I/Iu7JTl9sFeegGUOAHprF6PpaBJ10qJ9IAvEpQEztb6ogBVRM62OJHuoXNrVrpyNiqTsSigsQxnZPfUtuRtWatq2VYBlCeP2WzOW3XXHp3F/RxpcR3uWjDz7d/WoYHtgQfHwH0kMKIDA9e7khXWUEZZzvmHxChNfL9lTaYHuTfrIJpuD14g4Yy6Zm1GMofbHZ2ZfJKIJbzfekP9vuL7\u002B0qfkLF7aEDoeS0tDZ37B0n3inAIbjxlYvsdTpTaIyLpvmripqHWX7VcsQOlWtgfJHM5xfSy800Oem22XdmsDhXKQ48y2GCoIWq66/z4v8gi/iphoF0uNosdlGw0H8Hb8KMtmtdJLEvSUeSKOAeQFbplk5\u002BvCq24nEzD1QQ0c8FonvsZyuTwmdHejw54pD6DTX6xzkxiLKY1dT6KRRcHnh4jIVkMdkqVdTmN0LtfQDhOQEfFgqV1BrJVJFXmZlT61vEwVUKldxc0HFlSlFwqljTGfASPQht4rhqm9xI0rw6k0zmKLuq1qMlw0WYL4nJWKo4g4CpQa5TVt6dn/r/FP21K7cFiYGcKEJN7HnC1LMuoUIyD047kVKdk9LdDTaoJq9I4wTSxM4onFo9W1Q0kIErb/64zAWueZllZ/avvxsLpMbKevGuW91zCnLz/jX9aQNQsp448FmqmWlqbVzYed0/MbeOaRWPfBMgRMKSu3tkZ/3yXwx90rRtIOGIRO6AmpGVtMx\u002Bb//uwDaKGKuWF97tBgVf5RnQwV8CIEgzBzcln6ox/Qav5ff9BJ/W8roJ1ggDmz3oIbV3xPJse063u7n\u002BZXgBZBrXPSANYeB6\u002Bs\u002Bk\u002BUo/L2v6PH70ujgTQmmpRknm2I1BCHHuLF0d2r/U/MojyIIEd4tNAyn6DKriw/u2ZBqXlCFCYvDYUQMO3GG\u002BIL1t8HrnpM\u002B9mdRjR/zHDGhiZnakPGeo4WWSLCWIPifHO\u002BzsdNOAz8BL2vtN3hr0EEWaq3brGeNWxQ8UVHeqNFqtmwwP25eV4Ze1WWJsWwJKnRzf7pKx3CEIlq/EbHpIoaWhn0IO5DWtBcreNb\u002BA6WkMybZbykbH/L/qB0To0XUcbLi9yrvAPLnnMejI0qdiiKxFt6LD7dde2aODJN3wxTNUwsgHwh6tTI39c5hd/yoXiH\u002BYohnTWX/hX/EYPBjc92y1dA/eWsWNmGsUxnk\u002BANp5a5teVyIZgWlJJmMtlQ91IHwrqIsaOS25CgquvpIFol8XntF8fp9Jm/KmlTNhYANcn6X9E1dOXzJtpEwYa8LWQ4QDFfY\u002B\u002BaLd4Q2Yc6T6V6oHUR7sCI8HyD\u002BfDtpSMS8v0FGvXkoMHqYDIDFKtuuOc0yiEBqj6Tv1\u002B022n\u002BvHirDeaKJSSvlg\u002BjN46Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "lrThFCCPza3t2q9nSt8PBA==",
+        "Date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "ETag": "\u00220x8DB42FC7554FE9B\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ba7f56fc-953b-6b80-4d48-3b28524216e6",
+        "x-ms-content-crc64": "odjUwR9D67Q=",
+        "x-ms-request-id": "1388c24b-301e-0034-0be5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:27.0753435Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66/test-blob-9653002b-3b3d-8e62-5139-da8fc8dcbc3d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-cb8e6c66c87989e5c1ec6057ffa66bff-97789b8001f71ccb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9fe92e20-27e4-885c-d288-aebce7c1cafe",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "kJdjpLS\u002BrVLdUcQL1XE7bQouYObCIyTB8/BpArvwo3GM/pi733EybVIAuex3V7jf/myFmnvWe2xzobDDVKuX7K5SftfYgI6Y\u002B/OTwWk4Spw4iQNOagj2toIrRz3Bbxinacw9JNjhBn3d7Z6HQroCOlcUi8qnSIGmXMhUrThQ14zb61ed\u002BiXDV4KFcX1pbnPIKAzmreNN/yBKlsgQjFlFjBYRrFdiZUAxUDRHIdcEPO5Ui4Qraimpjes2UmRds8opQORmWMEcZsPMtFyvBt5JRlravADVGSLsaB9rKxPb1J1pHuDynuQsNyXBXrbN\u002BYYN7QwJgvbKUyfCeu\u002BisTuv8N\u002B/Ruf9V6h1rYTbFLpsH2\u002BYXT4H0lGmn8u5MCP0iYbpEW3WDbKfEJVjk9Ry7j5sVlqAClP9qB6NGKccQyaEgSP\u002B8QJMlRG8\u002BE2ooz59NLCMTdnJdH8y7GlPSPQLg8xu3xKwc/08H8BJwxEGVQTgEOT2j/VNugykzASZ/U0csXWAOcMrzMGyUC4Zf7FuLJdkbjcQFPPXISQGDKb5oyFzLRGbhRtBtEQjRD/HMztbNaBtNI4VC5yCqReeJb8auawMplKf06Z7I7nz7M\u002BzD\u002B7pq9cGjG6SXSF1GNwEoo\u002BFCYuSu43ou2H58RDVIh/Mz5kptXnnEy0\u002BeUgxKrvKdoEpbeNEIFRgAO91DZpevToCqElC2\u002B0VnfZdVEFEt5GmL3qPq7Q7iK5FyLSKcgWS37sNL4JxiJuUFNDt58sSHElezt4fzxKGxh\u002Ba/BM5iyvwynWFNogONabf\u002B5fkTqDiM6tqLKMncxCph2hi1ouHWoik/BxWjOXBT5k3QNN7oXd/t8hnzl\u002BIyVdk3K4frF4bV6AOQFGEi6fFqdwJ7zI8Lubx4x7CIIwpHDPE8q83oqI7HOkzbWEl\u002BiwhoSWCftklJ67ILcg/WDYT5CQev5n3jgY5zdNJCcGEy\u002BjyoH5np51an8oBbnTZ/MOyH4g8BzqSKhMeSLEF2x7tQ2LgTLe4rD2HxCDO9SCSX9EPl\u002Bk4SMOuYHZrSV7sVMOsFCoR\u002BbAL\u002BXNLtUMZwzTyjOjf9kQ0tPueMetBTGPemnBdIeH1gGYhA5127JKAlJxBeL12DF5\u002BeGAvcsjEyqwQbRrTvKJT/QuCvvKnvsdpHpxP/9SmZ44R3qmAxQ2dXDnwZX93rNf67nqx9E1r17qYxVQrdcvYagWMwd740jf\u002B5GK4tlhI8nHEVRFZ9HNApQbv6P\u002B5cuduGPt56uv5ARtDsw/rsyFhT9PiZh\u002B5fnWSSxvYCeo3RHJ6Sp5czweGy1P1FkFkVPLkjZgs1gvHtJmG55/PIfcxC26ccWiDBYDMW5vMxGgzLfYo83xRC25ms5YF1udotqpbxAvTx\u002BOKYYgYX3tw\u002B/AwUrmopy574P8ANb7Sfi6YZKXwcP9dYGYTnpHzOKzy9rem1IQuvw983\u002BQL05EluONZf/rWf4rw0/FSlAich6dTDT8GK6mqaqSVdJAbUo3U7uatmrmxHHYttQGS2ysH31g9t8ZSH4w5rxVWQAv51YFkfaYh7u3uovDI2HWoF455jpQ43ZrGgs9adOqjWtxrNOCALV2E5fFqTxXWiUYWkZiH3bJ2wffmnfvXx3oDSkcTXaSVKOkw9KijzY6E8PiIROJSG30q9HPomZBirR52ZwTOwiyhgGmuV\u002BgJ0/NpYqwCToOXsS7J6WgxrI9ZzUeKLGaKti7M5sN5o8SVICF/fzbjYF6a3rXVBNjDcNTZVImhf6aM36t\u002BNWjAHg1qNMlHsSxYdm3o702wtLJWCXbun0479KF786CLZSr22sCoa9APfL6ngd4buI9Y2yr5KCzy0X6\u002BLj8ozL2LzRFD8hWNCEniRoy3Rh5wHzwSIhh2kTz9AwhC6TyQ57ABG7PN18V5y9LhF\u002BGfO4tfTg8DFamlFTvURe4MSh8MUl/ctipqo0d2mFdFlHpbXsh94potjNEGWwZ3\u002BJLWbYCz1MWBwoRg9KvHjX1RYIDBeOcmjmeE38WO1Vok8qq1oCvXkcC02ptDHe7vZf9TtfqFtn\u002BrsN4YLvT/8\u002BwqOwEAEexSes7ADJ5L4nF5lXnGOiBfnzwqCvBMvmLLteevGeHs7lQSATsrxanhX81tnpl6OLjMypzF1gf7Bbts9Fe3nMiPjaclsznlNNmTSaoi3yDJUXwu4k9EJxhMFvt/v9BSKcMF3RHxVIR/5pbDMYxc2SaboqPaiLl5S2WP2Z09ZXQJQR/mHQIO1/z4r/u5gfWL7z3V5BwteKEJi5KrYnvnQYEhufBsdbskjMqm4dm9v8lwA\u002BlfaIBX28h\u002B3ZFvYnWAEG16l8cEH3mBsVhRhpbHTMvJO1\u002BSh9kAyd4n7ZgqtClVJtFrQycBa\u002BRv3rcoBVQytpDFpicV7YiUec7p3THgVvwu/GDEXAmkx9B6I6ki2MOJ9TYIZQ0CPzhI18lZGI6yjoe6\u002Bgn0bVqHId9Xm8recqEKX\u002Bj62PHvLLwne4U/Sq9ByJQiZ966lYfcgEMuqqRuamQnTriluLWVys1NzPLVR9cvFdM2vArDUMlhHliuwYEXuREgF/v2mw/ejJwQbMmUBjhs/pTRN61ZZP7vRJld5wlMNRLgtC/bOXnDVy9tsuMAzBcfQcLsRYFkxrP9B1d1gaWTxDe2tFEIkcUbDuB\u002B67Ea7niCPaVGX\u002B\u002BRfO183jEiTdaJ2u6sShfFF7D90Teh5doB4hje80P/TGVHJDhkjLKT\u002BMAJ9BHDbqRhvCb1SY2475YSevwZRFqTiY2JZSXeYYv9atl2mPDJPnR0fDYcCgPXjzWiURG2erRmdmqDOQh\u002Bglqb9960QVelSTyHpMcjdn\u002BKsdbwPBB5R\u002B8kECKGRgRr9vrbgRIkIk3e/AfULtXsQv/r\u002BYgyjkZKIbDvjzA0HwM4HK7NR/VtZY\u002BIEUAIpRgZOM0imkx8OGizkV9hNZMcqdwEnBInHvoJfZT5qnwGQXyY1VdjEYS2u\u002BNFGbaWCy/7a2hjBAgF8hnSGR24g47rrU/iyGA7uZdYTeAv4QREcnFk/T8Uoj10k\u002BI9kPhn/jhUWmtms0POwLHQCrYn1RAUjqarU4VP1woSbjV9/imf8U6o2oeY3b8ulTyNQ5eHTL3SKAJRu6uyBYJhVEUNUcGIMRlnf/qIe7Dnfb1IwpRyiyF3qtUnTTWj9dUFN4h5IER7BRJ\u002BH83CSqxRaj7uaUPu7skjlabrYeTkxIklgkQobVx4zbyB9GtUtWAp1uL3tIySF0m\u002BVouej6QumVtEncdoKf3hdZuGbPlez\u002BBGwosB7A/8k2v6aRbR2j4YU1sQDxiYwK3lFT7wC6tQYIeqWMwZLKxLRwlcbr/mEJtdbRieTb/IrQHdHNfQDIfAqQiPJoJx/yauxMcOPFLt/gSjk56SshLH4qrLOxDVejuCnMS2V\u002BoZ623x74j3unCv8B3SLXnoLfb1x0PXpsQW2EqMi6CNNqcaiqcwocKJ0Cg5HErzA0zCmW7OwI\u002BmQUWp2xc\u002Bai7QIbp1t6PRuIw0a/cbnYl6ItX9yvExv3UYc0hhh8WrS2X5afqQfUup8OHimVSXi6O7L7hBQKA9n2JEXUNacDDGiCCSITSO6aSKVNoQTyUggOikpVgMaQrEvMmYSyAHTn\u002BwGxE0BWpvLEUTt\u002BzFLU88JNxbtcrYuR8VzWRq9p6EgwVaXzQU63t\u002BNXgT\u002BbIe/o96WydDq5i112HxHzcFBDanjzTma80bKDhh3YBRxcBt9s7V8Jp2QNdtpYfSIsxDeDBCbGl9N5PBXjPu4c4YYxKghChpMBScME5cecZGSAZrHmRPD1lX7787E5FniF8IVUF1Mp6k2kgcpTsaIL7MexUtg8NqyFO4SZVpLRyCNajvVCSF0BZoxkQbMmkdPM4Abpd8OQSbnoztvOkIO6wsmnCTK8yaR6r/xbx\u002BTpXqmg3GaL\u002BEBvujU7WXlxQtX4uY75j4iREBZSbsfHRIHFD2AyHcQtLsp5R18NcXArCW0mYx5l/98RD7xAKYl4mGWjdloZPyUBy4q0gEg5k66mN2VqkOFzbw\u002BRIQ4H3QUw8K75WfsmEcpIFJeDsW\u002BG13wdqfIkHgeEMBdKeB4XCf6Fc5\u002BpQDmjcBWbInxZ762gCkmR6iMDDNKXZRnj26msIRqZDj3f7ZcyejnciPuLOkBpqm3UhR/LcmbNAdsfv6R7/vFhsOF/wCyiX2/5NoPXHDrJijE716v63ZvHEtvMEsqFYJoKGYlu\u002BdpBIiW/0jvi5fWQRiVjQBdFduNFqL1A5jylY8Xp3PKxapBW\u002BrV2Svtf5DzmK8yVIiCCtKKmKVEc8Dv5Cm51\u002BQjy7uuVDFVR3zvn5bSAaspgAEGlZyhQGzE/OfqJjTCM6esz4zzg8BXbINV2vjOcnJVhiPoswJHQotO6VcJa2FH7WwvZXHedjwA72jZS2V0Noq1lJ/RGYBlJU0BpJqpDcFiDe1Mns0Ad1Anp8PZbjcl2rLMk9aBttPrij/k3JFhl6Gntz1351f9dR0PqXH8i/dV28onnHoqoJcZoNSNW5q\u002BhdAicbb5rfNbDx65cc2iLz5ITsDHejtnfRamXkZDMBlCkONhmloAnC3WzI1bcS6Jt3HWRMyZ90vU\u002BvSgE0\u002Bs197FNuDqAFSkR7LTMK1tzAvn3ObUbOsMqJmXTN\u002BlYIjeafSuVjpN33cdcf1Zxsbepu6o\u002BDaomGszuE4HUvO0/ucp9Ma4/7XRmj1v9zrt8uHSuOYw/KhSdZGJep2sBoyDaHMWMBIAZad4l145OKFwRcWsdNnNhAJ\u002B1781L0TYZZOw7E7H14LP0hM\u002B\u002BCUKGTzwWTTX/5HyteRwl1hSy3ZiYHGKiExSqG4C3GKGzsvdNL6CBJYQAGXB/jaqV0AqfMbc3Ffzv1CwnbDG1ONvK\u002BcYU2LZkMagEmALyMoVqBEt2F\u002BbqfJ0KbUt0WclSStCkpJPUcPdUOwAfIo3p7aGWvWfmPyDk4H05Gntq/9fuok0iXZ3xlYNEIezW20ofEH\u002Bp3axRfBu/v7QWq2aL6Ts4IIAwx5ADpSfkkh00HgUjGgn7wRI7nTYxcp3Z6uosyDihrqrJ3ljvljh0fNn\u002Bi5Gu44FckCgpDJNaD0UCObo9t8nkgn9qaUuxDCrZtxBcMvb8OvdYwDgAiJIXb88D7WyORrUAGfkiRIpFq4P9T1VzDdxeBg6y1PeR5AndQvl8rS7OW3BrTBj9yeZ9ExS0AzlMlGHypddty2G9fjX/RPGA2Q5VPvPVF7GzYDwYRcHi7dDAgL6HifdXYJAOrd3i/oTk7EoGXtRFZ3ywP0WbRXWv2oBVPrQzCU8HDc5Txnnj0HG3M1mH3I8MixlB10qxvCsqbsNNjb/AoeL7D0EF4ZEC3F7T5BIcKA3xWLOa8SH0VVGjOWemllKx9oF2jN099pl4Pwr77cgJDkbFTCUMJaCw9rn/Urg5bDX8Ee2ApZsgs2IqEsInCGeJmjsQ0Uo9pdDQtZYQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "fUf6IpmqFFbMAZzSuzN8Zw==",
+        "Date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "ETag": "\u00220x8DB42FC755FF983\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9fe92e20-27e4-885c-d288-aebce7c1cafe",
+        "x-ms-content-crc64": "IjRLAwYV95U=",
+        "x-ms-request-id": "1388c27a-301e-0034-37e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:27.1473027Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66/test-blob-f32dda5f-5715-8ffc-02eb-dac0367eb5f8",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7d37ab204f9ea82827c745330a30038d-e89e621c90ce4cd9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "df3dab16-ba22-0d7d-8db4-42647e9315fc",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "lrThFCCPza3t2q9nSt8PBA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "ETag": "\u00220x8DB42FC7554FE9B\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "df3dab16-ba22-0d7d-8db4-42647e9315fc",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1388c36b-301e-0034-1fe5-744629000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:27.0753435Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66/test-blob-9653002b-3b3d-8e62-5139-da8fc8dcbc3d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f219047f360542f65f5d891c03ec6317-1d2787db16b3c239-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3ba5e235-eb84-45dc-d3ca-bf2f4bdb768d",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66/test-blob-f32dda5f-5715-8ffc-02eb-dac0367eb5f8",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3ba5e235-eb84-45dc-d3ca-bf2f4bdb768d",
+        "x-ms-error-code": "CannotVerifyCopySource",
+        "x-ms-request-id": "1388c3a1-301e-0034-53e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ECannotVerifyCopySource\u003C/Code\u003E\u003CMessage\u003EServer failed to authenticate the request. Please refer to the information in the www-authenticate header.\n",
+        "RequestId:1388c3a1-301e-0034-53e5-744629000000\n",
+        "Time:2023-04-22T06:40:27.6381191Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66/test-blob-9653002b-3b3d-8e62-5139-da8fc8dcbc3d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2bb0f9ae7a24557680d507a6623a0b5a-63ecfaa212d0113a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9c2e9649-d9ed-f277-aa45-95a7801a4613",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9c2e9649-d9ed-f277-aa45-95a7801a4613",
+        "x-ms-delete-type-permanent": "false",
+        "x-ms-request-id": "1388c3e3-301e-0034-11e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-31fd8123-4a46-7d0a-f197-d436e6bffe66?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-592b8141ba78d15f7794dc9527ff30cb-e98fe36edd9b9aef-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b5e69c28-daac-9a9f-4722-eb5555b35746",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b5e69c28-daac-9a9f-4722-eb5555b35746",
+        "x-ms-request-id": "1388c40a-301e-0034-36e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "642759980",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_Destination.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_Destination.json
@@ -1,0 +1,250 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7a9f8c63b0df6649b01b6a470d1f77b6-dddf19639bab822a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f0d5681f-587a-96a7-e791-7832eca0360f",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "ETag": "\u00220x8DB42FC73CF0FB3\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f0d5681f-587a-96a7-e791-7832eca0360f",
+        "x-ms-request-id": "1388bb2f-301e-0034-6ce5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488/test-blob-dd8afb31-f654-75c4-2709-12e775ce8167",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-1fc16a14de88e69d4759ecfe77bc2de6-c794629ab7ae0c2b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e88eded0-fc51-e423-406c-4a7e723474ed",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "9xW9001jDXYH\u002B8OhXlJGOC2M9Q/jkGcppGDJcEbAIRgQEDrX42PCzu0T1lgyIhfVw9m56dlxhGeulC7tmZ0wRtqqkU0XblTJyiYhz7oO9oFJ9KxsBzc/nozSKU801DRP4499h5HJvVSF7x\u002ByT7Stn56so6XwxD\u002Bja/LAREUFlfXy0uwqkG7wfzZY5xcYjE7XJYmwiDCOXh9P2hyeCXgPf1opwH3Igg8wvCRumN0ni9\u002Bj6R\u002B7VAzEY3PN27ZRUXa\u002BSWe97svQDqN6gMwMIMZCKE88\u002Bh9ZUypNZF0K\u002B6dZ3mqusE51aZwT09p7QNRAuEOsirNmFFZWZPU9cIpuxhP7IaJhXm93zL6yKSdF3RJWDKsaXnD08skTV0xYN/kSpA3HgB8x31rTNL70tOsuEYbi52PeVGeiBy7YTQYjHpTEoIQafl3zJC1RRimy/z7e5EbFdVCWNFClJHjwWZFTrxUpMBNmFJMo78I1jA0\u002B7wjw\u002BmjAXqlDLWw0dVnlAsub/ZcUic8qd9CznIaOYKdCZzRwAF4ok1Fs5QKnMp45Q\u002B33mo92KmY5xYKXDcEitc3F8g4kdQFscmpFp6PMg0UyeViYl8YXyz3ONjrbkYWPSS814j\u002BQFc7riiclMYLCbEI9ZZRoiR4GrSfRVj7HkeHktV10l6AFoWOKrQ2f8pq6C8r3nivxJ8ARLjQYv7\u002BQJPhFQHskTtWiN8Mw3twRZ7qMFktzz/O28o6dYmlr7OKk\u002BYkUWrIelbz1VWZnwEnjAMZ6i6hzHFQFjk3th\u002BxrNkrgjORT/AwIbYCPfnqMTjJEuWKi8WA6MN00DstkMQ7QiR8bhjRkkAO5ch4n5J3aeT8bqM2JyUTpplwHHu5Bozxyv/Vbccj\u002B4Che6H9CEks/WpWLSYlARsDaMeDYXXIVeM7htSWofwh3HcilK\u002BDEppQQx8RYtVmyMXg0gD/oJYK2SW\u002BxYFwlltuNFCzBmxvfFYpLx5WuvMN0L4Osc/7Ij/dF7uFwE0Y36jDoy6At8ZZdVWq0nF7sCIysPDHZeSPcxIQ1e6w5bgFEE91lxfEiRz7tTx6TFPKZWeZUxNcUXnENCwYb\u002BHXpJOZob4iAh0KbifXy6ykFSbCSnCLG5KoqMLVrV7nqBk/JAys3KqRqGNGjuTrhIXJHCMJWiVtTIz88Pj/TFC\u002BIsIOmKej\u002BzR4LJ4RQIitvSA5CJE/3lHzzdeDr\u002B\u002BxllgOiGgm3O/eKSTukS2HXAgAUzPUxkfDgkRsGs7QIEtExpZGArgghuA0Wt9sTU0kaG3Pf1y/3NAUSwYntsIhDgjZqcqXQV1T38hToGtkVzT7S65dBKDuhOnGMbu1/NAeE0jWkqeGkSsQe6OUbDxkr/fNLG8XxAln7yDczROlneL4MY0ejcCNdLqHTIkBVhipXYHD5NBlBk9DcqeCpcAbbt28mDqzSh4zQ7ewkHuAZpUIM2\u002BN4bkSky893x8dDs72b92vRLnd\u002BhdnkKUYsHXXwwwSenJUiY0kqgkPcWsDFjToviCZ0SHbKjlUKk0X\u002BeK1ZhwTDpBcoeJQipqw0oisZH5wM/JRPe3qN1A4/F88ELAmWgtO7AegiBxCSUqHJlesq8XSo8nsYCguJNdAJ6GDEHnqjnh9XXR2z6fWEvSnZxD4iFSZbWzmNfXfIMcwYGB\u002BvzTQnJvfM05NW9QiGk03isHGR59M6acNAFSCnjytRm9DW1e/0sp5HVkKSBWUwB\u002Bkq5YFbhjFMdGRw5hDWJENoBVo4sL5e7f3SSpGRqGNdEA02famq9RSfimCLhMyNcTH\u002BKv8L\u002BFcrzPeDiDygu8wAE9YDn6aZvQ9FmCZd0mkxRdlfkn1jURe2C7GxJm3Y/8\u002BUinD2itGLZGzwxl8xzvmOUUJiQChOnMG\u002BTJP155ahbJlXyEj4O7sH1C0Rc4u4hT23I9Qqdb6mRe2vNz09lXzVT1nF2QWwlRaHW2z6PSk1BcdWPcTCdvbbsINaSQN\u002ByT6wOyQx8qs3Bo2\u002BoxpRqwjEeTJ15le4E9hi6imCVksSCJEtSgEFBBMcHzY2A9PciQV6ltDRCOLn\u002BChLzgiCtbBBrJuJJGEGv3QeWcchgRAFhmAkB8B7QP\u002BuRlHZuTUKmWmG9FY3U2Wjc9Zbsq8axnYXRkinXq3wxmub2t0PLQY/FL9em4y5zTP7gJTpH41QlIDbwXLtYju7lS7qnHiHk0bQHJ7vvCvpXnkUrN0ZBqfeSkZdNGuTUrGEowVezjG6c\u002BxOGQPvYddV8WP52LZeoY6GDFEyKl/aPcntaxkli5BIWTjwy\u002B2k7uluB0IImXn6JgF218HfiEmNc9s5AvW\u002BL2bSsX9\u002Bbdag4h1nxCId0aNP8kUXrrPOaNHuY1cRauzzr9fbNej6fLgr1fWjd8MmcKI46g\u002Bwp4GzBEmujwp\u002Bj3cxcxRKQZy6VXWM7Nm9K/ANx/K12YDcQghWKDGfTO2trEZ9cgOv3C8GfZSaJLqn9dlYoccYybX3VDAM9BlqGwmH30CSQLjsXevDr1vrQh5NrjJYRqsmleKQhh3SoucVm2KLEkV6FbUga0PbVBpaCxISvkXmEtRdYUldAbmbGboDrRP5Xy/Z05l8ONpnSkHHNnoLwOSiL4mNLbH7HBT7hVKI16YHYaziOOqsatr69hYIlso/j1jWYX6KbDF\u002B3beFgLOI33OawNXOKIf59sSvkzea84ZJvPX5sXYofPV6ZFoyJ\u002BkncRajbdX1cWbQ3Gq529j54\u002BoxO8S9jy38ckPgU8Qtx8/biCEh94WwVEqOKNULbqEcgYFwAeslaeLopvuRFB6ioxWb3lO22OtlgOd5LmZY8QOixNJDvMXjtR4/OVGJHz8s7IS/b49OZaiVC4AErDp7j7T371BLX\u002BdPuCg0d5\u002Ba22GnTELhmIF0U14prbFF3wnjw6mckTDv4I2dcLdmGu0J\u002By8fXF/4mvYzg5vxIrE1CtgfULT2/UkwuGy1RCjKDTlxH7GBJoKq6ymyaQ6U/b7bZ2XeR8k5E/3m7qPzQ1XNaXZigAL/tONWdGWKQ5Q7m7qt2dzD68VvNwy0mjjet6jT5ACXMn2727OCiNNjrs9pqlLoRWl5Cn2w80j2Sxmrd729t1\u002BTo2k98v4pQGPyC4g8SvDl9nE/WtmC5j80xY\u002BZ1hEVpvdw1Qboq1NqUMkavue/uQEpxYBLflyFEb0qCCxuj2pR3GWQy3Tp/Eoe1AkPaChXdAuOcBCQyiib68RJvqIn/MFfyOKCLu2NQMk2LalSdaiU0pMg4B5ZwRI89eCvnz6o99dIsJ9F1UYdATBHWpx\u002BSHUctOsOBhyiBgfQRTkN3aCLjjbRCsUIT/1NAt7uEWd1va1rk\u002BpSmfC7pqqYdZAMECOPvMxmrD6wE2XuwQM9s/SgW4eLokm2OPRFFmMbcNltQPK6XlWaDhBvuoCEY9ftfvK19xoIgW7Z2YPXIJbalaKMgYARglWeBUx2HOfJMdQdWJhwZXm/ZL\u002BD4ITRw\u002B56lCXd\u002BOJX2/udF/LOkWWGEKivusj\u002BaTApzRzAjaHQzUFe/IfC6znyxXyc006G8NJa/dDcIgkleyr1tCvFlk1ZzEmwcJXdxCRvvPRLYZbiotxJZpDR86o4OIBczTcNLS8vQwYE1oA9fDirbWUV2hqUExFOey\u002B9iNmeeDcUgPftYY/FHB6P3stbDOlXJYZFIl1myLklv7H/cbstZV5JKftBvgzVT777BDVG829GZWJSWVXZrbg9yKLexapiYXhtEuLtFmd6cNKfasOE38tCuQxZ2gsIb3tDBPZq94oTmaO82OCMWE772OmCOUP1uOjWmwyeCYZtZKNnqhJwD3lIjNEgyAbqtWC9XQIihjU4TUsNk1t9dY8cT3M9Ja08ishwOa1x1e/i6\u002BWr4KuESt5tLlzGY3wdyxdBA3mTrZCygNM5skyHxnhbK6d10ZTjlwSVz/ZQdSdMUm2WL9F2Tj5V\u002BWDYS5iR5mfkajfUqPqCXWx1/t2aYQur7V/e8Zam5dxpINg0C0xsA\u002BmObArvd6lzE9FlAVBgupdULF44s/TRPoVaaogiTlIgCPr0C/UAvHW2a93EQeSLCWVB397tNFD0vS6FlA0hUcV\u002BRPhVa6\u002BhVHDogkcXDPygzmAj4G50MtSq/07HeidolBkYRfzsNZ62n4ptBLII3bEx5cWs/nBWChIjq2tg2dlJgO0u/8YAtJjCbUDjBy0ioiKclpVhu5aowTvpyIoyVcaxI4TE2t7qMDEt6ZEvcgLkAAlJxENE6MRWhT2KFusOjxd6MuSpXshDsmVkNNIFeU45BceB6ZGCbTq/bVSgYBpFHll5tD8eO6JBBRLd37TyUQzuUREjjaaG98Wp6vBzo1FLHhV4jMQPG8kkQON\u002BpY2GzBxIsQ4IIpGy8rx6dFGyzWLAkcCfesVI3zZI/kzDCFI4Ix3UK/FDQ/yDxZkHlKZ4cnKBvhPM51FWANHYwCRE7\u002BpqQlEz3qJwfU7EG7UrQEuQz4zaQkk\u002BazvLfSsgaoLYPtWvnFJURZPQEEHFB8ucKr\u002BGSPCXaq2gK9YVZ2B2UBLL7NzffKP4O4r4CTEHeWNwLlNsmSKSQNQoDnF8Pt0zWcAu\u002Bhvvva4bjgxmn2F8mbJzpTgNCrbwOawItm0yfP2sxa9w2X9IgHGkUAsVK6BzrHW/CJilJU4KPsBv5wdA6BEPudqxC8AyKyTHaLmq2w0LlQn4c3NkB6BgZpq\u002B2ZlpZGj5BnLGwaC1jN1z3ryVX2OzY1H9R3WeqrI6UKUldFKKXQRRsdSbRNNoQ\u002BaV8CnjywY3CnVIbB3zW1u/jHH7kBeL6IC4Q62OGB5\u002BlASOCLmIVoSe7WncQvDmXlZ527hhbbPPCQioK4dYqfJWydcYZFKiNzXsXKKtr6aP0eVXFDxmHCZRvv6x3yv8RkN3hXkYzvkD1qSCdBEQIVpiGFmiAJS28Kywx6VT8FcK8BZeNiksdwPsUz2Y5KcVQJ2jT8bSWkWuwZXMZwZTsOZMeIT7sesxNaFWta1WHgsEm4YIr6GQOJXQsHWTXw/8maNXS2wjGo\u002Bxchkle6WYWKKJyMyASgBEvD/vKgF2ntWSWhwJ/tKf4YD2Vj2Ha7zwOFjSCZdCe06jE44sNPCOO9REkiGIjlnQ6uZLifPDvFGD/vGpo5Q9UN7NZutDc62QaBtoQ9maZ6n\u002BAh\u002Bx9vJb31Y9qDX\u002B5Jg/BkFDuyhtjHY5uyDYWnl46JdHqqF0jFnscoaUBsp3koODKDyXV6yBkXWodzvRg4XdxcCetjr2ynnnVkmh2IWswimdVTE84JHqxhkrzBUeG\u002B8Bt0AK2NtJjF7DrwBj37jv/LQRNC5ToOQus/Agyv5kyTtZoCBFoelOU8jTeTGQh\u002BZhO89gDOfBrhdb2yXqKMFfXubFCT\u002BXqlvLw\u002BBlfyaznSwJv48vA7xUmPEJ6cXEYysGdBpLy36nyZFzlUkGWy7wqD744WgyL1sqcHBNjcCVBmC1XwsMZ9GtYvb\u002Bu25yTQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "GU1ET8BAoIaGaNWac8ydTg==",
+        "Date": "Sat, 22 Apr 2023 06:40:23 GMT",
+        "ETag": "\u00220x8DB42FC73DB402E\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e88eded0-fc51-e423-406c-4a7e723474ed",
+        "x-ms-content-crc64": "OTa9JRlL4ok=",
+        "x-ms-request-id": "1388bb5e-301e-0034-18e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:24.5997614Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488/test-blob-8a3223b7-7f74-3a0e-def2-8bc64d4676a0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-b463ac80cf80e1517bda307321303eff-b41d3e6802fa62c0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "085723f9-9193-a8d2-a808-b085fb80b069",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "CLot3d\u002BK/EGfNAAagQNQn9DRajfbz8ZRz1MJXnFclvr1qna3BpYOLCbx6j9\u002B87nbouv2e9w/xDjz3A6LgJ7QQ54GJdaMmJk5wz0Q6eWG0tuZLruFZhoetuU9xCqIgqyIIaeheM7jTwpRvLifLttTbAky8VLiStyD6G/wTtRvsUCRh8g95VoNtt\u002BwM6lif4cK6lcgVZBZptbKHZBe8wA24gt3DaYSFoevJTtzMRYyIWnn5mR8TluwN\u002BHxcsfKrsPeelGe6nHh99TPcTBU5nS/mPwndgybuZOvx9bEIaPA5HZ4lLfFkzb3Bu6QrN0qW1FtMdrKoji2QsC97iOaHNYwD4y621G8\u002BgTGL3AdCwy2hWuFV\u002B/I9UI\u002BwlH2B6QSXekYX51Qb3//sDfWBHPHmDe0Bmm4FcXmZxpKfBn/xvJfs9KHBatvZRXrhaa48vDOdioZQgA7WkcjMviCBvNm/\u002BlEdlGhQJOMRKFUzJAfLnQpewbv5YTyJFiKY9Ky7V8ihYW8dHyfLTaWjf1f5o63BASDWYrtdxplUlL4FtzA2VdBMkYKYrn4iU7PWFiHkj3J01/OL5TVNQ5rVyIqphdZ1rOlHrRIrKFKi888HR7B3r8UL0J98arDbP03nwuXzuI2doKk4XOJgSe9hKTEmRfwqXliFXfU3OQJ4rK2EAyVsrzsBaecHPxLiq0av20G/tLlR/aSNbhqYpqdm//B0nAbKNLn2JNwU4x8FovKuhx2A\u002BPf0ckWAn0EgaMN/oH9irc8/5ebHiY/dPNpFh4toKd9Jpgb4gGnBCVU41fwY1ULfozTjbqE2\u002BS9oFzVrexe1uD7j9fp4qi2lfpyRjvOThGeXpeSWRPt\u002BEuzXUGk0lc49gx29dR\u002BIpzkHfe/EpWp7lJLN09UzH3NDZaMNYRmEcOjOVAuWFg9IDz7rjsbLea1Cm/vWZoI4yqOqec98ewYfQw0HNlFepb5DhcSWR1CseCv1ioUd7gomlUmoK5w/y5P4zAv5xENcJDZ9kqD9YoMTPgHjRvCAwZTDIKDH9rniA/ow3bsE8rOomWaO4BtpKTLGVO2aXESjd8q29qOiVG28W07mzEUHzgtOOu1KMeF5mjduAWGMB\u002Bd1TaWwjjvPxgU40oTMghyt/oaiTCGXWUYpfVysdFML8FOncX7fVwAPvjSoUR9crNfagEKa6fuF3jRfh1CfI5Gx7SIxJRDdzmdGks3s7sgmzJBE0fQQcQaX4VNKf8/vcFqi9mQ9K0eG/PHbVFct2S9sOPqAWlHdobvbmUO9k06XVyJzCfhkKaFIvdUCdRzvaghkHkcVbxYIxVToIZHECWljQ/10uo82x88ZN5x822xfLC97WbUHQifMakRjvAgPRLSrnvFfeu95LRZ3/Dd5jCooSPViiO/0XAGVaBBK0wvHCfMn0Tx7P7F/wixej0XwUt5ae3MSrPvEt0LvidKfLloKsPJEUfrtrQlEIoaDVYy75RVx8FfYtFz3Ixn5i7WeoNOSVB6Tq8DjbI4pzoo1ASG2c\u002BT9bT3CMfxVTW6hNCFTpYHy8QFt6DkUToPJrqXSweH4AxfQ4TOV0CIifh6SQnhslmkIQlAgCEurqN56OEMWQotM6PEJQsROHSEfS6naggxLnRh8yn\u002BR2DrMZThVG9ffC/uTRZlHY1Ok\u002BiUuwPyhkSbSLltq2bgLutD2PR2L\u002BMFJQD\u002BuRzyyxHnE2BBaYtc\u002BKpPRQy18dHJDh4qIkSY12MFj5YC880oqXyohpcFn8Rg5t9KJ\u002BrXUDMvNav9x6jMTjv8PNr0WQXdJpyPDGs5w25ayjxlTq94LT9j074hKuHU3DdcCWPqa4zabABNR0PI9nE8o/1sZgCLhA6bkYZGu/y6uy8z3boLb1\u002Bvi\u002BGvKuX7mtxN5YbkZ3Y30IRUT9oGlLAEk4wUlRm2MDOevdse3Fkon/ap\u002BNZ11lO5\u002Bww1tyCFqfYwq5dZ5wXDl7RTRqqaGPQrLK/jXJvajrw5WpkMgHkTGRTk7jHBz7jw5WEhIpCpH\u002BMYCopxoUxaVhzbH4xstxY6QC2WtSrDalz28nc6uGwskDu19HbuoXfIiZgU5q8shC5L5\u002BJiEmm5VZ8ueq7UIJ2wro9QtsKfTJ61ziuRroOtym5I79GJyX3R/J/XwCbJ82n6ZDcf285sq5pDrUQ\u002BJ6YbgbBAjDHLJuQSfrkjyIt37NvClklLje6f3EM2RRw4k9T4uz92iWY4Lj1TDVwUSeMPzMFpfJBcz/PBoK/uleDI2urlKg1MAGN0iWcL\u002BICRi5NfJ3lbzhdEm\u002BtLtei2SpldizJxLx7Wwstd9fIoUddzLxQcjm1mbAvToY4hAEt6vT/Nrm1NIFt0iWSt/dklG0oU14XTmrws9h4nno6PtMJ/4zeyWqJpJg\u002B4qAQIuW8xroVEDSjGpiODobdPJYHN5NWiLhqhcsCoqrB2GvG3JD2v9fAIS6aZuTwULrnqGgGN68MvZYtUjzvFnGJ3UIwxzH16oC\u002BRxZguCXTdjUMGvZCv6C8th76yWmW0Q69DIWmw4mI8cHrR/CYrAVwWdgL3vt7SyGhcA0S\u002Bx0XJ3ILo6ucKLavgykwW3usJAoZhm\u002BNjvYTQcVkBU94efag0ByCkQhd0DElXFvSSvOl8UwC9XSxhZR79GHiOCNnMwk2k4dbKZMBv7Y\u002BaDKaQPrVvhQDdYB9806EBpiqe5QNvilSm7doSse5ATnCcxll4bdnCH4PZ7mItJw41yb6W0AeMK4JS6VDbXNMRnRGv4AxIiTlQ28Z/lpzxecbL3egwqX5oEJvXJoOI58Kwx1FQfUcB7ECFRfRBDJTlYHCKD37r4fOTR9BxcWK1yPQDzs9Koft/yfCnq2SJJwMG8cUT/thExeVdvTZ3kHvdz3wAPT7Fmr90CkWOQzaPCR/MaoCdocobvwnp7ePFCDl1ytvniOnEQFYFn/OStYKvzrMWqib7Py6y5H013K3brgIMGHhbp4E1ByopmAHXiQmGOh4wr14SeYqsNaNsj2OoKfHwhpwJUyYy4KL70acs21t0rqKOq/6k\u002BZ/urnLdyXjGgW4Q5gNsfOb4/s\u002B7F6jigFlI9\u002BHBGX7yTIz9G6WzVBYqNU85G/RYBzG8lqwu6OL2Cy4YldKWBGfvHpp2b2FARKm5keFYqWRl7/CvBYPRw2OpBhB2mr9EkzDoSf1Z4ZjQe1EDdVcBnmHKs6Xi5v/kHlo2zWhQyanqdf2xb19mCw1X34kxzk0MqGiurOcZYqwwBCujIhQwf7GoGABZUC4CZKeYigZ2sk8MKiT/oh3B0BNQgGs0w\u002Bj4J2DYibVNs1g5rEhAgdemulLblvjwMNyT5kjtCM/DzaC\u002Bn2OmnSiav3fMxvXVgU47qsUZWCzwCPaDRKNsYKqIdt6ngeFz/xwpQdeBJGrmvmT5sV0KqXV0zZdsIlmELV7MQ08XLf9sx6qo7xdUb\u002BSMnYU/cq5NfsxpMrNKB93DpRN4tOAaz5FkjemyYbpdH16z4ITTRbqwfsWCrfpLIsDN5UoD27oDcc302uXEmhwSCxJVlyZY719ZyDUalyGWGGop5XtvWkSkr26332rU6\u002BSocKLn9oqadPbqqhOE6NqrXsF6m7Who7HOsee3oQ/1hNxRcid/riLgjnGFhLAwH8aUC4GoWlAuB8zwGUWj4tLm9SU2MnayLLCfmgxEGx4AnpEgI5aOTCqMI2pajpXdPayen46K\u002BexQ4d/QCb9D6uut73qzgr88V6n7qg8LV50bwV1gpnyPdqSk0EG2vkJqSTl\u002BrJ4aKrrsYUfljk/dRYpCtUhh4kNvHnnWDrF9hplnkGHWjKr\u002BAZeic0Q0quhVx4u3dAj6CGf1D44lQxsJb9uufv3uB7jfQ7Swv27\u002BO3OQgUcmxhGRbIj64H0c2L17mQRphizqZ7/S1zBUSUn49tMblMLU46jJHRF19Cc7w2v3NCZplLVHphqHU\u002B7hPSM\u002BAempAEP6p7VcoGgadXOYlxTFXBQjj2Ee0\u002B6oTZC56ODtNvI9kcIn/I1wDPRMLTCn7rvZG\u002BAPG3KHiy1VUloloriILD6AWwVSnWCGs4Jt0aa9AV7U38wA3huAtQaU0qoySmo8wwDyJpO2h35/iGfvGrmHl1D7UcLsiE0i/6X\u002Bvcu2VGgXMQ6ly9rLHVhOgFa0kJtNDTpaN/mnTzuy0Cbtt8qyyTT/1\u002Bmq4cx1MDNqngj3bm8KsK\u002BRWxxucOHS8/q03mWOm7YitLiyoixt5AbGPLEzu2G34wcaIG0XkWcH2O7RwVLN3AJR1Lq2WA2DI3cVpzMvnzeZ/Ppec3pICyNRqso\u002BnCO0\u002BV\u002Bv4eanAIr5l/32Aekz2Di2OMRXbmmHCMmXZa5DRYdTYa7UgL1Q8fxwZdx9Ugk5HdKRh2NfXYr2J9kdEJrctlF1op87X1d7ZkfH5wmMCrW/XUjcsb4k9AQj3VnkMuBik6\u002BKB7Bq/r56FiAcl3WBah0jXbNSAASTUa2bF4L\u002BljNmZVNaAQIFVV\u002BJYZqdCF2OoXI7wNQtD5Oq9rYCzuY8fH/ttTEiJ2gbHQhTyJ5q9klQDXYPwtZeOFXArwpMA4d4TeUasFIrbHkKIKLM2Uf0PwBsscBwLLmpjnzbYXddzhqB2nu5T0b3JaH8BaEzkV4OzHAK31LGCCArcSHVTwoBrFGIS/7LOu\u002B6dYsfcycXdfwezZQHU\u002B/HutJajd4kIdaW\u002BllQq0ZfQpGAT2rHp5T5E/skt4J2\u002BlhiwJAscawRlVO0iHjNx8q2vooChwSEABM9YHrjAGpUIAAB7eq2M9Hkb7oWEh4cK0sxbvn4c3JU3sB97xAyLpTpYGh4zNrgAIu4HhhJbe70ITQuspJxXKyNrA8pOEPAsUElLbG1o15xUG5uP1VaCnDRic3cBHsCeAS76yDLtsdH\u002BGzWJEA9Pn3WvGEjAhxXMqKfWK915K3FIrSt\u002Bbg\u002BppqmJkfog\u002BYvlEpQBUga33XnZLh\u002BK10Y0RS/EQGLkETFlxXGfNzVbq67b8NkJd5kqkM/xZUAwHo8jlUyKXLkowQGim4yU2KZEfUJwruas6s1Wma\u002BTMquxdabiu2GokU81sy/XppwMlfgprOf9v6/otuq/c4LJlc5V8WXl8l0E2\u002Bwzevv2lQQxScP3qYXD8/Y2\u002BcS3KV2MLB0hQfV2JuNa5NE7ygSz8eHmTen\u002B0ixIkj2vrviYjbJOZw7elVNO\u002ByMgnIS0x\u002BmxgwfikJtzzRow2O/3xrgqwhcerWM1lRyOl5KGnnVnk8oUPiuwtjzXGpn07fyjVvSrNZqtlhqGu\u002B3rVDkIrS7kiQTlo8iMekwaB5KJAOcgKwCeG6ia\u002Bj2vjUI9xSHDzm2rECT3vfMsHvtOU06H/XrGy2k4apGGCc8HdhZGTrUqFnklHfDCaK1NsfztTGavJ8/HNzn4i2Pb5QZV8Eec5ZAGJD0VYp\u002BKBGK76viU2L1oWA4Gfxe7cYrVSXiqbHglsIwsp2gpWYUwfTKXPOCrBwyJLZg5lmZ4g==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "FJNOtWhutPnWY9OMdMKj4g==",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "ETag": "\u00220x8DB42FC73EC54B0\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "085723f9-9193-a8d2-a808-b085fb80b069",
+        "x-ms-content-crc64": "eeNVVlg8MbI=",
+        "x-ms-request-id": "1388bbc5-301e-0034-74e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:24.7116976Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488/test-blob-dd8afb31-f654-75c4-2709-12e775ce8167",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-101475027790897b92bb7d5bcd2e3b02-4d389f2c95f9ca97-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c266bacf-9101-9a4f-f720-575cebf96529",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "GU1ET8BAoIaGaNWac8ydTg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "ETag": "\u00220x8DB42FC73DB402E\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c266bacf-9101-9a4f-f720-575cebf96529",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1388bbfd-301e-0034-29e5-744629000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:24.5997614Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488/test-blob-8a3223b7-7f74-3a0e-def2-8bc64d4676a0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-95af3a122be25eaa1379c6e33749744a-0895c004ac49a26e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "41b5438c-ed19-0567-80d7-deba0e533a7c",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488/test-blob-dd8afb31-f654-75c4-2709-12e775ce8167",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "41b5438c-ed19-0567-80d7-deba0e533a7c",
+        "x-ms-error-code": "CannotVerifyCopySource",
+        "x-ms-request-id": "1388bc2f-301e-0034-55e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ECannotVerifyCopySource\u003C/Code\u003E\u003CMessage\u003EServer failed to authenticate the request. Please refer to the information in the www-authenticate header.\n",
+        "RequestId:1388bc2f-301e-0034-55e5-744629000000\n",
+        "Time:2023-04-22T06:40:24.8706793Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488/test-blob-8a3223b7-7f74-3a0e-def2-8bc64d4676a0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8d6006facc932eeff83f58d705f998ef-6e867e404d8f4bf0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a7cfaa12-2343-bb0f-1815-507b9f658421",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a7cfaa12-2343-bb0f-1815-507b9f658421",
+        "x-ms-delete-type-permanent": "false",
+        "x-ms-request-id": "1388bd39-301e-0034-48e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-eb3dab4b-124b-8cf5-d565-d1dd3b235488?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7bcd05e27515d30dcd625591d67b255f-284ff5af86ad0af4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e7d82c4e-65ff-1d76-dced-7ede7cc91b81",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e7d82c4e-65ff-1d76-dced-7ede7cc91b81",
+        "x-ms-request-id": "1388bd7a-301e-0034-05e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "479761247",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_DestinationAsync.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_DestinationAsync.json
@@ -1,0 +1,250 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-13c2e85eb709ca8c50aa9db105b90ba5-a303209490893b19-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0549be33-cff7-c6d2-3dff-fef808e30d56",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "ETag": "\u00220x8DB42FC75D03AED\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0549be33-cff7-c6d2-3dff-fef808e30d56",
+        "x-ms-request-id": "1388c447-301e-0034-6de5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d/test-blob-f7794ec3-af73-fa28-580d-3023ab2b5c60",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-7abd22426e2d707a848c256f67a6be3b-5d0a5802b8900c37-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "8f25de59-ef0f-03a0-52c4-a56d1f83824a",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "MS8rvS4KNeEJ63kVIMixKjXxjrYp6N\u002BElU6s6p\u002BuGhGjnsbYuFAouBmX7Yg2E9qPXAbuuZ2lN0lQpifgXUtCWtBncYIC2HHlydWdkfpWTYJzHY2YwGFz/mZ9iBEoR1vOVJK4zqJYjISVCe/IB6VO\u002BVilbD\u002B9qppv83MbhU9fvIF5zzxnnX7gG5AJA7dxq/bALo64gtscEKr4SdsuPAc0NUxuTzhp51zaxVGutKfj/Uh8WlbApzmmXb\u002BSb1Sjsd6I1M5qAlu\u002BV0cy3r2KbVsDFUuTsuKxc40SyPJ51ncHNhRyJt/ZePrsvQIPjch8G\u002B9jjloIEP7812FAVzppRYDPKqepF0d8KpxQpvTfouXElqwCFUgd/yYWdk5\u002BmCHAg3iBP2Ih0wOo52S\u002Bt2oJHDV7e8CNZi84sSuBkqH4/ZF6kCJ8XWKCo8OpWi7kX0e7DFkZAxxgMhxJSY03n0Bhr\u002BnSQyZHjb/S\u002BNf95AwAVFLjxYZI3/p0Gl4FMhTUSwSDR6pFERwgdH\u002BaRgpFY00QSPQ7U9m5GdDuXSjIQVqr/qzTeZ1hukI1wlEGrpnvL7cR9eofmfcryS3aV7TzWDMl7khecemvr46yBZCHs2s3/i1xtkxwi2W1p7BvhmOOQmoe4b9Qkb7NYUVbbZNmoxbCo1mGgaHntWPiqck5PykqI8MmadGr5mxvpFQGFB7RTgSZrOIKB8DINyxcbuj0lCIbMEnPQDlEF73sF91M4KBEEFrFn5JHIBwDXjKlT3iEexAy6\u002BPVAg7KVJUkHfDje1eLF12NLvSP1BAtzOEHn8dFaJzNGvS9bg5M\u002Bkv9IgMrIOLbGTca9kwboxfTqDUsw7TN37VUFWFizalOQDSpkbENAaz\u002BK4WQKnJQsXbd6sbYIDeWL0NN1wqBeEyOzLUXchFmxaaJLZcvPLRDBGTqhePidSD8EmJtvyqifbM5Al68OD5kdiQgT/OgZ/KOCtKllvNprFaVG2Cv\u002BAZ756/k9TpWhswmhg6\u002BwSYtXKtv37RX/Oa/0FYHJxzdtX4epGhDu3G4N4MGfxDkquowaL\u002B0PxlRI\u002BrJJCXkT1\u002BvSNCQnx296aA6t6cxUX3W2yVs1r9dKXVlzYF9eZdM0\u002BgkVjY/VArNcn4eeohxINJt80n/eHifUh9bKtKcQG8J7eO\u002BDPpGloYan2RBP67t86yuEIZNTVtvhQQX5Ck4MDIOFY2ksxTXJlzD5NkUXhJwbjcl7TDpu6CITof2L7Jc4m4xMikhSUCY1\u002BkqimiCWybxpnbyEkMCJVnsG2SN4feqZgFq4ivpTyT3jRVGvjE3BfNgBIg8atAqLw3QNC3bC/bxfyNnF3j7CFdR\u002B4Quu2YotRVwLdxvbvwxQLIdGBr3G4EeVD8N0O56ZPsw6m9L\u002B3Onp34Xat4aghEnNdfF3u89Wd8DD2YnG\u002BUn9sjgPoON5kQ/dnGb4LCjBNIt5ZoXtIYL85GPSOsMgIuZ73QVOUOOmk\u002BShmd\u002BoXkuXwuU\u002BjZLEEFC1Evx/Z5YMvblAvA8jcuOnktLhC4ejVEYYejgeIZVTt8z02T3nJyxOVRxmJ6J8tI/BVvr/4sTI0f52Zy1d7pwj7QQCLlnlwKumkvZrPWzj24VoXIqak5UILAd/sIA\u002B8GaAQjqeOkY2G5YPGU/OXZSRkotn9ZHRSVmu\u002BgJSpk/rZ6JP6vsyRaF/ckE0i3pFOc5yrd401vrU7zjhLwBD43VGY/GtfnLZX00qKINQnL3fKcBz3/hx9pDnuzuCUVZg\u002B07L7meIl7tbWU6RCq53hBJ6wcV/z8O9FG1gxcN3Fw32iS00RO5WVpIFGEapoOvisDcpR0\u002BRIOtLTpn6Z9H35EIA2kGBAz8j5Gszevd803OBflWMTc\u002B\u002BZagB6TZUnC7ADTQEaMZqYa04BWMkXeX0DnsmOOm8a5ZygnTZfxnIz0g8cy3DeKqtFtyoVEismgeCDZr7LmMFQ\u002BFdkeZRkSJTLzXa6Cq4MJWQuOIM09dNxehtFzG/DaDlNy9MpaaEG4X6VWUSkbIdCh0FKrVBOK/KD8v\u002BJHow1CGU9fD7a4svDF1cUn6yO3R2EAzUeeMro/6/QlWaxjdLyYFDvZvBId6R1h4YJOYxV9SXh9RtHFo\u002BaVHye\u002Bk1VEZmEIi9br2YdS5uAmPE078YTeqBAz4i3q1nBRQKDqX1nIHX8hRddCkW/1LmPtn2OVXS2i3\u002BtBEIAzHbVilpTmZIeKXiLSGqutnBagPrfN/TcQv\u002BdzS39yhwj\u002B7iQh4/7bDsXYZ0E8x0aB8UPQnNHMYSCCUdqxcx0IG9cV0yiHj7wbyS/t9ZX10/ig8VY7neY7LokHn5IgKZ\u002BozE9qKvAd/mWHuNel4m\u002BKiH3iEH3GzHns3qSff\u002Bwp96OMQSlKi6UEgvbwt\u002BESlUwdeRcQQhkd5f/ReUhPfn51WcE0FZ1CQ/zU2Y2K1hiU3klYggLZGbWKcl8peRJcuQR0e1oj3n\u002Bu2zkWO2SLlxPnOJ8C9vx7nEAPrac\u002BGMbueCCFFlrCdQPJqabJwt5M/t9PRjxzWcYL/N8WEDDYcMJyJ79EBny1JMOfNUlZsdlhvq7L7taKeyJafRl/qGTS8TjkV58fCPRemiF41CB4sksBtFGCEIHr66ic6YlnOXxeyEQQcVo\u002BRrW6aVS1Dab94c7OefATTNy2\u002BGvyfh9u91yhHgvcZDzsx22fy6ctNtoFowu6mL\u002BIT3trXXjyT8SWS3X0E/ObIXmN3baGd4U1icGN6N8XsFqhGM6McQrD/nupBXwxNSbqan2SKL8JAdf2MdO3YGLlgpcfVvchCqxuzd8\u002B2XIJBFSep4JdhYuflBb6mkM3CJ4Uw4LpEd4vxWPRI17fyihl7Sl/GLjgi/0Pf77cKnBpN8E9JhXvH/J2buIijGIov83ukK0Vt/PlNDuF3ZYjU57vZ\u002BudoqASds03CKnawfua4sPw8ZXDU4PNW\u002B3eaUJcUx9DMyR6jx0p3B3j4q9GCnY/6vrSMl4FLBBrzEa2MAmK2rWOl47XIFOmxxF743DQh013nn5HjiC9PgMUDsLWd6gQVQv1u3bnaMqnL2tIjUyfl0T1PpWPR0yQzVWPvxGQzFNpZ4po3s/ajDWznF65cLC2dHt54TkWhRG7YO4dW625Fl8X4yXCMrh5Gq5j26bt21ik1UaWGu8aVuJ4rXndvTSH\u002BooDoZGO8EG/AMaKtq1qzYmVdIJnIv9z/YxDSYE\u002Bm115290c6jXHGeUA2xYoj6A1Dd/wSESyINeOk6QFS6a8gGVlENrMTedTzl6dYkvlS23oDj\u002BlTlMUx7cJklqRwdJCQFqsw3rFaL/4nH3qFMKLpUQ2GTlnGzIWUE0nwr\u002BIwgiIWx3xNIfzJqV/qLHRLrLwfekSX6iY2ykkmnMtoaYAc95xXbmkmmzAQvaT53KAQSWeM0TWdmJj84P0zJ4UxYUDfzTTY8z1T\u002Bd4UhiyBPO2oFVJk25dKfl4EW45s83Sq31tkGg5rOFUpOdhWiBFre6MPihEyzIaplE7W1Jev5wVqaqfQHSLePdz9O6G\u002B9PZMmODqXGhidxLVu4W/lWS\u002BelLS6x5qm16BMUw0NZHk6qBYiju3xIqcB/OV\u002BmKdHqh4PsBP7AjX4v2CaCocLUGB8dHkZgooBrXHNeQr1KD85BKkvPbQlP2Xgag\u002BNVtggNqxFAmQuLedUDgKiLYkrA1dhoQXd3FKsF3TTeVi6dBaZ7QJesCWayxbB2y\u002BxgxGctSa4a/XSAlpZmOrvWrROmZnsCECGjJNxhtYvHAEjOpRjNoQyAchgh\u002BroBNc663BicwFVhXrRFeiTRuUf4uZZNl5WjGQwXJeRi0BVnoe8NptljOk/zbUZkeCbXvsjAOUEjw54pB8MchZpw/o6e7dhFxAJ\u002BhX9GSjpfTpDVP3crkpbUQ\u002B5A5K8GVrSlgm7HxZpekeq2UbPB3Xlj2bkiN0YjRWvnupn59N9jaD7KoMfbh3kGhp2MdTDjEnZk7Qrl5B9ugj0C0BrwVK0LQvmE9zyhmEJAK6C4ltArBJgjhQfEjXQfbB6ayLduBiHgcSI3XitJw0TIpbhupftc19ty3N\u002BVRsWFdYseFs\u002Ba0hWO2BW946Z82cGzC9e7oMYjPfDb\u002BylSSzpcseiQK6yFPcOi793VruQk9fMN0jrtycTE\u002BujOvtb8LIzrYSHN3L4lPd4UGLDoTY8MpwUmRGj/bvgT2zCztn7spsNA\u002Bk3CZxlE6KRs2aET3K1ZwgfRxdgT6/IpqfGNYXdfJ2H9p1NBSk/r4WvEkoVXAA6DafRnCuDrLR5LmM0nx4c9DaI/FjVaGIfH9dR8X1l80pny\u002BgeC\u002BByBAnpFBaFyxCnkh4TTF\u002BnZOUFsrwUcft3E3sYjJM2PqhWFvhO7FQLmRTG6h8fEmbqwKcC2FkkXZIOsgDbrX59sZO1vXWnWHhROhlnTUecF8DULcvr8yYPcfkmAHpTb\u002BvWiTiLqVUxQ6hu8d5//NBKclo/x39yUf5tZkt8QRf\u002BPcotkMRO0G5r4upjvQFHz3To243gE2isZDd6XkLJtMJQcLQUEiwMO6Irk\u002BSVDtT85VbWU6VKHephgSyM1LIrom3n00xNc/1I3OAr9L9D1xUivbjsM2FdBhKJslD/fycvwDG27TtIb3GZjbaFHmlq3eoXalc5P67MSs15g8GsSV25O/RNjOnZ2g4HUmXq1\u002BfpXpSm59TP9oCC6qJuDquwLURYzCJ03RDAPZAJMe0JIXLlUGUsxWFI6QUzyuJHq8tiV2ThkcvFdEGD5upEhsTTeckvSL5Ggygi0CLdQRJueFHEpppIZ4\u002BnIBwjqR52xCJAIFEZGCMNG5R8/oHo6DMvFW5YgCAqixI5iGiiIxnJrAvAnSCBFSBut0sGC2jNvjgo9FPv3kQCFZV\u002B34/6qzi6cxJ16ErSrgAOKciVJH/pK8owuW6GGY2H/keLQjWQdAxSS5gWV9XtVkYTofR7bPEVlbOFyjHJ9BmE7inDBywKfbX8QpinkpQ0Q2LocnfZDFGWdexByqoaiFd\u002Bkamr6g8aCWQ\u002BvypYbcLfkYbO4YHhq6GYbNE/iHMLobpBaMEqSFkTjmkT2o0nPcfpYnkjS\u002BbVnSYH031\u002BGkDw8t2v1wUB9QktuxMYjZDUsS7JFmY6KFXTa4va4nTb1bPoYyevtybC520v9ZCT/Q9VM2IOtMQatoqH3Ku5JxLUEaWfMCqpZPnHxm74ynKFP658Ra8SjWDvzexc59q7CYBaW6PrNIzk645oRq6VYaxXwpz9POFjwUREr2J\u002BTH0fTPyuXq6OmcshV5ngqkbyWmw/xSU9vczfNpofpoUqpl9RSPmx5wM9ySiR26VHQ1b9klU2fkdX4Y7vj2gUbzNF9vE6jyGNAHNpAjv8a6InV7NDIdQwNCgX\u002BWcqwlea6Vo1TCT0TLQ1cJIhjXxLm3YsiDe00U0fVcLJIpW6Yj4bjhjhhx\u002B9cwr/DbFCDmbrjF3xPjof5hfNFfYh62neuw5UA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "UiLDUWywew4tLDURPjmuaw==",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "ETag": "\u00220x8DB42FC75DCDF64\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8f25de59-ef0f-03a0-52c4-a56d1f83824a",
+        "x-ms-content-crc64": "qMrKDdJ0FVg=",
+        "x-ms-request-id": "1388c47b-301e-0034-20e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:27.9658340Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d/test-blob-9f21b78b-891f-6a26-3c94-ccc151c5e2bb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-c5f0714852f3bd6f31a63267152365f6-be179c48968dbd74-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "030381e9-7b02-d55a-774a-a20f524440b1",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "GDdOm8aqQChci1WMtE40L1XD4r370FXPt7pTeyLfsYzi6lXnNeaD4Xf4Q5Q0mrbtX51sjuIlv0fifuMMVsUGfdnIqsn5TfluPwFFAo3Amh0DZhyEciOqvCsNBbYCd4uy8sW7bO/s9BGj/U7h37y6IePFCPCoggq1He2e60hDbMh1kxDHBS4uF3IK4HXVyN1uU\u002BTSPG6bCXC7Bk4CTQnJYJGGa0yr8hy1l/F\u002BnqGV31QQMJdkcC9Z2omgC/7fK8loQYDjT12QwmDHHaR9HWvPJib58R1xZfBiLJHCC\u002BYd1WsoFV0gsZD3f203nFOK3L0e0eXY5Tqr99uQgSLLzrd5qkc5VAgOrnSVAnGwOsic10/UozoBRPAxfB2BkC9tK7G2vfIMUYe1ECJwQuPI\u002B7wS86nS9yp8eGVXB9fqjB1EJ9bA\u002Bn3WkIbIH5MXkAIMaIFgbpyGmjSGOUWMtUmwyoMEKxoNCAA/PGMjCtiWZedjSp5WiR2BvoyiOcE3Sts8GFQPEmTn/2CAITI5Yo9b79NdKWqrWkFlg2yOa84/CPGH5vKEh1KCe0s\u002B1WjrR1v8Rknt2iBxkb0SqY73WZOSQRlAsXyd12iA2q0ebYTZejwRkSSEUi3RFlU0cd3EiyK3q5NOqpXfX2/gbP9yUiQ5OC5S5shvDe/rb5snaGWLvE\u002BKZsHxitCmMTG1o\u002BUuXsMw\u002BziucqRaSJ6kYzr6uPcKVbCv5\u002BtjR65eq7WWumkJvBDX9mws3UqrMB4iTCaVq3k5qk41fnbXzbSKUMbvw400m6YpI8KL3XhmBLfNQPuHyP88XQ8a1D6a/yi4oY2DvGyQ7bF/a4i2rczWznq/Co24A4fHs2Z\u002BGsZojySZ0zzr40hLPFJKB1x3ha9CRAXD2/Sb/54FuwkGEtPqF9xjHdqQ6\u002BsydM07bvsqUC22O9XBpLQv/tSd5Sc/RCp\u002BYPCAE2jVsVgakWcnX5Gi2mvbT9b9KXInNB4G8gXE8i\u002BjvA4LqjzF4Il8pxNNCJ5C\u002Bwu8ZPRTgDZ\u002BWd9Jz79TVp43hKOClzAuFW9NgIJf2it/w/f6B446TzzXjVFdfBHKKVB0FYT7wGPajU6FBv\u002B0Hn6zyQvHWE4Q/TRmqwnf0Jhdglcx68SmhAOTH3o/tUk8Im7SqbMFA9ACYxhPlBRa\u002B7y2KIOogzO5DEUIMzjU0EfrKoibDSflV3\u002BGLoesV\u002B/uOSS9iY3FlJ86GJxt/dCYLpPQZGqMvu2V0NADIVWsDbVVGvkTFka6JZbpYPSKd1mv7v/z3PKFYno2J7m8wXJJjgvnGOPWhBdNFT7Tol75C1h2VDNVuTHC0Ld\u002B3e\u002BN/mMkn9Lpol922Grnpsa0sb8cPRtgRW0\u002B9NTaJEcrWKcovxfarwKLD2j5AHzJbRJqDh/4YZ/TLLn25av9D34XSn/Dv\u002Bav2QG8kC6zZkTwdYbCbxUoM/YHVZJd48pXjgDq4rX8Bq4ruzUdO9FxIMZ0BnAkO59o7xeIu2lTUfU3ZQItyISP9G7XlrTgCvclljTM6d1ZMlNggfOdc0pE12k/5tbOQ1dB5RIBTaTriOQgYyQ0h2gY3TKvzUeR8YAkk75KoSQgVlPdigPLV\u002BWudPkOfRAlD1AAJgijH3UQsPOR3bnloObA/wzRV/xkTYZNAFhOgnRw/oNuSXobfTfdzNoQOXorydMSTn0DVLhTnNiCVh4dwi1\u002BId82dldrpILU9IoiUxQLITeEOzT2bKnLG62hmScYwAqtkhea9VJ8pqr7L2AtMUjEdjTnmIb5h7U1a1upygtavDR/dcH9cSzkCJWK\u002Bz1Jnepk3SLzMCeEtAphZYn30tyeoHIrrbyGxwUHApDxbox4681xROzpZ4sM\u002B8C3mwuj7TW461rKHvAu3hYc6y2WkkV96Xm8ho3vtTnmHrH7zyv6YxVbOIMyrs3cQmbWzHtddml7ObKS5menyDYg4/8\u002BMw7qIocYO1nCSzur30MnGei9iahIf5Z5Z32ts29MEcrOng9Y7KrzRToPue135gckgK9NY1pW9rN4cboKaojqdTpw3UEzzy09yUNuOcWoAYF1iTPA/q1weKhb33rv6NuyJUSzBgnG8LGCEJkW57ztz285leBUKXaMAGSY1\u002B\u002ByTuBovBSB9Pp3r5mBPe4UWZDrbRALtlP6XfvOJwakLRnC0MK5riuobNp0weVH0\u002ByHeKfUrWnfp5eMbV4Zss3004J/v20sWqpkQwE1lvRus4oORq9e0H\u002Bv4igqLEHNjrkNgO5jxxN\u002BWh39b2loqhCiHrrUCmsdlQMC0NxEAi5pl7RHJxYGCut2kOySYWAWRzgYhw2G\u002BIRN8OrqYPc2OVjulNe1IIL6nBPPXXp/izSi7IikLHog4p8w\u002BTcrG6nzQFaUo82IYSa1Hev6t5sKzmW2R3Rukg3dzrE4hCdLzoBp2x0j6\u002BdmGYti7g6PJioDJSvRddM1ha5IttUbUNz/ak5qkNx\u002B5uJ9Ty7pDKP\u002BTaeHNF77eVmsNFZv2jQSS8muYoS/JZZNhT9JVCWlS3gKSmktlBt9A/D1vluGDwutawRkOqkfPygROa8fsiU0BujdZJDL5beuMV6Tymc6x3Yzm\u002BggQRHO6gpBG1prXVHKwLdzqap64YZNtQhLi3TA13I47BY8FMTWDnqFislcQtMNyAqvxx7MuLli0owIg16WgEToM3E6jqvynJov9Fe88HI1PcJpEQ9TbDNd2UE4zoob7wqEdA9i0zpevSqDnMNipeEa00abLG40lMY93bRqus4PFAVMN3xi0mqIC1Pl0M9w\u002BjNfHfpEf8KbUN9IJPWF9AJcdIi9Fm5ltwHbEyEaT8T3zeOACpzUypRCsOecGa10AhdRiFxHsuTF\u002Bmb5aWyhgAEbUVcSBOlmiKnzemWGyJ5TZxEKycZnsBr/uxA22mEooTDmgMhWYf0t6gCyUzd\u002BPjHHpQFbl7Y6tKE9E0nZMK1Hy9k1oEjW/QUT3N/GtVzigHzfbjVfzQp5rMwmGU60U7pSa4heSZ7p8aj8R7rXc/5EWpPM\u002BsJ45/3Ou/R7r\u002BO2Xoglc0rUhDbe9XyMYoVPoTjN4b6751n32oOKj46qbULERugxsv\u002B0cNZc7gRF7IV4fhm7rc0l\u002B3cvLZnHSvSoM4g5xxycHu84GHHoXvlVsu39ERB07sB1n0pxAoRm7SXhs7p8DCRo22Apg5RbPJ1\u002B2XuryTjjNEXIxCfSKxxr0itLB6o\u002B2aXJlTawSmsrGWOt8ygJuiTt/X91tEf8lbBEvrBpEDXyPwDV4jMCM\u002BnanKvEJTfzYRcGXgkrySVezP\u002BGbIu6wQgtu7MnNNfx68qVmhebOHB4UF2YYrIrxnbbdhY0e8ddINqilmqEyy1AFXI/lS4NwpOODRsuIV5WAvQ8TL3AvW8DN3o8\u002BaEG84QwWE0/7DFHzbSCpW6rL/97S5R1R39vf1gDO1200MnyhxmW/sgRFxXC9X4JPhcBVwh7wK0MkawFwNn1O7DTk/zrkB1UFTE2ajR/s1IAZkFAAeRVORAb5fZtkT3vHNtk72GBHq35rULWRFZ5jd5aBFqXtDrMfVrsz6sn5oPzR05YG8Pwf0eTRlSifvS5olgYE4zjV2ehl3IHlE4C0sa\u002B4/0HIHIaaoUSBG3lKv5lMi1SDtP3EO/mt4NR6Or5kXON45v2sYHm/agH0VP5u21zoWEhr8Tzx9MNIWnuyYGaGXL5WEZib4GrbBAq7z6c7fsV3UaI1\u002BKvmhzI6JAY9zQnbLjg/2MnETLgdUKzyNeUcTNt2ew7EkGQSr0pmobwk3XcA4KGu\u002B2Y7swTp2Gf/NFENHdcqh5H61p2ULWl/Xes8OLN1sVVDbVG1esgJ2rf8U3s5WUOk\u002BhWlBcoEGs38vBUZrd\u002B0SUM7yfCFtUzJ8Tvl19ouRgRnlz6d0KtLP1KDuL6y8CzYB8n3/Y\u002BTHwSI2xTOXgLzznYQ8hahFrjX8MqeAjzOFwDPDY/QNoi0lHf6FTVWvOEPj6oIof3WNzFRIAzFNR0HuoQUPxCzI9ftXB3e5sFDgXPpTrJShbUC\u002BNZevxZ7759a8lqxAn2QXGvSWwXgN1BvzV7Y26aqtTUPEQY6FGSBcay\u002BRDRm0n72WTIGgCpvIoGGLrG3otP48D1lYfF3VggHESlZYbNbyTsf4kK0pDTKn\u002B5EtCXzCc6YhZP2wXBNvwLp/28A1cEOaiW2l4CRREwImsIC8uIiVAdagNwfZQeKkmN/iqSFicotdgnAPHIOBwFHriauSsxgx6sn5hTk7sUeK8UdEbnnQxE31XyYIhfVDLma1/bg3AeXHsL5XaO1CEcE4hBs8PWHYCsVtrVPiOWTUtmbShcOfQ/9hjL27eVtQoz1k0AHaBuEE3eLy2WSR5YdJgrKGf5v9qTAr2rCkHIFqDPoWjVlTCq91zbfgnHqK36cmcfao2jOhZybRrjwwULFRiMxqe2gt5ngDAKHUHQy1kQsZjaqasTLGdRYygWxzRX0GnxO\u002BIFQ/CIt\u002BldmBzVoqHA0xFtMGxseZlAZB\u002B1Ubn7s03Y35B3Cm2oUvHCtZRKfMCHVfMj6Z/8hMJJxd/Q0mYvYeTP/cIRScmkxd56qsME9uheLvvF2Mmu21vOLUSO13\u002BLklOven7\u002BdQwqfyTBgtn\u002BRM/2cqNqaYkbISJnQxuEFe5e7xdvVHtpYLnum1mk7FiBz\u002Bl0l2TcICjKlFlcljLxpWk2Y5LBju9UjRLqfM4wdjTJ5XMxD36Jgc/vpcAhDcmH/PXvbonGv0H5IApS8qNamh4kk7C\u002BwJbqrOHD0ukvMoBIY3/ZQAerAiYyN\u002B90N48rlQui/XkYyDxfBcGnA\u002B1Xyu6KCY4kgFkWeZCKi4indnVRlz3ejTQGMJpCejtGA/84220A6i0BBhSxi4PojTy0uI5MVmuweT25g9n04gYe0HaRUrAbpoxHUJAoLAGxHaJdjcGs\u002BqyUiGEvRmZUDCQNkrsNVzuMmRECBAXah0w8CGU2llREctbJ/MlO618l80NsGppFo8Vn0fSwqfWnuQEV8j4AHnbQyR/lRFpxPa2y3RHCbmyy92Wfz8VglMngIkPIOfggJNXMnFF6X15r9ZNG/svk5EuUYvvZYU6xbzRWBSIXqQO0kbk89dEaN5cGNNoxGZb9/D33M9b8R8OGGywcJFo8U0uQkWwSqO95eitk0yx0gFaeWAjlIHYst0n1tdql/RM8yeGOoIgp61NNfbmrmHSXEprWfstRVzPVY9kjHPIV1HwYKAlL5t/NdW21l6K8gR/VXqM/z39H6nKtuDyuBs5hOKk9k29qSyu6CAlenMCRGOK5Tb5O1QT80D6XnS2jHm6fU174f\u002B2wahJ3hMd26U2yHJ9Z9bgPEmKlQMIx0679F\u002BmavklhmJn0CeKr11E8hefx5YGOSSm2j0H7Uz8rf5dkeW3e3CoEUIMGZOvVZDsRaLraP\u002B4sb82/5C4IZUVZyYlLR13jXqm97ZT9iOQ94CsF6uqEUT\u002BpNwqfHvj7\u002Bw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "YUyCC/hJzDNGgIFIddwBAA==",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "ETag": "\u00220x8DB42FC75E76528\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "030381e9-7b02-d55a-774a-a20f524440b1",
+        "x-ms-content-crc64": "hLz3UxcvRbE=",
+        "x-ms-request-id": "1388c4b6-301e-0034-56e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:28.0347944Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d/test-blob-f7794ec3-af73-fa28-580d-3023ab2b5c60",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d42b48e6df07e3ae022ad8410f52dbf5-265257689e213f6b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9cb62308-f8f4-6ff9-e3d6-2417e80d8be9",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "UiLDUWywew4tLDURPjmuaw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "ETag": "\u00220x8DB42FC75DCDF64\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9cb62308-f8f4-6ff9-e3d6-2417e80d8be9",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1388c4f2-301e-0034-0ee5-744629000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:27.9658340Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d/test-blob-9f21b78b-891f-6a26-3c94-ccc151c5e2bb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-2bba900535641ef980323b8cc5b740cd-5b3867ad41280cbd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2f07525e-a38d-c8bc-f73a-db0524c46d01",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d/test-blob-f7794ec3-af73-fa28-580d-3023ab2b5c60",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2f07525e-a38d-c8bc-f73a-db0524c46d01",
+        "x-ms-error-code": "CannotVerifyCopySource",
+        "x-ms-request-id": "1388c536-301e-0034-49e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ECannotVerifyCopySource\u003C/Code\u003E\u003CMessage\u003EServer failed to authenticate the request. Please refer to the information in the www-authenticate header.\n",
+        "RequestId:1388c536-301e-0034-49e5-744629000000\n",
+        "Time:2023-04-22T06:40:28.2277861Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d/test-blob-9f21b78b-891f-6a26-3c94-ccc151c5e2bb",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-313a9d0e3a18b2f27764bc92acc2655f-ad988365f35c76a0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "95b9e074-5c06-265b-a393-697593057be1",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "95b9e074-5c06-265b-a393-697593057be1",
+        "x-ms-delete-type-permanent": "false",
+        "x-ms-request-id": "1388c56a-301e-0034-7ae5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-3ec71919-f366-617d-0311-825f7b770f2d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a5ad6d34ea358e935084cb8e13c86ee9-77ae27b9b25fb646-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1106149a-c3e0-2504-75e6-e39745e3792d",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1106149a-c3e0-2504-75e6-e39745e3792d",
+        "x-ms-request-id": "1388c5a0-301e-0034-2ee5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "50675770",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_Source.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_Source.json
@@ -1,0 +1,250 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2c6f2ac95d399d950a1597651bf5b24a-d6ee0741ca582326-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "de0351c7-f730-2245-4bda-bdee3c333d59",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "ETag": "\u00220x8DB42FC74567BA4\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "de0351c7-f730-2245-4bda-bdee3c333d59",
+        "x-ms-request-id": "1388bda2-301e-0034-2ce5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75/test-blob-0cf0d622-1d90-e391-dbfe-ba94c4de1763",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-03c5b5954e3526032382fe35b50424f6-b8513c662194375c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "33c8d25d-8b05-b68c-05c4-6b9effa15643",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "euvOMhuORdNVB/Goc0sAJNA5G/dbbaKqwCADMjyxXWzDWXNRZQs\u002Bk5Edtogs6W\u002BP/pXDi8MfCA1IJHL7ixOWpKmE5BnYrr/F\u002B4hmPbYZfdawczOm7tKppFFlCECYQgd9hxLepwVWtk/W/Y86uMpWL6acShff77bX2z/IcqZ\u002BLbiB6LakOtbRWb3k0PBCbuyGD9ia/PjvnpdcB8zFjkSoV9DXuc8UsvTQy/Ba\u002Bh/FlWxSQWLN5DHAkUoeSDMKC8t4O3kgarUdcV3kyjEHlKN3lnJfckzh2nOeFyeE9WnBxb8l4b\u002BmpSq2Nc8F6RkAuf2mprHBqph/l2EFglOOmHvzIgRx4rLk0fFHqD182/BZnl4p3k64ABonpUpeoCPWKJ1TEccVjtdKwdXAeQJbArtwq\u002BP1ZLotOyLpSjxohjDOcYCgKcopRA\u002BG3hx594YYzKOO7fQ/4MPjJtWkK0Sa4juk8QiButjxRmfUboWds0Sc0X6Y2pg7j5C9vQL0hRnK7Pzg1AV\u002BlxHKnKeNanI9RXKRCFrGAgiiaWJ3w/3W/MBNCYKJvN4\u002BHTlszT3xrSQegHePYn2/A\u002Bn0PmujBtMT9J/mQGHvs4iUU\u002BogWTTLsbs\u002BWUOFRppDjgWYlH5zmxZlWdmdCm3DLszu\u002Bw\u002BSnqq1KYywZK2Qja4ForJbVh4KILjUugBbLadNeyp2lkqLsO9b42vywjZp1csql2e7Z9et5NpWvuSpWvvlY\u002BmCGfZjevLC/3OzGF6Ba\u002BU1MJU/kRNTybJvNPILsYlwDV9N5rvUxx11\u002BWhk\u002Bsx81FP\u002BdCllptHVL1BE80UAt03qQwv\u002BNIQpYGl4yZiq7s7m82CeDD1fCmeNeLZqj9PXdUEbebfBfaDO1RTA7dw5KkGCXgDlYasQijikcbzOvtCVoFRWj3QXJHW/zzcpnx2KVE116DHS8ROWCu9\u002BHQzjABZDKkyI4prMajmLJZJz5\u002BsbGR1uWdWfw69AwIWFmQdo3M8h5XXQAnKyqX73R8uBIiMEYgPvdKZAo2adRyEVRtEyIknDUgF1SxeqvLBXp3zjv51hgDcDeWco4EEOM7pQnWKtxSSCvdAhjhfsRLj26PzquYiEs8WaLqnimnG/ZxddWh9NquJXYQHNQPIgFzSuMfdFI3oxy\u002BmcE5Z7nyNeYSb/j\u002BmZqT4akliHt3PTeRd0NGl5ekOdK441sZdL3MHebt7LIIdLFIi5K5EhqhR1yZl/B2u55OfjYmRaY/enzraWqEmVB1mPKB/gwE6ye4B6wOf\u002BzNVWJIn26L4j8LCQElzbigHL4ME/795L2CSYMObj4KMPqALgP4S/nh\u002BbbDhuUK7x1/B\u002Brt8mvt32C0tlXbfXPw8NgGla\u002Bkp9DEGhpIKl3Ih2pln1ZDLE6eol6jQ4WkFowywpYc9Fl9ylAaKdhRpaUS7D7rZd4drdSZd/NRAWRbEAOeBVfHu4MQ98UGOPJmPPypkGdGuKCuJSSxg3xWLMj7vxnUs6BNSzCr2n4ZF3TSIzr2p3ENBFdS/\u002BAzBjgGussMCnnokYlcXEUmmt4ylQ2v71BBb4VX/rqyccPAGjUIpS\u002BjHRz66ZGxmksr1nmJIGrSgybXxUtFpBvPNh\u002B1nEIQLfWun3fwtPXOj8U6PBhBOUFo7YcOIN/kXWjxO7OB/A35C6hz2pDi4d4xGTV2G3fzjgzOXK7LAg0VyjIe/4lCTJPHQSB/zW6whguo3ReqbkHw/b22s69fPfmrXgBew\u002BJU/tyhvspXg7CuHdajEjTle2vwLgHLm4j0aBMmxG9eUbIpU95K\u002BL93qWn9CJXYvBvEteKkbqXQiWNDvUa3IL9BT8wUic5WqnKseISXzoLzG7v3Yh6MueMcSMp7B0tosHi6u8jZtDJNbht/9\u002BYhSLrQQJGav86gxJXZCDED65MnQ8gL7RLKKWd5ugPzDLIM6wAPmra5zfCqCeci8KvxSXJ4SKQuFWuYFicqEQXKvbfT3B0w9EDsfYXHUeM7lyi7iHCBesQN3tWkZ3SPj6z670w/TySewEUhm9suVrN4bI8OfpiFSTLzxf1HnIzcXO3YzHKXDEf0LMgrX\u002B7o73gSLAr1gREUZaYJO3k3RyO4VT7tVZpA4WA3CkHAaelUCuZ1NXCB1svMtGbcjcDevOWUYvqv\u002B5ntwTqavobfRAu8tTCSwgGzNn5jIJEzdGOvaE1cO/bupA9ch2RF9xhE/XBbH8iAO/rT4Tx8PNr4ulzW61Y5cxgEzgExNkqtbT9WLjMg2FSbHyxSiEq6cmckU80XfwvCC3pYVkHHXwWwJnQNFh6n1\u002BH4O9wp5urdSluqDNJ9lf4zlBK4yIIC08AmklHGvVxYfIvrHzM/mCSPiwv2HUIzMpCFyYH7/w9v5WgMA0SZFo0PUZBGknbK8/v\u002BKU12HLaN82\u002BxQOPKXI18eznLM5Tf9nR\u002B9suh7KAputWWDcXB6dixfh/k18WpNQUC2hdM/8BnHiLY9xXq3Ba/l4YeNE63upFhGbV0\u002By6u1cHGrwKY7MsFPu\u002Bi\u002BOKyxpIJJUBPivC2Sy\u002BF69YK4iMEOiFUFD0EJqrLGQVfFLGurlMje8Xeb1rBEGPjEwDk\u002BkzMns7BXqJlBQ6VdHH7ZyZt1z2C52ZtJcrWkwPZEQOp5h64koXy3V\u002Bgzna3SOro1ak9hTvTYhLmb2jz\u002Bruui\u002BQK655TMtSgawnd0hj/pezv7c1aq5vH1oP70iMdDuKUAjKCvF1chZLUjSox9YAJ9rmMBAz\u002BQ\u002BBYMxUaZ2Chk1wXOd/WbPmPk2gqdh5xldDz8etpkPrVpb5COnk4Mi4yMvnOGrugI4nP/HCk083R5q00FmV1N/JhQZQRhCJwV1E56EMko3slU85RmZR6MMHwcFPcBCu4vPr3XNkXjp9nT6Uvaut6vTMyHsKXI55d5xDSIRPOpEM1cStILUaSDcU\u002B6ln/WsXmdcMgmeVpEZlcmXXIRW2LmKtR\u002BfnAIo/skAD9aDlEboxa66tArgptzF\u002BR\u002B4PQ2chns1GurWDMFlMzRAnka7lQCDrpfVnCOvqQ9C2aPjcMG8ZIlbTnpbErjtVYDWoAeWCmMeNI51xulXhnDbkzMegcNzgzq9X0aGKJvf6Eej2AkHrM4/xTsyRp2fBMgJgH\u002BEztO8YxzN2Kodlwzzlt6is61m0\u002Bdl37yIQD2cHlt9fagcWhlz5nXtOtQkIi0vP7C//FAboqyXH\u002B8XNCLfMLlOnxlk1jvEL8w4eZkTQLyOWAGM3SEKYtr7hDsqXLJSDgoa1YMTy2h0\u002B82D4ygThN4zidshUlOYRDw/aVH/mtIa5WuP\u002BWs5eo2YF\u002BJUhn\u002By5/9d99LWMbu3gZFG1GIWdWD6aP29hItz\u002BQ5OiDpwRL29jIFRoqIARLSv13fa8qUrgaKBWR2C9GJ06f3EiKiARj3TiUjgxdK\u002B\u002BiRIDawUmAdpIgaY7\u002BqfOpge3bilO7wML5E5BmhdS7zQw175Oea1X1H1WmWh6FZTNE6vwecZGL5nPN4b25GeDNZKyCyLpQGxaH1nr\u002BFWakY65tIZrYnVtqqgkf0ImoS/Vk6OVx8qx45N/lhpsmjdEdGX4PS/hF5NdBGB6xQDqc75p1iSxxImDx9EzK8xawRCwoArcLqQANLwQeMOqdt6SlSKcAoPSkm/cNDVe7ivHAkNPiiU1zgTaaeGooUvGGZDyoFapvv5Mng2bP/puoUZQCXZAGqy5XIbdwdjiKfEj1dqkbE3VHUOEwywXms5Ka4ibWFgVRj7keQPPi/zlqrRcdynfynU4uywy\u002B1eAocH4k1ZQRpFZDk/bwDNJxVGGn1i3uyOkaqFTYt1sIkqnI5cB1vimlWPiw2jZxAoB7rWabFw/CObeVGi0/OPz7SwFdJxcCC6ZIAn0lPe6ymaXEbRn0bYuqBrwI4KP8ZhALtZ8lI9t5aaHAUwSCnQvY0nCHesvTBt11oyBrCRryW5xdKXhPjWXKWwN4JAp3J2mgIB4zZPtUKK6xv4C7HlCGzgd4JXODmVUKvS/IWuLTDnvGutkMzuahCPDJjd3lH0yi4VXzDvHmHJa5KKfLm93L7rEE9FOHig8QxyyCyguHFa3jFXmM3/950J4yQ5ZO1X0jDa8c0CrpK1dW4jfVY1KbMgMJ6HZkTw6xmxO1RUZ40eGvb8xsakVy\u002BfoSNf23lH1LpxGDNPz2vr6Qa0UHM9YQ7gBWNfOWPsfNhu6MUhkQ\u002Bfamaa4k5Zz0qKENzA7wa8YT8UftYW55tXhJxb4Oemylf2FeYMo36/hzYY1SmGLIzRsoaFDBI5iILLQ16x/u5i40WFydogr77AVfeg/RFx0FcPii1hIL5EvYxjQGAgDohHtfHjAWOysQLIxbcbmYpxWnIGonTAAcKHQAxNvG9eoEduWEgfjs/0XNgrmFsHKSQC8ubtGWsUhrMvXMFXZfSTaiVwrEBCUcuiEkWblWhmfxbnS8qJcIbbWdGU8DIOnPbkly42l33jv6EaSwYlefFKyNyqbxoqCvqelFJurWCZlHVPtv06MOiZBIsobiWAteDgSShVYy3cuY00mAIqdRFAgbaQ1sL0EJjzEWuPAZzVHd5yjmQ4QzBIcv1vBZfmbo956Oxu798d6zmQYlHCTbjxX3ojuOatBz2FSGPFhAoADaPcFRmvZi7/VKIqqOHehiVFfqYcwrWoy\u002BCu6Kd7WGcuj1Su5TeeQvhMJGRDgl9cp8I\u002BgAZk40vtM0o4AH6GhPs7/BiMMKDupjutz55RZUiBUkHlPdhhyawJwLLtZkF6xqBoCIZGz3chT9nKthOtnM4Btq48oUYj2TJsg2/uAED5Mgn\u002B6FzCO4LKw\u002B3\u002BlhOYWyTk66\u002BTPSRZRS5T2UsHM0\u002BZ0IMJr7NxP3srct5ZJEIf1CdKChSQZvXlpKMubmE2wo\u002BeZMaPjqxwcqw0Z8pGACDrNAUjvCk6CWmOJAoQQ9AZ9LBOur98kEV62pdoXP8qn6SCQjlcEgVmZFtcAGqiYC/bGnIa90Vhb6S/qOKS0axqZIRljgCXvOGr6FZjH4/a2HpojEGMD6deIdOVnGoi1JKu8ZvlPNIuRF2Qbw/v/U8U5NBoKURr3lTdB2wtAR93iBTDtC309ZunOUjj\u002B6CYbySDgbeZuqpNQxNGCDVlAUM9GOb7K0ghIO81wPD8h\u002BK0RJhIqX9o3s5pdXEarexmQjgFpeO5nUPbYmDHZPm6UbwxksSdHFjD1TkYkbbXB3MDzn639\u002BH/\u002BqdUbEYeoHrUryS06RooySXgQdCpoQyNBFvtxJV7AlnbMpgcSLARpDW/Q\u002BGRIh1Y2wVY17URVVmax2frMdvkWa3K2beBC4B1z52a6V0q\u002B\u002BI9lOmPIiqjydw/goBIJXNZ2uozx0hm18\u002BE4ggYd2v7b8yFrZzyVTaCJg/aQokALakpQA9z9jSZ1r0ZCkAhi1JwQxKzw3fWZ4WzsaA4i5VGhLVf7zZciHmY69fe2Ur2YZu9av53TGoxUtmJv0WTYEoo04aLwpsbE7uZGw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "P1nGUuqxBe6ZZ4Uzrh6Z8Q==",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "ETag": "\u00220x8DB42FC746347FD\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "33c8d25d-8b05-b68c-05c4-6b9effa15643",
+        "x-ms-content-crc64": "TdF\u002BowobKW8=",
+        "x-ms-request-id": "1388bdd1-301e-0034-5ae5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:25.4912509Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75/test-blob-909231de-4a5a-024e-f58e-e52991034e3f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-1d63caefc4aabc92d64d4a76c5f8d29e-fa6f54c1f00cb785-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "045169f4-b2e6-773f-9a15-0614bab7dd21",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "lP\u002B\u002BQPJlFUwUQYh2UrEF2cpT8Aa4nEESg8Y9dqZiJAJ1KwoA4xZQeBtGfBnC2K9EiQtePhJIh/e9q7wrKJ\u002BmsR2GASenBfa0AnjqcSAoUKsW\u002BO2aBOXvLaMSQjhZJE98oMr8PNaInYQVqjuaXRbXlVoQFTCxC603l9ODlMO\u002BW90obtBVLBTVjVpphVmpVNCNOqzdSA8fypUdxKUDBQjAV09ece5FgWhGO4fVSIZTjUID9lkW4BLOCaQ7N2dv0YhSqC0KS\u002BPhR7hDlwyISoEPyTdiAA6uqnY8kGhKCkkB1mn\u002Bg6BYSUFeIa\u002Bg0kkFRb4iLG0wDNF6o/23zbt6lz1uQsCiicfhtoD2BN5fDdgsN0qpJ97c0cqYhN\u002BioHuF44pyMY\u002BJYrz3QXXtOQjzGpUlipZx0G9eknH2CgTnPhUFcCBU7dtJo9SNsuZo7pfBpGpKfRXlFBIaE58dk1e4DwJf58nnny253OfB4x6I9qTaNGaancEAIFsOOdo8Kw991aLkCAfN2gU8kKEtIzD0khz6Q17xHXJAX8du2WVTfbDYRA57o\u002B2cDFlgXQwg0vwqGaa9Qeiwi7cwpKg/XwCf6RPwVd8ieO4uXjYFkcBlII3KQ7\u002B/ljvIJ7hWS/9EXK1YwHT5L3wdB6C4juOxq/r3yoMbdRxB4FPXJy4myy3v6QGJrNBMa/ARrTseBwdXFnu\u002BX4B7KeeRF\u002BAhIQdN9jxzyKTiKP8pql\u002BTCcfgItlLgBCzaGytc8AZ95TwKknoxLf/qz5ide58lLQg6CAgsPUG1aH2mo3PxVXkyDBqOYAVqkUQ4Xab6AoiN9O3jIug\u002BUef6VWo8SkpL\u002Bbofq29EVo0Cz3aD89\u002Ba\u002B2X1GO6GDjJRM7py1Aqbbkb5rGQsmlcZSV5goFOxel3IX1oEB3GbxatHzre00UKCZ6Dvigd7rmDOm89QJW3e37kcarSwlybVXea4pMvfpHgbnjiygbAWTLE5NauiS6B9qO8\u002BmGbN0ZC6GmxggslU7zeXNId1LB3Ixd3Dt6F7cxJGezvc4MvRTYxoOKdD9cnnpAZ0CxcYyHzRNZJIylovPqdZ2kfNuA4rheb6zTO2hRAT29Nax2g7bXK/C6t5SENyOPn/6duCGiv4SEUwXjtJWrCCdO6G1Dd/XqzVTmyi8n1jSJQ5tps0kcGnYr7iyw93NfE6txOUq2TCgIsurMv/VZYHjNWnT6PVjaLtH7G4XFOdnhi7qDtpzt1vdvYPxeU16A0o2345j\u002BYNJSlwp4vzSiR3kQ6zQ\u002B1anb44d9itxYe993ekT4DVY85ybkLR\u002BWcRfCzRmHTWgmQfjn2AAVfNX19h8vBUTvqjYi1AQNVqiORW5vvr3C1S5zTTRIFDVSJ2ZM7jb8a2/S0yLnYHVkFO9QVZaVqcIYNyDwu7QMo5YAzLChwGhxjd4CmOua33C1DzRI976evHmgMLsWD6\u002B3xi\u002BM4pfEwlSC4su4lxDWfVesO6iDx6/bYhA2/Y\u002BtX34uSta8DfjY8EjjxhTy5iVozbNnZdADN/6DtXyHjcTE1YNJikg\u002BGnNa10tjoAGW5H/qzi/YSfmqLxbUOFh4VWaEGuyRpV/ZLrNACJKIo5f47M0AnMOU6IuJn181Zd4a3n3k34URAT8gDaN8mEFrIYuC30\u002BLe7ii7y5lCAX8p8jRJSoQp8QO6\u002BuR4JMgGFBKIn3TtoqSk2bFQexWr/k1I2XWq3cXVnnHc/Nj9ZspgtLeGuWIKPE\u002BQpXHT2XXtDvyWL0pSXDdMswEDEKXLpnLn78deJEXrPp0mGjdUAsT77\u002B3cZzeADliAOQZgBiyqxP7\u002B7Oquj\u002Bq3q/GsLEH/\u002BLA8CCC37z87Z\u002BBu3eo\u002Bizdxe1Y5VhbaTGADJbxF0\u002BIWgUFVI/4L89W/woUKP7H/eCC6O7DrxaGaYrvAs8mC9pP9WFyo6Gc4ZoiAeZOR0A2vBK2ci5cxKrugu8BCSz8LPMzxDOdUVo\u002B4gdUoakwNCZKuEa8c5mr7yy2hCC2m9RpIdTzHn8MlWq0d4wrCCb9vkrEulDmQ7lZh9UC5s01hEYu64PUPRmnPibYB/wNgOcJuMXV8eGHhuIbmZaqDa6Zfu9J\u002BCCnKX0xHXwuCju9SAbx\u002BS4HX5Zgp2SduKOC/Sx0QoUMx4TCZpNIpNBlWXimWk2TtBR8kh9Y5VS8BWzZshxPtcuysIR\u002BL5aevrrB/0nr915V70Ub96xlt94wBl0icva0Gaew96nFFYh94ddkluYK0BIOh8LXM74bTPymSiU1eEvEDeGmOwO0jNW8mhXZARz4KTZPF\u002B8z3OnllaatHs9nSGWLoIkAYJUOWfbtGpWoQkvfrhzu6mRclCz7vKVZC24KWVGwTWCX98SdPL30RsZQPVdezXCudF39KwhYCKfzsU6I4r1D\u002B/DrR7pUUa2qaFFqq4NN/jn9W\u002BT3syJUO\u002B8grYtvb2AFDEVic4W2ViKsUsK68V0gobcUi4rYTETOkw/PN6AiPvztYZs974qwRwHCR1xjmUaOAAvUWuPZLMP8k9x56yKCjhfFzZPF5rYoYECFFgTobvnFQTOYTeQZFDDbQVuqOl/jQ7lImc\u002B2yBlRq/afVBa7FCTmsKnu5kAvqLVe6qVefinkpdZLn9EqEnkaRqHtecAeHCk2x4W18Fl5GPEWV9139y3Iuq5Ac3RTuKIw1J\u002BeQjL1QM54K7qkLrF40obgE7qfolN0JMMR2ay04wrjhRu52trCIRMO\u002B89zJIv4x5zxc6TnlTJMKh1v42chx0SzwKmZvveoIfKnjKqAAPw3FRIPw3Nh\u002B/PpbbC9Uj2v7TSGw2PeYwipSU22PASLzCUdOM5RFgfVTcS5rFFC7tOw\u002B6Nx/UGYVLIJYnohq7/rXZ2PnBlzWtcwrXGbJLK3Zlp\u002BBURlFc7ngOAYS7OJt6IIzlKzt066PaDIQU/P/TADUfwfo6Z7hkvOqB81WxMnpvnTklZgB7MPx8ejmNCDF4OsGPW3bhP/kUgG4Q8zgOaRoJ5V/G7dn05JD9/e1\u002Bl7T5CbiT4ZcDjl0/0OXSKj3EbhEfQ2KRsQ0n2ral4wHL1ej5V6l/ekdDBhbChx0z4rqTOY/cXxQSJ5hrrAcgXesbdDr9GNJUhPOJnH1Ljuov8/f8EqmyL7aUpzAQ084AYugrp1LiNsnoPrTcEoLWxljue7hPJEsBqUSEKHGiQ7EliXmVICeXDfzuE9Q0ldzzvaCXYpgVsT5dKj4OXc5YBfrD9okJQeZxVy37YRB3DNNnkGqRCyEYz9g7N/YpSO/ulc4ZMN9Tqnv6JcuqWlAt5d0qpo1jhvqZ6uaxDknwR849zMsCXdvz0\u002BYu1yUVrnWIDRIY/qIiSs7Tf0X4opwxyZ49bI1E64gBNpKndO/VhDyxKME314ksG0I8Lt5WO3FKPM1HGEHoAyGJ18fPexYfPfsJR7mbOjIU0RELCLyp6zthXTfijmv6yOXfbf\u002BBHKBsHTDjDLP3rwLbMgcwnTplICzMrd3efG9PTr6T\u002B4wyk/Sw3yuLhp5Hqe40x5xkyivreg3S9K6CTaCBk/41I7N26J4Sf/3O2VmORMQv6XTTKkRS6IG\u002BH58GLpGKyjKgEoZ6/h7\u002BEkpuHGC0RG\u002BqkmRr7mm54nrx\u002BIj\u002BzFEsA89m7nJ99StV1Nf55Iwgydtvm1wtXxuJJnALSMVWPwY5AdiRTVY9LJ141dmRv/2u0S6tj3D1PuTznYfCMqwl/9WRwOLzj3xFcq7\u002B9ElCN2aynHfWqK/VBALz3a/OOvoxUtXD//7auwGyaBzCNkqbcaYhT5Y0Dxdl/Lzf/7HMtze0zWFzfjenl\u002BE2ZEBTEw34WGvJrOtj/UP\u002BncNCOrtPpbElDWjpKDNuufe0/arXEulu56dFwwpMUNAdtOA0ZV0lpr6PLcXkzzB4WvLz7z\u002BY54sZ0xMUCeKm2PxYi7NTehRaTxbsB\u002BUjihi3DWgXWKGQhI0VGpIKEZzb6FTJTAN85SCemV/orJ\u002BmNgk6XTx6j0BayAbmPh\u002BCUD250B\u002BQGn3VeigHeP8B59ftryRJD/SgoVjUroQ8VucBHEkibpyAFdvLZSLUMxaBWOBvOE87OQBI2W6Gu6u5mOMBBly133k7bVkIvaqRjK5CUxWjzV5XxeMI2VVt\u002BVowEYx/0uy6C3mnM4r18rtVt0yARGhWFctEqQC5bQXjjbQ/GKweUfmBiEfb/JnTohMnsyIIrXUxmjuA\u002BymsAJ5zg2XW9toPd2VTPvwguhkxsQctUfnjmuB\u002BzX6wXVbQFUepaHlz/Kt5GDu8ta65ER/iT0nivu6kj\u002BhFmClbntnOgul0dxHf/bSbtDm\u002BJyVxhbwejc4M7VaZBNhQ7iRB3blhrfKFRNoOApGVBwq05mjDE9JtPNDLwdWSmzI5js9QGZZAXHkyrEDiEIt8t6ZL5F6vTZpSFOCoVewdMqmoFLOCBS10NEnv0KeRSyxFjwovRvbTSgE1PgT118ZM1XnXejwXurK416/Uv30ygIm0Ysbh7euylIpyTMboflyDYvstuhEwbdSXtm8HPorEAn27QXU/qyeOJKVx5W2rkFkTEVyCBQZ4hDUyCnd8q5X/bkpJbT0nQ/fTX1Wrvohm6\u002BXV8\u002B1uQj13Ar1/zaCwEbjPsncjImMcK81krqWwzMWsix5RpreoUSwNEiq/p3ZXI03cnAwRQ8mCucgfyZOXxnX300JCXqsBZyEK1hA4nERXDUsX1DC5WwdUzuyvSIeYtUv0h9Qz1MSim3UrBq25Sd1DyLwIf/JFPrg67U\u002B\u002Bkd5ZciDERBSwI3iGtTj7jhSZm4TPK7/LUHVZr4lcOSe05AlWkZSM9QXI06VDQcr5SbBjoRHK72ZejeHrapSLFCpREZEvZPxADOa/BlfaSA6qoCXZOFfVqjTjOAOy4Upxfb\u002B7MnA5ieSz45RrC\u002BjORAXTQMqushuSe2dcTGz4zWtcTYiYH1WecNYBZRTDap5L1LQ936C/gstj6LbInX23\u002BxYpDv4gdmSwdM/0bQzGjxDJEHf4uy3K3Ir9NHaelZOYiWo\u002BmlugK55PTWqQi1W\u002BXRmmP4zFvwAoXjJzYwIuEZ98W\u002BPiyDS1KSTZqW2DOhF1PpcdOJYGksoqFjwpbMhcIXvLFC\u002Bx25Uk8NZoLBXSZWQhPiRq0NkJdcjZuPH4i/xcfUgx\u002BCXhg2MB\u002BEe/nmb0V7DYCG6kMVBigZ5mmCLjbCUaC66N4K0\u002BP3qBaRiRSddiJWEA4IONuEw3jzZHuytAXowipVL4JnbD2cj0Ioh30TfGxLLBokuhTJMillG29oQPQQpMruSEqj7qfQa6mZWD//3\u002BQLa4frwAQRj/lVAlDONEpKG962JTQlq0FyVE5rL9XtZTuHYNlwJODC2LhNSuhTAjdjUzxdRbqz4cBCeW\u002B1qlwnZ5kVStNw2fb580h72FxZH1IbC9yVjB\u002BA04MZLat1CTJcKeNPObtj8nVJZ1ZuOAVj6Vodnp6Djdt9lHdQV6xPhOoWH7J5DeGWtxg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Ue/uTylGxhOVjUShxwyohw==",
+        "Date": "Sat, 22 Apr 2023 06:40:24 GMT",
+        "ETag": "\u00220x8DB42FC746E42E3\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "045169f4-b2e6-773f-9a15-0614bab7dd21",
+        "x-ms-content-crc64": "\u002BpblLWC\u002BwXc=",
+        "x-ms-request-id": "1388bdf1-301e-0034-79e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:25.5632099Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75/test-blob-0cf0d622-1d90-e391-dbfe-ba94c4de1763",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-14121e5d68e098f322d2864706f06d41-19917d75c72b46fd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0f4e9cc5-a914-a7e0-9492-982ea0c9b399",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "P1nGUuqxBe6ZZ4Uzrh6Z8Q==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "ETag": "\u00220x8DB42FC746347FD\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0f4e9cc5-a914-a7e0-9492-982ea0c9b399",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1388bebc-301e-0034-32e5-744629000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:25.4912509Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75/test-blob-909231de-4a5a-024e-f58e-e52991034e3f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-6d20089d9c8569defd1f9257b1f024b6-9183a213a1c9bc1a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1d4f7534-ce68-110d-019e-7bd814f1d62c",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75/test-blob-0cf0d622-1d90-e391-dbfe-ba94c4de1763",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1d4f7534-ce68-110d-019e-7bd814f1d62c",
+        "x-ms-error-code": "CannotVerifyCopySource",
+        "x-ms-request-id": "1388bef3-301e-0034-65e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ECannotVerifyCopySource\u003C/Code\u003E\u003CMessage\u003EServer failed to authenticate the request. Please refer to the information in the www-authenticate header.\n",
+        "RequestId:1388bef3-301e-0034-65e5-744629000000\n",
+        "Time:2023-04-22T06:40:25.9190876Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75/test-blob-909231de-4a5a-024e-f58e-e52991034e3f",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9d99ba052d85ec7b7a6b24c832e56932-db397fb03b848a31-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2af95ca6-957a-6830-260f-c2119cbe3357",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2af95ca6-957a-6830-260f-c2119cbe3357",
+        "x-ms-delete-type-permanent": "false",
+        "x-ms-request-id": "1388bf45-301e-0034-33e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-133a1513-57a3-e51c-aff5-1e96841e6d75?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0103488c0a94f6d0408b7aee77c230b0-950109fa54b235af-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b9346dd3-7a58-11db-5fe2-94da7dce5f52",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9346dd3-7a58-11db-5fe2-94da7dce5f52",
+        "x-ms-request-id": "1388bf8b-301e-0034-75e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1741768598",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_SourceAsync.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerMismatch_SourceAsync.json
@@ -1,0 +1,250 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5daa3c8aea92f1b4e6169f24f9c8584e-655ac2102d465f2c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "16b44e6e-fade-41b0-acdb-02d330597a68",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "ETag": "\u00220x8DB42FC762B4624\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "16b44e6e-fade-41b0-acdb-02d330597a68",
+        "x-ms-request-id": "1388c5e1-301e-0034-6ae5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9/test-blob-7627185f-1e97-30d7-7ea2-e2abe3d9d21f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-d4ec8162e617e143f77741e93bfdf762-9fab1199dad88262-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3379369f-2f99-cad1-2044-35850152bbb3",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "SfYxHEsYGx9po5melLYbPy5\u002BN2nrfs1Pd4OYPBgEXtII4oo6J14dR/0HDPSFOJzIhqJ9ZKFpM8oo4aXHgN8GZUTGlrEr4RfQYfBs43HZyj7nz7V1h/kwn66/EUa4VcceAaevvqLqnKSLrAOx/E9YTxZm37Apkd1LlfYDa8/RFwspTeLKKgub/TIQ6dr1f6JeZsIvUXYW9W/JZCir5jHVupX4h69tjiULy\u002BF9GKcDVRZUpQUNocWVE1hyAMbi7xcBOy9F/ffz8dicJIaUmNzIxg4SV0EsxxjPY3RW\u002Bo5fKNvKfNx3vlgeYbQscX0/AHp7qjq30JjW1XQWdZmDnPZJPfuqyRwAUAe28/aM/1abkGL521BUp1hD9KZoYUi\u002Bm8S94jOClDdee1kyANyhSdYeeuU2icGm9ZWjZ9V1mO\u002B/\u002BFcyzxwiGfsrm2D2Iad7oqvQSeZjhxEDFu2e3i1h6eNpcwiEb3m6/GHqC\u002B5gr9TuJ8UqpE4IW3BGLrgvgzrOyrF9ja6e9jIxFk2EeHwjomYYsLZoN0SUYBeXPkDAingnHEA84yImTzGS\u002BY4AhOL0IoxSFtODZZJt6CyWBrfxcIvUXVw7575D8mCF1T62k9w0oxy0bnSlo7auzvv2j0h5oIgCLCaFuTvNDiNy/pBUtlRPYmObPQEXL7qmjRjDTWMYCzW1tGe2rurh52BQM6UlWRinpi3l3mOG6v1s3ysiCsDAWvJbnwLsmbN5uVWhxvsUgDMAHKY1MizRLslqSs\u002B\u002Bvt2fkNmyyroVug16bCQN5SQBV174Iu4aiifFiXA4gk/juvt4AjYiYrZ56mGYu8YHw0mlaPNxxpvvhAWy7UFK3De\u002BlrEpleLt3vSofzeMgc5gvcUmkxpbcvRfiX0xcHV0Lg0q2iUU3i1mt4n\u002ByUdkYgI2US97I0gdYiO9ygxkvG5/M1ApYqepS9\u002BXv9yQXamt\u002ByZ6\u002Bh5F\u002BQvFDXcCVxMhAvobfpb2OgBbjQZP42NsjAR6EM/m6cJPOjlFZFUvp/PMdr3hdd8TtsElH20X9hanWIByh0dEOxg4y0RcsdWrK\u002BUSg2ymixclZ1kNwMpUN0MjnQzUvB\u002BshzulqKmbtgTsefOHBXOpAcxoTSDtNnpN45MAOBPI1m7GZvsxAONtibBUIUbWzTLQepxAbG/\u002Bv1DAV8QWm37xI6OFwZ93dwDo\u002BsRwmBUzdhZgL753h2r/x6ercKgeV\u002B4yY/2jUQyTWQKbV3GqjiY7jOCttWu/eZw4hfn4ywZXyaPWPjUXkCUKzdW72y/4VDmAcOTIcaGCcuphaswSm438RI3O1FDwI/y7o\u002BiVBJ1sQDDAd1sij1gBU8tLtSVZ9zFHv5ehKoDokEznDM257G1M9CqbUiQy2bU1zICEpW7XYqy2TUUGyhWw1\u002BcPO4KLSGdd/sD6vqQNFeXhbF7/ZOreEKohAp4oRSoV6ns8Ip4yqYMYJ6at3KQHqDhfJF63sHP8MSrXakbJNbmW5dMo0PJHr8La5j1DMTQGGVllyCDLXToIQPFzWj89T/HtFvbQ3tdFGHWb3ck2uQD20VDsY2yYy4iYIJAB01SDnZZLVRo9NTqCIK\u002BqMIBw0ofxfYnvUeyEVEpuOL5GREUhGEAy6mPluZsVakO97ZsIKE4JD1bKk0uqxgHPz/18O9tqiRc/PecjC8Pu2eapx2avZg9vPTTuVoT0iCRiFemdmC5nUmSDyOtn5QSS3LpkAP6aIGnuDf2mezKTS7TCwfXZUEG4QnUCLJ0kCFcwXHrKj4cmyPWAr4swwNYy8Hw2pCQOuIx4rL6JmPPLyQSmdh\u002B3yLwsnPkAWKC1h4Gezzwh7WQzIaPuUeLJnTACteaHikq2eifACQcqDV/rwyU96si3qtufclR8yXbZY//J/qO6Lvw251UUYORcCBNDA469i7JnSgsK5xf1OrGx5qYIYQ\u002B8MJUoBgJzokn3Q2pAOMboHNdMYbOXsEflQK2kYnk\u002BU6cEhtL5lISw9KfCE6OttQHqyMnOvP9cJYBOQ8ZVzj/Pue/CPLL074hSnGwL1ZyjN4uruZqwb5eoqGFRqlG\u002BWyVo8lm063hP9tlBex\u002BSUFDjqgs6qRWlH0lXGZRQokQ3lEFHo\u002BJD7kwSW8LAbvR4FlcRbf9FhLEQwtMPXNHk/1SVCufeS61toLy\u002BJ01T5bBV3wM9PzVE8RCPN\u002BEPM5J7LlxuK2QMmcqpo8xDh1xjvNwiun3Np78eUBjWTxTMXm0pQvnx5bpMSUY5k5toAGq0LHoE7HkUroecT9pLNUq23URfGURictci1XE3kxMktlCuIiKZx3H0FZRyVJXfARP7grVWCOYlUbqi4hcI3RpzeJiKnBMnHBXTawSw8B1CQtRdOxFeza1piNBo9uVa6zd5/9v8VWX/1GWfg53idWGcYJ9DqqEJFavrIBNCviYweH/MNvBBRe1vXWervkkPhxJvzJZGF0GVcOkwETVRvRU/bwseFT9wWhuy1Ew6XVdh25gA0/KP6WA9NsUHETS4HaBRbE4\u002B8XLT/nJ6lEP1WxOSzzWcUOoir4Wq4N55aUjn\u002Bras6PAIIukmLdSAFVUdSNuydEL\u002BG821L7zJlBGTWZQpk5mNSXIiiqxMdSMVopovjJcCx/UG6d7p9rkzPo7YktNAV4G7kP9pj\u002BmVsqaqn4wimQd5kZKfIqq7o1K470sddOJP1UsYc/yYmTgLcDc3P1ctEaWGXgFBoDTXAOyssKCedz3DWslBCSUL4PdZlLFyg2T7i96mlxXhDTUWQHMP6\u002BmYbPn5dOSN6wd/en0K6AyDZHyIsSTC\u002BOAo4U2UKsmy/PUNwSe4eQ6AbZ/WJhyX1yUpk9z2hzrE1nQY0JKW\u002BcE\u002BzH6I/CbkyuttB0OE69HDkAooa5btu3S6SOuyoKl86XTemFmdDtr\u002BRMnxiH/2QOqjVD\u002BHbo0rUREJzbM6MSpB8R7OplJ3JoEvKSbN\u002BzL1xAgAD0tp9Hvms0dIk0EnwxKer5dhKJmXKy69V0RnXVXeFAmqOiHf2P2i5/MLLpJACGUULkybk5xuaOMcq5w2f1Xyan83fInwv9aavkCmjP2cfE/fUy8IQoFtO9E\u002BwixgbGedGcMTCYvbI252AdRbyNzmgC5MVywl6Sj9yUC4sv2pOVLYCHI5iXPDAy/BkkGsEnP0V0L\u002BExU7eC\u002BbFUBLI3BwzMeCg79prPa7iVP8ZFfmUbfMw1u6qyU8nZBDnnQyeOC/UMV5KY60iqpLQorBPhTXtcOIfl8VtSCiReUuJg6CiBFzPRORbCcoGDmwb2mbel98a\u002BiwqvmAqZqk1\u002BOohWSbybl5TgAARkicYGUmZEa3B8uGsrom0d4X8pR57JRDf5LUFKWvISxefCWgFEmTWkRT7dAYItOpdffaYVtsh1mzWODTUVChB\u002BWeJzWVhb2Vg5hPJf/DK12/Kp\u002Bt1L/Q8vXM7LtowAj0seXrevqdFO86Rd7DHGFZ8C2DEyaw9DIlzTVAyZkBLMKPWnMZ2LBjIRavc4/hDdaTcvyO5a3hQ72zxqzFXEpWOBkcM8HtQBh8IPIQAYCjQ79erFadc0YVrha1ZhEEnsTLWDt1xdoUpTLkEcW60UI9D4LsZrDzucTSBoWrONoGeIEtRKhFLX7lSgYkuWKBWtzUeFaPFzcU2J92o75VaW1Y3ZlDjY2a9\u002BEDBxupzwBiUKyo17\u002BDd2BJGGwJz4q/j\u002BGZzNvIPs1POoF1ixAcawifFFISrZGu1GY5\u002BXQgkShXQ3c5DwIkmhLeWJ09DutQLa1jabo3reJP6vd1j0RYLqlZHUeY4lsGe3pANFT0cMZ66cvGvSdtIJaV6iUKrwvOhSnz5PCkuEtRXe5A9nmNWnkw\u002BqV4knGB7P2wAvg1\u002B8tucq4rAIzW1jGAdF85LCkdB4\u002Br2rVlVfO3cvjz87VSG2Ii0YTKYlrsWiN0\u002BB0RSL/UkvppiiEWCR26c46U4\u002BN7LVj9FlqkUqU1v3\u002BR8F3Wpik4HmC66ZFADMdnEO7LWHc/\u002BcrEEzJlL0BVNMqhhBm/5M1kXMSDwETGvQmSPEK2aWYIUfaSEZL30u8gZbXHn4eupywhZvyyvDiG/VYo0/L9nspkmDIiLNI6bYnVYluO/x2C5JUWlQJqVpW\u002BDBQ7z//8IsfrYgZUi3pZ5vly3Vnd9/04pe5d5gjH\u002BUKdZCC\u002B/52J2ECTo50XLVgavK4I93g74RUWAikQnzu\u002BI2jDtyZam\u002Bdb6AUZSVRgIXiWQypZvgHKYYMKp/x0eTgE1YA0VHYyvyHHrQ9zIZfBteGwelwRZGRm\u002BVWjT/Pq52/MFXTULM0CY4MIkhHyVz/rSfIaw/7c8nAbzVogjm8t3MWgpgwj7IkUrhbYCdJSdKEVuAUB0CNw8CIDuF5y4dUT2rVLUrAzx1xoBhXnA\u002BmdyFm5CtZqLAyiL7bpHzQqosxBxS4dBiHw4vCpmcoNiew5Zu8Fudf\u002Bqa6pqCP6SacoPWNJpj67gME3yCjlwJNBlabJsLlEJej1Qht/dF3\u002B9phIgFtmxOKufuYtzvGuGOgbZxN8MJnu5Bh7U2MiOwtkONGPnEA329DDGzLTFlb3RiozYwxKgcX/WpxC63B/i0LayZUfH3uo44tCuRVnGs3Bgw0479j/GbYMj0Kk9e9fQ4/v\u002BUzB2Caui3\u002BBB8iwmEDOgGhjRpxp27DeE485A\u002B6b4nWGdyCBAKrmimNYfhLuXPcB1XSH/PzyhR6c4sWXdIeR5SRSKSEfTYC9fLw5EVyd77aYOC55FOZ5k/EC5B3lTxXcx5junDLV4of0yoBAuXTB/vMO/jxYF9A\u002B2ZYwHWlj2CymXEnEr1OEwlWmhUllONp8QOYq1lDZg7DIr8ObpcUekfFTmVwr/U6fijzmsZKG2KC8s9yDOALczdmZ\u002B/\u002BQ6B2QiPNYEp99UEOXiksU8tEdQdcj3/Hom1jvd8yDkgFPD6EfVSmeLsYBPmOY6662x9sHe7oobQgrp\u002BybaJvS\u002Br5BSHup9ZyofhIRIaGOUK\u002BqOK/wexZGJqKZ8608A8UqLkSlVqMyDNI\u002BX/yoF0tnnVc98DDr4X6n\u002ByHZEAHua3pM5vNc6fkLdyzdsRwang9WMVZW/xKVP0zG/VuCWfzQUPOBWzBYC7ReMXkDDi9hjVwSgt6rmGxot6amluudiR0wDWEomEPe/iah\u002BM6ZkTEcZHD/cNcdJLiHGaSKsXTJwKhc0wDOOPQZM4O4CqCeziV1iTF6nhlGEuipoX6fVE2x2DcmPb0wTit85TxTZBoY6Up\u002BFCdDTiGOFsAYJZd1et82BjFod5FoRDsF/rnc8q7OkLczID8lbooWlyb8GCmUBmtdHF3or3G5Fs/sPVBosiMSSZTfQVmfEZinUuBqaywScPdNf9ZQ5uFGegpvOTA5reQD6s\u002BVtcQRvQrEQV2QTqqj2sxYGjNNwWOzmcdPMNhobaT8Z4FdfLszPMHLi6SDtSxfzF5j4ZKxtihr4hv9wo0yXNO4lOcpRl0RJd5xgQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "wprBz3YPw\u002BPE8l/AIZAXRg==",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "ETag": "\u00220x8DB42FC7636B20D\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3379369f-2f99-cad1-2044-35850152bbb3",
+        "x-ms-content-crc64": "a699gKxtWSI=",
+        "x-ms-request-id": "1388c619-301e-0034-1ee5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:28.5544973Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9/test-blob-adf2343f-38b2-d261-29b8-5747a64a36d1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-8f300f6ce955b6a74e781c1913aadfc7-2263e2b86f12b8d6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e6770f9f-8666-fef3-6954-aaae660de95a",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "VMJx72U96AbtZMJWut54stBeCnxmROhn1KYK4deJI9YOZDA\u002B4MxOAkzrv051CxhLP6V2SD\u002B6axDaChu\u002BMwYvY0DsR1WtOdEEDwgveoSa8siNv6ExE9uWVPkgZNaxj85FvFwNiMPDngbTcTg3ivCLQBhSMHRl/lBlVfNcjNT6U3856b4ojGkFyiGaXaKiX8kIlCS\u002BXl9a4L0LqDPQZhEx2B64/aAyY7OuTWVTyqCuwvUpVPiwPPQg3gkAHOQ1NGQPaYSD6WEo1TFwDxH5BxUdXeU9phEZgZwpmB6XMkbOeRgBQ2EbKtiUAH/GPyziJtf04r7\u002B\u002BI5S9ujoWlFDkaLqoZb5\u002BMS0ATMNqaWSUkFvRnFHok\u002BIz4GJrkx5M8\u002BHUW/c3J2W6C4TQOCK8U7owKSmeBPf\u002B\u002B9TYtIUcEp3O85khVg2tnaj2V5DNGJu/d4yoO2o0ru8p1V/iHnLgXjkmwUSJmv2sgouAp61nMeM5GXz4s9czmgTp94Cti382FflXphdXNZyPO7jes8cBgqN86QU15\u002Bph8yc/36N8/vdMSpH0D0vLoiOgabgeVSY96HTdcOI6AC4O9fLwF1X5EjzBkil1TbMXsQbhVb4yA54AwfduX44VEkqjpRmY20rNp1d7XML8yJqBxb\u002BbWOqwHPJU71VeivKurH/e0aiZvtW8E65m9qabBDlcrJoOubmf84hnRCw1rxxkzPBDHjbyKAbp3wU8SWYLuetbwd4YoDLGft4gMnrpRqRRwen2V\u002BXCqoRTZJp0Y6piG4oA2a0\u002BTGy9vN9YkfXLwFigqod8FWHFWVdZxXuYUdsz/hawqK03E3V9ONsGadjOR2QB07ki5gZoO0AV5IcxJWrEJJPfG1frqVcR/txG/u9\u002Bi33XVn5iERfQSG0s4W7uTBOwQkUE7yvMFioh0Ocp4XxQl1lJGc7sYdO7ztLq/ogoY7LI1nyqeZwSCwAUAEAwpmbwnAnVpTJEg\u002BBxSOBZIVeh\u002Ba00YQr/5l39Nw6OmGGTS2hr\u002BmK\u002BUv5ARBKcOPC7\u002BSnoskaS/AVcMLXr2G4jtiu\u002B3f237Sb042au89z4Y\u002B1tAX4kpiXawI8jD8mskrpQXM4m3RrzA8vC847gJAhoY4zIfpbv/tAFpB1ulJ0dSFDsXlcO0UaSuj1yIfJXOtxG\u002Bux85BPjYF394Xk9RK8u5at984XxGVIGdcSZvd0d7qkBJ5nw4GQ9CP35UPANVTWOQ3xG2QcWVeFaNq5PCeKAoDLQPFzVfcUHQOrIN4hiOODOy3qg1tViKpH4Vqn1rf7bOLD9fViY\u002BMV3P1hcDl4ZOD2NQH6oH8ldbhHK3OcbEZLsLP8XpLuINhJ1KZd9Bdwz316saC2AMxjnYA9GzdweHC3FcCGewVNBxUoscvYx4Gg11z2Irqlla/mmMASsQWh2Vw2pt5W6VN3LKqLjU4Bi9X\u002BnEPaeVW1EYAQoONFO1UPh9hvoiGjSu0If/YQGgdg5Q3qFBXBxl8GgJReRUlwMvBUfAZ2kem0W1FW0vpfpfd4sLvVWidATcB4aCGMRQSkmEwFu50B6lMkNrjDa/Rkptqd5ZWOmtfJFC9F/SnHJxZNsjqtWupZd8ZnsSNufOHME8FH7l9vFf11O6Zuu\u002BwqXA6idri6t0zvRG7PJui0WpdNeelngDi23Zw8OB5D67vZPVQUzAYoElx0V6rxoO4UwOEPIEICw9zW65gcfX4urFiy9emUn46QJGaN8iiOxT2tJ3c9NMp41np3PuBtDJTdRqpRPqoFgCBSfvvcddC0RyZbblYG8XiOOh5vHGGuIhfRr6x9PIaSqKZX6rXOnGGpw/a5Ep4\u002B11QywwSLlmS/pFvjCsYkNgufycWvrwfCv529xVhq9BB5kthXSniCBhJCmEVZ6pGahI3rGkjZjydNcARmztALVLBKanfuzeuSHMOzbBbBaNQLI0HLf9rIoAKwCtp0HDhBN0SVD4AarLaiWf2FJSMQiwcvWqqOQNTWgsp0PcMQHQCKcTTSLFlU8XaKKCbcQnrfn3/SRcGNs/dvvoy1pW7zkTv9\u002BrTuPl6u2mk0BBet\u002BT9QlZ1EPdc\u002B/b49Ym7MnkwHlpbq30jF8GEgJGpYWa/fwcVNZQ/Rr1Rjvv32sNvw4TscLG2Awxn3iqQ7Ixlt5aMOXqCpfzk8NudChyBKzz\u002BGMEMuOy1CXv6rVdprlYw79tlZ51I6RmIC4PWGPTz5rbtktfLVPql2zP\u002Bi/Sle0aFaB5BH8OftTOngLFs4uyHCsqgfBt\u002BZZbgw4xpSmEk5ow9TKzarsbzTd2kJ9RJOPhDe30uAP8vBwKLYFw3NmrOgp4hL5JDrFwDsTI52kG\u002Bm4aQJdLj9uGREkWqT05qvBd21aE2JAlmA88hLlPI8SzAyMjVowyX6ou8kB1MlV0NmPUaxwSgiHN9KiYHwsiRxCEY6YKBlRkK3usVeZPsGWpuE5VariooHEBVVHjqkCvDKsv8M6/ajAPYE\u002BgZixLfkQy/mbM3Nxn27MlCLDygHE7DVk7L8\u002BW6k4eRfppCEpUxdcdoLvZ0i/OyBULimGPHO/edVjTAF50nAQYvpbR/sN40ELZ1O/FUSspbGeqm1/snzkampLhgbWImQSnwSOY7MlRkroepTgACSQtqZP22gCkPC9tx1Qwl16NUUvrHYAHgI\u002BeWPilzenxCpFus9ghgc70A4UEOxV1EPtrgVP8JOuUJhkUWIEH/n41bMzCwdN2a8\u002BM5woK81VqKUgNOjyWBOWl2p2/HSk97AUW3t5Ysk8X5SWEfz3hmTLDuj9JCsQxn1fnHPdFx16mTwsE5CSHAXb45VUHEZWnxEFa61L59NFA1T92cZVXwi3W7iAi3KUOTKjIQBVvKo3CP1il\u002Btv7rEo5tB7lAJ/RoRM3MDNldOesTK6qIaS70aqhtDJModdB2zHl\u002BSiGKTwY9q7yN/paXLphCa49QYqVfeJkQ1xdlP9L5WTxj3vPFiNikTsFuZmwV1d325g5BImnQItGIdXfy1G/tlKVWN1OofN6yrBfn7RIs/wE1clXAtDbWj7weORdgsXZRgNHKv56OSmkzknZV7DW/X3p2uWYWLNxug6uTikPLTf6dkmw8Yj9iqyfskSXAfJ\u002BGYt2Y7fgMP1P1WD/2\u002BrwlZEB3tFnJgvk/EBJCJZ\u002B2rgMICStiMmACkVcYSwoDb6xnyyjlSMhFvN/kXdnlzhm0Pqo46u2UwzXccScGsTfzO6Rl2l5y0WU2xkxLfdCKHMc9YAhfxoS\u002B0wfzBNelPw\u002Br9SI1g/O7QW1FAiChSUVlVlRjyU0vk3UfpwtWg8iNkYc8o4iyUJzTgiKbGsBgGYXCjbJ/RXW\u002BeGGpFdjkZL2kt3CdYKW4swW7jEsukHi0v4mBl/YWEkwRgisnCTrD6x1g8mNTxrjcCd6sx7Uqk\u002Bfo9FpPYszLjqUgi\u002BJ\u002BkanK96UtzaIVYPTQpY4baUqW6u5DPhDgcIRMlWe\u002BLz7WXXQw4cwT/MZF15Nhfr1CsCFajaDwP1eU6oMc3TQ6VzW5\u002BkQV5od6huor\u002BWZ9fvXHCeFCZ6Gd5iIgn/tM9x\u002BOC4Bdp4B5LM2d3Aq2yEHtF2uJVddS\u002B/OUHBQh8UqMLY/KnfHmI9d1Td0XpIeW5xngN4SPw51IOxOMxYtoWzuDDbJ66CpQBveUFAv6P1dv/TT6Pb3B/G3ygmbeVV5MDPahlJbRH/7zkCyQ\u002B6\u002BVUf\u002B8IMhSbhl5wRFAhGnHca2ZRAcVVKq8mt06Cq2NMQDCXTBrIjSR\u002BZ7ZJ9OFkJuRLB6C\u002B7ekf/lQ/4nrFGdr7IwMgis5WFN5B0poOCzXOwpFqN6PDjVNGd03FiKqquU7cTtHdQ5sW9PPBfRpOEfMfcSDoW\u002BI2N5Ww2RKAkYwzlhlMMrxj8H72U0KwARA4\u002BGZapRaKwl1rpRY7LWmIlWNnjeYBAt82u4Gh8gefhjaFd\u002BGsJut1qdS74IymKMMVbb3fSHMpN/WGI\u002BmV6M9Wyx7gtbWH22538eQSRSFSkJO9jIVJwD3CW0DrJQMC4MEEZRVuxXINjZFPZ1ePF/HUNJNW11xKDArgHlp1m7ZrdREjDeAM5Mogr//z\u002BlnmMkROF/FvqwlkulgKjaYYmPHb4/FGbAkQx1DINiddVxGx\u002BusVJ4TE/MkHvlOHAlYkBxcNGBdnoMY6PU\u002BhpnXhB2NHWZO7AnFtFucnPq22icX5pC4PTz76SVkk2\u002Bk0I1VUJrbwQKjDaAWmoAEwP2IZhLSKpwJH0rgkTQ85lieHOfOS0xf2xUgcNTsoaa89ygn2C1Y1qntSDFT\u002By/OZidHeHmYNnmxKIr5rbXLGHmgI5oMFQovQUo94P8bD\u002BPlVg6xpSkpIMCydrOmXyTwJjO3r9eVvk0dGDczXlF6lhynFFunGXNQewLZXZ5aiOYhSb7LZ2AIU5e9lIz19cJvN\u002BCW/0rNTQzAZzTUvGCuwpNNEhSWsy64nsDD5YTiXoE8aim9x42fU/yyCvwrN5czDtH9pOet1ICx2mCGDWeL3gizlFI68P8Fsb4X5KQukWctjNqy5LWdjpGlC\u002B0tFUaZKiz3d6NA9B3W9/clmfPYg0j5WHyM1PVTFgW8lekN2Jh7fr57OxnH6JS83/C\u002Bd/ShyISkM7zGDFE3pGGZhGIwxR9eqhs1YUgvNW/n0/kEkJ4NHs1kaaTbsXJpQ5K4KmQ2iBbRY83daGs4dP5Q4jxUMxPDiGmQyFt6gvSoyB25dwsLsUfiNyzQM7JmL/SqitM2ERCC9KH6ocO/VuDVNKBJgv3zRSz0cf/m71S7Lpxi0/QhcrsJNn5lDQ\u002BEJtxL\u002Bv8SGKz6t0WmPZ8QnAlJQ3MjWIbss8HlPEh/jjQhcE8jmvBZqRXzaBiyfzUb\u002BJp1H82YYM5VX0s9KNhkeykNgM1T8QEU85pdM\u002BxqPjSIzUeuCnJqhRN8zjupGIA5ivDzoP5rxAuVYCg3Oyzd6yESsFuQtmy2ovu90ybJa9caI6T7epk6IQU8FKpGN0ninuMalmgkpNSEOP4CrfTkz/RRHRuL4nCH2I9WVKHGcG\u002Bx2zBDrtFu8XrQdz2bN3cQV0Sx8RoyWrxukrnY0lAyvciSUNLAoR0m5iuct2827KUYQf1ZFH9Rf4B30RwXkiMqnblxBOakU7Ynjw7ulaNNO6YUwIxS1alNPNFOSMwBD1AIchWxwee\u002Bd/JLNYlsZuXdKpl5/tGS28gMJ8gVVgbmJn\u002B65ieNm3W\u002BWkyeB6Aj3NnrbSI2hwx\u002BeZZNpZ4fqR3rYQ8JtXzCU48ju6SE9NAn7EruKeTks6NvPGyNQ/XborEusqKVFitdKR2XEstr9YTCJbVXLYM1BrFvnnUQNROVRBjzWkIxktofkQDLUZzUA0bryxpAhHEx\u002Ba/xJXeySPAN/cqyeJ9CkJLfN5yCbbEUm5syJGn1VMOrwVySPGlibUQMvVPSJYqnpTaLYVDUs4v63I3cgCSGFKkLCrc\u002BrFQleMZUcaxhQnYQin83afNy0xHUm2A==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "aLbVWiVt2Ciml3yEIZiPhA==",
+        "Date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "ETag": "\u00220x8DB42FC764555E7\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e6770f9f-8666-fef3-6954-aaae660de95a",
+        "x-ms-content-crc64": "YNYmxOwik9k=",
+        "x-ms-request-id": "1388c653-301e-0034-54e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:28.6504423Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9/test-blob-7627185f-1e97-30d7-7ea2-e2abe3d9d21f",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-46ecbfc3d12261ed658b422c8fe4f6e8-9c92147dd6bdff10-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b414b902-40fd-7072-ed7c-df8cff7b4bb9",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "wprBz3YPw\u002BPE8l/AIZAXRg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "ETag": "\u00220x8DB42FC7636B20D\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b414b902-40fd-7072-ed7c-df8cff7b4bb9",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1388c6be-301e-0034-31e5-744629000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:28.5544973Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9/test-blob-adf2343f-38b2-d261-29b8-5747a64a36d1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-766cd6497b8c391bf6df5181a4b7cc51-f0ecd4b1879ce443-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "acac68c0-35f8-445c-caa2-903a6eaec273",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9/test-blob-7627185f-1e97-30d7-7ea2-e2abe3d9d21f",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "acac68c0-35f8-445c-caa2-903a6eaec273",
+        "x-ms-error-code": "CannotVerifyCopySource",
+        "x-ms-request-id": "1388c7af-301e-0034-0ee5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003ECannotVerifyCopySource\u003C/Code\u003E\u003CMessage\u003EServer failed to authenticate the request. Please refer to the information in the www-authenticate header.\n",
+        "RequestId:1388c7af-301e-0034-0ee5-744629000000\n",
+        "Time:2023-04-22T06:40:29.1942414Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9/test-blob-adf2343f-38b2-d261-29b8-5747a64a36d1",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b13a9f177e8897a537bd105073336d9a-e30e7d8682c904f3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "96ccd7c6-9fcf-96c0-2273-31e36b30e425",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "96ccd7c6-9fcf-96c0-2273-31e36b30e425",
+        "x-ms-delete-type-permanent": "false",
+        "x-ms-request-id": "1388c7eb-301e-0034-49e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-7aee08c6-ca55-5571-333d-5b9f6bff2ff9?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-35876c256739b5f54b9cf616d6a1983c-8ce141b8b0779d12-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c556bbdd-2b35-d9aa-79a4-eb294189410e",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c556bbdd-2b35-d9aa-79a4-eb294189410e",
+        "x-ms-request-id": "1388c8c6-301e-0034-1be5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1985181737",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerWithSasAsync.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerWithSasAsync.json
@@ -1,0 +1,218 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-76972af6-ae0c-fe6f-9616-24ebe3abf24f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-72f7368be03191045fb099bacc6351a4-067fe33ca4ba07c3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1289bafc-6323-5907-891c-ae1c3f427c3c",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "ETag": "\u00220x8DB42FC74CEF59E\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1289bafc-6323-5907-891c-ae1c3f427c3c",
+        "x-ms-request-id": "1388bfcf-301e-0034-36e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-76972af6-ae0c-fe6f-9616-24ebe3abf24f/test-blob-4061d8f5-9c36-7ba1-c8f0-6f2d825a2c98",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-7a85e6ce5774075da93b79189d9c41f9-aa39f7a293e9502e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e2620980-ae71-835e-60d1-f60e879c4ea9",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "6oz8YlS7NqiWX5v4qOGR6kVYMcjQGnWMeP2t/J8lwmLBt9Rd4EjBQYPhe8THD7Gni8PX5hC0a88Xb\u002BlXDjoIcZ04NvENNAr8l\u002B9E7p6wxGhLBXHbTdtSDUsERnBfajNJ2AkmjtnAmla5208gb30xZqqACwjILSTB5imlCO6ZnSy8\u002BxWVijaPi2saInKLMZ3O09/G3l4qgKvlZaevGpJoID0iZHNnm9x08YCdrgqxNbWL1zQO077OkXtpsCSO33DYsQI0aM0pZjgDUe3djdGhMy/yI0NeWUx\u002BVNL4/eu35hEPxPwHfM3oYXH7CoHR8QSpyHz1nLsteli1thT6MWhMTGvczcnVmbZiCcLRYk/LrWLOTjVuwkpV4kmkUsa47TAIr74W9SM61C7Fk5L5WxgJ6gixLOIy3okhhut/MEfwqRyRybOQtbc/k3kHqC\u002B4W4Yxm2i\u002BBsBN1dE09G44u6Tn1el1aJJkeDVQcploKzVaaSpkTZXfMqJbRPPiW8BJB9fVH9NFQvP0zCIzbZQm5Kqb2otD020PB6NGGSOfgh10B2vBkwthFSY3cIFyrMQONF9JRoE0BTNqxhgv/yjPVUoFvmUpZVGeOsRlDGPsnFveN\u002BXDVjycQAE3V8zzMhX9Zxo3be5e5c8Oqgy8z/jPfiq8UMdDDP8NaH5j8Q6FqgevZ6VJtS9tgFIVtasw33AJZ9iiN\u002BFOulsbKQRv\u002B/PBif8EDWhThsn6TtB0LlZT3YgNWoo14nMmYKxKLYsq/YRfUyurLNIIteEPp\u002BgR2YwEx0t7YqBpjKaL3qy7CVg90FFLFNoqp7G1BKWpJjuLFYcgRWY/r5rk9seFH04mTKyI0deWxcSx2R\u002BaxV36wGZqAMglmsPy/iC2Zh4SpYdjj7j5IFRk9E/CbmtGpOk96TZhGh\u002BFAbLoldO24F6mnzSXNzalAZ8RBQt5YyxYq1k3eX3nsYpo3o4GEIuBrhTwG883r22zl\u002BeXTxQTC56FkOp6fmbhv\u002B6pL1mon/AUkFf3iEdcIPzrhOGVUGF1VNLwgICgBzCtD1zgjX8TC/j3g7\u002B9HINWKG/tjvqFTG6NM9qHuB9wc4knSXnrfJN813jpns2huDhOmVcRs3g1KMLtU1mljFPYhhA2ltIKaqzbcbaBm66h63uiOB7IXr8Q8SG2/Sg610olEBe8ayJlRC6qNkHBtIwUS2feAlQ0EChQJaSxVGyEoZprW4uX5IBZPPPvHSh9Tz2UobHAXNT28P/ubEV9tPDBJpWnVVgBfWfnhMZgRfMA0tZnHLK7w0TGdWqLqHg63IgDLfeT1vnkkyRK2dcOlqsM7plvFZg\u002BBmJQ4eDtdtTurKg9XRj7bfzcg4iNcOptuN\u002B/frrey8fwxCaVQ/QZ9hxQXCwv0DiSEYGdkpEPsJZ44ikBLvcaD\u002BHhTZjxZioHw4xrPRO9PuemLG04QTk14BOPHGDLF8glNkxLTYKgoatXlc4Fo3OCu6RBWgGK4c6orGyEYUnJPKvERgfHcfBkBovB4atqLz2gDGG7ibzGmlR9o6EWGz9hjVgiQVxsu0q03FR2yP8iPXwv5FXoDbLv/ayySc1OTupMYFRSR\u002B7gM1EWB61nUNFVWmYl5zbqeICmM0OvuXJ8ZY5qKWir0PWNTrAD0QUFh6zbXe5nKWe0YujUrBSrMXnfmqIf/SdpqYpwl5mF5qZ6oKyX1FyDFTsntsd/1yPh4hw2JDdi5omFcrNj9pHNLnxBWQtoFF0dW4Rm\u002BEdf6dJnj7V8T8FuF7oiEWGpHx6qWYdLPn0Xec2/Gcmy/O5BJYng/GfbUd\u002B60kJRRQL7cztmvJ6/FKtUTxXnvDX4vBvL4evYyCK3zgeokGs7xTTLxKaNTD9PgRHei61R85SpwhYnhmMXI6oYru2XF4M/GYnhHPiPam/bfGDZ\u002BT11Zdty/81VFD/QtKH7dJ1SuGqOnnIjb9acGlinSwoDPSlto0kSJBe16gVJEWhXlPbRiMP1S1vLUvUE1uV1rsg1zXZ3jdFUQJNS2LRs2V5uRYVh1cNGDvHOolBTDU4yQDw9FETy3wYkfUgwonOmXniXlpBfFNgF77\u002BEqeuAADNEIJh4L8UafGV/PFd6Fmt\u002BJ0PXvHe90yxjOCSFbTUapHwV64LbLi\u002BzfBoq39eAitlTBoKoqES7hk1sFPeglQ8wZZjbZSroo/gUJD9ck/NU4q1LMWazcvs4WWQ1bho3EucL\u002Bno\u002BpSSuamOJk4QEX/NZFzFJVWSofPKdogzGszTe3BFYUZh5Fj2IncYDKd52M/pw21fo7r2DYn6HoAIY57Yuq7dyrA1b4AD0wLidpFMTJm8SVdjd9e5T1e4a8XU6b7UP1X0nA4bsFftW9C0F5b0qdHmTBpLeUbbJH9ceQe6KulEDjs/V6yPoJUDdhgHATu8w7337p2kjMYPHXuSvzdMMyzrcAlfuVYhWquFRAcu1CNDo7VFxjhPo31xMDY0\u002BOVdt0brH5EuXQpr0pfyH0TC4ElYTxt\u002BBmj0m9CL6oUf7F3CJ5C8R7SOFUKu3fOkWYA4sk/s2KnJ36zZ9oPApnaBS\u002BY2M/u0ApyQyjnY0yh1TEJMUzQ5MxO39Efn5k00zXLIKZYNciWEgLOzWA5z8QyAZKY9cFM\u002BSBjSgjuz0BxPW/zLDKmSa94Yx86AhdcBQAc7Y32q\u002B1kfjd19Ou/t0KyXYAARpOBi8fzEIKiAucJF0T40eHCepGCnq4LMFSzuLvMd7SXS858m2G2A4tqsmtAbN2mxtVg/\u002BL\u002BjbfldltjP1fG1Ysycct2jEaADHcGF9xCysN3HPHWa4fRmM4WhxUGUtQjk9zgDfsSIEqe4ON7\u002BGXboruX7BJl4HoDYOj9X/UhebmS0oQPUrzIZOy3R4qUZZBoSuRpfmaxzaNS7K0CFNBFfWc52RXR3E/\u002Bz4clrqj/bwtIlRUQt/tC4RTQrHYPtkAcYcoTWoyKhm6Uar7vnB8KY32hyX\u002B7NLV75ufxAT/J/wk3CTze3AR\u002Bzh6mjF08Y1UF1jkIbfzAYT0Up2OkiYU\u002Bynu1qILSK4dpMwthBLhoP4OS\u002Byr2wYEMdqf/yjSQ2jSZd7HRhsrCI6qhnzrxb1yEvHfgAZ5aOAjqqTHa0mFCyGjW15z2hqi4wMdwRSJWGwdLew3MsMiWPz\u002B45t2Y50FJXsbSGofPniXPJzDG2eLWlJ4qn2djhheQMJhdTa/LL9mGNvZbg/CPi\u002BzX/YmHz1Vc0lJPflfZ5di/MenvckCF9AdXQJL8iwCdqxOKi4ieCGFC8HtNi7GBrFEdrFIWkAmcUfmCMI6yUEdBsdNEX1pAISl4rHHFOHhV1aQx3t6\u002BhxsJ/imPC9fSgKAkC9nePVz23YsoneOXxxmBPFrqcHFokyrIOmEgsRVRlivRoTyud5hXSwFTlfkncicQDd\u002BM\u002BAAuy3ivFgLr1hxlxve3tiXc0sSykzVwFP0xkMg6EKNF1K4rstXD/1GVa3Tk7c7xb7vxMysKymTKrrZ7fYVKsbVpL/JZnANAGNNjHTfAiyc\u002BMCEMON2IOwpJUQQvSIHcWqm/e83Mp9O4sSpHl70s\u002BhOPTT1UPnjX4OT4EDr/EMBBlsKOEQ9ZYZhdU4ezMJNNHGbgoAtUeCwg15rYxJeYuZBaBgD6rukUJdulBurxJLBRqvPUHnC0/R6WXUl0gKzwtJnnaTqSUn2N3Ho/v3ExP7LahxmTtKsflQjiVEGvn6U\u002BpEJBCcuFv1iGVjIGhU2tVS2GqfmDbP/\u002Bx8QhoA4r3kzFARsu8CXnVMfBDW5pGR/LRP8UGPW7q0dSQjH3VA9Kanf1QXQyjmUHn0Uhsl\u002BRlb60ZmsfB8VHGVXD3L3j//C4hqLmY9ebiMaaHHmgifjnsKyDMv2kO1KirigubqGnI69UaTusuyHnKN2kdPtbpo9s7BwBUL0DFEtQM8WvfSoU4vjKTCDNSwWKrBoQD7ZXVweosYKFpcLiUVTgTHdsN7uzj5ICgVpur5EWdrSS4xSFCOy\u002BBrunj00l1/rb3Q6OLmRubHAkRMWtShHhfy8OX25AWzOarjDwDABU3LlfksKSiFhQNIaUYLQXEMypthAeJ4ici3HK83AjblB/33gcTadPXubGvhrXq/qPc510VlXgNqUgwwdQx5ToLMY2FIFMCsMVWlcpV3l9tO93O3/ivwgKj5jC64qv7odB7oFEoYd5M2jKbvv\u002Btu87sw4n2YwlBX2\u002BK5ToiR9IZWvP53j4KRNYDggHGEAcC8i5hzh8iBT7LNkThnXygLpZgfmALt92Q4n6z9uEHe0toi/MLvHm2\u002B1WxLqf1JKdVY1NvZZWi9z5Q0Oucbg5dx775eRWNlHIYrYcOWok5m73XWpeRlBW1yZS0uuuOFolHV2rk/6\u002BRy8rhUrgSlJyxGzktxRd6yC\u002BpR6\u002BA2N2Gjpb5xwMeUJwORZLIrEFZozT0A6OyXE11zIs7P7f8EO7tXsQhFNGZksqZH4OArh/uT6B6iNk50C5Jh/Z35xDoEjSj31F9OI5nXmzVFTzJ8R5vTPAThYgVs4qV15DbIa\u002B1sQ1O3NLKcRMWFy5oYLrtg5LYCJYc1IisjivK52D5iDi9I2QzfxRLpN/g\u002BW5dqU7PqFQB/xkVmNiEnlKq/4muHIrxr0FWvgB\u002BkGe6P98eUuDY\u002BzsM\u002B4kjp4aLrtzBoKVSMtjja/4NeOpXh26xX1j9Zk9tzgROoST90ge6yxMjuO/CZAkCOubmz4JQuXAebkgpjkSRV9adA5G35Zn2Uq3bM8qC8vdT\u002By9khv6F/eew42O7kTzOkmUZIWR7TlVM8HzQdYWpn3tU2ZcVKMzUGwWqAwI2Or1xCKFlZdGS2KjaG5Z9sYRiC0fkZreltWWUQQZizU9TFrW/Y2zkRDWpxgDuPw06Vml9S/u\u002BUdQJy1c7zSDLLAtdhwTgwlIbfccOPqCyu3pYXeqc4YVTlMTdtZQVqHcQ4pX5jLQIVZQXYc40rBc3VxPY43M2Kk6GCe5ABwi6AdFT\u002BVgKuSrGUARWiYO7Huitpl6EPMkD3rRLc4bFxFKPWV/45LK7KJnlEpNq46DKyusFklyuNcUITB6nw0Wj/Iu1yywjvjo19n3Anyo5mPsTfKifwDX14Sea8JSUF2lQQRYHtRh0qwysz5/e6ZaazrcjkEadBDxVv\u002BYEhM2hoeMUcFoUMePentGf7vCWFveNACHhcIMitzzVsfUybCY/Dym8ynU4hpzTRPFxARlPv6jue4SrwDFf8bkdQoPqrC6vXOPG2UyCUH2FDi\u002BNsbIjhfZMQ/Sdk0r0XNi8H0AY5JTGwaQ5hOJYbCcLJrIFzjwK/biJnmg6Dc2UznxzwjU5aCmWyuwN6gET89PNlmiY8o6YsSGLk0osiLPaoLZl6K3xzb6IcwdT\u002BRO7eaqUbHtg\u002B9/t2w0XsdjfZj44N0VKrgsl28iuEIOHSLgNzBWjlBw4daTWdBGc3h/hrQjFF8XKbM\u002BfcpCysutcZo5VBeHHO9IiA7w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "yW40jHNdi\u002B9Ap3s0xdTYCg==",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "ETag": "\u00220x8DB42FC74DB9AAC\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e2620980-ae71-835e-60d1-f60e879c4ea9",
+        "x-ms-content-crc64": "42g4bg91czw=",
+        "x-ms-request-id": "1388bffd-301e-0034-63e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:26.2797996Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-76972af6-ae0c-fe6f-9616-24ebe3abf24f/test-blob-7e0a01c5-6926-6579-c078-a1f9691658b0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-8a97d1a14c3b4ba35b761858992693cf-672e4e90d66462a8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c7ca2102-6386-6b64-1f5d-75cf8eb9580b",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "oJ9O6iWdfbm\u002BiR2QSFyrfI8HyDuGWasWkP0h\u002BQxkGkp5Rm3oTWODJ4NRwJxM6B1kzCVqYk4cKkfzN1ooe4SsWm/SFwLvwy8rg6C3NJkPyafgvSzn\u002Brf8XBsm9RYJWqz/pWYtetAadAn2Pt\u002BuZfWt422ySL1YxGC31bvmyM4YIijzuI8z4k/WxUgj8bvYTvYmeBGoVhLup\u002BEGdaQUM6w63Ru2uq1megEe24J0NNKk34fFwFC9cMwWBBCtLW2qwpGc6BSfIpRJwP4PiXqPeXIOYZUdT3NbfWxPoLWcuE2UdBnx2Ey9Bb3ze/9RredRhoqen8vXjXIeQGqoT4HerQiwehVgnqEmUVzYKtRzCtCF/hkq/RmBvean05fiFbU7FM73oDLR8ejpeE1v/mKdqjaZI1Fns6/uL70uuMsKQzumnRUGfGmdswwxQYXLEr\u002BECilgSPFj02EeCHF1ozgd3jQRyGFNly3N/HBENnEpIxz9qq6iqftJQsmz53P3KA/UFGJRuUleNnL7k0yBH53v9OVUd/mJejU4x4WXma\u002B61dNgcCEP2GrSn3Q7pxWvyCMrw/KNorAWS5ktGPHExpzDQL54IK984Bx7gdiETdMfif9ibNW8LDIiSiSH4b94DtjXeGZXN6d0r\u002BPWEiHYkf3GDY/xYVrGBhOLVdaK9P5cAnP/rdVsyFJY7b3y5hoRSbgnwdQwh6x\u002BEHFTy\u002BHQ6brkeRCu2eQoWUU8mXSd0yD5egseYzMqK3rGgZxjGfxxhwMCDmwJY3DU/meP8\u002B044D1QWlHVsoaGuk2V51dHxEBIyxJwmsW07xebSWTLmjiNjaBfE76rm9R9fFQec3sYjDonRyfbyEV3nGs5Omgiuh8VCFq26LGBnDA98h5xlXucgr0qpFMQscRb53ZTcWFsW8E1CWsgYaSIpar3ntUnBgbvnber9xbLBVeVWwA6LivO0JddO4wQeyAYof6pGBLvM\u002BFwZNOqwGOqaQQTigWkTnd\u002BKM09ysp63iKWk1YYIexEpigfyspXJBA0stGI/PAadFOHKu9FsWkW9YWxEy0NkkgXz\u002BTdhYStJwS9CRf48uExfB8Dkff8//W\u002BCNREpRHiJyCJcC0MPe7O2QPrh6dSHQOjgJcOCgFRG9DuH3yvaILz2\u002BL2b4G0JT4wNLf0EHdNbOvRoCV60x0fOFRdHR5yH3CA\u002BKzFW66C71pY3tVKXApYoLKQ3shceAfF1zYsVwcgvRVGcxjKiBA9T7HKIfVH1NtJBHxr4UCoJH\u002Bl/4N3VZhTNyDAA\u002BnyjhiiU48XkVYRfQJa4lKKtdvUnk6YJYiMxfkZd\u002BrVhtHyV3ZkyI6xkZIok4GBHXJFyIJE7GWbWWiPFY2V/RpsO/cxaIvcJuxNIgy7cJEHC6iG065nkZprVv0N1LIBG5N4u1eKT7TnaKKW98lY3\u002BnXiArkDiprBapcxRGNz1E5SwZ5Q7Q5fLvzn2sL0ZnQEncUNkyoHQxpDLatLYqjWZhRXavD35s0nQxO8G\u002B\u002BYDQRjLKZeZkEkC75Dzf\u002BjE4xUEXSunTtDTLc35hAWiydqqyCnKHXCeD/TMx9ydBkNhC9HKAq7KW/I39/vZkAxDYBXGWLe/CsWkZk026ncENid6mHgj2Lc74GwngiV0tH/oeVe21r2bogEMJZxRg3GLM7HEbveEL5dummhLl3igL7HdTmEvTW957vZ3F7Mq2lzqrF5zoFV4ZFnAWDxFQAqIa/XqhEUQa/ZCWnABDQfUM7ALYPsaLI9cVOoHXuUjNK7r/qvNMFYX2kBoIVXVd1dR7CSMOe8fbj92ji9rCQ0BHyXRFR5cFwNZ85a6sgspdu2StWLApvq/3IBsRqI2vMEzVwIwBFI49dURIkZIVLw0TQcx2EOaQHgrEUiN78BRI0bFh1sI\u002BXKbWc\u002Bdr4S0Z3fUOAma9OR9mRaaBOMJqwYEz/7/gt1hO0OUpn6EDKDzdqnQuafGtj5iR\u002B40buSfga65mN\u002BFtOSacwy2Bk5l6Yxlpp45KPFeThnAnTr/LMxu9STP2nPBbbHFRjarAK/v/F5RzshGVli9W0q1tSepm1YwVwEpph8YlDjsc\u002BK6sz150KDcnV4EGK7MEn8pG7iaG6rgarmexlZPOSqfaeJ2AqgdS9R23Q34PE5iXZOv/4iAUmhHykiD2xpKnVQjdK68Vg/HG8/UEz6s\u002BC57PGjCn0miDxeKLjhviWDKPE\u002Bp1MefpgeD2OO4rD8pqtIaGK6hh/4agWWHMifXZ4JvGeb\u002B8xNm24ZhTsZl6WLYYINWRXDCGKRBn0NiCHPfrGFRWYJYKqe\u002Bs00oQEkntJfyrtGUcSIRrQEyrWPP9MMCgZJVBI/ggDXbp4IjmchbKdq7f1miSztPT7yBFY1D7s56Fb62wrAIEi6buNmf7gM454OJFIV5YEZnFbTTb2q4l7jDuXQJpFcqo107BoJRv1GpSD35utpJALV4X7z7NLLD4yEgzCSfL0MsbnEoPlnEBWZjOhc8vuzeiri\u002BkUSqP26qdyNRMOMtGhj63VxZEMJrtEpGmAqbhyQ0QjF70J3\u002Bgi8CfccmYsRzNhAOMeGQhWn2Ut0KU6dkDuAPLP6hsUmLDEstVqL7NVGFw1HqnVUyo8zHdX2w5C6Hnm7nJ0XV0XTWczWWYy7HCy2LdIBFiXGKzHkh6jvbyhgslbg0BA4br/HtFBovrECd8HpANW\u002BeQhT9XGrco/c5Crkded12kvcff9SeWGVXayAok\u002BnBi5SojkOjNqejTvwKpBlhAiJjJ12DMMWbD\u002BmvpfFKpBANd48kdPuJ02xPfCDYg7Rb9mj9xXyMPkrPDX5p85C2WKrr/TyaTJ0m6UPxQ7SUwnw1Q7\u002BITN6jgTk0VWd9L9/LiSOF/JZ3wanb1uwoivqWOksCJK/hPgvMSGvzZecluclkNbqRDtXlvYIFvHXyewY\u002Bnhscevs/6lsXyaQqdGuyph0StFVABSt1LHcd63GVyc1lxMfMGU7ONEtveUUhuzkmQwZY37ag/pj/l150Ef7Zgf/WxL\u002BT9pzeVIAJ0IvWU2E996hrPOoWtMY\u002B3HHgShJMhfdVSvZ5glx5eos2px4NGUPtRipWfkUFwA/5ZRoq7gp9vVqUgQh6tHVL8bJu0B2oIcMuAwP39geiT3rmgB0yTpyAyOnDeIg7coG1CnySpu/yUTNXDOr2dcdC8jGNhDRYGaMl3hcj5Lk64oCCQuuLD6iK9C7Z60GhmkMicIZWvf5dXPDZfMjYznyKLBpadDLrt\u002BKZAoAFfi5RdEPUAWQy5DSSNOXqsZLfsjWyX883VxYANriTvat\u002BR\u002B7Sd/iE9L0IVzflyE9dAQZfuUBaQy5vKi0t09q7nyaJI\u002B0HCDmaWs14ugiHUZ7WozWyQ/RrJASwY13bVxDiTLgRXJRSVfjMtW6C0Ykl19ieRyCVCUsiHg/YRpTrvvOshm1AdfT6dF085Z6V6EJ7mpt1TQ/wTUNs7z6Ueg9T4PZq1lsb1WHjk9LDaCO8nDW9bKwJZnHjvDkp44a2Vfpd6PSYKxH3X8Upkak9LOUvoEMI5x1TSoqEdyoR8eHrLU3YdX8vJHEjxgzm78TIto9ECjNDrX7s\u002Bp56A6Pn1W3TTmRrZKdl8IvR5REAfGq1y8Ca3fe\u002Bp3/e\u002B4rgtSDNO/CvA6FQbUHn7gm3Ychd3H4ztEfjXQdmJKbkjHkchUtbFLkgUXjJVV5\u002Bov/t9zW3cR8cvPDo6e75SN76e9DYy1jOXF0fPYr1am7pZKoXiC1hPRtaD8hKcjrKJxipzumNpeeXL6roqEOUF0KB/3U00cChmT7FfsuQc9oiRQZiW6uFa87CgFiCiITXxeh1uHK1hVVX\u002BCWquCcb9qvAxmM9IcunDJO2clFoLxC5/bjTGrtXfL\u002BxCmN16qOnpom8wbIRmpQs3rvu/xLz/8kU4MpuSOvgaVmzfBdYISHgHtvXu21emFMUpkwPeH2szRqaYPnpOW2tzFhobi58xL2Z/uA3HERrxkhnWZKv4ODcFr8MzcA4BuVuOf8E9jo0l\u002BGOZXmdZbDWLqqhcd/bDdtnjFdvcAbtYfgK2OJVVsAeMrGxEXt3TqEOJp8lhoUFkzwTnXnSxSfakQOBkozOgMfag08uKexf8D2mYUlnx9tzBTWmMclWS22Z1nBn5bwUP6XHSvNF13lPs608LGPeYsk4Hp1XKF8OhEfRlEN76AqBgjGjkIzYLS3MVn4cGh8Ju2OnP9cuzRdWyMa7dEM109uSupoiOtJMX\u002BFvmsHQ4moox9jfxLgjUsUqXNe2LLjahoKiiW9054CRWt/1vzJFddZsgqx6Vh8jb1fVB\u002B36hjMohQQ/PmkKs\u002BBYTmnYPaOS1OcBWaocYDBzfxoHr9\u002BiltSszSo\u002BBjdtYd7MEhelSyG0QjMG\u002BTyZHCTDy79O8wQAtaeVK2B5ZM6vk/fLQE4YzjPoU22sq62oE7EFakp4Lm7Ku2xwAC/BSu1kV2U0zcvWqv2LVp\u002BmZBn5/Qe/Y/qEJ2WJAJTRqL4EJxiASEQ4Y1XlPr9M/MffJFdSdhMYAdbi0C//q8029QI/hy\u002BHFivFwYmxyjVLRzqdudxNjzKq/BUxrWgUOMeIrjm9DXWYSA4rnLSZVkehl5j1YeHw\u002BXXPlJsaVXizsYjCORv7nknE9XHOEfKOEZXdgAXfHtbVl7Sz7WjajfKVd9s7xy0rpglfIGxwIteDQYL1PNVi1JKh7JFnR6DQ6nePOKoXUkp4sdoMj/56ZWTdIJvl5UEdIpNIieqLtG5YfkXk8Po9e/9IjIr7ZlSkJ3csihcU6wUmYhYGzshf/P17tAGolXR6n7SsrWjGIbxOpGJzXypHQ4NAzp7kJq026I\u002BNj7JC\u002B5ICsepiaE2cYDBZyCpl3K3DJHB\u002BZ9bllnkHdbTZOKIJ\u002B6jAcK1P1NtFpF5eim5ywQvhultBxJPLLRtxavKIsyeeT8yBlWvwg1\u002BVOLN4hxwKhKSo545GyDcFBVOBznnovOE2wDqR8Tuv4TcLrJvgUpYPZtZN39upV4eVfJAYfsTVrHvCMcbReJN5CQZHSxurJLK9gleTqu0VnXiy/HSrl3JyJgAQHhDfLf5C1NbFUgx7\u002BkftWuxtMgGerKReLowe3XGD1RUbixaR7mRpUMYGQDtsNwIszjyWBOP\u002BgWFsgQ9yI/dlQXz3YG8xS3yH8\u002BE7iGxo8ed54h9E/dAhHQmlJV1k9yzeoQ7OZNaS63KwHhECsvkFA58X\u002BDHoEEOs1kNlnBYvEvy0bOddqo0Q5wachN\u002B/LloAkCHOTQ765oC7IY6DLV9skPsUTlYRt1kB9wE7W4tz7bf5VPvkUNX9yYZWkoj\u002BncmnP/PkqtAD/ujIzFYNv5r1RzPWmdhjeEAlJoTfuxTQA1lHhBuXj0LX5VYDG4R/4AnrUVtFKAPxQ7ezz3RLNEPT\u002BMj8xjt/bcfw/qRyUFy7pTZ65GnJmutVRkBT47/OjKESLyLLgynea/ODVClffvNq\u002BCo90F/g==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ysJjX5EGv4AlCn0Kds2YAQ==",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "ETag": "\u00220x8DB42FC74E8B81B\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c7ca2102-6386-6b64-1f5d-75cf8eb9580b",
+        "x-ms-content-crc64": "Yj/fLG2vArY=",
+        "x-ms-request-id": "1388c034-301e-0034-19e5-744629000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:26.3657499Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-76972af6-ae0c-fe6f-9616-24ebe3abf24f/test-blob-4061d8f5-9c36-7ba1-c8f0-6f2d825a2c98?sv=2022-11-02\u0026st=2023-04-22T05%3A40%3A26Z\u0026se=2023-04-22T07%3A40%3A26Z\u0026sr=b\u0026sp=racwd\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-b2328d9574486caa7ea1b52d1b6b0a7a-ac630d1025570e25-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "82801022-3d12-3e77-4172-ba1a89e229e6",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "yW40jHNdi\u002B9Ap3s0xdTYCg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:25 GMT",
+        "ETag": "\u00220x8DB42FC74DB9AAC\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "82801022-3d12-3e77-4172-ba1a89e229e6",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1388c059-301e-0034-3ce5-744629000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:26.2797996Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-76972af6-ae0c-fe6f-9616-24ebe3abf24f/test-blob-7e0a01c5-6926-6579-c078-a1f9691658b0?sv=2022-11-02\u0026st=2023-04-22T05%3A40%3A26Z\u0026se=2023-04-22T07%3A40%3A26Z\u0026sr=b\u0026sp=racwd\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-94b9a90b9ca4d1372c906299e7309ea6-c8dffefd5e24797f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7dac889a-d639-87f9-9c42-0bdb23a01451",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-76972af6-ae0c-fe6f-9616-24ebe3abf24f/test-blob-4061d8f5-9c36-7ba1-c8f0-6f2d825a2c98?sv=2022-11-02\u0026st=2023-04-22T05%3A40%3A26Z\u0026se=2023-04-22T07%3A40%3A26Z\u0026sr=b\u0026sp=racwd\u0026sig=Sanitized",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "220",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7dac889a-d639-87f9-9c42-0bdb23a01451",
+        "x-ms-error-code": "BlobAlreadyExists",
+        "x-ms-request-id": "1388c17f-301e-0034-48e5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified blob already exists.\n",
+        "RequestId:1388c17f-301e-0034-48e5-744629000000\n",
+        "Time:2023-04-22T06:40:26.8275758Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-76972af6-ae0c-fe6f-9616-24ebe3abf24f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c64343947b95f68f4feddcad31b81ffd-6d857656943299ac-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "007f1022-ac36-53ad-21d2-853ebb7500c5",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "007f1022-ac36-53ad-21d2-853ebb7500c5",
+        "x-ms-request-id": "1388c1b7-301e-0034-7ee5-744629000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2023-04-21T23:40:26.4567611-07:00",
+    "RandomSeed": "379955760",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerWithSasAsyncAsync.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferCheckpointerTests/CheckpointerWithSasAsyncAsync.json
@@ -1,0 +1,218 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-dfc89d90-21cc-3983-6ff2-07a3aa085d2a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d396d1af9fa50652d7a9e123a4763dde-54625739f976ebca-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4a5329ed-de81-e000-dde8-d9008dbcea36",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:42 GMT",
+        "ETag": "\u00220x8DB42FC7EEA2957\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4a5329ed-de81-e000-dde8-d9008dbcea36",
+        "x-ms-request-id": "245d4e3a-d01e-0003-78e5-749485000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-dfc89d90-21cc-3983-6ff2-07a3aa085d2a/test-blob-d027c87f-b099-dfbf-06cb-94c74e3893fc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-c7d7101b316b8f72bea88dff952c8731-17debe1f4c77b7e9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "87f7debe-8969-a874-0fc7-b1aa05915932",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "XwtRuFXtUji3h8xStfl3uTUz2iTkSHtz8NKR7m0QEkZbw2Zc\u002B90L/9cbkvkRrirjcSDLWeLGUReQ3siCW2TKpnSF9/GTGr5XJ9pNybWBYUKnrn1NRbhklXJPzBwViKNyUeuFi7c4UFdiczIIeIhhD3yF2q3mfWG8IWF/RE2hQp432njJ/NWLbl0m69GGXB3p7r2gj631jNSKyGpVuAwJwTGT0Z0PlxKm\u002BmxPwJGPNcVEllWPALLwQU6kPzNrNbZRHCmg84t/2Vaq\u002BZVBpctC\u002BpOkECK2ecB\u002Boo9Pa1jfO8S2/qRn7kI6xbz/5AcdrpuDYkSgxiSTm6JpIlD7L27\u002By77Qi6cn2gtQaktmtpS4YfP0zAkTP3SfImMB/szyPpVOARlJTCPzXIg5T1zZLeQNscBcBmNl6otJMWlDJds/Xiu1F7V7bxXQAG\u002BB2vAXxvV/800LlTgy6RaN/xu5rzas\u002BvAwIxUukkGrjAXz5BCbMWpzxDGOM8nzgy6e7W/5FlE51OD/5qPfUGELXwkyPgUG8s6wResEHcYnPZ/mj6TSsXW0ug8wnErHlHTQg9O/wEUpmPuhSdBmNLcZ16kD\u002BMC8OK2UfoT21lWD6LF2NJnzaH1avfapMWikToVXFsWhw5uzE0slK0LBM8KlHWAe7/8eJm4sqTvJEwZF7zD\u002Bnr\u002BQ4SUWwyBOzTw6mIo0AxMHhV6GOfBWdRpf6QBE4DsSw5QDFTs7CCvfz1gx8RCxlQ/yPWnReGTPOWwKttkgCe0AKNX1Me3XzH0ypmmXJIMJrlPxUaLSQEsvM9zPMFFRv8ZrMMg6u2QhGnHsntH7OBTpAQiGLrdLLueKxf0RCJsr4eejK/O6zvLvzzYw5aJ5NPrH5i9Jy5APIALhsPZnDxLVwL3pWAwgLjIVl1\u002BAGklFEJACSSJs4hVXkwvx2R78h78kWyTlkNzup7f9NDQxjgW4m59lZMbvad6nksQBLlQTGA\u002BfW78kX4CzFKJqbq7gJgUGOT1/liP5NfFGPf4Y7Xhj6RslkTJGkzwfsVAjhPovxmu\u002B\u002BvUWlILrpibN3SGCmycpB4WTu5TSv6UBYOTT1bD3F3aSWfKDTVWYOesMeLYanRYp\u002Bn11nAvW7DtPFDSeGNB21sar70E0prkv\u002BoGpxkfv58LOqtsygXpru223Mzgh\u002BiEalqLvb63U9FTDRaGJLSb0YC1x0G71Q1RLQDPUfXKBDv9gjy\u002Bl/3gV\u002BbWHbjvY4Y5Hw9MLsCqzJFJNoy55/3bhQjeiKZ32TmC0W9a4btUZcl6ljbqfdV7VrWrdV1tJm/k/pSsENrfwUHRyV1RU\u002BrZ9NDHQ1HK7Qs3ZzHwzGPcFa8DceMmpFTuntDxGLR4JgbKzYCMqeceHg2JeKmo7vTd8bOyTd4Ht0x/1KB81dRWuz0vKf7jT2vH5VfVmS\u002BrRbPcFycAydgkwxo0ENVCnUQ5Nr1oecT1/qZL6miGMh4g0I7wnMKtUfFlCmbkrz6WhUQPnGJuPs/q6hSAuN9vopD4EzxKTfyFi\u002BDMB3NeEVNntWUgdpW7tpG/BbaqKJkR9WfV6Jv\u002BSDdHihB9ojtcjNTFHQd6Syv7PFyqi0RJ22NLug4LhCS3ZWkt3OyBPhBWXnjd5Q\u002BVm6o72qg7U7zy/a6xNeQtVQSwDbeaSG4/dgJIVCzPa/ZTsiJjz618eBGoPt890AQsKQlwLddX/08//GCl8v\u002BQJ5G0XYfByYVbM5Gh8g2PAaX\u002BHCsjWz4i/7bXJ9NI1okSFBtNhXaAbmOAFPpBsgk9rP6\u002Bq9bUcMhXlWHQ6qW2El0Ik9n2QXgvea3Ln0JD3UmpmXbUii62PadO9fAUs4O5ygadOSIzS2\u002BCky4lDNGKF7QUJ1Ey4YQyUlI2p0\u002BEGsouDdE7oqQndk4HUfr8kTDRxN4//Iguiuh\u002BburT\u002BKAj/nRn9v78TnUT8K0HK5ONMcEhYOJtRBpCA4LovTO9V32p51OClJ4x0XppLAvbJ2NU8TklrpvBtrZeIfN8E41BUp0zWUQ8Cp0m849kABgOatwjl8v2l6Th5DCdJHaqscHpJ9lup84fGOqcArsIWbKeT7sXXH/FTr70TXETouYmeD3NftxCn8MSAHrhVpDp2Yp\u002BAtS7l1VCI9kadlZZC3YAdYp5Ot7SX6/0BVgA4/QuCnfmlaANbuToj1sDJClstPkE3N0KbKKvq6Mkx435PUPk7G/icnXV9wqhkKuD0zeGh0xi/AcXI5nROun86KtW71IbHje5jkaDMunWZN/3K9hrnjxBmkE4zczSDTeP1Q5jTqFZaLEDyPkF380dQLq93g8NkUpvFVUM3kxq630O91nfcxo\u002BmcMra9FDO7pwH40SEDMofkPD9DVISIpkmN179uhzPc2gg0BL5il1K92enMLDWNtN5nUWG37g8k04wtLzy0DOAN3DbZDy3JgaSshbra/HpUAGKhBzWSZOv4zzDyNagWCYzJvg/\u002BtKXwXY/8y2iUShcR2O7Z0wWqe7cLID/9F4w8Vrwt0T5qVUv88Kml1VmDZIUZ4By5fDaHH0JY85Rl80YDwLSsprjY54Ni3OJcBGZdh/u64zdvQxpFZrH70WH3Vv0jYhTk1r4MQPhZFl9UKxrcOyvY6xAOlH1aZz/G3NYha4XleKJRuPE9bqJ/Fiy7MXuW39Z2HqvtFM3XSm\u002B\u002BBWQid6rZbvJ4ikJ6m3ytz74Q3zWEb/0/60zaOCPUum5Bv2k\u002BHN6BocKJXlVUO0MvPwUPhqt5\u002BdVm4kxd/zaOZBAT\u002BRwTb7Lfjz1zOxGn6\u002B/JqvkehPPDB4VT1zpSI6KMOvpFAAJnG49Sb/dtxv7DvzaclBQ9b98cUPGWv5h4TatapsAXYqvtoo8pjFT8VQDGkBgD9Y9OTosbaK8QkFw22eJMEx/\u002BrFyK7zGFE6OKIDvw0C\u002BAdJfbzBh1O/n8nNIzMvJysAHgyCO7eMZdyXrnkQizH8BsdmUKcEbHSXCijhJfUeDxF6/5z8gMBTuRvcLdTarxSXzRxrxNKD/62b6zGKr0PrdZ9nmY\u002BVA4YHFpePJEKjuFsUSVjYtkpC\u002Bv/zYJWSxQ3X9LQ1dxWFAsmWYLI68Ntq9C7WdmXrEsNVJKKPpZ7sdFGJuy\u002BOakVFj0aPQlGYBAYkhGxquFKn6OXw4FJy\u002BV0qpexcrTmr3I3ljOcjW8xxvRyYZyEyhb/\u002B5c5JmYn20pHpZJhlO1bMfKfegStvhJEVgyMx2pY/9BwwYctrXkMH8r5ROfcwDIXJz\u002BZ5VASQk2E9MBpmxPv/qXB4MNWPYSJg2pJtGk6Z4XKdZAqvwqAbn85mLioonSnCUYyGu9usPm7EFH12J3kWo06nyVzxT\u002BbMYJELJTL0ODlkqsS\u002BFyma8Smf664mpXhVU4rfgNfI0QWltltGpRU709xADXiwVIghDNg3VWA4qbsYsdGoFLdlm9nDFGDSUEwQYBvN4pQDpP8Cunf/lX\u002BhbQicLfNHk7sk3nGi7TwrUriMIvFIassjFQzWpV5DagZaHatYNiZYzNBgqQQmYLe\u002B12u7c3aOVQJBeRTmcOpY5XRvRNOU0xiWM1Ic68HC/LRVF832h/qTz8SlFrkNdl/mB8OTtxvkKgRPJTwgbW08fnxgjVkYZl1933kK77hjhLj2Nuf\u002BM0mccO3Jp166c15bZJg4rOkCzZ1iEdee2TpP66CDKjaJQks2xBhrUr8Cw2war4scJtvT82lGmB1x/Ze3eb\u002B\u002BN0UrziZRBeTMl37iY1JrgCmzM8DErzrNRqYpxMaEt9UDQIwq8uFgzyDzB1vuYDjPBnlqBEn6\u002BYQOXouAJ0EiS\u002BOl4x7CQJFITmCj0ave4uJpWr5NGrOPBEsEGJRV3Kff0L94RIEaCMXoHbXlWyfcL3\u002BpFsyG1S0sGtrXvif89nG8wADsZppdU030YPj9paknK\u002B0YrMXbWP\u002BOSCmmRk6h6ytAKJsi78jhS8d\u002BjnA0MnEtrJI65Emr5WcFXhpstw0DVnnRuX0SADggN2ECXM6PWhW0dJW4awbhmEMwHZGucJC2ezv6Znj0H6haFqzkpYSYegQEtD53Ru9y7B053eaqccbQT\u002BGSkPeYwFjpYlBZ/PK6m6eJqbhSPzBIh3Zfuj3Fr6DmEFmnBeUQa/fljeSbFPMuf0ZDHMgKfgytRgmBPQYbJ7Kvc\u002BiVF5HCeT3EbLFPsXKDMTr7go7Y25JM9b/bjy7tymYx66EKlWuwgKeKRhFbYZSa/gvPI6Ej1phWSCHV5uoO1qJPGcXReJvTSwHrTpWA8ZAnPJEjIqrBDhUIsE1J3pm5e29vDEfOyYVv\u002B9ifNIQC1VaNrqpY67f7iguwxMROiWhoMdMmEeFMVHcLsybOIdWNBd72uC/zXI\u002B7d4Y4HgC9IXJsNwa03MNxQVYzTTiRKWQyJ77pV808eNFDbp5fEDpyTpGwYe7S2CUfgXrZvBNXJkoeBfpF18mlM74xcXIlFjEbwQKm3Md5Y0\u002BVydJSYrjB7ERQPQpALHbIDzIsoWq2\u002Bm9Jvf8MsEmCoKaurAn3Us0Bb4Ep0NUq25CL3s2VSMHk4tNnCKS9sTv\u002BzZxjkYBo0LxlLzHliSWaIuJqhNF77Vvkyck6kEokQ7pJLwc4x0YQIw4RMB2P/1WtyOXCVyxqgtxEesu3MkByPOt3nFoeYVuYVmXHark6WMp3iMdgZeyN4qgm9Ex\u002BXOzNnvcyFGL7j2uOJgDKoxgnCiIBQ6l5Edb\u002B6b2x\u002B20PHfV0\u002BcvGCEBne/lb1j/vwz\u002BQA\u002BoqeR1HUI0cNy6lSZf\u002BfwQLUaVQXQHhncesHTubDyp\u002BHfeC5KTYMak\u002BpdERvi5hWVc34G2aQ6boSN9ZlzNRhSQEKyugf5pjMyP8Ebcsz\u002BOVTsfgYyq4495Qmp/Jfp516SCtDZMGvN281LFNni3vu3j/wEhvbSX5S0dJU\u002BT\u002BlbCFhiiWg75Mko3mJ4p5b0WwZN8izb5SCnv\u002Bs8JLuWz4wj8AxBgFVTu6ry26hUmbg9wBmO8F28vyM3\u002Bsm8/4ANUc7WVLeKctrw\u002BnZB6Ml4EuYzPmSiCB8uZ3DpScVL1rvqpUnZvkUAs00\u002B3fYnepYZv6fjiYFbq0nvp\u002B0GoSkVZSO6VwN/nlShMosXY2ooxyyaj4odaEz6jzoAKdZX\u002BdJkKXjSrOOS2eFTQpc2BAgfhuDArBFfN/zWv8gJf7R\u002BCTj4sznxVloJB/WoyiW1xErx4GM1l03AxTF8PCzbSVps1XlePZDOLjBGt2Qbti3XILt9F58RSLHq9\u002B4ItVptbb5bfDSsV4b547Jyrt/ppQ7DZRtxnnH7G0zHc0WixbjWGUmlgDo5Koj0QzPs3pmRwRKfBRA\u002B\u002B49MoGCn5SRBFx35XJVWQ\u002BUUynpSfRt\u002BDjzzNXIzA4Col136WR/ZkQWksywV84IEe71tinrV7H60DlIj9O\u002ByThNdUIU3nCrFO3k07cnvKBq6rrn0xbkFkurfRgqN9ZxV8iUYuGL8zJ9SaE8B4P50hOZ3aQY1w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "sc0vw9/YDi\u002B9UVTiqpupUw==",
+        "Date": "Sat, 22 Apr 2023 06:40:42 GMT",
+        "ETag": "\u00220x8DB42FC7F310813\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "87f7debe-8969-a874-0fc7-b1aa05915932",
+        "x-ms-content-crc64": "DcTPWpqyuvM=",
+        "x-ms-request-id": "245d4f34-d01e-0003-5ee5-749485000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:43.6168723Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-dfc89d90-21cc-3983-6ff2-07a3aa085d2a/test-blob-72d27f58-82f9-8a95-d126-c9c52694070b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-aaac9d7d1f7a6a951399e9f08b268e7a-0c30f29d424bddbb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f71d4dbc-1eb0-cbe5-6177-829b0fb8ada6",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": "P7na/62QbmytwE8vt7ZS7oLjGvwbIGA8SWy2Q7\u002BvgXrApmtLt1qExxFmxDgzZdIb09tCQnoL7x5ZnrVA2iqt/j/UbxFLBjcnXlLqtVwnCOOZm2/kbD4AtbdM8hmlRO3muMX5X/bBz8yjGuMoIDnCMZXRpz\u002B7yZIA1LlZ/xQeghpkA/2WLant18ujQFJb15R9icGD05yuK\u002B8z\u002BYo8aNC4hZjIwx08KwPs5M9zGIhApfwl3HVTmq59ttcNYzQesG/76rq6khN3QV69lu/NOhNn8lSOF4xaZevpSw1FLsfPzjRfdy3NhhPorpoXlQO/sHvEpnDgj5njoIXP0EcGMhKW7si6bcLmmWxBpWnxQ8/nKpqSgYhX7j6bfNeo/rXL4nuHgac7BEK43Q0Dn\u002Bov8l2156asc7GKP/\u002BKH/HrPpq3dcPtacInrCVY2qN6U09Ua4p68hYPH27K/EKoseRRzJ9zTCknQoibjjuAVJkNEOuvNbRncUuDp1VUIm1/f/tABw0DBwYlLSgB3mTbjsrVvOxW\u002BHsw6VtU76TU0yAbGw4/P02MCgjliQiLZZLnpxmLf2WAKYaAEB2yrxdhUVoH5sNVnE59SLLjcW9ypIPIbEeLSFO7mvKIvy8w2lvwgziuhH/PkgvKDTaynbgXDWuZ6ULQ1ggGS0zRzNwfTW5W8u02xCAE\u002Bdk8wDsdCP05cbLElvAYIK0vqDgz/cUvq8DHXKrK4ElKlPBokxXN6ENOl1sqWrZ9PdE/Bxvo0fsUDRV7VaxTb5FoeQIAsIyYYr/05GZqBFAJSh7YitgtYcL0VIb/UpOX\u002ByjKweC0fY1Fp6Vb8\u002B2UqgjEcQuNeuS4Oxg/C1sGmA8sXeg\u002Bn0NwVMyRk\u002BMz0W7VX6p\u002BOuCHCoBDEYbIdXIxPw\u002BVL5YEVgrEVBw\u002B\u002B\u002BcBhWmpaquxh10upVNo\u002Bo69p99aYFTUnaLY0AmguebESA6ZQowcHgrGgLexZolCnFx8B6085JuTLefG0ZmiEM13alxEzrcBoIjVk9\u002BcIjcYlTSsJLI5h2RzBhWlVk1wJG/qOvwt/c2kemckZ1C79gqwrjxl9ewaPuP40ciiW0o7ZG9wsug665dmCKlLFCATuA8L9acQCi6Dz/sZNSwFAh8d6QLgSkQhdcOk/uxCzynC5Bm4l2aiKlpA7eLsIbZqYQaKLSsdMm3L6YDkawtBQP/SVlATTGq5er6ooF1hNVMNOp3muKH\u002BpLKr7a7lvb9O/63jGstlVxSb0LNsdZIPabMs1zFuW4dd07GeZ1\u002B8073/WqGwfhuIp\u002BKJSufukS8fm4P6ueaN36MlhUYZx\u002B\u002B03v32bRvxX\u002BuYpDBO5RCfbkKCfsvcwhnXcnr9ivjUbt/z1Gzq\u002BCQULjyXYRW1PvqThRYEl0kj2BzjH/ug9NTzwzVQWxCktXYebVCPRWAEITN/agXh0NeWz/xPBtkoczlopJ7gZeLq7tCg5Sn4lJO73/3HIYrPEfJeuYwUVK6c9foWJqDCJLxRlXs0QOqtnTppkyfbYFGvmZKrgatV1ZkiBPAv4m7y\u002BbtBdowOmtAIsBtSq8CGwJSoZo0NF6IQ\u002B7/hEjz6frvLdppsmurFof7Bo9GPAirYm0Nbhnzg5OIYMHrMLYeUDTJghjQmGiaq48WOS3PRgfmVCHf5nvg/65K4U2lv\u002BXR2LZWeL3v1soAdsaK3UphuR6\u002BBNiQQm286IZuibsa8OulQFx7eMlF9n1b23OxViJj5SQu57sNPZpImZA3gU0S6YHe5Zjp6kBRdBJbOGr6C5JkCqSS6A0smAbGLt85EnUwRPHx1myJefrn3W\u002BksgUvTpH903aog/1wrk2SI7thGGWdKvN5CDEl2pCpqw6di\u002BX9luBNPz8Ci8TwfSQi91Y/hsEKC4sVtkJc2/Th/tju1yZnlIzbF90qnp8uhI8NAuc\u002BaiRNl3xe6\u002BCd7GdGHIzsBaYBv17JZG7n32zv5zGzU9kRp5CwoUOqCKioOSd14H4SQoLpD0OIdQW1ZbQTcwCy7pyKNHj4O2BmV7ayHS9Lbfru2aSuykSViS6O/z\u002BLlpmr\u002BUqK76wFFgcegreI1lfWbfe5IJVYACBb9K9KbTgk2r0dCiPgvIJO6cehkEeNCLLatJFH0nYAT/kqLvb8uqjK9av2b8g39a1xbjrRunPYyuv4c7Sq3QhLGL4qupGLTi8a1pqfmpzqosLj1mA/MpGJTWQPBEbwIBifq1MKCTsf5hwLtufVPTBLDcz1xwqkD\u002BYsoWktfEXkKrKB/\u002B9J4JmHx\u002BxEM3\u002BpsAwzw/Z5\u002BlkN\u002B5to2WvN7mnWI4wxVz1BAS03cf8eY9xqhvFc\u002BbhTbixZcABX3QcxtdmCbg/vdFjS8sLFQohZ85u\u002B/lZ2cPSxhrFf2\u002Bc47SAqBbwlm/HMfw6Ujgb1ii\u002Bn/3xolN6su0Dg0Odek5x1lgWinzzMNFul8oNL4ebtu/iFu9xm0FhBfU57QMcKce9yIvQBVu7u18ckxqJbYNlZ9xju1Ne8EsGtXSHyUPOQm4CX2b7u7GENmuQVPg216hhxIU2uH5kXshAyV/nI/ILXlCshx4saawa33T3zqtC393cFfTOh5nvnfCeuvJhrQJphQanilCKNWrZK9kJfJAs/flyGw4NTMbGvOkdnb65uTJijkmkq1WNQeCJ9Wuw5hFgcbz474H0XDg/0M1nfKe8H2Kmpv5WeFKT5Nktc0dbFdbHvRvxsMmgbiIBZMqIFcU43dYJCk8jGflqZQq41tjw5Mr2r8\u002Bbyl6ZBjjMRROIG98D9KVxUguXlKMih1vO95dZEI//gXYFrQN3YAQGZsTV0kk7tNIzj5LPbwssaTMC2h6hczSTmIpo/keR\u002BeIHgS3eTLUCkzK1JZD9MCJq6TPQdJX1ZPOAQknO0raakYWgt\u002B3tTix98Dbb/F2jplhn/gUTwXVMEiwqXfprQ8CMKoQLTHhEfasHYoRfGXil3KvhVtShdtAQVKWxsuAyAqx2T8HJqFngI3BqDG7w/PizhIFOifz72qOz\u002BufCgsq61V/X6Mmm7CRSASNUR3phH2e9Di5u44i/inUuBb1iHaC1rycPKQQvDJhc/HjJl5MpQttwFXScS\u002BHHKF5UeOZ27/OCrphTYfZTjgGWEfcf5eLiBLLR4fg8GVM1SAC12oOx1gx1Nvj61eDlLJdjBjn6pzJrYnQjlP37VpU1HhnlraN91Dvqmq759y7B/MVgyQMpSpDOSmgPjkEeieBjtcfW/37j9TH\u002BEByDcXtVYag4mo2CG8N5F2NLbkX63BC\u002BhjFm\u002Bv1WjNPRKzqESsjsuiyo5e9i0an0XdgbqIbsAzQLxPtJ/maq0h25sOCY9NyaXrQpQfYhW6SHYp0VOuRc9Rf2iHXdosvF/gPRqSC5W2kLgUnCwsFN2mlGsovZlac5bMvIomxWzLv4Y0PyT7KD3hckGbmaijJWuK4MluBP7GhsqExk8LkMpLSd2l99S5q2wuRkpXvtnuKZYem\u002BWjXLuHbrlZdmLt1eJ3T0/K/S6W0TVcQL20b8fwlp247fTlqO0iHokbXzUKQHFn4G6JIytoh8qwRhz90/7xaODENejukqZiqN6le3H/Uv9MTI5ZZnJxUGUpNGLRJEuKKvZVRQqIeU7HJ3tNwgxYsPMcsYZwmAJtU\u002BWDxF1EkYOTG1F7qg30w9JAkT/3JI1Z0YRvtHPEGZL05/IlBbXxg5X4uae73AXlJ\u002B20MAbCdi5YKfLY1NwQzgG\u002Bh8Mbz74dTg2p/mrmnvR/ioyFD\u002BmLMnHDzNvCGK\u002B56Oql/FVCylgvl\u002BH4GHfEcov\u002BWUpPir8YMlVSWALiWjVe8BZ/QKKePMA0VngHkxn5/lpQxL9laV0rjckA8HFVTDyrmShgRDHpXxyKGjRGEJ87WFmnkpZ2\u002BYe5U7LYnkxO3wo8XPnxmLopZ2Wi2k4o5X0pxJcYrbqmNaCgp/B\u002BEMHQOzsqCrOmSr\u002Bffiox0x45kG41r9m0NjJQlidYUPHJqlek0p8S/tvJg3rXeC6PdGGBZxaCSWHnGwUJ2nOMTfnO1tTTjQF/JpGTbCxe3L0DwCHF1\u002BnaR2H2vLaZCSRnPTWACKJZvOdgAUCF7t00iD5HBRlSxnYQ9I5z3dBK5RxtLC/23dMbqgQ6ZdWoVViEwTN3UgQKFHa\u002BcBQT5t8WFRwkF8KtPqtqLFoVGGGhZ5827xud05MXYhe4N22/CMQkI1C5hD2V1oKIDCaq9fwVHQl03PbDeEKIDLWr9QY\u002BqyOW8PQQ6OJioBmYFcZtbW0aoxpjSivNYaoNMHiI6uB8SmECEwQIBDUnEjvdKmN8G55HkVHr2mD4yY9JA7dp2bY4HMtka1ppEZ7kPDfv7zZHkRXaQFiOkG8ACUp0vgF\u002BvTmFpQ6YF69D3n\u002BzB54pCdlZAXGhj5leqYtbZGEQ9VKdZn7\u002Bakonr3pllmLZ24nR1/9wG72Q3C2fJvuDPLJOM\u002BgsFaAfKp\u002BOMVL2O/k2hc0Bio1hn9mVDYlQXkNOpHPHF2J5rMXosaxg4ulqmaE0aaEugbEl7JQPlwgXzsxcQIzeLiOWvNkHGdngAb3vKnPnG/WhICPBoivOahS80eLgBKFdjGp9nqzIJmjYROvWH2yVL7PXuh9pHIz4x1LESkf3AP0bkp4Jan1I2Pm66V5A\u002BEuoJ6EvCUmC82/ehddaBNwg4EPuu4zNi8U1juEmrjIuuM8GGyKmx/ezmZ4vK\u002BWl7dQdmggaUjy/2pzc\u002BXpoW0Q8sMwHVOi5ehlMOiHtnmDfj6ENCRQqE2aSRkGGyc58Sz1Z83sYnpnrYx/vzRcb0Tw8/GnZWlIwEpxmdQ2nM7BKz\u002B/kk6rkx/EIIaX0OkVOd3UESc1ko/DrKeHesSiLRDBvpP4oNj6RVzV30DmsO9dWGP6Younj5Sz\u002B\u002BWnJBRXJfN11hZVHJkA3c/KX7dK3Pu4JiJkp86FHjL/RKT3Ux1EgrVRbN7VCD/G\u002BYS/2S/hZR7p7wH18n4k8LfjWdf0CYqygdz9\u002BXAY4xnmna5FyUEHGeOKDWQbUow7KHwq9bJn0u/6CVtO52\u002Bu0QvoE1DP3yt23D/0afwmlzNMxsz38e1rfsrCT7/ltDZz2zhcMz8/a01QsBVyb2Tz13YoAiCett8agJCKDZNvjSgJgI7DymPwEVuDoz3b9RNh0nRFvbYV0SRZQbKutV255SLtaOrWLA0SN\u002BzFHxehQouBJD8bJc9187NqZoSxRVv9xboe6owki6JrM4nFTLYMuAMnKZEensNTe3U7a8WIYPKQy1Vdglf/WJiYs/JFsKb5Xa6BihvK3yr2y3MW7R/c3tKXMIFcrzWrK9D0gerRCcbOPg4bBtbWyewuZrrk5Gt4v9UfroAhnLJ02mJK1lk8Jb2oRK8Rwdv/wGqVLkh6xkNle8YVsV9GrKFfoih0j/OS8jz9OKO4avn5I\u002B4ZiG5l\u002BhQe4VqXJnRiZZgNtiOvhzR3BjgLfYmjqRDIHI1tLSAy9aQUVa6U/8/IntcHrrA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "jRNON24w3lpQryd3WQ4xhg==",
+        "Date": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "ETag": "\u00220x8DB42FC7F3DFE7C\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f71d4dbc-1eb0-cbe5-6177-829b0fb8ada6",
+        "x-ms-content-crc64": "xDxxCclhUFs=",
+        "x-ms-request-id": "245d4f79-d01e-0003-1fe5-749485000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:43.7028244Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-dfc89d90-21cc-3983-6ff2-07a3aa085d2a/test-blob-d027c87f-b099-dfbf-06cb-94c74e3893fc?sv=2022-11-02\u0026st=2023-04-22T05%3A40%3A43Z\u0026se=2023-04-22T07%3A40%3A43Z\u0026sr=b\u0026sp=racwd\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-3184ed2830d77e8685a139b24bde9e1a-540b517c65fdf545-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "676a7831-f3a4-17fc-ac9b-ccf01ef187e6",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "4096",
+        "Content-MD5": "sc0vw9/YDi\u002B9UVTiqpupUw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "ETag": "\u00220x8DB42FC7F310813\u0022",
+        "Last-Modified": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "676a7831-f3a4-17fc-ac9b-ccf01ef187e6",
+        "x-ms-creation-time": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "245d5063-d01e-0003-7ae5-749485000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2022-11-02",
+        "x-ms-version-id": "2023-04-22T06:40:43.6168723Z"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-dfc89d90-21cc-3983-6ff2-07a3aa085d2a/test-blob-72d27f58-82f9-8a95-d126-c9c52694070b?sv=2022-11-02\u0026st=2023-04-22T05%3A40%3A43Z\u0026se=2023-04-22T07%3A40%3A43Z\u0026sr=b\u0026sp=racwd\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-e3be101a70122e122100b152692ceaaf-40a77b924f957edb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "966ab6e4-454d-0b02-9be4-c72060f2888d",
+        "x-ms-copy-source": "https://amandadev2.blob.core.windows.net/test-container-dfc89d90-21cc-3983-6ff2-07a3aa085d2a/test-blob-d027c87f-b099-dfbf-06cb-94c74e3893fc?sv=2022-11-02\u0026st=2023-04-22T05%3A40%3A43Z\u0026se=2023-04-22T07%3A40%3A43Z\u0026sr=b\u0026sp=racwd\u0026sig=Sanitized",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "220",
+        "Content-Type": "application/xml",
+        "Date": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "966ab6e4-454d-0b02-9be4-c72060f2888d",
+        "x-ms-error-code": "BlobAlreadyExists",
+        "x-ms-request-id": "245d50a2-d01e-0003-36e5-749485000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified blob already exists.\n",
+        "RequestId:245d50a2-d01e-0003-36e5-749485000000\n",
+        "Time:2023-04-22T06:40:44.2088191Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://amandadev2.blob.core.windows.net/test-container-dfc89d90-21cc-3983-6ff2-07a3aa085d2a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-651c24735dc62ffb5acd7cb763e3a9bd-6303f896b833ad1a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230421.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "680c0846-f187-2e99-f6c1-df92859b2e77",
+        "x-ms-date": "Sat, 22 Apr 2023 06:40:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2022-11-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 22 Apr 2023 06:40:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "680c0846-f187-2e99-f6c1-df92859b2e77",
+        "x-ms-request-id": "245d50d0-d01e-0003-63e5-749485000000",
+        "x-ms-version": "2022-11-02"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2023-04-21T23:40:43.7910422-07:00",
+    "RandomSeed": "1970336816",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\nencryptionScope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferCheckpointerTests.cs
@@ -1,0 +1,279 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Drawing;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.DataMovement.Blobs;
+using Azure.Storage.DataMovement.Models;
+using Azure.Storage.DataMovement.Models.JobPlan;
+using NUnit.Framework;
+
+namespace Azure.Storage.DataMovement.Tests
+{
+    public class StartTransferCheckpointerTests : DataMovementBlobTestBase
+    {
+        public StartTransferCheckpointerTests(
+            bool async,
+            BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, default)
+        {
+        }
+
+        // This test is written to ensure that SAS stored in the
+        // the path are not stored in the job plan file
+        // We expect only the path and the URL without the query
+        // to be stored
+        [RecordedTest]
+        public async Task CheckpointerWithSasAsync()
+        {
+            // Arrange
+            DisposingLocalDirectory disposingLocalDirectory = GetTestLocalDirectory();
+            var containerName = GetNewContainerName();
+            var sourceBlobName = GetNewBlobName();
+            await using DisposingBlobContainer test = await GetTestContainerAsync(containerName: containerName);
+
+            BlobBaseClient sourceBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), sourceBlobName, Constants.KB * 4);
+
+            // Create Source with SAS
+            BlockBlobClient sasSourceBlob = InstrumentClient(
+                GetServiceClient_BlobServiceSas_Blob(
+                    containerName: containerName,
+                    blobName: sourceBlobName)
+                .GetBlobContainerClient(containerName)
+                .GetBlockBlobClient(sourceBlobName));
+
+            // Create Destination with SAS
+            string destinationBlobName = GetNewBlobName();
+            BlockBlobClient destinationBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), destinationBlobName, Constants.KB*4);
+            BlockBlobClient sasDestinationBlob = InstrumentClient(
+                GetServiceClient_BlobServiceSas_Blob(
+                    containerName: containerName,
+                    blobName: destinationBlobName)
+                .GetBlobContainerClient(containerName)
+                .GetBlockBlobClient(destinationBlobName));
+
+            StorageResource sourceResource = new BlockBlobStorageResource(sasSourceBlob);
+            StorageResource destinationResource = new BlockBlobStorageResource(sasDestinationBlob);
+
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                CheckpointerOptions = new TransferCheckpointerOptions(disposingLocalDirectory.DirectoryPath)
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            TransferOptions transferOptions = new TransferOptions()
+            {
+                CreateMode = StorageResourceCreateMode.Fail
+            };
+
+            // Start transfer and await for completion. This transfer will fail
+            // since the destination already exists.
+            DataTransfer transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                transferOptions).ConfigureAwait(false);
+
+            // Act
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await transfer.AwaitCompletion(cancellationTokenSource.Token).ConfigureAwait(false);
+
+            // Check the transfer files made and the source and destination
+            JobPartPlanFileName checkpointerFileName = new JobPartPlanFileName(
+                checkpointerPath: disposingLocalDirectory.DirectoryPath,
+                id: transfer.Id,
+                jobPartNumber: 0);
+            Assert.IsTrue(File.Exists(checkpointerFileName.FullPath));
+
+            // Check contents for checkpointer file without the SAS
+            using (FileStream stream = File.OpenRead(checkpointerFileName.FullPath))
+            {
+                JobPartPlanHeader deserializedHeader = JobPartPlanHeader.Deserialize(stream);
+
+                Assert.IsNotNull(deserializedHeader);
+
+                Assert.AreEqual(sourceBlob.Uri.AbsoluteUri, deserializedHeader.SourcePath);
+                Assert.AreEqual(destinationBlob.Uri.AbsoluteUri, deserializedHeader.DestinationPath);
+            }
+        }
+
+        [RecordedTest]
+        public async Task CheckpointerMismatch_Source()
+        {
+            // Arrange
+            DisposingLocalDirectory disposingLocalDirectory = GetTestLocalDirectory();
+            var containerName = GetNewContainerName();
+            await using DisposingBlobContainer test = await GetTestContainerAsync(containerName: containerName);
+
+            // Create source
+            var sourceBlobName = GetNewBlobName();
+            BlockBlobClient sourceBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), sourceBlobName, Constants.KB * 4);
+
+            // Create Destination
+            string destinationBlobName = GetNewBlobName();
+            BlockBlobClient destinationBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), destinationBlobName, Constants.KB * 4);
+
+            StorageResource sourceResource = new BlockBlobStorageResource(sourceBlob);
+            StorageResource destinationResource = new BlockBlobStorageResource(destinationBlob);
+
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                CheckpointerOptions = new TransferCheckpointerOptions(disposingLocalDirectory.DirectoryPath)
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            TransferOptions transferOptions = new TransferOptions()
+            {
+                CreateMode = StorageResourceCreateMode.Fail
+            };
+
+            // Start transfer and await for completion.
+            DataTransfer transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                transferOptions).ConfigureAwait(false);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await transfer.AwaitCompletion(cancellationTokenSource.Token).ConfigureAwait(false);
+
+            // Act/Assert - resume transfer with wrong source resource.
+            BlockBlobClient newSourceBlob = test.Container.GetBlockBlobClient(GetNewBlobName());
+            StorageResource wrongSourceResource = new BlockBlobStorageResource(newSourceBlob);
+
+            TransferOptions resumeTransferOptions = new TransferOptions()
+            {
+                ResumeFromCheckpointId = transfer.Id
+            };
+
+            Assert.CatchAsync<ArgumentException>(
+                async () => await transferManager.StartTransferAsync(
+                    wrongSourceResource,
+                    destinationResource,
+                    resumeTransferOptions),
+                Errors.MismatchResumeTransferArguments(
+                    "SourcePath",
+                    sourceResource.Uri.AbsoluteUri,
+                    wrongSourceResource.Uri.AbsoluteUri).Message);
+        }
+
+        [RecordedTest]
+        public async Task CheckpointerMismatch_Destination()
+        {
+            // Arrange
+            DisposingLocalDirectory disposingLocalDirectory = GetTestLocalDirectory();
+            var containerName = GetNewContainerName();
+            await using DisposingBlobContainer test = await GetTestContainerAsync(containerName: containerName);
+
+            // Create source
+            var sourceBlobName = GetNewBlobName();
+            BlockBlobClient sourceBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), sourceBlobName, Constants.KB * 4);
+
+            // Create Destination
+            string destinationBlobName = GetNewBlobName();
+            BlockBlobClient destinationBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), destinationBlobName, Constants.KB * 4);
+
+            StorageResource sourceResource = new BlockBlobStorageResource(sourceBlob);
+            StorageResource destinationResource = new BlockBlobStorageResource(destinationBlob);
+
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                CheckpointerOptions = new TransferCheckpointerOptions(disposingLocalDirectory.DirectoryPath)
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            TransferOptions transferOptions = new TransferOptions()
+            {
+                CreateMode = StorageResourceCreateMode.Fail
+            };
+
+            // Start transfer and await for completion.
+            DataTransfer transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                transferOptions).ConfigureAwait(false);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await transfer.AwaitCompletion(cancellationTokenSource.Token).ConfigureAwait(false);
+
+            // Act/Assert - resume transfer with wrong destination resource.
+            BlockBlobClient newDestinationBlob = test.Container.GetBlockBlobClient(GetNewBlobName());
+            StorageResource wrongDestinationResource = new BlockBlobStorageResource(newDestinationBlob);
+
+            TransferOptions resumeTransferOptions = new TransferOptions()
+            {
+                ResumeFromCheckpointId = transfer.Id
+            };
+
+            Assert.CatchAsync<ArgumentException>(
+                async () => await transferManager.StartTransferAsync(
+                    sourceResource,
+                    wrongDestinationResource,
+                    resumeTransferOptions),
+                Errors.MismatchResumeTransferArguments(
+                    "DestinationPath",
+                    destinationResource.Uri.AbsoluteUri,
+                    wrongDestinationResource.Uri.AbsoluteUri).Message);
+        }
+
+        [RecordedTest]
+        public async Task CheckpointerMismatch_CreateMode_Overwrite()
+        {
+            // Arrange
+            DisposingLocalDirectory disposingLocalDirectory = GetTestLocalDirectory();
+            var containerName = GetNewContainerName();
+            await using DisposingBlobContainer test = await GetTestContainerAsync(containerName: containerName);
+
+            // Create source
+            var sourceBlobName = GetNewBlobName();
+            BlockBlobClient sourceBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), sourceBlobName, Constants.KB * 4);
+
+            // Create Destination
+            string destinationBlobName = GetNewBlobName();
+            BlockBlobClient destinationBlob = await CreateBlockBlob(test.Container, Path.GetTempFileName(), destinationBlobName, Constants.KB * 4);
+
+            StorageResource sourceResource = new BlockBlobStorageResource(sourceBlob);
+            StorageResource destinationResource = new BlockBlobStorageResource(destinationBlob);
+
+            TransferManagerOptions managerOptions = new TransferManagerOptions()
+            {
+                CheckpointerOptions = new TransferCheckpointerOptions(disposingLocalDirectory.DirectoryPath)
+            };
+            TransferManager transferManager = new TransferManager(managerOptions);
+
+            TransferOptions transferOptions = new TransferOptions()
+            {
+                CreateMode = StorageResourceCreateMode.Fail
+            };
+
+            // Start transfer and await for completion.
+            DataTransfer transfer = await transferManager.StartTransferAsync(
+                sourceResource,
+                destinationResource,
+                transferOptions).ConfigureAwait(false);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await transfer.AwaitCompletion(cancellationTokenSource.Token).ConfigureAwait(false);
+
+            // Act/Assert - resume transfer with wrong CreateMode Resource
+            TransferOptions resumeTransferOptions = new TransferOptions()
+            {
+                CreateMode = StorageResourceCreateMode.Overwrite,
+                ResumeFromCheckpointId = transfer.Id
+            };
+
+            Assert.CatchAsync<ArgumentException>(
+                async () => await transferManager.StartTransferAsync(
+                    sourceResource,
+                    destinationResource,
+                    resumeTransferOptions),
+                Errors.MismatchResumeCreateMode(
+                    false,
+                    StorageResourceCreateMode.Overwrite).Message);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #35701 

- Added back in verification for Source and Destination (originally was in the JobPartPlanFile)
- Added verification for CreateMode when resuming
- If SAS was added on the Uri when creating the StorageClient, we remove it before saving it to the job plan file