### PR TITLE
[Service Bus] Connection Idle Timeout

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- The client-side idle timeout for connections can now be configured using `ServiceBusClientOptions`.  
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -124,6 +124,7 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusClientOptions
     {
         public ServiceBusClientOptions() { }
+        public System.TimeSpan ConnectionIdleTimeout { get { throw null; } set { } }
         public System.Uri CustomEndpointAddress { get { throw null; } set { } }
         public bool EnableCrossEntityTransactions { get { throw null; } set { } }
         public string Identifier { get { throw null; } set { } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -121,7 +121,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 options.TransportType,
                 options.WebProxy,
                 options.EnableCrossEntityTransactions,
-                options.RetryOptions.TryTimeout);
+                options.RetryOptions.TryTimeout,
+                options.ConnectionIdleTimeout);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -53,12 +53,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
         private static Version AmqpVersion { get; } = new Version(1, 0, 0, 0);
 
         /// <summary>
-        ///   The amount of time to allow an AMQP connection to be idle before considering
-        ///   it to be timed out.
-        /// </summary>
-        private static TimeSpan ConnectionIdleTimeout { get; } = TimeSpan.FromMinutes(1);
-
-        /// <summary>
         ///   The amount of buffer to apply to account for clock skew when
         ///   refreshing authorization.  Authorization will be refreshed earlier
         ///   than the expected expiration by this amount.
@@ -189,6 +183,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         private readonly object _syncLock = new();
         private readonly TimeSpan _operationTimeout;
+        private readonly uint _connectionIdleTimeoutMilliseconds;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="AmqpConnectionScope"/> class.
@@ -200,6 +195,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="proxy">The proxy, if any, to use for communication.</param>
         /// <param name="useSingleSession">If true, all links will use a single session.</param>
         /// <param name="operationTimeout">The timeout for operations associated with the connection.</param>
+        /// <param name="idleTimeout">The amount of time to allow a connection to have no observed traffic before considering it idle.</param>
         public AmqpConnectionScope(
             Uri serviceEndpoint,
             Uri connectionEndpoint,
@@ -207,13 +203,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
             ServiceBusTransportType transport,
             IWebProxy proxy,
             bool useSingleSession,
-            TimeSpan operationTimeout)
+            TimeSpan operationTimeout,
+            TimeSpan idleTimeout)
         {
             Argument.AssertNotNull(serviceEndpoint, nameof(serviceEndpoint));
             Argument.AssertNotNull(credential, nameof(credential));
+            Argument.AssertNotNegative(idleTimeout, nameof(idleTimeout));
             ValidateTransport(transport);
 
             _operationTimeout = operationTimeout;
+            _connectionIdleTimeoutMilliseconds = (uint)idleTimeout.TotalMilliseconds;
             ServiceEndpoint = serviceEndpoint;
             Transport = transport;
             Proxy = proxy;
@@ -464,7 +463,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             var serviceHostName = serviceEndpoint.Host;
             var connectionHostName = connectionEndpoint.Host;
             AmqpSettings amqpSettings = CreateAmpqSettings(AmqpVersion);
-            AmqpConnectionSettings connectionSetings = CreateAmqpConnectionSettings(serviceHostName, scopeIdentifier);
+            AmqpConnectionSettings connectionSetings = CreateAmqpConnectionSettings(serviceHostName, scopeIdentifier, _connectionIdleTimeoutMilliseconds);
 
             TransportSettings transportSettings = transportType.IsWebSocketTransport()
                 ? CreateTransportSettingsForWebSockets(connectionHostName, proxy)
@@ -1367,15 +1366,17 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         /// <param name="hostName">The host name of the Service Bus service endpoint.</param>
         /// <param name="identifier">unique identifier of the current Service Bus scope.</param>
+        /// <param name="idleTimeoutMilliseconds">The amount of time, in milliseconds, to allow a connection to have no observed traffic before considering it idle.</param>
         ///
         /// <returns>The settings to apply to the connection.</returns>
         private static AmqpConnectionSettings CreateAmqpConnectionSettings(
             string hostName,
-            string identifier)
+            string identifier,
+            uint idleTimeoutMilliseconds)
         {
             var connectionSettings = new AmqpConnectionSettings
             {
-                IdleTimeOut = (uint)ConnectionIdleTimeout.TotalMilliseconds,
+                IdleTimeOut = idleTimeoutMilliseconds,
                 MaxFrameSize = AmqpConstants.DefaultMaxFrameSize,
                 ContainerId = identifier,
                 HostName = hostName

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -17,6 +17,7 @@ namespace Azure.Messaging.ServiceBus
     public class ServiceBusClientOptions
     {
         private ServiceBusRetryOptions _retryOptions = new ServiceBusRetryOptions();
+        private TimeSpan _connectionIdleTimeout = TimeSpan.FromMinutes(1);
 
         /// <summary>
         ///   The type of protocol and transport that will be used for communicating with the Service Bus
@@ -55,6 +56,34 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         public Uri CustomEndpointAddress { get; set; }
+
+        /// <summary>
+        ///   The amount of time to allow a connection to have no observed traffic before considering
+        ///   it idle and eligible to close.
+        /// </summary>
+        ///
+        /// <value>The default idle timeout is 60 seconds.  The timeout must be a positive value.</value>
+        ///
+        /// <remarks>
+        ///   If a connection is closed due to being idle, the Event Hubs clients will automatically
+        ///   reopen the connection when it is needed for a network operation.  An idle connection
+        ///   being closed does not cause client errors or interfere with normal operation.
+        ///
+        ///   It is recommended to use the default value unless your application has special needs and
+        ///   you've tested the impact of changing the idle timeout.
+        /// </remarks>
+        ///
+        /// <exception cref="ArgumentOutOfRangeException">Occurs when the requested timeout is negative.</exception>
+        ///
+        public TimeSpan ConnectionIdleTimeout
+        {
+            get => _connectionIdleTimeout;
+            set
+            {
+                Argument.AssertNotNegative(value, nameof(ConnectionIdleTimeout));
+                _connectionIdleTimeout = value;
+            }
+        }
 
         /// <summary>
         /// The set of options to use for determining whether a failed operation should be retried and,
@@ -124,6 +153,7 @@ namespace Azure.Messaging.ServiceBus
                 RetryOptions = RetryOptions.Clone(),
                 EnableCrossEntityTransactions = EnableCrossEntityTransactions,
                 CustomEndpointAddress = CustomEndpointAddress,
+                ConnectionIdleTimeout = ConnectionIdleTimeout,
                 Identifier = Identifier
             };
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -27,6 +27,18 @@ namespace Azure.Messaging.ServiceBus.Tests
     public class AmqpConnectionScopeTests
     {
         /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheIdleTimeout()
+        {
+            var endpoint = new Uri("amqp://some.place.com");
+            var credential = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>());
+            Assert.That(() => new AmqpConnectionScope(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, TimeSpan.FromMilliseconds(-1)), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="AmqpConnectionScope.CalculateLinkAuthorizationRefreshInterval" />
         ///   method.
         /// </summary>
@@ -146,7 +158,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var cancellationSource = new CancellationTokenSource();
             var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
 
-            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default)
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default)
             {
                 CallBase = true,
             };
@@ -214,7 +226,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var cancellationSource = new CancellationTokenSource();
             var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
 
-            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default)
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, endpoint, credential.Object, ServiceBusTransportType.AmqpTcp, null, false, default, default)
             {
                 CallBase = true,
             };
@@ -355,7 +367,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 Uri customConnectionEndpoint,
                 ServiceBusTokenCredential credential,
                 ServiceBusTransportType transport,
-                IWebProxy proxy) : base(serviceEndpoint, customConnectionEndpoint, credential, transport, proxy, false, default)
+                IWebProxy proxy) : base(serviceEndpoint, customConnectionEndpoint, credential, transport, proxy, false, default, default)
             {
                 MockConnection = new Mock<AmqpConnection>(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
             }


### PR DESCRIPTION
# Summary

The focus of these changes is to add an option to the ServiceBusClient to customize the idle timeout.  Previously, this was a hard-coded value of 60 seconds; that value has been preserved as the default.

# References and Related

- [Allow setting idle timeout in ServiceBus client (#35663)](https://github.com/Azure/azure-sdk-for-net/issues/35663)
- [Event Hubs - EventHubConnectionOptions.ConnectionIdleTimeout](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventhubconnectionoptions.connectionidletimeout?view=azure-dotnet#azure-messaging-eventhubs-eventhubconnectionoptions-connectionidletimeout)