### PR TITLE
Add task to verify json files contain required members after ToC generation

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -16,7 +16,7 @@ jobs:
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:
           SkipCheckoutNone: true
-          Paths: 
+          Paths:
             # This is for retrieving code owners for service level readme metadata
             - .github/CODEOWNERS
 
@@ -93,7 +93,7 @@ jobs:
           Write-Host "##vso[task.setvariable variable=PackageSourceOverride]$publicFeedUrl"
         displayName: Set package source variable
         workingDirectory: $(DocRepoLocation)
-        
+
       - task: Powershell@2
         inputs:
           pwsh: true
@@ -125,6 +125,14 @@ jobs:
             -ReadmeFolderRoot "api/overview/azure"
             -PackageSourceOverride $(PackageSourceOverride)
         displayName: Generate ToC for Daily docs
+
+      - task: Powershell@2
+        inputs:
+          pwsh: true
+          filePath: eng/common/scripts/Verify-RequiredDocsJsonMembers.ps1
+          arguments: >-
+            -DocRepoLocation $(DocRepoLocation)
+        displayName: Verify Required Docs Json Members
 
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -67,6 +67,14 @@ jobs:
         displayName: Generate ToC for main branch
         condition: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Force.MainUpdate'], 'true')))
 
+      - task: Powershell@2
+        inputs:
+          pwsh: true
+          filePath: eng/common/scripts/Verify-RequiredDocsJsonMembers.ps1
+          arguments: >-
+            -DocRepoLocation $(DocRepoLocation)
+        displayName: Verify Required Docs Json Members
+
       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
         parameters:
           BaseRepoBranch: $(DefaultBranch)


### PR DESCRIPTION
Add a call after ToC generation to verify that the json files contain the required members which cannot be null or empty.