### PR TITLE
Fix Key Vault's ShareLink sample

### DIFF
--- a/sdk/keyvault/samples/sharelink/README.md
+++ b/sdk/keyvault/samples/sharelink/README.md
@@ -14,42 +14,8 @@ extendedZipContent:
   target: /nuget.config
 
 # Shared
-- path: /sdk/core/Azure.Core/src/Shared/AppContextSwitchHelper.cs
-  target: /Shared/Core/AppContextSwitchHelper.cs
-- path: /sdk/core/Azure.Core/src/Shared/Argument.cs
-  target: /Shared/Core/Argument.cs
-- path: /sdk/core/Azure.Core/src/Shared/AsyncLockWithValue.cs
-  target: /Shared/Core/AsyncLockWithValue.cs
 - path: /sdk/core/Azure.Core/src/Shared/AuthorizationChallengeParser.cs
   target: /Shared/Core/AuthorizationChallengeParser.cs
-- path: /sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
-  target: /Shared/Core/ClientDiagnostics.cs
-- path: /sdk/core/Azure.Core/src/Shared/ConstantDelayStrategy.cs
-  target: /Shared/Core/ConstantDelayStrategy.cs
-- path: /sdk/core/Azure.Core/src/Shared/ContentTypeUtilities.cs
-  target: /Shared/Core/ContentTypeUtilities.cs
-- path: /sdk/core/Azure.Core/src/Shared/DelayStrategyInternal.cs
-  target: /Shared/Core/DelayStrategyInternal.cs
-- path: /sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
-  target: /Shared/Core/DiagnosticScope.cs
-- path: /sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
-  target: /Shared/Core/DiagnosticScopeFactory.cs
-- path: /sdk/core/Azure.Core/src/Shared/HttpMessageSanitizer.cs
-  target: /Shared/Core/HttpMessageSanitizer.cs
-- path: /sdk/core/Azure.Core/src/Shared/OperationInternal.cs
-  target: /Shared/Core/OperationInternal.cs
-- path: /sdk/core/Azure.Core/src/Shared/OperationInternalBase.cs
-  target: /Shared/Core/OperationInternalBase.cs
-- path: /sdk/core/Azure.Core/src/Shared/OperationInternalOfT.cs
-  target: /Shared/Core/OperationInternalOfT.cs
-- path: /sdk/core/Azure.Core/src/Shared/OperationPoller.cs
-  target: /Shared/Core/OperationPoller.cs
-- path: /sdk/core/Azure.Core/src/Shared/RetryAfterDelayStrategy.cs
-  target: /Shared/Core/RetryAfterDelayStrategy.cs
-- path: /sdk/core/Azure.Core/src/Shared/TaskExtensions.cs
-  target: /Shared/Core/TaskExtensions.cs
-- path: /sdk/core/Azure.Core/src/Shared/VoidValue.cs
-  target: /Shared/Core/VoidValue.cs
 - path: /sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
   target: /Shared/KeyVault/ChallengeBasedAuthenticationPolicy.cs
 ---
@@ -119,10 +85,11 @@ dotnet build /t:CopySource /p:Destination=<ProjectDirectory>
 
 The sample project file and _Program.cs_ are not copied automatically. Only the source necessary to build the REST client is copied. You are welcome to copy and modify the rest of the sample source as needed.
 
-You also need to add a reference to Azure.Core in your project. In your project directory where you just copied source run:
+You also need to add references to Azure.Core and Microsoft.Azure.AutoRest.CSharp in your project. In your project directory where you just copied source run:
 
 ```dotnetcli
 dotnet add package Azure.Core
+dotnet add package Microsoft.Azure.AutoRest.CSharp --prerelease
 ```
 
 ## Using the sample

--- a/sdk/keyvault/samples/sharelink/ShareLink.csproj
+++ b/sdk/keyvault/samples/sharelink/ShareLink.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition="'$(IsSample)' != 'true'">
     <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
-    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20210602.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230427.2" PrivateAssets="All" />
     <PackageReference Update="Azure.Core" Version="1.26.0" />
     <PackageReference Update="Azure.Identity" Version="1.4.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.1.1" />
@@ -38,13 +38,12 @@
     <PackageReference Update="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\..\..\core\Azure.Core\src\Shared\AuthorizationChallengeParser.cs" LinkBase="Shared\Core" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(IsSample)' == 'true'">
     <!-- Link files needed for Key Vault -->
+    <Compile Include="..\..\..\core\Azure.Core\src\Shared\AuthorizationChallengeParser.cs" LinkBase="Shared\Core" />
     <Compile Include="..\..\Azure.Security.KeyVault.Shared\src\ChallengeBasedAuthenticationPolicy.cs" LinkBase="Shared\KeyVault" />
+
+    <None Include="..\..\..\..\NuGet.Config" Link="NuGet.Config" />
   </ItemGroup>
 
   <Target Name="CopySource">
@@ -52,7 +51,7 @@
 
     <ItemGroup>
       <!-- Collect all sources and ensure they have a relative Link metadata property -->
-      <_Source Include="@(Compile->HasMetadata('Link'))" />
+      <_Source Include="@(Compile->HasMetadata('Link'));@(None->HasMetadata('Link'))" />
       <_Source Include="@(Compile)" Exclude="Program.cs" Condition="@(Compile->'%(Link)') == ''">
         <Link>%(RecursiveDir)\%(Filename)%(Extension)</Link>
       </_Source>


### PR DESCRIPTION
This should not only fix the ShareLink sample, but make it more robust against future refactorings. It'll have people add package refs for Azure.Core as well as Microsoft.Azure.AutoRest.CSharp and does add the nuget.config to the ZIP.
