### PR TITLE
[Service Bus Extensions] Add MinMessageBatchSize and MaxWaitTime to options

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
@@ -82,6 +82,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public int MaxConcurrentCalls { get { throw null; } set { } }
         public int MaxConcurrentSessions { get { throw null; } set { } }
         public int MaxMessageBatchSize { get { throw null; } set { } }
+        public System.TimeSpan MaxWaitTime { get { throw null; } set { } }
+        public int MinMessageBatchSize { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public System.Func<Azure.Messaging.ServiceBus.ProcessErrorEventArgs, System.Threading.Tasks.Task> ProcessErrorAsync { get { throw null; } set { } }
         public System.Func<Azure.Messaging.ServiceBus.ProcessSessionEventArgs, System.Threading.Tasks.Task> SessionClosingAsync { get { throw null; } set { } }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
@@ -79,10 +79,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public bool EnableCrossEntityTransactions { get { throw null; } set { } }
         public Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { throw null; } set { } }
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
+        public System.TimeSpan MaxBatchWaitTime { get { throw null; } set { } }
         public int MaxConcurrentCalls { get { throw null; } set { } }
         public int MaxConcurrentSessions { get { throw null; } set { } }
         public int MaxMessageBatchSize { get { throw null; } set { } }
-        public System.TimeSpan MaxWaitTime { get { throw null; } set { } }
         public int MinMessageBatchSize { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public System.Func<Azure.Messaging.ServiceBus.ProcessErrorEventArgs, System.Threading.Tasks.Task> ProcessErrorAsync { get { throw null; } set { } }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -90,9 +90,9 @@ namespace Microsoft.Extensions.Hosting
                         throw new InvalidOperationException("The minimum message batch size must be less than the maximum message batch size");
                     }
 
-                    if (options.MaxWaitTime > TimeSpan.FromSeconds(150))
+                    if (options.MaxBatchWaitTime > TimeSpan.FromSeconds(150))
                     {
-                        throw new InvalidOperationException("The maximum wait time must be less than 2 minutes and 30 seconds.");
+                        throw new InvalidOperationException("This value should be no longer then 50% of the entity message lock duration, meaning the maximum allowed value is 2 minutes and 30 seconds. Otherwise, you may get lock exceptions when messages are pulled from the cache.");
                     }
 
                     configure(options);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -85,6 +85,11 @@ namespace Microsoft.Extensions.Hosting
 
                     section.Bind(options);
 
+                    if (options.MinMessageBatchSize > options.MaxMessageBatchSize)
+                    {
+                        throw new InvalidOperationException("The minimum message batch size must be less than the maximum message batch size");
+                    }
+
                     configure(options);
                 });
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -90,6 +90,11 @@ namespace Microsoft.Extensions.Hosting
                         throw new InvalidOperationException("The minimum message batch size must be less than the maximum message batch size");
                     }
 
+                    if (options.MaxWaitTime > TimeSpan.FromSeconds(150))
+                    {
+                        throw new InvalidOperationException("The maximum wait time must be less than 2 minutes and 30 seconds.");
+                    }
+
                     configure(options);
                 });
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -147,6 +147,21 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public int MaxMessageBatchSize { get; set; } = 1000;
 
         /// <summary>
+        /// Gets or sets the minimum number of events desired for a batch. This setting applies only to functions that
+        /// receive multiple events. This value must be less than <see cref="MaxMessageBatchSize"/> and is used in
+        /// conjunction with <see cref="MaxWaitTime"/>. Default 1.
+        /// </summary>
+        public int MinMessageBatchSize { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the maximum time that the trigger should wait to fill a batch before invoking the function.
+        /// This is only considered when <see cref="MinMessageBatchSize"/> is set to larger than 1 and is otherwise unused.
+        /// If less than <see cref="MinMessageBatchSize" /> events were available before the wait time elapses, the function
+        /// will be invoked with a partial batch.  Default is 60 seconds.  The longest allowed wait time is 10 minutes.
+        /// </summary>
+        public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(60);
+
+        /// <summary>
         /// Gets or sets the maximum amount of time to wait for a message to be received for the
         /// currently active session. After this time has elapsed, the processor will close the session
         /// and attempt to process another session.
@@ -201,6 +216,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 { nameof(MaxConcurrentCalls), MaxConcurrentCalls },
                 { nameof(MaxConcurrentSessions), MaxConcurrentSessions },
                 { nameof(MaxMessageBatchSize), MaxMessageBatchSize },
+                { nameof(MinMessageBatchSize), MinMessageBatchSize },
+                { nameof(MaxWaitTime), MaxWaitTime },
                 { nameof(SessionIdleTimeout), SessionIdleTimeout.ToString() ?? string.Empty },
                 { nameof(EnableCrossEntityTransactions), EnableCrossEntityTransactions }
             };

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -157,9 +157,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// Gets or sets the maximum time that the trigger should wait to fill a batch before invoking the function.
         /// This is only considered when <see cref="MinMessageBatchSize"/> is set to larger than 1 and is otherwise unused.
         /// If less than <see cref="MinMessageBatchSize" /> events were available before the wait time elapses, the function
-        /// will be invoked with a partial batch.  Default is 60 seconds.  The longest allowed wait time is 10 minutes.
+        /// will be invoked with a partial batch. The longest allowed wait time is 10 minutes. This
+        /// value should be no longer then 50% of the longest message lock duration; for example, the LockDuration Property.
+        /// Otherwise, you may get lock exceptions when messages are pulled from the cache.
+        /// The default value is 30 seconds.
         /// </summary>
-        public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(60);
+        public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Gets or sets the maximum amount of time to wait for a message to be received for the

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -149,7 +149,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <summary>
         /// Gets or sets the minimum number of events desired for a batch. This setting applies only to functions that
         /// receive multiple events. This value must be less than <see cref="MaxMessageBatchSize"/> and is used in
-        /// conjunction with <see cref="MaxWaitTime"/>. Default 1.
+        /// conjunction with <see cref="MaxWaitTime"/>. If <see cref="MaxWaitTime"/> passes and less than <see cref="MinMessageBatchSize"/>
+        /// has been received, the function will be invoked with a partial batch. Default 1.
         /// </summary>
         public int MinMessageBatchSize { get; set; } = 1;
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -157,8 +157,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// Gets or sets the maximum time that the trigger should wait to fill a batch before invoking the function.
         /// This is only considered when <see cref="MinMessageBatchSize"/> is set to larger than 1 and is otherwise unused.
         /// If less than <see cref="MinMessageBatchSize" /> events were available before the wait time elapses, the function
-        /// will be invoked with a partial batch. The longest allowed wait time is 10 minutes. This
-        /// value should be no longer then 50% of the longest message lock duration; for example, the LockDuration Property.
+        /// will be invoked with a partial batch. This value should be no longer then 50% of the longest message lock duration;
+        /// for example, the LockDuration Property. Therefore, the maximum allowed value is 2 minutes and 30 seconds.
         /// Otherwise, you may get lock exceptions when messages are pulled from the cache.
         /// The default value is 30 seconds.
         /// </summary>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -157,9 +157,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <summary>
         /// Gets or sets the maximum time that the trigger should wait to fill a batch before invoking the function.
         /// This is only considered when <see cref="MinMessageBatchSize"/> is set to larger than 1 and is otherwise unused.
-        /// If less than <see cref="MinMessageBatchSize" /> events were available before the wait time elapses, the function
-        /// will be invoked with a partial batch. This value should be no longer then 50% of the longest message lock duration;
-        /// for example, the LockDuration Property. Therefore, the maximum allowed value is 2 minutes and 30 seconds.
+        /// If less than <see cref="MinMessageBatchSize" /> messages were available before the wait time elapses, the function
+        /// will be invoked with a partial batch. This value should be no longer then 50% of the entity message lock duration.
+        /// Therefore, the maximum allowed value is 2 minutes and 30 seconds.
         /// Otherwise, you may get lock exceptions when messages are pulled from the cache.
         /// The default value is 30 seconds.
         /// </summary>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -153,6 +153,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <see cref="MinMessageBatchSize"/> has been received, the function will be invoked with a partial batch.
         /// Default 1.
         /// </summary>
+        /// <remarks>
+        /// The minimum size is not a strict guarantee, as a partial batch will be dispatched if a full batch cannot be
+        /// prepared before the <see cref="MaxBatchWaitTime"/> has elapsed.
+        /// </remarks>
         public int MinMessageBatchSize { get; set; } = 1;
 
         /// <summary>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -149,8 +149,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <summary>
         /// Gets or sets the minimum number of messages desired for a batch. This setting applies only to functions that
         /// receive multiple messages. This value must be less than <see cref="MaxMessageBatchSize"/> and is used in
-        /// conjunction with <see cref="MaxWaitTime"/>. If <see cref="MaxWaitTime"/> passes and less than <see cref="MinMessageBatchSize"/>
-        /// has been received, the function will be invoked with a partial batch. Default 1.
+        /// conjunction with <see cref="MaxBatchWaitTime"/>. If <see cref="MaxBatchWaitTime"/> passes and less than
+        /// <see cref="MinMessageBatchSize"/> has been received, the function will be invoked with a partial batch.
+        /// Default 1.
         /// </summary>
         public int MinMessageBatchSize { get; set; } = 1;
 
@@ -163,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// Otherwise, you may get lock exceptions when messages are pulled from the cache.
         /// The default value is 30 seconds.
         /// </summary>
-        public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan MaxBatchWaitTime { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Gets or sets the maximum amount of time to wait for a message to be received for the

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -147,8 +147,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public int MaxMessageBatchSize { get; set; } = 1000;
 
         /// <summary>
-        /// Gets or sets the minimum number of events desired for a batch. This setting applies only to functions that
-        /// receive multiple events. This value must be less than <see cref="MaxMessageBatchSize"/> and is used in
+        /// Gets or sets the minimum number of messages desired for a batch. This setting applies only to functions that
+        /// receive multiple messages. This value must be less than <see cref="MaxMessageBatchSize"/> and is used in
         /// conjunction with <see cref="MaxWaitTime"/>. If <see cref="MaxWaitTime"/> passes and less than <see cref="MinMessageBatchSize"/>
         /// has been received, the function will be invoked with a partial batch. Default 1.
         /// </summary>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusOptions.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 { nameof(MaxConcurrentSessions), MaxConcurrentSessions },
                 { nameof(MaxMessageBatchSize), MaxMessageBatchSize },
                 { nameof(MinMessageBatchSize), MinMessageBatchSize },
-                { nameof(MaxWaitTime), MaxWaitTime },
+                { nameof(MaxBatchWaitTime), MaxBatchWaitTime },
                 { nameof(SessionIdleTimeout), SessionIdleTimeout.ToString() ?? string.Empty },
                 { nameof(EnableCrossEntityTransactions), EnableCrossEntityTransactions }
             };

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -243,6 +243,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                     // Wait for the batch loop to complete.
                     await _batchLoop.ConfigureAwait(false);
 
+                    // Wait for the background loop to complete.
+                    if (_backgroundCacheMonitoringCts != null)
+                    {
+                        await _backgroundCacheMonitoringTask.ConfigureAwait(false);
+                    }
+
                     CancelExistingMonitoringTasks();
 
                     // Try to dispatch any already received messages.
@@ -750,7 +756,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                             _monitoringCycleReceiveActions,
                             _client.Value);
 
-                    await TriggerWithMessagesInternal(triggerMessages, input, _monitoringCycleReceiver, _monitoringCycleReceiveActions, _monitoringCycleMessageActions, backgroundCancellationToken).ConfigureAwait(false);
+        await TriggerWithMessagesInternal(triggerMessages, input, _monitoringCycleReceiver, _monitoringCycleReceiveActions, _monitoringCycleMessageActions, backgroundCancellationToken).ConfigureAwait(false);
                 }
                 else
                 {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -19,8 +19,6 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
-using static System.Collections.Specialized.BitVector32;
-using System.Drawing;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -525,7 +525,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                             await TriggerWithMessagesInternal(messagesArray, input, receiver, receiveActions, messageActions, cancellationToken).ConfigureAwait(false);
                         }
 
-                        if (_cachedMessagesManager.HasCachedMessages && (_backgroundCacheMonitoringCts == null))
+                        if (_supportMinBatchSize && _cachedMessagesManager.HasCachedMessages)
                         {
                             if (_backgroundCacheMonitoringCts == null)
                             {
@@ -699,7 +699,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 
         private async Task TryDispatchRemainingMessages(ServiceBusReceiver receiver, ServiceBusMessageActions messageActions, ServiceBusReceiveActions receiveActions, CancellationToken cancellationToken)
         {
-            if (_cachedMessagesManager.HasCachedMessages)
+            if (_supportMinBatchSize && _cachedMessagesManager.HasCachedMessages)
             {
                 var acquiredSemaphore = false;
                 ServiceBusReceivedMessage[] batchMessages;

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                                 acquiredSemaphore = true;
 
                                 // Get set of messages to use for batch here.
-                                messagesArray = _cachedMessagesManager.TryGetBatchofEventsWithCached(messagesArray);
+                                messagesArray = _cachedMessagesManager.TryGetBatchofEventsWithCached(messages.ToArray());
                             }
                             finally
                             {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -439,12 +439,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                     {
                         try
                         {
-                            // TODO: TEMPORARY ASSERTION
-                            if (_backgroundCacheMonitoringCts != null)
-                            {
-                                throw new Exception($"No messages should be waiting in the cache if the receiver is closed. There are {_cachedMessagesManager.CachedMessages.Count} messages in the cache.");
-                            }
-
                             ServiceBusSessionReceiver sessionReceiver = await sessionClient.AcceptNextSessionAsync(
                                 _entityPath,
                                 new ServiceBusSessionReceiverOptions

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Azure.Messaging.ServiceBus;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
+{
+	/// <summary>
+	/// This class manages a queue of Service Bus messages using a minimum and maximum batch size. This class is NOT thread safe.
+	/// Concurrency must be managed by the class using this message manager.
+	/// </summary>
+	internal class ServiceBusMessageManager : IDisposable
+	{
+		private int _maxBatchSize;
+		private int _minBatchSize;
+
+		// This is internal for mocking purposes only.
+		internal Queue<ServiceBusMessage> CachedMessages { get; set; }
+
+		public bool HasCachedMessages
+		{
+			get
+			{
+				return CachedMessages.Count > 0;
+			}
+		}
+
+		public ServiceBusMessageManager(int maxBatchSize, int minBatchSize)
+		{
+			CachedMessages = new Queue<ServiceBusMessage>();
+			_maxBatchSize = maxBatchSize;
+			_minBatchSize = minBatchSize;
+		}
+
+		public void ClearEventCache()
+		{
+			CachedMessages.Clear();
+		}
+
+		/// <summary>
+		/// Try to create a batch from <paramref name="messages"/> and any messages stored in the cache. If <paramref name="allowPartialBatch"/>
+		/// is true, this method return all messages available even if there aren't enough to hit the minimum batch size threshold. If
+		/// <paramref name="allowPartialBatch"/> is false, this method either returns a batch of at least the minimum batch size (and less than the
+		/// maximum batch size), or it returns nothing and retains all available messages in the cache.
+		/// </summary>
+		/// <param name="messages">An array of messages to either add to a batch or cache.</param>
+		/// <param name="allowPartialBatch">True if batches smaller than the minimum batch size can be returned.</param>
+		/// <returns></returns>
+		public ServiceBusMessage[] TryGetBatchofEventsWithCached(ServiceBusMessage[] messages = null, bool allowPartialBatch = false)
+		{
+			ServiceBusMessage[] messagesToReturn;
+			var inputMessages = messages?.Length ?? 0;
+			var totalMessages = CachedMessages.Count + inputMessages;
+
+			// Enqueue all new messages, if any, to the cache queue.
+			if (messages != null)
+			{
+				foreach (var message in messages)
+				{
+					CachedMessages.Enqueue(message);
+				}
+			}
+
+			if (totalMessages < _minBatchSize && !allowPartialBatch)
+			{
+				// If we don't have enough messages, and we can't return a partial batch, just return an empty array.
+				messagesToReturn = Array.Empty<ServiceBusMessage>();
+			}
+			else
+			{
+				// If we have enough messages, pull all the messages off the queue to return.
+				var sizeOfBatch = totalMessages > _maxBatchSize ? _maxBatchSize : totalMessages;
+				messagesToReturn = new ServiceBusMessage[sizeOfBatch];
+				for (int i = 0; i < sizeOfBatch; i++)
+				{
+					var nextMessage = CachedMessages.Dequeue();
+					messagesToReturn[i] = nextMessage;
+				}
+			}
+			return messagesToReturn;
+		}
+
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+		}
+	}
+}

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 	/// This class manages a queue of Service Bus messages using a minimum and maximum batch size. This class is NOT thread safe.
 	/// Concurrency must be managed by the class using this message manager.
 	/// </summary>
-	internal class ServiceBusMessageManager : IDisposable
+	internal class ServiceBusMessageManager
 	{
 		private int _maxBatchSize;
 		private int _minBatchSize;
@@ -80,11 +80,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 				}
 			}
 			return messagesToReturn;
-		}
-
-		public void Dispose()
-		{
-			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 		/// <param name="messages">An array of messages to either add to a batch or cache.</param>
 		/// <param name="allowPartialBatch">True if batches smaller than the minimum batch size can be returned.</param>
 		/// <returns></returns>
-		public ServiceBusReceivedMessage[] TryGetBatchofMessagesWithCached(ServiceBusReceivedMessage[] messages = null, bool allowPartialBatch = false)
+		public ServiceBusReceivedMessage[] GetBatchofMessagesWithCached(ServiceBusReceivedMessage[] messages = null, bool allowPartialBatch = false)
 		{
             ServiceBusReceivedMessage[] messagesToReturn;
 			var inputMessages = messages?.Length ?? 0;

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 		private int _minBatchSize;
 
 		// This is internal for mocking purposes only.
-		internal Queue<ServiceBusMessage> CachedMessages { get; set; }
+		internal Queue<ServiceBusReceivedMessage> CachedMessages { get; set; }
 
 		public bool HasCachedMessages
 		{
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 
 		public ServiceBusMessageManager(int maxBatchSize, int minBatchSize)
 		{
-			CachedMessages = new Queue<ServiceBusMessage>();
+			CachedMessages = new Queue<ServiceBusReceivedMessage>();
 			_maxBatchSize = maxBatchSize;
 			_minBatchSize = minBatchSize;
 		}
@@ -48,9 +48,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 		/// <param name="messages">An array of messages to either add to a batch or cache.</param>
 		/// <param name="allowPartialBatch">True if batches smaller than the minimum batch size can be returned.</param>
 		/// <returns></returns>
-		public ServiceBusMessage[] TryGetBatchofEventsWithCached(ServiceBusMessage[] messages = null, bool allowPartialBatch = false)
+		public ServiceBusReceivedMessage[] TryGetBatchofEventsWithCached(ServiceBusReceivedMessage[] messages = null, bool allowPartialBatch = false)
 		{
-			ServiceBusMessage[] messagesToReturn;
+            ServiceBusReceivedMessage[] messagesToReturn;
 			var inputMessages = messages?.Length ?? 0;
 			var totalMessages = CachedMessages.Count + inputMessages;
 
@@ -66,13 +66,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 			if (totalMessages < _minBatchSize && !allowPartialBatch)
 			{
 				// If we don't have enough messages, and we can't return a partial batch, just return an empty array.
-				messagesToReturn = Array.Empty<ServiceBusMessage>();
+				messagesToReturn = Array.Empty<ServiceBusReceivedMessage>();
 			}
 			else
 			{
 				// If we have enough messages, pull all the messages off the queue to return.
 				var sizeOfBatch = totalMessages > _maxBatchSize ? _maxBatchSize : totalMessages;
-				messagesToReturn = new ServiceBusMessage[sizeOfBatch];
+				messagesToReturn = new ServiceBusReceivedMessage[sizeOfBatch];
 				for (int i = 0; i < sizeOfBatch; i++)
 				{
 					var nextMessage = CachedMessages.Dequeue();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 	{
 		private int _maxBatchSize;
 		private int _minBatchSize;
+		private string _sessionId;
 
 		// This is internal for mocking purposes only.
 		internal Queue<ServiceBusReceivedMessage> CachedMessages { get; set; }
@@ -27,11 +28,20 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 			}
 		}
 
-		public ServiceBusMessageManager(int maxBatchSize, int minBatchSize)
+        public string SessionId
+        {
+            get
+            {
+                return _sessionId;
+            }
+        }
+
+        public ServiceBusMessageManager(int maxBatchSize, int minBatchSize, string sessionID=null)
 		{
 			CachedMessages = new Queue<ServiceBusReceivedMessage>();
 			_maxBatchSize = maxBatchSize;
 			_minBatchSize = minBatchSize;
+			_sessionId = sessionID;
 		}
 
 		public void ClearEventCache()

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 			_minBatchSize = minBatchSize;
 		}
 
-		public void ClearEventCache()
+		public void ClearMessageCache()
 		{
 			CachedMessages.Clear();
 		}

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -7,79 +7,73 @@ using Azure.Messaging.ServiceBus;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 {
-	/// <summary>
-	/// This class manages a queue of Service Bus messages using a minimum and maximum batch size. This class is NOT thread safe.
-	/// Concurrency must be managed by the class using this message manager.
-	/// </summary>
-	internal class ServiceBusMessageManager
-	{
-		private int _maxBatchSize;
-		private int _minBatchSize;
+    /// <summary>
+    /// This class manages a queue of Service Bus messages using a minimum and maximum batch size. This class is NOT thread safe.
+    /// Concurrency must be managed by the class using this message manager.
+    /// </summary>
+    internal class ServiceBusMessageManager
+    {
+        private int _maxBatchSize;
+        private int _minBatchSize;
 
-		// This is internal for mocking purposes only.
-		internal Queue<ServiceBusReceivedMessage> CachedMessages { get; set; }
+        // This is internal for mocking purposes only.
+        internal Queue<ServiceBusReceivedMessage> CachedMessages { get; set; }
 
-		public bool HasCachedMessages => CachedMessages.Count > 0;
-		{
-			get
-			{
-				return CachedMessages.Count > 0;
-			}
-		}
+        public bool HasCachedMessages => CachedMessages.Count > 0;
 
         public ServiceBusMessageManager(int maxBatchSize, int minBatchSize)
-		{
-			CachedMessages = new Queue<ServiceBusReceivedMessage>();
-			_maxBatchSize = maxBatchSize;
-			_minBatchSize = minBatchSize;
-		}
+        {
+            CachedMessages = new Queue<ServiceBusReceivedMessage>();
+            _maxBatchSize = maxBatchSize;
+            _minBatchSize = minBatchSize;
+        }
 
-		public void ClearMessageCache()
-		{
-			CachedMessages.Clear();
-		}
+        public void ClearMessageCache()
+        {
+            CachedMessages.Clear();
+        }
 
-		/// <summary>
-		/// Try to create a batch from <paramref name="messages"/> and any messages stored in the cache. If <paramref name="allowPartialBatch"/>
-		/// is true, this method return all messages available even if there aren't enough to hit the minimum batch size threshold. If
-		/// <paramref name="allowPartialBatch"/> is false, this method either returns a batch of at least the minimum batch size (and less than the
-		/// maximum batch size), or it returns nothing and retains all available messages in the cache.
-		/// </summary>
-		/// <param name="messages">An array of messages to either add to a batch or cache.</param>
-		/// <param name="allowPartialBatch">True if batches smaller than the minimum batch size can be returned.</param>
-		/// <returns></returns>
-		public ServiceBusReceivedMessage[] GetBatchofMessagesWithCached(ServiceBusReceivedMessage[] messages = null, bool allowPartialBatch = false)
-		{
+        /// <summary>
+        /// Try to create a batch from <paramref name="messages"/> and any messages stored in the cache. If <paramref name="allowPartialBatch"/>
+        /// is true, this method return all messages available even if there aren't enough to hit the minimum batch size threshold. If
+        /// <paramref name="allowPartialBatch"/> is false, this method either returns a batch of at least the minimum batch size (and less than the
+        /// maximum batch size), or it returns nothing and retains all available messages in the cache.
+        /// </summary>
+        /// <param name="messages">An array of messages to either add to a batch or cache.</param>
+        /// <param name="allowPartialBatch">True if batches smaller than the minimum batch size can be returned.</param>
+        /// <returns></returns>
+        public ServiceBusReceivedMessage[] GetBatchofMessagesWithCached(ServiceBusReceivedMessage[] messages = null, bool allowPartialBatch = false)
+        {
             ServiceBusReceivedMessage[] messagesToReturn;
-			var inputMessages = messages?.Length ?? 0;
-			var totalMessages = CachedMessages.Count + inputMessages;
+            var inputMessages = messages?.Length ?? 0;
+            var totalMessages = CachedMessages.Count + inputMessages;
 
-			// Enqueue all new messages, if any, to the cache queue.
-			if (messages != null)
-			{
-				foreach (var message in messages)
-				{
-					CachedMessages.Enqueue(message);
-				}
-			}
+            // Enqueue all new messages, if any, to the cache queue.
+            if (messages != null)
+            {
+                foreach (var message in messages)
+                {
+                    CachedMessages.Enqueue(message);
+                }
+            }
 
-			if (totalMessages < _minBatchSize && !allowPartialBatch)
-			{
-				// If we don't have enough messages, and we can't return a partial batch, just return an empty array.
-				messagesToReturn = Array.Empty<ServiceBusReceivedMessage>();
-			}
-			else
-			{
-				// If we have enough messages, pull all the messages off the queue to return.
-				var sizeOfBatch = totalMessages > _maxBatchSize ? _maxBatchSize : totalMessages;
-				messagesToReturn = new ServiceBusReceivedMessage[sizeOfBatch];
-				for (int i = 0; i < sizeOfBatch; i++)
-				{
-					var nextMessage = CachedMessages.Dequeue();
-					messagesToReturn[i] = nextMessage;
-				}
-			}
-			return messagesToReturn;
-		}
-	}
+            if (totalMessages < _minBatchSize && !allowPartialBatch)
+            {
+                // If we don't have enough messages, and we can't return a partial batch, just return an empty array.
+                messagesToReturn = Array.Empty<ServiceBusReceivedMessage>();
+            }
+            else
+            {
+                // If we have enough messages, pull all the messages off the queue to return.
+                var sizeOfBatch = totalMessages > _maxBatchSize ? _maxBatchSize : totalMessages;
+                messagesToReturn = new ServiceBusReceivedMessage[sizeOfBatch];
+                for (int i = 0; i < sizeOfBatch; i++)
+                {
+                    var nextMessage = CachedMessages.Dequeue();
+                    messagesToReturn[i] = nextMessage;
+                }
+            }
+            return messagesToReturn;
+        }
+    }
 }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 		// This is internal for mocking purposes only.
 		internal Queue<ServiceBusReceivedMessage> CachedMessages { get; set; }
 
-		public bool HasCachedMessages
+		public bool HasCachedMessages => CachedMessages.Count > 0;
 		{
 			get
 			{

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMessageManager.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 	{
 		private int _maxBatchSize;
 		private int _minBatchSize;
-		private string _sessionId;
 
 		// This is internal for mocking purposes only.
 		internal Queue<ServiceBusReceivedMessage> CachedMessages { get; set; }
@@ -28,20 +27,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 			}
 		}
 
-        public string SessionId
-        {
-            get
-            {
-                return _sessionId;
-            }
-        }
-
-        public ServiceBusMessageManager(int maxBatchSize, int minBatchSize, string sessionID=null)
+        public ServiceBusMessageManager(int maxBatchSize, int minBatchSize)
 		{
 			CachedMessages = new Queue<ServiceBusReceivedMessage>();
 			_maxBatchSize = maxBatchSize;
 			_minBatchSize = minBatchSize;
-			_sessionId = sessionID;
 		}
 
 		public void ClearEventCache()
@@ -58,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 		/// <param name="messages">An array of messages to either add to a batch or cache.</param>
 		/// <param name="allowPartialBatch">True if batches smaller than the minimum batch size can be returned.</param>
 		/// <returns></returns>
-		public ServiceBusReceivedMessage[] TryGetBatchofEventsWithCached(ServiceBusReceivedMessage[] messages = null, bool allowPartialBatch = false)
+		public ServiceBusReceivedMessage[] TryGetBatchofMessagesWithCached(ServiceBusReceivedMessage[] messages = null, bool allowPartialBatch = false)
 		{
             ServiceBusReceivedMessage[] messagesToReturn;
 			var inputMessages = messages?.Length ?? 0;

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
+		<Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" LinkBase="SharedSource" />
     <Compile Include="..\..\Azure.Messaging.ServiceBus\src\Administration\AdministrationClientConstants.cs" LinkBase="Shared" />
     <Compile Include="..\..\Azure.Messaging.ServiceBus\src\Constants.cs" LinkBase="Shared" />
     <Compile Include="..\..\Azure.Messaging.ServiceBus\src\Core\Argument.cs" LinkBase="Shared" />

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
             Assert.AreEqual(123, options.MaxConcurrentCalls);
             Assert.AreEqual(20, options.MaxMessageBatchSize);
             Assert.AreEqual(10, options.MinMessageBatchSize);
-            Assert.AreEqual(TimeSpan.FromSeconds(1), options.MaxWaitTime);
+            Assert.AreEqual(TimeSpan.FromSeconds(1), options.MaxBatchWaitTime);
             Assert.False(options.AutoCompleteMessages);
             Assert.AreEqual(TimeSpan.FromSeconds(15), options.MaxAutoLockRenewalDuration);
             Assert.AreEqual(ServiceBusTransportType.AmqpWebSockets, options.TransportType);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -64,6 +64,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
 
             Assert.AreEqual(123, options.PrefetchCount);
             Assert.AreEqual(123, options.MaxConcurrentCalls);
+            Assert.AreEqual(20, options.MaxMessageBatchSize);
+            Assert.AreEqual(10, options.MinMessageBatchSize);
+            Assert.AreEqual(TimeSpan.FromSeconds(1), options.MaxWaitTime);
             Assert.False(options.AutoCompleteMessages);
             Assert.AreEqual(TimeSpan.FromSeconds(15), options.MaxAutoLockRenewalDuration);
             Assert.AreEqual(ServiceBusTransportType.AmqpWebSockets, options.TransportType);
@@ -107,6 +110,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
                 { $"{ExtensionPath}:MaxAutoLockRenewalDuration", "00:00:15" },
                 { $"{ExtensionPath}:MaxConcurrentSessions", "123" },
                 { $"{ExtensionPath}:TransportType", "AmqpWebSockets" },
+                { $"{ExtensionPath}:MaxMessageBatchSize", "20" },
+                { $"{ExtensionPath}:MinMessageBatchSize", "10" },
+                { $"{ExtensionPath}:MaxWaitTime", "00:00:01" },
                 { $"{ExtensionPath}:WebProxy", "http://proxyserver:8080/" },
                 { $"{ExtensionPath}:ClientRetryOptions:MaxRetries", "10" },
             };

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -165,7 +165,24 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
         }
 
         [Test]
-        public void AddServiceBus_ThrowsArgumentNull_WhenServiceBusOptionsIsNull()
+        public void ConfigureOptionsThrowWhenMaxWaitTimeIsTooLarge()
+        {
+            string extensionPath = "AzureWebJobs:Extensions:ServiceBus";
+            Assert.That(
+                () => TestHelpers.GetConfiguredOptions<ServiceBusOptions>(
+                b =>
+                {
+                    b.AddServiceBus();
+                },
+                new Dictionary<string, string>
+                {
+                    { $"{extensionPath}:MaxWaitTime", "00:05:00" },
+                }),
+                Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void AddServiceBus_ThrowArgumentNull_WhenServiceBusOptionsIsNull()
         {
             IHost host = new HostBuilder()
                 .ConfigureDefaultTestHost(b =>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -147,6 +147,24 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
         }
 
         [Test]
+        public void ConfigureOptionsThrowWhenMaxIsLessThanMinBatchSize()
+        {
+            string extensionPath = "AzureWebJobs:Extensions:ServiceBus";
+            Assert.That(
+                () => TestHelpers.GetConfiguredOptions<ServiceBusOptions>(
+                b =>
+                {
+                    b.AddServiceBus();
+                },
+                new Dictionary<string, string>
+                {
+                    { $"{extensionPath}:MaxMessageBatchSize", "100" },
+                    { $"{extensionPath}:MinMessageBatchSize", "170" },
+                }),
+                Throws.InvalidOperationException);
+        }
+
+        [Test]
         public void AddServiceBus_ThrowsArgumentNull_WhenServiceBusOptionsIsNull()
         {
             IHost host = new HostBuilder()

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
                 },
                 new Dictionary<string, string>
                 {
-                    { $"{extensionPath}:MaxWaitTime", "00:05:00" },
+                    { $"{extensionPath}:MaxBatchWaitTime", "00:05:00" },
                 }),
                 Throws.InvalidOperationException);
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
                 { $"{ExtensionPath}:TransportType", "AmqpWebSockets" },
                 { $"{ExtensionPath}:MaxMessageBatchSize", "20" },
                 { $"{ExtensionPath}:MinMessageBatchSize", "10" },
-                { $"{ExtensionPath}:MaxWaitTime", "00:00:01" },
+                { $"{ExtensionPath}:MaxBatchWaitTime", "00:00:01" },
                 { $"{ExtensionPath}:WebProxy", "http://proxyserver:8080/" },
                 { $"{ExtensionPath}:ClientRetryOptions:MaxRetries", "10" },
             };

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -767,7 +767,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     {
                         sbOptions.MinMessageBatchSize = MinBatchSize;
                         sbOptions.MaxMessageBatchSize = MaxBatchSize;
-                        sbOptions.MaxWaitTime = TimeSpan.FromSeconds(5);
+                        sbOptions.MaxBatchWaitTime = TimeSpan.FromSeconds(5);
                     }));
 
         private static Action<IHostBuilder> DisableAutoComplete =>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -851,6 +851,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 bool result = _topicSubscriptionCalled1.WaitOne(SBTimeoutMills);
                 Assert.True(result);
+
                 await host.StopAsync();
             }
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
-        public async Task TestBatch_MinBatchSize()
+         public async Task TestBatch_MinBatchSize()
         {
             await TestMultiple_MinBatch<TestBatchMinBatchSize>(
                 configurationDelegate: SetUpMinimumBatchSize);
@@ -767,7 +767,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     {
                         sbOptions.MinMessageBatchSize = MinBatchSize;
                         sbOptions.MaxMessageBatchSize = MaxBatchSize;
-                        sbOptions.MaxWaitTime = TimeSpan.FromSeconds(30);
+                        sbOptions.MaxWaitTime = TimeSpan.FromSeconds(5);
                     }));
 
         private static Action<IHostBuilder> DisableAutoComplete =>
@@ -1461,7 +1461,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                [ServiceBusTrigger(FirstQueueNameKey)]
                ServiceBusReceivedMessage[] array)
             {
-                Assert.True(array.Length > MinBatchSize);
+                Assert.AreEqual(array.Length, MinBatchSize);
                 string[] messages = array.Select(x => x.Body.ToString()).ToArray();
                 ServiceBusMultipleTestJobsBase.ProcessMessages(messages);
             }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -409,6 +409,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await TestMultiple_MinBatch<TestBatchMinBatchSize>();
         }
 
+        public async Task TestBatch_MinBatchSize_WithPartialBatch()
+        {
+            await TestMultiple_MinBatch_PartialBatch<TestBatchMinBatchSize_PartialBatch>();
+        }
+
         [Test]
         public async Task TestBatch_JsonPoco()
         {
@@ -710,6 +715,23 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             }
         }
 
+        private async Task TestMultiple_MinBatch_PartialBatch<T>(Action<IHostBuilder> configurationDelegate = default)
+        {
+            // pre-populate queue before starting listener to allow batch receive to get multiple messages
+            await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}", "sessionId");
+            await WriteQueueMessage("{'Name': 'Test2', 'Value': 'Value'}", "sessionId");
+            await WriteQueueMessage("{'Name': 'Test3', 'Value': 'Value'}", "sessionId");
+
+            var host = BuildSessionHost<T>(maxMessages: MaxBatchSize, minMessages: MinBatchSize, maxWaitTime: TimeSpan.FromSeconds(5));
+            using (host)
+            {
+                bool result = _waitHandle1.WaitOne(SBTimeoutMills);
+                Assert.True(result);
+
+                await host.StopAsync();
+            }
+        }
+
         private async Task TestMultipleDrainMode<T>(bool sendToQueue)
         {
             if (sendToQueue)
@@ -958,6 +980,18 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 ServiceBusReceivedMessage[] array,
                 ServiceBusSessionMessageActions messageSession)
             {
+                string[] messages = array.Select(x => x.Body.ToString()).ToArray();
+                ServiceBusMultipleTestJobsBase.ProcessMessages(messages);
+            }
+        }
+
+        public class TestBatchMinBatchSize_PartialBatch
+        {
+            public static void Run(
+               [ServiceBusTrigger(FirstQueueNameKey, IsSessionsEnabled = true)]
+               ServiceBusReceivedMessage[] array)
+            {
+                Assert.AreEqual(array.Length, 3);
                 string[] messages = array.Select(x => x.Body.ToString()).ToArray();
                 ServiceBusMultipleTestJobsBase.ProcessMessages(messages);
             }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -476,7 +476,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                         }
                         if (maxWaitTime != null)
                         {
-                            sbOptions.MaxWaitTime = maxWaitTime.Value;
+                            sbOptions.MaxBatchWaitTime = maxWaitTime.Value;
                         }
                     }))
                 .ConfigureServices(services =>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -695,11 +695,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private async Task TestMultiple_MinBatch<T>(Action<IHostBuilder> configurationDelegate = default)
         {
             // pre-populate queue before starting listener to allow batch receive to get multiple messages
-            await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}");
-            await WriteQueueMessage("{'Name': 'Test2', 'Value': 'Value'}");
-            await WriteQueueMessage("{'Name': 'Test3', 'Value': 'Value'}");
-            await WriteQueueMessage("{'Name': 'Test4', 'Value': 'Value'}");
-            await WriteQueueMessage("{'Name': 'Test5', 'Value': 'Value'}");
+            await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}", "sessionId");
+            await WriteQueueMessage("{'Name': 'Test2', 'Value': 'Value'}", "sessionId");
+            await WriteQueueMessage("{'Name': 'Test3', 'Value': 'Value'}", "sessionId");
+            await WriteQueueMessage("{'Name': 'Test4', 'Value': 'Value'}", "sessionId");
+            await WriteQueueMessage("{'Name': 'Test5', 'Value': 'Value'}", "sessionId");
 
             var host = BuildSessionHost<T>(maxMessages: MaxBatchSize, minMessages: MinBatchSize, maxWaitTime: TimeSpan.FromSeconds(5));
             using (host)
@@ -966,7 +966,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public class TestBatchMinBatchSize
         {
             public static void Run(
-               [ServiceBusTrigger(FirstQueueNameKey)]
+               [ServiceBusTrigger(FirstQueueNameKey, IsSessionsEnabled = true)]
                ServiceBusReceivedMessage[] array)
             {
                 Assert.AreEqual(array.Length, MinBatchSize);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -409,6 +409,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await TestMultiple_MinBatch<TestBatchMinBatchSize>();
         }
 
+        [Test]
         public async Task TestBatch_MinBatchSize_WithPartialBatch()
         {
             await TestMultiple_MinBatch_PartialBatch<TestBatchMinBatchSize_PartialBatch>();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/WebJobsServiceBusTestBase.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         /// <summary>
         ///   Performs the tasks needed to initialize the test.  This
-        ///   method runs once for for each test.
+        ///   method runs once for each test.
         /// </summary>
         ///
         [SetUp]


### PR DESCRIPTION
These changes add an option to support a minimum batch size in the Service Bus Web Jobs Extensions package. This feature was tested with one and multiple senders to the same function app, and the minimum batch size behaved as expected for both sessions and non-session invocations. The number of function invocations in these cases was greatly reduced.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
