### PR TITLE
Remove CA1825 suppression

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultSetting.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultSetting.cs
@@ -11,9 +11,7 @@ namespace Azure.Security.KeyVault.Administration
     /// </summary>
     [CodeGenModel("Setting")]
     [CodeGenSuppress(nameof(KeyVaultSetting), typeof(string), typeof(string))]
-#pragma warning disable CA1825 // Avoid zero-length array allocations
     [CodeGenSuppress("Content")]
-#pragma warning restore CA1825 // Avoid zero-length array allocations
     public partial class KeyVaultSetting
     {
         /// <summary>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientTests.cs
@@ -37,8 +37,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void VerifyDataAsyncArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (byte[])null, new byte[0]));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (Stream)null, new byte[0]));
+            Assert.ThrowsAsync<ArgumentNullException>(() => Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (byte[])null, Array.Empty<byte>()));
+            Assert.ThrowsAsync<ArgumentNullException>(() => Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (Stream)null, Array.Empty<byte>()));
         }
     }
 }


### PR DESCRIPTION
Now that #35376 is merged and includes the fix to dotnet/roslyn analyzers, we can remove the suppression in lieu of Azure/autorest.csharp#3262.
