### PR TITLE
[FormRecognizer] Updating ExpiresOn validation due to service bug

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/AdministrationOperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/AdministrationOperationsLiveTests.cs
@@ -176,7 +176,18 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             }
             else
             {
+                // We have changed the following validation because of a service bug. This needs to be updated once the bug is fixed.
+                // More information: https://github.com/Azure/azure-sdk-for-net/issues/35809
+
+                /* The expected behavior. This must be added back once the service bug is fixed.
                 Assert.Null(model.ExpiresOn);
+                */
+
+                // The current behavior. This 'if' block must be completely removed once the service bug is fixed.
+                if (model.ExpiresOn.HasValue)
+                {
+                    Assert.Greater(model.ExpiresOn, model.CreatedOn);
+                }
             }
 
             // TODO add validation for Doctypes https://github.com/Azure/azure-sdk-for-net-pr/issues/1432

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationLiveTests.cs
@@ -511,7 +511,18 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             }
             else
             {
+                // We have changed the following validation because of a service bug. This needs to be updated once the bug is fixed.
+                // More information: https://github.com/Azure/azure-sdk-for-net/issues/35809
+
+                /* The expected behavior. This must be added back once the service bug is fixed.
                 Assert.Null(model.ExpiresOn);
+                */
+
+                // The current behavior. This 'if' block must be completely removed once the service bug is fixed.
+                if (model.ExpiresOn.HasValue)
+                {
+                    Assert.Greater(model.ExpiresOn, model.CreatedOn);
+                }
             }
         }
     }


### PR DESCRIPTION
Because of a bug in the service, some of our live tests need to be updated to stay green. Once the issue is fixed on the service side, we need to update them again to match the expected behavior.

The service team has already fixed the mentioned bug and we just need to wait until their next release.

More information: https://github.com/Azure/azure-sdk-for-net/issues/35809