### PR TITLE
Fix classification policy cannot delete selectors + cleanup

### DIFF
--- a/sdk/communication/Azure.Communication.JobRouter/src/Models/UpdateClassificationPolicyOptions.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Models/UpdateClassificationPolicyOptions.cs
@@ -48,10 +48,10 @@ namespace Azure.Communication.JobRouter
 
         /// <summary> The queue selectors to resolve a queue for a given job. </summary>
 #pragma warning disable CA2227 // Collection properties should be read only
-        public IList<QueueSelectorAttachment> QueueSelectors { get; set; } = new List<QueueSelectorAttachment>();
+        public IList<QueueSelectorAttachment> QueueSelectors { get; set; }
 
         /// <summary> The worker label selectors to attach to a given job. </summary>
-        public IList<WorkerSelectorAttachment> WorkerSelectors { get; set; } = new List<WorkerSelectorAttachment>();
+        public IList<WorkerSelectorAttachment> WorkerSelectors { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/src/RouterAdministrationClient.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/RouterAdministrationClient.cs
@@ -186,8 +186,8 @@ namespace Azure.Communication.JobRouter
                 {
                     Name = options.Name,
                     FallbackQueueId = options.FallbackQueueId,
-                    QueueSelectors = options.QueueSelectors,
-                    WorkerSelectors = options.WorkerSelectors,
+                    QueueSelectors = options.QueueSelectors ?? new List<QueueSelectorAttachment>(),
+                    WorkerSelectors = options.WorkerSelectors ?? new List<WorkerSelectorAttachment>(),
                     PrioritizationRule = options.PrioritizationRule
                 };
 
@@ -220,8 +220,9 @@ namespace Azure.Communication.JobRouter
                 {
                     Name = options.Name,
                     FallbackQueueId = options.FallbackQueueId,
-                    QueueSelectors = options.QueueSelectors,
-                    WorkerSelectors = options.WorkerSelectors,
+                    QueueSelectors = options.QueueSelectors ?? new List<QueueSelectorAttachment>(),
+                    WorkerSelectors = options.WorkerSelectors ?? new List<WorkerSelectorAttachment>(),
+                    PrioritizationRule = options.PrioritizationRule
                 };
 
                 return RestClient.UpsertClassificationPolicy(

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Infrastructure/RouterLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Infrastructure/RouterLiveTestBase.cs
@@ -41,7 +41,8 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
         [TearDown]
         public async Task CleanUp()
         {
-            if (Mode != RecordedTestMode.Playback)
+            var mode = TestEnvironment.Mode ?? Mode;
+            if (mode != RecordedTestMode.Playback)
             {
                 var testName = TestContext.CurrentContext.Test.FullName;
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DistributionPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DistributionPolicyLiveTests.cs
@@ -36,6 +36,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = bestWorkerModeDistributionPolicyName
                 });
 
+            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
             Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
 
             var bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
@@ -70,8 +71,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
             Assert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
             Assert.IsTrue(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
         }
 
         [Test]
@@ -96,6 +95,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = bestWorkerModeDistributionPolicyName,
                 });
 
+            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
             Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
 
             var bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
@@ -158,11 +158,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 // any value will be sanitized when recordings are saved
                 Assert.AreEqual("MyKey", azureFuncScoringRule.Credential.FunctionKey);
             }
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
-            // test longest idle mode constructors
-
-            // test round robin mode constructors
         }
 
         #endregion best worker mode constructors
@@ -182,6 +177,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = longestIdleModeDistributionPolicyName
                 });
 
+            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(longestIdleModeDistributionPolicyId)));
             Assert.NotNull(longestIdleModeDistributionPolicyResponse.Value);
 
             var longestIdleModeDistributionPolicy = longestIdleModeDistributionPolicyResponse.Value;
@@ -202,8 +198,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             Assert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers);
             Assert.AreEqual(2, longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers);
             Assert.IsTrue(longestIdleModeDistributionPolicy.Mode.BypassSelectors);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(longestIdleModeDistributionPolicyId)));
         }
 
         #endregion longest idle mode constructors
@@ -225,6 +219,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = roundRobinModeDistributionPolicyName
                 });
 
+            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(roundRobinModeDistributionPolicyId)));
             Assert.NotNull(roundRobinModeDistributionPolicyResponse.Value);
 
             var roundRobinModeDistributionPolicy = roundRobinModeDistributionPolicyResponse.Value;
@@ -245,8 +240,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             Assert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers);
             Assert.AreEqual(2, roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers);
             Assert.IsTrue(roundRobinModeDistributionPolicy.Mode.BypassSelectors);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(roundRobinModeDistributionPolicyId)));
         }
 
         #endregion round robin mode constructors

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExceptionPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExceptionPolicyLiveTests.cs
@@ -44,6 +44,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             };
 
             var createExceptionPolicyResponse = await routerClient.CreateExceptionPolicyAsync(new CreateExceptionPolicyOptions(exceptionPolicyId, rules));
+            AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
 
             Assert.NotNull(createExceptionPolicyResponse.Value);
 
@@ -83,8 +84,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
             Assert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
         }
 
         [Test]
@@ -129,6 +128,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             var createExceptionPolicyResponse = await routerClient.CreateExceptionPolicyAsync(new CreateExceptionPolicyOptions(exceptionPolicyId, rules));
 
+            AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
             Assert.NotNull(createExceptionPolicyResponse.Value);
 
             var exceptionPolicy = createExceptionPolicyResponse.Value;
@@ -174,8 +174,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
             Assert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
         }
 
         #endregion Exception Policy Tests

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/JobQueueLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/JobQueueLiveTests.cs
@@ -34,8 +34,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = queueName,
                     Labels = queueLabels
                 });
-            AssertQueueResponseIsEqual(createQueueResponse, queueId, createDistributionPolicyResponse.Value.Id, queueName, queueLabels);
+
             AddForCleanup(new Task(async () => await routerClient.DeleteQueueAsync(createQueueResponse.Value.Id)));
+            AssertQueueResponseIsEqual(createQueueResponse, queueId, createDistributionPolicyResponse.Value.Id, queueName, queueLabels);
         }
 
         [Test]
@@ -54,6 +55,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = queueName,
                     Labels = queueLabels
                 });
+            AddForCleanup(new Task(async () => await routerClient.DeleteQueueAsync(createQueueResponse.Value.Id)));
             AssertQueueResponseIsEqual(createQueueResponse, queueId, createDistributionPolicyResponse.Value.Id, queueName, queueLabels);
 
             var updatedLabels =
@@ -64,8 +66,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 await routerClient.UpdateQueueAsync(new UpdateQueueOptions(queueId) { Labels = updatedLabels, });
 
             AssertQueueResponseIsEqual(updatedQueueResponse, queueId, createDistributionPolicyResponse.Value.Id, queueName, updatedLabels);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteQueueAsync(createQueueResponse.Value.Id)));
         }
 
         #endregion Queue Tests

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterJobLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterJobLiveTests.cs
@@ -88,6 +88,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 {
                     Priority = 1,
                 });
+
+            AddForCleanup(new Task(async () => await routerClient.CancelJobAsync(new CancelJobOptions(jobId1))));
+            AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(jobId1)));
             var createJob1 = createJob1Response.Value;
 
             // wait for job1 to be in queued state
@@ -107,6 +110,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 {
                     Priority = 1
                 });
+            AddForCleanup(new Task(async () => await routerClient.CancelJobAsync(new CancelJobOptions(jobId2))));
+            AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(jobId2)));
             var createJob2 = createJob2Response.Value;
 
             var job2Result = await Poll(async () => await routerClient.GetJobAsync(createJob2.Id),
@@ -133,11 +138,6 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             Assert.IsTrue(allJobs.Contains(createJob1.Id));
             Assert.IsTrue(allJobs.Contains(createJob2.Id));
-
-            AddForCleanup(new Task(async () => await routerClient.CancelJobAsync(new CancelJobOptions(createJob1.Id))));
-            AddForCleanup(new Task(async () => await routerClient.CancelJobAsync(new CancelJobOptions(createJob2.Id))));
-            AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob1.Id)));
-            AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob2.Id)));
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterWorkerLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterWorkerLiveTests.cs
@@ -53,12 +53,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Labels = workerLabels,
                     ChannelConfigurations = channelConfigList
                 });
+            AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
             Assert.NotNull(routerWorkerResponse.Value);
             AssertRegisteredWorkerIsValid(routerWorkerResponse, workerId, queueAssignmentList,
                 totalCapacity, workerLabels, channelConfigList);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(routerWorkerResponse.Value.Id)));
         }
 
         [Test]
@@ -71,10 +70,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             var totalCapacity = 100;
             var routerWorkerResponse = await routerClient.CreateWorkerAsync(new CreateWorkerOptions(workerId, totalCapacity) {AvailableForOffers = true});
+            AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
             Assert.NotNull(routerWorkerResponse.Value);
-
-            AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(routerWorkerResponse.Value.Id)));
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateClassificationPolicyTest.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateClassificationPolicyTest.json
@@ -1,22 +1,23 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
+        "Connection": "keep-alive",
         "Content-Length": "214",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-fdb3f7d93e6c5954deaf76dda051ad31-8f3346b5ebe6ceb2-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 6.0.15; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "cdfe9c6691b59fed6661c58d96b1387c",
+        "traceparent": "00-cedff8a42fda514d82a00b95f86f0b10-9efe773d8bea2644-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "bfc92dee32410ba01e83bb0ad2ff0a23",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:27:58 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:50 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "LongestIdleDistributionPolicyE9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729",
+        "name": "LongestIdleDistributionPolicy34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -29,17 +30,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:27:59 GMT",
-        "ETag": "\u00225c00297c-0000-0700-0000-642de7df0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:27:59 GMT",
-        "trace-id": "fdb3f7d9-3e6c-5954-deaf-76dda051ad31",
+        "Date": "Wed, 26 Apr 2023 15:51:51 GMT",
+        "ETag": "\u0022a102f5b3-0000-0700-0000-644948980000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:52 GMT",
+        "trace-id": "cedff8a4-2fda-514d-82a0-0b95f86f0b10",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03\u002BctZAAAAACHKo1WKnXoRYkTebXA7PVYWU1RMDFFREdFMDkwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0l0hJZAAAAAD61U4KZg7BTJGcCsWh3UXqWVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729",
-        "name": "LongestIdleDistributionPolicyE9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729",
+        "id": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
+        "name": "LongestIdleDistributionPolicy34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -50,23 +51,23 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/B11100F883993AACA3FA9307301795579BB38F61B86F56C364?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "189",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-05a55da273b68ee132ebcb2ba814084a-db9dbe0311a487bd-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 6.0.15; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0ae0c7e6d430322a6f62600ac67e1250",
+        "traceparent": "00-e5121ad20544e44cb0236827e39e5534-35cf2a6079f37e43-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "2455e9ed3f569b2936933a4db952d491",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:27:59 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "DefaultQueue-Sdk-TestB11100F883993AACA3FA9307301795579BB38F61B86F56C364",
-        "distributionPolicyId": "E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729",
+        "name": "DefaultQueue-Sdk-TestFDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791",
+        "distributionPolicyId": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
         "labels": {
           "Label_1": "Value_1"
         }
@@ -75,37 +76,37 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:27:59 GMT",
-        "ETag": "\u00220b00b72b-0000-0700-0000-642de7e00000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:28:00 GMT",
-        "trace-id": "05a55da2-73b6-8ee1-32eb-cb2ba814084a",
+        "Date": "Wed, 26 Apr 2023 15:51:52 GMT",
+        "ETag": "\u00223500d377-0000-0700-0000-644948990000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:53 GMT",
+        "trace-id": "e5121ad2-0544-e44c-b023-6827e39e5534",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03\u002BctZAAAAABwK0gnV0agT41nE3aZ\u002BB07WU1RMDFFREdFMDkwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mEhJZAAAAAD5bhLT3N8FSJXq70rznYG/WVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364",
-        "name": "DefaultQueue-Sdk-TestB11100F883993AACA3FA9307301795579BB38F61B86F56C364",
-        "distributionPolicyId": "E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729",
+        "id": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791",
+        "name": "DefaultQueue-Sdk-TestFDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791",
+        "distributionPolicyId": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
         "labels": {
           "Label_1": "Value_1",
-          "Id": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364"
+          "Id": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791"
         }
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "314",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-436aa134b3fa488f10ae71d04a634b8a-771e46fdf472f342-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 6.0.15; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "2e9965f3b4885798b8ed650fc87ef213",
+        "traceparent": "00-5a79083b53d9c34eb3e268769343b4e9-f70bd7305bc2f943-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "fbe44149bd5ac80315adaf84b911848e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:27:59 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:52 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -114,7 +115,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364"
+              "value": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791"
             },
             "kind": "static"
           }
@@ -138,23 +139,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:27:59 GMT",
-        "ETag": "\u002239001e88-0000-0700-0000-642de7e00000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:28:00 GMT",
-        "trace-id": "436aa134-b3fa-488f-10ae-71d04a634b8a",
+        "Date": "Wed, 26 Apr 2023 15:51:52 GMT",
+        "ETag": "\u002231008d78-0000-0700-0000-644948990000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:53 GMT",
+        "trace-id": "5a79083b-53d9-c34e-b3e2-68769343b4e9",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "04OctZAAAAADz6KzFecYFS59S6qCKYBR0WU1RMDFFREdFMDkwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mUhJZAAAAABnbRnmp3eLRLOMGyeK0bjRWVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729",
+        "id": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
         "queueSelectors": [
           {
             "kind": "static",
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364"
+              "value": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791"
             }
           }
         ],
@@ -177,33 +178,37 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "396",
+        "Content-Length": "450",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-349568de2b53bf017c803e1562d9099f-db368565bb2256e0-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 6.0.15; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "7d53ff4ec8de92af72cc5d5230e2d8e8",
+        "traceparent": "00-57a03406546a694d9da787fd1b3164dc-350a794f9f94b34f-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "7586a4fb60f1afad042d89adf75352cb",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:27:59 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:53 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729-Name",
-        "fallbackQueueId": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364",
+        "name": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2-Name",
+        "fallbackQueueId": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791",
         "queueSelectors": [
           {
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364"
+              "value": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791"
             },
             "kind": "static"
           }
         ],
+        "prioritizationRule": {
+          "value": 1,
+          "kind": "static-rule"
+        },
         "workerSelectors": [
           {
             "labelSelector": {
@@ -219,25 +224,25 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:28:00 GMT",
-        "ETag": "\u002239002f88-0000-0700-0000-642de7e10000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:28:01 GMT",
-        "trace-id": "349568de-2b53-bf01-7c80-3e1562d9099f",
+        "Date": "Wed, 26 Apr 2023 15:51:53 GMT",
+        "ETag": "\u002231008e78-0000-0700-0000-644948990000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:53 GMT",
+        "trace-id": "57a03406-546a-694d-9da7-87fd1b3164dc",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "04OctZAAAAACoBDy31IdDRa435mUfCRnmWU1RMDFFREdFMDkwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mUhJZAAAAADa08W5iKI9TKOBjqd1y0Z9WVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729",
-        "name": "E9DB67AB81334039A42BAA26570FE2E3260D8F1C35BE618729-Name",
-        "fallbackQueueId": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364",
+        "id": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
+        "name": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2-Name",
+        "fallbackQueueId": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791",
         "queueSelectors": [
           {
             "kind": "static",
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "B11100F883993AACA3FA9307301795579BB38F61B86F56C364"
+              "value": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791"
             }
           }
         ],
@@ -258,11 +263,55 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2?api-version=2022-07-18-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "115",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-ca04a5ccf353f8469aee8c8223aca229-38599ab8d3f45840-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "91c12aaf0e1a2fc8e68d0fa98fa5e224",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:53 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2-Name-updated",
+        "queueSelectors": [],
+        "workerSelectors": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 26 Apr 2023 15:51:53 GMT",
+        "ETag": "\u002231008f78-0000-0700-0000-6449489a0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:54 GMT",
+        "trace-id": "ca04a5cc-f353-f846-9aee-8c8223aca229",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0mkhJZAAAAAAHZbYzX4gsQYZjvJwu/QloWVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
+        "X-Cache": "CONFIG_NOCACHE"
+      },
+      "ResponseBody": {
+        "id": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2",
+        "name": "34B6AB0FCD67B7AC430C817D4C2C96284E00ED487DA0C8DAE2-Name-updated",
+        "fallbackQueueId": "FDC53F14E849CB5321E6844EA5CC9232329A6E590A0DDB0791",
+        "queueSelectors": [],
+        "prioritizationRule": {
+          "kind": "static-rule",
+          "value": 1
+        },
+        "workerSelectors": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-_RCvjUNnWUiLJYLTnXpiuA-",
-    "RandomSeed": "1066505355"
+    "id-prefix": "sdk-Rw-oBy6g10KSp3tBth1YaQ-",
+    "RandomSeed": "1725781094"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateClassificationPolicyTestAsync.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateClassificationPolicyTestAsync.json
@@ -1,22 +1,22 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/418F502DB461E04133098B89C5C922B1EE19BC234CAE289269?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "214",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1dbd02b2a09dee41b42e349c8a355f0b-fb4d12219d0b464a-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "4b76938a64aa597404bae9f5780ed942",
+        "traceparent": "00-78406c7adaec994398b7fdccde8951ee-456bff0111a8ee46-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "31f6a711cdfb413389f56104ece105e1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:35 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "LongestIdleDistributionPolicy418F502DB461E04133098B89C5C922B1EE19BC234CAE289269",
+        "name": "LongestIdleDistributionPolicy9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -29,17 +29,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:36 GMT",
-        "ETag": "\u00225c00ad4c-0000-0700-0000-642de6d80000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:36 GMT",
-        "trace-id": "1dbd02b2-a09d-ee41-b42e-349c8a355f0b",
+        "Date": "Wed, 26 Apr 2023 15:51:58 GMT",
+        "ETag": "\u0022a102b9b8-0000-0700-0000-6449489e0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:58 GMT",
+        "trace-id": "78406c7a-daec-9943-98b7-fdccde8951ee",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02OYtZAAAAABY6U3GoIZiTIPyx3N2FLhHWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nkhJZAAAAACU\u002BjwjGaryTpX5yBzS8\u002B2zWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "418F502DB461E04133098B89C5C922B1EE19BC234CAE289269",
-        "name": "LongestIdleDistributionPolicy418F502DB461E04133098B89C5C922B1EE19BC234CAE289269",
+        "id": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
+        "name": "LongestIdleDistributionPolicy9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -50,23 +50,23 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "189",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-93c1d309a242aa46ae4a32194f06f860-c506257b0f453e41-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "9ee846f8c833b869f53be1e31a36c44c",
+        "traceparent": "00-846133878e94794eaa37c5af19870ecb-a5706f4c382ee344-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "e858b7791b8a0571331feca00c8cd9d9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:36 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "DefaultQueue-Sdk-TestF8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99",
-        "distributionPolicyId": "418F502DB461E04133098B89C5C922B1EE19BC234CAE289269",
+        "name": "DefaultQueue-Sdk-Test9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9",
+        "distributionPolicyId": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
         "labels": {
           "Label_1": "Value_1"
         }
@@ -75,37 +75,37 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:37 GMT",
-        "ETag": "\u00220b00c726-0000-0700-0000-642de6d90000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:37 GMT",
-        "trace-id": "93c1d309-a242-aa46-ae4a-32194f06f860",
+        "Date": "Wed, 26 Apr 2023 15:51:58 GMT",
+        "ETag": "\u002235001678-0000-0700-0000-6449489e0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:58 GMT",
+        "trace-id": "84613387-8e94-794e-aa37-c5af19870ecb",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02OYtZAAAAAB07Aa3JYaLSrEAWsq/50vUWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nkhJZAAAAAB1fWZBuf5QQKW5st62seh5WVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99",
-        "name": "DefaultQueue-Sdk-TestF8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99",
-        "distributionPolicyId": "418F502DB461E04133098B89C5C922B1EE19BC234CAE289269",
+        "id": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9",
+        "name": "DefaultQueue-Sdk-Test9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9",
+        "distributionPolicyId": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
         "labels": {
           "Label_1": "Value_1",
-          "Id": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99"
+          "Id": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9"
         }
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/418F502DB461E04133098B89C5C922B1EE19BC234CAE289269?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "314",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-e25d11b7249ada46aaca815b21733679-426d8f92ac291d43-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "0737cfea31e861580e0acc5e2825e5c9",
+        "traceparent": "00-34f44faf92492f47927c2d949be32961-5be192b99838014f-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "114e5b36ef4f5f45e67c8bfe0e9be119",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:36 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:58 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -114,7 +114,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99"
+              "value": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9"
             },
             "kind": "static"
           }
@@ -138,23 +138,23 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:37 GMT",
-        "ETag": "\u00223900616f-0000-0700-0000-642de6d90000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:37 GMT",
-        "trace-id": "e25d11b7-249a-da46-aaca-815b21733679",
+        "Date": "Wed, 26 Apr 2023 15:51:59 GMT",
+        "ETag": "\u002231009d78-0000-0700-0000-6449489f0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:59 GMT",
+        "trace-id": "34f44faf-9249-2f47-927c-2d949be32961",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02eYtZAAAAABD5wL6h/gOS5dutkUcMJjaWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0n0hJZAAAAACDKOe1MNp9QKMrAzKb1U9aWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "418F502DB461E04133098B89C5C922B1EE19BC234CAE289269",
+        "id": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
         "queueSelectors": [
           {
             "kind": "static",
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99"
+              "value": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9"
             }
           }
         ],
@@ -177,29 +177,29 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/418F502DB461E04133098B89C5C922B1EE19BC234CAE289269?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "450",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-f13c5c4fe943d343b46073c48f03bc73-8d44e7544fd29948-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e64f9a0de0aac26329be556e83913fce",
+        "traceparent": "00-5c011e184e81494587894baf8c356170-38c965aa69d53f4c-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "525c12bd9291f59735f1fedbe09334fc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:36 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:59 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "418F502DB461E04133098B89C5C922B1EE19BC234CAE289269-Name",
-        "fallbackQueueId": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99",
+        "name": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF-Name",
+        "fallbackQueueId": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9",
         "queueSelectors": [
           {
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99"
+              "value": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9"
             },
             "kind": "static"
           }
@@ -223,25 +223,25 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:37 GMT",
-        "ETag": "\u002239006c6f-0000-0700-0000-642de6d90000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:37 GMT",
-        "trace-id": "f13c5c4f-e943-d343-b460-73c48f03bc73",
+        "Date": "Wed, 26 Apr 2023 15:51:59 GMT",
+        "ETag": "\u00223100a178-0000-0700-0000-6449489f0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:59 GMT",
+        "trace-id": "5c011e18-4e81-4945-8789-4baf8c356170",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02eYtZAAAAAD78Zj/muRrQahBAaE1rUXLWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0n0hJZAAAAAAiYmSjSZyMSb/\u002Bv9j0AJvAWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "418F502DB461E04133098B89C5C922B1EE19BC234CAE289269",
-        "name": "418F502DB461E04133098B89C5C922B1EE19BC234CAE289269-Name",
-        "fallbackQueueId": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99",
+        "id": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
+        "name": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF-Name",
+        "fallbackQueueId": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9",
         "queueSelectors": [
           {
             "kind": "static",
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "F8993C64A333CB6FBF6FD4FFAA83A8FB3DAC1FBF41451CDB99"
+              "value": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9"
             }
           }
         ],
@@ -262,11 +262,55 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF?api-version=2022-07-18-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "115",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-5f698cf9d5f3d742a9ca116fd4038076-85f6cab639daf64d-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "91ce871cf393899172f9010e9073f698",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:59 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "name": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF-Name-updated",
+        "queueSelectors": [],
+        "workerSelectors": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "ETag": "\u00223100a378-0000-0700-0000-644948a00000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "trace-id": "5f698cf9-d5f3-d742-a9ca-116fd4038076",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0n0hJZAAAAABdyseO8bc9TZRIWhA6jJjMWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
+        "X-Cache": "CONFIG_NOCACHE"
+      },
+      "ResponseBody": {
+        "id": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF",
+        "name": "9219A5F77FF8C4969A5F40A112FA355691B101E0D8FE07CABF-Name-updated",
+        "fallbackQueueId": "9BE02F49A5E3020B5B2D9A442479B209B7164543618E7CF1C9",
+        "queueSelectors": [],
+        "prioritizationRule": {
+          "kind": "static-rule",
+          "value": 1
+        },
+        "workerSelectors": []
+      }
     }
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-wAOPy2caXUSUkMYWsYdP_Q-",
-    "RandomSeed": "1811875582"
+    "id-prefix": "sdk-l15mn6WViEeM1FijtnWjVA-",
+    "RandomSeed": "405167038"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateEmptyClassificationPolicyTest.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateEmptyClassificationPolicyTest.json
@@ -1,22 +1,22 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/D26714FFA10D6DC208D02048C9DF1E836F81510EB3A00C2786?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/8AE8345022E9487149D778CEB5FB96293EFDA546ED4E28A028?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "214",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-0023b3c61bfa58c329273e40d68044a2-2f30ad651a49a1ef-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "807084ce3d98c379aef1506f0bc1f821",
+        "traceparent": "00-593b364e31f2d240a6fc7a9ff06b3660-0e395041b1193346-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "3e2a2b39255d953a424486d69796e44d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:25:50 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:54 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "LongestIdleDistributionPolicyD26714FFA10D6DC208D02048C9DF1E836F81510EB3A00C2786",
+        "name": "LongestIdleDistributionPolicy8AE8345022E9487149D778CEB5FB96293EFDA546ED4E28A028",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -29,17 +29,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:25:51 GMT",
-        "ETag": "\u00225c00df64-0000-0700-0000-642de75f0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:25:51 GMT",
-        "trace-id": "0023b3c6-1bfa-58c3-2927-3e40d68044a2",
+        "Date": "Wed, 26 Apr 2023 15:51:54 GMT",
+        "ETag": "\u0022a1022db6-0000-0700-0000-6449489b0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:55 GMT",
+        "trace-id": "593b364e-31f2-d240-a6fc-7a9ff06b3660",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0X\u002BctZAAAAAC8jriNyAmoRbkD6EqFWW7IWU1RMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0mkhJZAAAAACiH\u002BOOsttPRqBrn8T/oVPAWVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "D26714FFA10D6DC208D02048C9DF1E836F81510EB3A00C2786",
-        "name": "LongestIdleDistributionPolicyD26714FFA10D6DC208D02048C9DF1E836F81510EB3A00C2786",
+        "id": "8AE8345022E9487149D778CEB5FB96293EFDA546ED4E28A028",
+        "name": "LongestIdleDistributionPolicy8AE8345022E9487149D778CEB5FB96293EFDA546ED4E28A028",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -50,23 +50,23 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/157F0AD59A13AC7662C672719DC819A5BAEB8A749BBC40E4A2?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/8F90ECE892EC90681945A43A63CCB4200DF9B39F3E77CC9992?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "189",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-7e0df52dec375198d13f53de44506ed2-b50b41012c6bd846-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d41a96f30ff898aa6932da9913bafbf8",
+        "traceparent": "00-d016eb278f93694795471e5401f64388-7f1c06f5b705994f-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "b1ddef46a1091740ed652c26784ee358",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:25:51 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "DefaultQueue-Sdk-Test157F0AD59A13AC7662C672719DC819A5BAEB8A749BBC40E4A2",
-        "distributionPolicyId": "D26714FFA10D6DC208D02048C9DF1E836F81510EB3A00C2786",
+        "name": "DefaultQueue-Sdk-Test8F90ECE892EC90681945A43A63CCB4200DF9B39F3E77CC9992",
+        "distributionPolicyId": "8AE8345022E9487149D778CEB5FB96293EFDA546ED4E28A028",
         "labels": {
           "Label_1": "Value_1"
         }
@@ -75,37 +75,37 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:25:51 GMT",
-        "ETag": "\u00220b005529-0000-0700-0000-642de7600000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:25:52 GMT",
-        "trace-id": "7e0df52d-ec37-5198-d13f-53de44506ed2",
+        "Date": "Wed, 26 Apr 2023 15:51:54 GMT",
+        "ETag": "\u00223500ea77-0000-0700-0000-6449489b0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:55 GMT",
+        "trace-id": "d016eb27-8f93-6947-9547-1e5401f64388",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0YOctZAAAAAC8rKNaS6w2RJ\u002B3DQSDp07GWU1RMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0m0hJZAAAAACNPrGiOkLuSJULHJj1mRVHWVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "157F0AD59A13AC7662C672719DC819A5BAEB8A749BBC40E4A2",
-        "name": "DefaultQueue-Sdk-Test157F0AD59A13AC7662C672719DC819A5BAEB8A749BBC40E4A2",
-        "distributionPolicyId": "D26714FFA10D6DC208D02048C9DF1E836F81510EB3A00C2786",
+        "id": "8F90ECE892EC90681945A43A63CCB4200DF9B39F3E77CC9992",
+        "name": "DefaultQueue-Sdk-Test8F90ECE892EC90681945A43A63CCB4200DF9B39F3E77CC9992",
+        "distributionPolicyId": "8AE8345022E9487149D778CEB5FB96293EFDA546ED4E28A028",
         "labels": {
           "Label_1": "Value_1",
-          "Id": "157F0AD59A13AC7662C672719DC819A5BAEB8A749BBC40E4A2"
+          "Id": "8F90ECE892EC90681945A43A63CCB4200DF9B39F3E77CC9992"
         }
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-viboRT3Skkq2WPoRe2BpBg--CPEmpty?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-72s7qEZkl0WAge4zFBLxIg--CPEmpty?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "42",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-daee2df11dcf9dc44b272040425ae17e-2136d6f490303464-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "0b86680767196c60e3ab39e4b766eb6d",
+        "traceparent": "00-7e2b35120197b54d9bb9216ec745acc6-8f859732a7e7fa49-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "bb3f0ecc0119c7f8fcd87973ba864d58",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:25:51 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -116,31 +116,31 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:25:52 GMT",
-        "ETag": "\u002239004d7c-0000-0700-0000-642de7600000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:25:52 GMT",
-        "trace-id": "daee2df1-1dcf-9dc4-4b27-2040425ae17e",
+        "Date": "Wed, 26 Apr 2023 15:51:55 GMT",
+        "ETag": "\u002231009578-0000-0700-0000-6449489b0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:55 GMT",
+        "trace-id": "7e2b3512-0197-b54d-9bb9-216ec745acc6",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0YOctZAAAAAAvj7oZjnyFTqIOox7go9hxWU1RMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0m0hJZAAAAADQISJxgtZyQJldQQX9zbxJWVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "sdk-viboRT3Skkq2WPoRe2BpBg--CPEmpty",
+        "id": "sdk-72s7qEZkl0WAge4zFBLxIg--CPEmpty",
         "queueSelectors": [],
         "workerSelectors": []
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-viboRT3Skkq2WPoRe2BpBg--CPEmpty?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-72s7qEZkl0WAge4zFBLxIg--CPEmpty?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-ef2c8d1166305bf7a230e25ea757bb5a-a303ed563e6c63c6-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
-        "x-ms-client-request-id": "d98a12677a9cbe21dad8176563e0b0f4",
+        "traceparent": "00-ae712c2025355048b644be5f6b157c90-9c259a1cdf325749-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "f50bf5855b6a97daea1350f8f9131df3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:25:52 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -148,16 +148,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:25:52 GMT",
-        "ETag": "\u002239004d7c-0000-0700-0000-642de7600000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:25:52 GMT",
-        "trace-id": "ef2c8d11-6630-5bf7-a230-e25ea757bb5a",
+        "Date": "Wed, 26 Apr 2023 15:51:55 GMT",
+        "ETag": "\u002231009578-0000-0700-0000-6449489b0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:55 GMT",
+        "trace-id": "ae712c20-2535-5048-b644-be5f6b157c90",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "0YOctZAAAAADGx6hYEU8cT41e8uuojTfLWU1RMDFFREdFMDkwNwA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0m0hJZAAAAAALZP6NFN/vRoLixu5cPXJ8WVRPMjIxMDkwODE3MDUzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "sdk-viboRT3Skkq2WPoRe2BpBg--CPEmpty",
+        "id": "sdk-72s7qEZkl0WAge4zFBLxIg--CPEmpty",
         "queueSelectors": [],
         "workerSelectors": []
       }
@@ -165,7 +165,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-viboRT3Skkq2WPoRe2BpBg-",
-    "RandomSeed": "1992775314"
+    "id-prefix": "sdk-72s7qEZkl0WAge4zFBLxIg-",
+    "RandomSeed": "1503390901"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateEmptyClassificationPolicyTestAsync.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateEmptyClassificationPolicyTestAsync.json
@@ -1,59 +1,22 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-swTGTnDb6kmaZwNGVDHN5Q--CPEmpty?api-version=2022-07-18-preview",
-      "RequestMethod": "PATCH",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "42",
-        "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-65a6d63e5f1ce54d9a6f18db9ecaf14d-41c16e4fb728c74b-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b26ffdaf6fc78ffd81942b515e438b20",
-        "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:37 GMT",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "queueSelectors": [],
-        "workerSelectors": []
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "ETag": "\u00223900716f-0000-0700-0000-642de6da0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "trace-id": "65a6d63e-5f1c-e54d-9a6f-18db9ecaf14d",
-        "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02uYtZAAAAACyHfUO4\u002BbST7KKThxA\u002Bq6HWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
-        "X-Cache": "CONFIG_NOCACHE"
-      },
-      "ResponseBody": {
-        "id": "sdk-swTGTnDb6kmaZwNGVDHN5Q--CPEmpty",
-        "queueSelectors": [],
-        "workerSelectors": []
-      }
-    },
-    {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/419F5265875869627399A960D54F95D27239335382D06AA512?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/417466E7E9329C0B652C6E3E321830B70D5EB55BB93D70A175?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "214",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-6dde519d4c608a41b3bc6d8dcf027864-2ea3179ae1314549-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e0d87077e60c41feba2f7baec49a388d",
+        "traceparent": "00-e0f6220acbcead42b8b4908a7c575af6-487d6af80ecd0644-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "eaa26f767ba326ee336e5e2a546b8b54",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:37 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "LongestIdleDistributionPolicy419F5265875869627399A960D54F95D27239335382D06AA512",
+        "name": "LongestIdleDistributionPolicy417466E7E9329C0B652C6E3E321830B70D5EB55BB93D70A175",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -66,17 +29,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "ETag": "\u00225c00014d-0000-0700-0000-642de6da0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "trace-id": "6dde519d-4c60-8a41-b3bc-6d8dcf027864",
+        "Date": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "ETag": "\u0022a1023fba-0000-0700-0000-644948a00000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "trace-id": "e0f6220a-cbce-ad42-b8b4-908a7c575af6",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02uYtZAAAAADkGGzmj/GoTKfVqTKJIcjaWU1RMDFFREdFMDcxNQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oEhJZAAAAACVY84CWWNoRq7YNREFl1qIWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "419F5265875869627399A960D54F95D27239335382D06AA512",
-        "name": "LongestIdleDistributionPolicy419F5265875869627399A960D54F95D27239335382D06AA512",
+        "id": "417466E7E9329C0B652C6E3E321830B70D5EB55BB93D70A175",
+        "name": "LongestIdleDistributionPolicy417466E7E9329C0B652C6E3E321830B70D5EB55BB93D70A175",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -87,16 +50,53 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-swTGTnDb6kmaZwNGVDHN5Q--CPEmpty?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-EaLxO9-tdke2XdT6w9ndKg--CPEmpty?api-version=2022-07-18-preview",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "42",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "traceparent": "00-7f4803980d37b64ca89564b3ce3847fd-2e3d97cd0c94aa4f-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "64ebe3ab61880dad47fbbb53428fe3b3",
+        "x-ms-content-sha256": "Sanitized",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "queueSelectors": [],
+        "workerSelectors": []
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "ETag": "\u00223100a478-0000-0700-0000-644948a00000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "trace-id": "7f480398-0d37-b64c-a895-64b3ce3847fd",
+        "Transfer-Encoding": "chunked",
+        "X-Azure-Ref": "0oEhJZAAAAAATtAVPdYARTJhA9EzuGMtsWVRPMjIxMDkwODE4MDUxADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
+        "X-Cache": "CONFIG_NOCACHE"
+      },
+      "ResponseBody": {
+        "id": "sdk-EaLxO9-tdke2XdT6w9ndKg--CPEmpty",
+        "queueSelectors": [],
+        "workerSelectors": []
+      }
+    },
+    {
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-EaLxO9-tdke2XdT6w9ndKg--CPEmpty?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-99b756537a4dbf4a8c29be1cc07faaf9-fc2f1464fab71648-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "3dcd97be9b48081573495f78baade277",
+        "traceparent": "00-c8f117c04f475e468ad12385448ba47f-112c218bedfadc44-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "9a8b7ef284ca144fc294a3a7bf9be3a3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:37 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -104,16 +104,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "ETag": "\u00223900716f-0000-0700-0000-642de6da0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "trace-id": "99b75653-7a4d-bf4a-8c29-be1cc07faaf9",
+        "Date": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "ETag": "\u00223100a478-0000-0700-0000-644948a00000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "trace-id": "c8f117c0-4f47-5e46-8ad1-2385448ba47f",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02uYtZAAAAADxiVsn1JOMTb6Qp4oezl2uWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oEhJZAAAAAAnVqEGgzHOS7gUpdksijrlWVRPMjIxMDkwODE4MDUxADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "sdk-swTGTnDb6kmaZwNGVDHN5Q--CPEmpty",
+        "id": "sdk-EaLxO9-tdke2XdT6w9ndKg--CPEmpty",
         "queueSelectors": [],
         "workerSelectors": []
       }
@@ -121,7 +121,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-swTGTnDb6kmaZwNGVDHN5Q-",
-    "RandomSeed": "121237681"
+    "id-prefix": "sdk-EaLxO9-tdke2XdT6w9ndKg-",
+    "RandomSeed": "548162489"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreatePrioritizationClassificationPolicyTest.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreatePrioritizationClassificationPolicyTest.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-9c7BqKp9Q0SFu4JMaj_YRA--CPPri?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-LTjt3hPBaEeIBxvX1ZCPBg--CPPri?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "136",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-162aae8d89808b4597eb684dc1ded0c0-7eca45f190c5ac46-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "505659cd06412116bab81f1c6a41ca17",
+        "traceparent": "00-fcc499454696d540971c6db0cb4bcc0d-5badb41751aaff4f-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "682e3e60352149f66bf88ecb5378cede",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:33 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:55 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -28,16 +28,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:34 GMT",
-        "ETag": "\u00223900236f-0000-0700-0000-642de6d60000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:34 GMT",
-        "trace-id": "162aae8d-8980-8b45-97eb-684dc1ded0c0",
+        "Date": "Wed, 26 Apr 2023 15:51:56 GMT",
+        "ETag": "\u002231009878-0000-0700-0000-6449489c0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:56 GMT",
+        "trace-id": "fcc49945-4696-d540-971c-6db0cb4bcc0d",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "01uYtZAAAAAAvSpMAm2uTTJ6TjPA6lFkCWU1RMDFFREdFMDcxNQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nEhJZAAAAADAIzxcvTyYRa5HhuCCssx2WVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "sdk-9c7BqKp9Q0SFu4JMaj_YRA--CPPri",
+        "id": "sdk-LTjt3hPBaEeIBxvX1ZCPBg--CPPri",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "prioritizationRule": {
@@ -48,16 +48,16 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-9c7BqKp9Q0SFu4JMaj_YRA--CPPri?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-LTjt3hPBaEeIBxvX1ZCPBg--CPPri?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-56c5c92a71e45b47b8fc81706df0e662-c0e2eaf1096b8e49-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "42b8bb9f95d50c515dbb502f01a1aeb6",
+        "traceparent": "00-dc8be30bc9c9df4ca72c67a40cf52b71-a6fc1e9ad1b5534f-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "f82799fb569ab7dcc97932b6836416c4",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:33 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -65,16 +65,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:34 GMT",
-        "ETag": "\u00223900236f-0000-0700-0000-642de6d60000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:34 GMT",
-        "trace-id": "56c5c92a-71e4-5b47-b8fc-81706df0e662",
+        "Date": "Wed, 26 Apr 2023 15:51:56 GMT",
+        "ETag": "\u002231009878-0000-0700-0000-6449489c0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:56 GMT",
+        "trace-id": "dc8be30b-c9c9-df4c-a72c-67a40cf52b71",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "01uYtZAAAAACdFWQKyBVxQIKlvfexpm17WU1RMDFFREdFMDcxNQA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nEhJZAAAAABaEOTeGcaYRZNovMOzEsM2WVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "sdk-9c7BqKp9Q0SFu4JMaj_YRA--CPPri",
+        "id": "sdk-LTjt3hPBaEeIBxvX1ZCPBg--CPPri",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "prioritizationRule": {
@@ -87,7 +87,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-9c7BqKp9Q0SFu4JMaj_YRA-",
-    "RandomSeed": "224140266"
+    "id-prefix": "sdk-LTjt3hPBaEeIBxvX1ZCPBg-",
+    "RandomSeed": "733031086"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreatePrioritizationClassificationPolicyTestAsync.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreatePrioritizationClassificationPolicyTestAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-5_QZHkLXQkG1RQC8fH7wSg--CPPri?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-cmtTAT-kTE6s9ruc9vphqg--CPPri?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "136",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-2ba3dc985959ea429c570ae0f8677968-4a3a874cabad0744-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "1697b237c44fc4ae9fc3e581692df231",
+        "traceparent": "00-6d70729f7d3aa94a8e2f84a3655e598f-c97f149ee00a0d48-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "eeb5a241cf08794cd72e63be9bc76ca1",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:37 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:00 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -28,16 +28,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "ETag": "\u002239007d6f-0000-0700-0000-642de6db0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:39 GMT",
-        "trace-id": "2ba3dc98-5959-ea42-9c57-0ae0f8677968",
+        "Date": "Wed, 26 Apr 2023 15:52:00 GMT",
+        "ETag": "\u00223100a778-0000-0700-0000-644948a10000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:01 GMT",
+        "trace-id": "6d70729f-7d3a-a94a-8e2f-84a3655e598f",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02uYtZAAAAACACYjH5J4ZSpCjFdDLmlyPWU1RMDFFREdFMDcwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oUhJZAAAAACG7S398ibGTasRBvISzdZ7WVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "sdk-5_QZHkLXQkG1RQC8fH7wSg--CPPri",
+        "id": "sdk-cmtTAT-kTE6s9ruc9vphqg--CPPri",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "prioritizationRule": {
@@ -48,16 +48,16 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-5_QZHkLXQkG1RQC8fH7wSg--CPPri?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/sdk-cmtTAT-kTE6s9ruc9vphqg--CPPri?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8b00dabc862a7247baac755996946066-4471e3485161a444-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "2de3028ec0bf2cb9b1f0821ad5182ab4",
+        "traceparent": "00-b09d5f2c51e10c4598d0938957157c73-1c27a3564cfdd74f-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "5727270e0ac3ea660eac591643bda1dc",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:38 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -65,16 +65,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:38 GMT",
-        "ETag": "\u002239007d6f-0000-0700-0000-642de6db0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:39 GMT",
-        "trace-id": "8b00dabc-862a-7247-baac-755996946066",
+        "Date": "Wed, 26 Apr 2023 15:52:01 GMT",
+        "ETag": "\u00223100a778-0000-0700-0000-644948a10000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:01 GMT",
+        "trace-id": "b09d5f2c-51e1-0c45-98d0-938957157c73",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02\u002BYtZAAAAAB7l74bU7yCRb7329szsN9AWU1RMDFFREdFMDcwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oUhJZAAAAADkLCh1UNszTrdvhk1FpWBHWVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "sdk-5_QZHkLXQkG1RQC8fH7wSg--CPPri",
+        "id": "sdk-cmtTAT-kTE6s9ruc9vphqg--CPPri",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "prioritizationRule": {
@@ -87,7 +87,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-5_QZHkLXQkG1RQC8fH7wSg-",
-    "RandomSeed": "458427706"
+    "id-prefix": "sdk-cmtTAT-kTE6s9ruc9vphqg-",
+    "RandomSeed": "585684085"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateQueueSelectionClassificationPolicyTest.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateQueueSelectionClassificationPolicyTest.json
@@ -1,22 +1,22 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/3E7DDB94B235F27F8B16D8AEC6FD56B80C7DBC1BB5EA4F5681?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/54FCDDD3CF0BB24CCEADA91222DC7138A3C1C3DD91F7F1DA9D?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "214",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-8a837e3e14f9ed4c9df3b723dcdb2b5a-eb556ad282082543-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b8616d98ad13e4e7cb60808e94375ce4",
+        "traceparent": "00-e5dfa244a2f1aa48933bdaf19457d3f8-99eb28c0ca757b48-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "9eed801f1464cca64f8cf89ef80a8883",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:33 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "LongestIdleDistributionPolicy3E7DDB94B235F27F8B16D8AEC6FD56B80C7DBC1BB5EA4F5681",
+        "name": "LongestIdleDistributionPolicy54FCDDD3CF0BB24CCEADA91222DC7138A3C1C3DD91F7F1DA9D",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -29,17 +29,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:34 GMT",
-        "ETag": "\u00225c00504c-0000-0700-0000-642de6d60000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:34 GMT",
-        "trace-id": "8a837e3e-14f9-ed4c-9df3-b723dcdb2b5a",
+        "Date": "Wed, 26 Apr 2023 15:51:56 GMT",
+        "ETag": "\u0022a102bbb7-0000-0700-0000-6449489c0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:56 GMT",
+        "trace-id": "e5dfa244-a2f1-aa48-933b-daf19457d3f8",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "01uYtZAAAAAAa\u002BmIadLkKQ50Gh76Jb189WU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nEhJZAAAAADM4Z8I8D//SaJ8mkS99XdlWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "3E7DDB94B235F27F8B16D8AEC6FD56B80C7DBC1BB5EA4F5681",
-        "name": "LongestIdleDistributionPolicy3E7DDB94B235F27F8B16D8AEC6FD56B80C7DBC1BB5EA4F5681",
+        "id": "54FCDDD3CF0BB24CCEADA91222DC7138A3C1C3DD91F7F1DA9D",
+        "name": "LongestIdleDistributionPolicy54FCDDD3CF0BB24CCEADA91222DC7138A3C1C3DD91F7F1DA9D",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -50,23 +50,23 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "189",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-014092382fd04e4a91c625b530f955cc-675f0da0e2b99141-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "522b2c75543c158fbbf19cc108e1a0cb",
+        "traceparent": "00-f2a7a76ecfe86f4b9541915b08af90ea-16c8e23816823d44-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "739b9dd9a7925497f9d5897efa3ab458",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:34 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:56 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "DefaultQueue-Sdk-Test79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD",
-        "distributionPolicyId": "3E7DDB94B235F27F8B16D8AEC6FD56B80C7DBC1BB5EA4F5681",
+        "name": "DefaultQueue-Sdk-Test20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B",
+        "distributionPolicyId": "54FCDDD3CF0BB24CCEADA91222DC7138A3C1C3DD91F7F1DA9D",
         "labels": {
           "Label_1": "Value_1"
         }
@@ -75,37 +75,37 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:35 GMT",
-        "ETag": "\u00220b00c326-0000-0700-0000-642de6d70000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:35 GMT",
-        "trace-id": "01409238-2fd0-4e4a-91c6-25b530f955cc",
+        "Date": "Wed, 26 Apr 2023 15:51:57 GMT",
+        "ETag": "\u002235000178-0000-0700-0000-6449489d0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:57 GMT",
+        "trace-id": "f2a7a76e-cfe8-6f4b-9541-915b08af90ea",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "01\u002BYtZAAAAADNNycBhe58SL3aaOvv4x9ZWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nUhJZAAAAADYTS9bm\u002BYXSYadweomaEKVWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD",
-        "name": "DefaultQueue-Sdk-Test79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD",
-        "distributionPolicyId": "3E7DDB94B235F27F8B16D8AEC6FD56B80C7DBC1BB5EA4F5681",
+        "id": "20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B",
+        "name": "DefaultQueue-Sdk-Test20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B",
+        "distributionPolicyId": "54FCDDD3CF0BB24CCEADA91222DC7138A3C1C3DD91F7F1DA9D",
         "labels": {
           "Label_1": "Value_1",
-          "Id": "79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD"
+          "Id": "20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B"
         }
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/9AD376AE427D94BB59A6E8D21866471BFE0C57E7152BFDD261?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/17433725B21BC189E231D3DFCAC4008EAA70ED6775CFE1783B?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "218",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-1fb40f9f7c0d7d48bcc7b02428fcb3bc-af88210de4711846-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "06d9897145db692e69b0ffd9cb84fbcd",
+        "traceparent": "00-9d908d7b6666304eacab7e0fb9390727-ac1ca3397e605a46-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "10f021be0336691a6922be86b0f9073d",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:34 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -115,7 +115,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD"
+              "value": "20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B"
             },
             "kind": "static"
           }
@@ -126,16 +126,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:35 GMT",
-        "ETag": "\u002239003b6f-0000-0700-0000-642de6d70000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:35 GMT",
-        "trace-id": "1fb40f9f-7c0d-7d48-bcc7-b02428fcb3bc",
+        "Date": "Wed, 26 Apr 2023 15:51:57 GMT",
+        "ETag": "\u002231009a78-0000-0700-0000-6449489d0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:57 GMT",
+        "trace-id": "9d908d7b-6666-304e-acab-7e0fb9390727",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "01\u002BYtZAAAAACSHLv2FjynRIpkM2tg5\u002BNvWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nUhJZAAAAAA2Q8wi3IfIQJql5OEftqX1WVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "9AD376AE427D94BB59A6E8D21866471BFE0C57E7152BFDD261",
+        "id": "17433725B21BC189E231D3DFCAC4008EAA70ED6775CFE1783B",
         "name": "QueueSelection-ClassificationPolicy",
         "queueSelectors": [
           {
@@ -143,7 +143,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD"
+              "value": "20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B"
             }
           }
         ],
@@ -151,16 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/9AD376AE427D94BB59A6E8D21866471BFE0C57E7152BFDD261?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/17433725B21BC189E231D3DFCAC4008EAA70ED6775CFE1783B?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f91c36abbf3e394bad4f693209c97747-306884f5bf796949-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "6aba4f3fef4d44f1dd4cfd221125dbe9",
+        "traceparent": "00-c0d093b4d4683f45a07b91989228b7fb-57fc45ab9d486045-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "d6e1c8f0c9347829e899a58e8a27d115",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:34 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -168,16 +168,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:35 GMT",
-        "ETag": "\u002239003b6f-0000-0700-0000-642de6d70000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:35 GMT",
-        "trace-id": "f91c36ab-bf3e-394b-ad4f-693209c97747",
+        "Date": "Wed, 26 Apr 2023 15:51:57 GMT",
+        "ETag": "\u002231009a78-0000-0700-0000-6449489d0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:57 GMT",
+        "trace-id": "c0d093b4-d468-3f45-a07b-91989228b7fb",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "01\u002BYtZAAAAAC1wN2aTsR/T7aA3IZutjtGWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nUhJZAAAAADIiZKl2IBhTZcsFUPQCR\u002BbWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "9AD376AE427D94BB59A6E8D21866471BFE0C57E7152BFDD261",
+        "id": "17433725B21BC189E231D3DFCAC4008EAA70ED6775CFE1783B",
         "name": "QueueSelection-ClassificationPolicy",
         "queueSelectors": [
           {
@@ -185,7 +185,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "79393A092581DB41EB648CF9C4795FD33C76877284EA2F68FD"
+              "value": "20F46304A095C48252C459BC3E7081DE93288FA6EF32E2778B"
             }
           }
         ],
@@ -195,7 +195,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-ZhRmzkoPz0qvpPBccF58sg-",
-    "RandomSeed": "329446008"
+    "id-prefix": "sdk-8eue2IoLjkiRIROYXgSy8Q-",
+    "RandomSeed": "1070221111"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateQueueSelectionClassificationPolicyTestAsync.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateQueueSelectionClassificationPolicyTestAsync.json
@@ -1,22 +1,22 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/3BA036F72522D2DCA489176C93855A969A6A461EE5AE195607?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/distributionPolicies/27949C55FC9DA74D47CBDA3C2CABB52ED6B436848635623422?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "214",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4267917f2ca9984d9f34a267f02b5e2e-3d079d539cf5b64c-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "e8ac52df1772c91d2a5261172ef9fa87",
+        "traceparent": "00-d8a43fc48cb3884ea496c1bfae12c235-06a85fd147843544-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "f21c13f6e7bbbedb8fbcd6f3caf74d1e",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:38 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "LongestIdleDistributionPolicy3BA036F72522D2DCA489176C93855A969A6A461EE5AE195607",
+        "name": "LongestIdleDistributionPolicy27949C55FC9DA74D47CBDA3C2CABB52ED6B436848635623422",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -29,17 +29,17 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:39 GMT",
-        "ETag": "\u00225c00344d-0000-0700-0000-642de6db0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:39 GMT",
-        "trace-id": "4267917f-2ca9-984d-9f34-a267f02b5e2e",
+        "Date": "Wed, 26 Apr 2023 15:52:01 GMT",
+        "ETag": "\u0022a10222bb-0000-0700-0000-644948a10000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:01 GMT",
+        "trace-id": "d8a43fc4-8cb3-884e-a496-c1bfae12c235",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02\u002BYtZAAAAABVdTDLwnBYT7jCssvWul6DWU1RMDFFREdFMDcwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oUhJZAAAAABvcCl50zjcS6j5/9nmoFg3WVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "3BA036F72522D2DCA489176C93855A969A6A461EE5AE195607",
-        "name": "LongestIdleDistributionPolicy3BA036F72522D2DCA489176C93855A969A6A461EE5AE195607",
+        "id": "27949C55FC9DA74D47CBDA3C2CABB52ED6B436848635623422",
+        "name": "LongestIdleDistributionPolicy27949C55FC9DA74D47CBDA3C2CABB52ED6B436848635623422",
         "offerTtlSeconds": 30,
         "mode": {
           "kind": "longest-idle",
@@ -50,23 +50,23 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/4A1DF50E766510D9B96C79C65B60C86612363117318945106F?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/queues/4344B55CDC78FBE5F29C3714505832357F237C334BD3728292?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "189",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-4678d757c811ac4abbb5f3a47e1bf037-b6deb196ac6faa42-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "d95a2db935da08708499284f2d142346",
+        "traceparent": "00-b690d60a4a9c7e448c094bb6f4061f9a-390bc8b503282f44-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "669cbf11ed4d29a00f2fda152a26edef",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:39 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:01 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "DefaultQueue-Sdk-Test4A1DF50E766510D9B96C79C65B60C86612363117318945106F",
-        "distributionPolicyId": "3BA036F72522D2DCA489176C93855A969A6A461EE5AE195607",
+        "name": "DefaultQueue-Sdk-Test4344B55CDC78FBE5F29C3714505832357F237C334BD3728292",
+        "distributionPolicyId": "27949C55FC9DA74D47CBDA3C2CABB52ED6B436848635623422",
         "labels": {
           "Label_1": "Value_1"
         }
@@ -75,37 +75,37 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:39 GMT",
-        "ETag": "\u00220b00d526-0000-0700-0000-642de6dc0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:40 GMT",
-        "trace-id": "4678d757-c811-ac4a-bbb5-f3a47e1bf037",
+        "Date": "Wed, 26 Apr 2023 15:52:01 GMT",
+        "ETag": "\u002235003578-0000-0700-0000-644948a20000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "trace-id": "b690d60a-4a9c-7e44-8c09-4bb6f4061f9a",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02\u002BYtZAAAAADxWBTMY51ISJpwiKEEblnoWU1RMDFFREdFMDcwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0oUhJZAAAAABG0FazCilqQbeEBnVZmrHPWVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "4A1DF50E766510D9B96C79C65B60C86612363117318945106F",
-        "name": "DefaultQueue-Sdk-Test4A1DF50E766510D9B96C79C65B60C86612363117318945106F",
-        "distributionPolicyId": "3BA036F72522D2DCA489176C93855A969A6A461EE5AE195607",
+        "id": "4344B55CDC78FBE5F29C3714505832357F237C334BD3728292",
+        "name": "DefaultQueue-Sdk-Test4344B55CDC78FBE5F29C3714505832357F237C334BD3728292",
+        "distributionPolicyId": "27949C55FC9DA74D47CBDA3C2CABB52ED6B436848635623422",
         "labels": {
           "Label_1": "Value_1",
-          "Id": "4A1DF50E766510D9B96C79C65B60C86612363117318945106F"
+          "Id": "4344B55CDC78FBE5F29C3714505832357F237C334BD3728292"
         }
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/E46C10A9781EDE53F239C8C2CAD9D9A94553356B52A58EF230?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/E52687944B50BDFF77E81D969222D89C8FEA1805B250241F55?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "218",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-b11e241b72a17b4fbfe8ee6af678e1bd-faa7fc2acdb5864e-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "f077be71ec330cf17d1059ca349767c9",
+        "traceparent": "00-4a2fca6fac08b744bdc4f0eb500266cf-b303aced1d337f4a-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "1233cfc53bcfde514bb22b9969200258",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:39 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -115,7 +115,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "4A1DF50E766510D9B96C79C65B60C86612363117318945106F"
+              "value": "4344B55CDC78FBE5F29C3714505832357F237C334BD3728292"
             },
             "kind": "static"
           }
@@ -126,16 +126,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:39 GMT",
-        "ETag": "\u00223900a36f-0000-0700-0000-642de6dc0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:40 GMT",
-        "trace-id": "b11e241b-72a1-7b4f-bfe8-ee6af678e1bd",
+        "Date": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "ETag": "\u00223100ad78-0000-0700-0000-644948a20000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "trace-id": "4a2fca6f-ac08-b744-bdc4-f0eb500266cf",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03OYtZAAAAAA1LKSggqKGQ4q5k4RwpYlyWU1RMDFFREdFMDcwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0okhJZAAAAABmvJLmNhgSRqh28FkVIs4GWVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "E46C10A9781EDE53F239C8C2CAD9D9A94553356B52A58EF230",
+        "id": "E52687944B50BDFF77E81D969222D89C8FEA1805B250241F55",
         "name": "QueueSelection-ClassificationPolicy",
         "queueSelectors": [
           {
@@ -143,7 +143,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "4A1DF50E766510D9B96C79C65B60C86612363117318945106F"
+              "value": "4344B55CDC78FBE5F29C3714505832357F237C334BD3728292"
             }
           }
         ],
@@ -151,16 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/E46C10A9781EDE53F239C8C2CAD9D9A94553356B52A58EF230?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/E52687944B50BDFF77E81D969222D89C8FEA1805B250241F55?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-8e3e8a0b97e7e944bcccf5b8dc86ced0-bcecf1fef49a054c-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "b738d25e68a3a9f9e1a464d8eecd9c15",
+        "traceparent": "00-0a9cc48b82899449970d85c992c9b363-977b1b1001287d47-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "f3e5956ea9d6084f72f3e28c0cc69368",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:39 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -168,16 +168,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:40 GMT",
-        "ETag": "\u00223900a36f-0000-0700-0000-642de6dc0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:40 GMT",
-        "trace-id": "8e3e8a0b-97e7-e944-bccc-f5b8dc86ced0",
+        "Date": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "ETag": "\u00223100ad78-0000-0700-0000-644948a20000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "trace-id": "0a9cc48b-8289-9449-970d-85c992c9b363",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03OYtZAAAAACCSJoiRCZeRo\u002BaH4qEU4M1WU1RMDFFREdFMDcwOAA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0okhJZAAAAAA/Bmav6AsJQoqIEqHMAGW/WVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "E46C10A9781EDE53F239C8C2CAD9D9A94553356B52A58EF230",
+        "id": "E52687944B50BDFF77E81D969222D89C8FEA1805B250241F55",
         "name": "QueueSelection-ClassificationPolicy",
         "queueSelectors": [
           {
@@ -185,7 +185,7 @@
             "labelSelector": {
               "key": "Id",
               "labelOperator": "equal",
-              "value": "4A1DF50E766510D9B96C79C65B60C86612363117318945106F"
+              "value": "4344B55CDC78FBE5F29C3714505832357F237C334BD3728292"
             }
           }
         ],
@@ -195,7 +195,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-YlCKVn_1KUKdW8N4T113Bw-",
-    "RandomSeed": "1259386297"
+    "id-prefix": "sdk-LTGMy6noqEGYtc-N6izCUw-",
+    "RandomSeed": "1154758393"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateWorkerRequirementsClassificationPolicyTest.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateWorkerRequirementsClassificationPolicyTest.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/1940BC2B366D79523F76340C6A8FFDB81587E09C27BA7124DC?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/4BBC0122B17880EFCE864F53B9AB34BAD19EFD321CD3F0B463?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "175",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-a1b938c0285df04a8d3bcf6e424c26a9-cbe756915f871e49-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "2732a81236645c4410a97d884f10b31a",
+        "traceparent": "00-e0b8a5b782ac344b8f08162380960210-615eb8c11e801943-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "0db2bb99a0b4440394eef597cfe4dfb9",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:35 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,16 +33,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:36 GMT",
-        "ETag": "\u00223900446f-0000-0700-0000-642de6d80000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:36 GMT",
-        "trace-id": "a1b938c0-285d-f04a-8d3b-cf6e424c26a9",
+        "Date": "Wed, 26 Apr 2023 15:51:57 GMT",
+        "ETag": "\u002231009c78-0000-0700-0000-6449489e0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:58 GMT",
+        "trace-id": "e0b8a5b7-82ac-344b-8f08-162380960210",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "01\u002BYtZAAAAADRpYS\u002B0KYDT7xgCUa00i0FWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nUhJZAAAAACrQgTtHIESQa9xseq0vaOmWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "1940BC2B366D79523F76340C6A8FFDB81587E09C27BA7124DC",
+        "id": "4BBC0122B17880EFCE864F53B9AB34BAD19EFD321CD3F0B463",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "workerSelectors": [
@@ -60,16 +60,16 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/1940BC2B366D79523F76340C6A8FFDB81587E09C27BA7124DC?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/4BBC0122B17880EFCE864F53B9AB34BAD19EFD321CD3F0B463?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-9bb099330a2882428989f0145fc9add5-c378e271c19e694d-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "18ddd26929c97ec16cb84a9f28428046",
+        "traceparent": "00-a1c3fef734d8ec4ba8cedc9994e4c096-33e3dcf13b7d524e-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "764d43f67c1fcdc9aa9c5c5c1b9795d3",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:35 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:51:57 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -77,16 +77,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:36 GMT",
-        "ETag": "\u00223900446f-0000-0700-0000-642de6d80000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:36 GMT",
-        "trace-id": "9bb09933-0a28-8242-8989-f0145fc9add5",
+        "Date": "Wed, 26 Apr 2023 15:51:58 GMT",
+        "ETag": "\u002231009c78-0000-0700-0000-6449489e0000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:51:58 GMT",
+        "trace-id": "a1c3fef7-34d8-ec4b-a8ce-dc9994e4c096",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "02OYtZAAAAABkOu/xZc/kRoUz9gg9d2RcWU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0nkhJZAAAAADUSU0HYVvUQq/A1RVbkBxJWVRPMjIxMDkwODE5MDMzADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "1940BC2B366D79523F76340C6A8FFDB81587E09C27BA7124DC",
+        "id": "4BBC0122B17880EFCE864F53B9AB34BAD19EFD321CD3F0B463",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "workerSelectors": [
@@ -106,7 +106,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-EhPRzR7tmEuQmUezPBkO-g-",
-    "RandomSeed": "2125725877"
+    "id-prefix": "sdk-T71-RqdvEUKVLps41YPviw-",
+    "RandomSeed": "719017333"
   }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateWorkerRequirementsClassificationPolicyTestAsync.json
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/SessionRecords/ClassificationPolicyLiveTests/CreateWorkerRequirementsClassificationPolicyTestAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/3343DFD0A0FCC302395FD47FFD58C8C210E98DBE3DA8AEAC8D?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/8FF2F0E4BF1AB8F0A7A06A6482CD3AB1CBDCB58E1E68303E74?api-version=2022-07-18-preview",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "175",
         "Content-Type": "application/merge-patch\u002Bjson",
-        "traceparent": "00-c1d10dad88082b47bcb4a81c226df9bb-c843799fe2e7ad40-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "deffdc0096dbccbba9eb491a11c32904",
+        "traceparent": "00-c5a600b4c2158b42ac30ef80d46f36a2-5d4e2fcafff40f48-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "92391f7b3a9b75590123ca8b16337c7c",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:39 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,16 +33,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:40 GMT",
-        "ETag": "\u00223900b86f-0000-0700-0000-642de6dc0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:40 GMT",
-        "trace-id": "c1d10dad-8808-2b47-bcb4-a81c226df9bb",
+        "Date": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "ETag": "\u00223100af78-0000-0700-0000-644948a20000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "trace-id": "c5a600b4-c215-8b42-ac30-ef80d46f36a2",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03OYtZAAAAAAvyEouXSqBTL1YrjZ68Ge3WU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0okhJZAAAAAA9tWta\u002BEdGQZfTIWA8RlL8WVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "3343DFD0A0FCC302395FD47FFD58C8C210E98DBE3DA8AEAC8D",
+        "id": "8FF2F0E4BF1AB8F0A7A06A6482CD3AB1CBDCB58E1E68303E74",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "workerSelectors": [
@@ -60,16 +60,16 @@
       }
     },
     {
-      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/3343DFD0A0FCC302395FD47FFD58C8C210E98DBE3DA8AEAC8D?api-version=2022-07-18-preview",
+      "RequestUri": "https://sanitized.comminication.azure.com/routing/classificationPolicies/8FF2F0E4BF1AB8F0A7A06A6482CD3AB1CBDCB58E1E68303E74?api-version=2022-07-18-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-a48dbe2dad11e3409e8ed7a5d0fe5967-7d07894d3a54804c-00",
-        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230405.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
-        "x-ms-client-request-id": "01dccd6f4a6022cee0c56bc977065fdf",
+        "traceparent": "00-7fc40972d76d1b479b0563e555f07eb7-c240ccab14cab24d-00",
+        "User-Agent": "azsdk-net-Communication.JobRouter/1.0.0-alpha.20230426.1 (.NET Framework 4.8.9139.0; Microsoft Windows 10.0.22621 )",
+        "x-ms-client-request-id": "d44dd20930480054efcf83bcdaef21ea",
         "x-ms-content-sha256": "Sanitized",
-        "x-ms-date": "Wed, 05 Apr 2023 21:23:40 GMT",
+        "x-ms-date": "Wed, 26 Apr 2023 15:52:02 GMT",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -77,16 +77,16 @@
       "ResponseHeaders": {
         "api-supported-versions": "2021-04-07-preview1, 2022-07-18-preview",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 05 Apr 2023 21:23:41 GMT",
-        "ETag": "\u00223900b86f-0000-0700-0000-642de6dc0000\u0022",
-        "Last-Modified": "Wed, 05 Apr 2023 21:23:40 GMT",
-        "trace-id": "a48dbe2d-ad11-e340-9e8e-d7a5d0fe5967",
+        "Date": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "ETag": "\u00223100af78-0000-0700-0000-644948a20000\u0022",
+        "Last-Modified": "Wed, 26 Apr 2023 15:52:02 GMT",
+        "trace-id": "7fc40972-d76d-1b47-9b05-63e555f07eb7",
         "Transfer-Encoding": "chunked",
-        "X-Azure-Ref": "03eYtZAAAAACnWS04clH/SLZDtuvjuJe5WU1RMDFFREdFMDcwNgA5ZmM3YjUxOS1hOGNjLTRmODktOTM1ZS1jOTE0OGFlMDllODE=",
+        "X-Azure-Ref": "0o0hJZAAAAABMHbnfHk68RagsuKQnaWI7WVRPMjIxMDkwODE3MDM1ADlmYzdiNTE5LWE4Y2MtNGY4OS05MzVlLWM5MTQ4YWUwOWU4MQ==",
         "X-Cache": "CONFIG_NOCACHE"
       },
       "ResponseBody": {
-        "id": "3343DFD0A0FCC302395FD47FFD58C8C210E98DBE3DA8AEAC8D",
+        "id": "8FF2F0E4BF1AB8F0A7A06A6482CD3AB1CBDCB58E1E68303E74",
         "name": "Priority-ClassificationPolicy",
         "queueSelectors": [],
         "workerSelectors": [
@@ -106,7 +106,7 @@
   ],
   "Variables": {
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": "endpoint=https://sanitized.communication.azure.com/;accesskey=Kg==",
-    "id-prefix": "sdk-00S8nFUkVU6nIOTN1rU6Vw-",
-    "RandomSeed": "1746494593"
+    "id-prefix": "sdk-BW3JhHlNdkqdM3Ce-WTeNw-",
+    "RandomSeed": "571670332"
   }
 }


### PR DESCRIPTION
Fix bug where passing null for worker/queue selector throws exception.
Fix update classification policy, so that prioritization rule can now be updated
Fix cleanup so it happens even if test fails

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
