### PR TITLE
Fix bug when serializing DynamicData in net461

### DIFF
--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
@@ -293,13 +293,18 @@ namespace Azure
         {
             public override DynamicData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
+#if NET6_0_OR_GREATER
+                using JsonDocument document = JsonDocument.ParseValue(ref reader);
+                return new DynamicData(new MutableJsonDocument(document).RootElement);
+#else
                 JsonDocument document = JsonDocument.ParseValue(ref reader);
                 using MemoryStream stream = new();
                 using Utf8JsonWriter writer = new(stream);
                 document.WriteTo(writer);
                 writer.Flush();
                 ReadOnlyMemory<byte> buffer = new(stream.GetBuffer(), 0, (int)stream.Position);
-                return new DynamicData(new MutableJsonDocument(document,  buffer).RootElement);
+                return new DynamicData(new MutableJsonDocument(document, buffer).RootElement);
+#endif
             }
 
             public override void Write(Utf8JsonWriter writer, DynamicData value, JsonSerializerOptions options)

--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
@@ -293,18 +293,8 @@ namespace Azure
         {
             public override DynamicData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-#if NET6_0_OR_GREATER
-                using JsonDocument document = JsonDocument.ParseValue(ref reader);
-                return new DynamicData(new MutableJsonDocument(document).RootElement);
-#else
                 JsonDocument document = JsonDocument.ParseValue(ref reader);
-                using MemoryStream stream = new();
-                using Utf8JsonWriter writer = new(stream);
-                document.WriteTo(writer);
-                writer.Flush();
-                ReadOnlyMemory<byte> buffer = new(stream.GetBuffer(), 0, (int)stream.Position);
-                return new DynamicData(new MutableJsonDocument(document, buffer).RootElement);
-#endif
+                return new DynamicData(new MutableJsonDocument(document).RootElement);
             }
 
             public override void Write(Utf8JsonWriter writer, DynamicData value, JsonSerializerOptions options)

--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
@@ -293,8 +293,13 @@ namespace Azure
         {
             public override DynamicData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                using JsonDocument document = JsonDocument.ParseValue(ref reader);
-                return new DynamicData(new MutableJsonDocument(document).RootElement);
+                JsonDocument document = JsonDocument.ParseValue(ref reader);
+                using MemoryStream stream = new();
+                using Utf8JsonWriter writer = new(stream);
+                document.WriteTo(writer);
+                writer.Flush();
+                ReadOnlyMemory<byte> buffer = new(stream.GetBuffer(), 0, (int)stream.Position);
+                return new DynamicData(new MutableJsonDocument(document,  buffer).RootElement);
             }
 
             public override void Write(Utf8JsonWriter writer, DynamicData value, JsonSerializerOptions options)

--- a/sdk/core/Azure.Core/tests/DynamicData/JsonDataDynamicMutableTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/JsonDataDynamicMutableTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Core.Tests
         {
             dynamic json = DynamicJsonTests.GetDynamicJson("{}");
 
-            json.a = new MutableJsonDocument(new object[] { 1, 2, null, "string" });
+            json.a = new object[] { 1, 2, null, "string" };
 
             Assert.AreEqual("{\"a\":[1,2,null,\"string\"]}", json.ToString());
         }
@@ -88,7 +88,7 @@ namespace Azure.Core.Tests
         {
             dynamic json = DynamicJsonTests.GetDynamicJson("{}");
 
-            json.a = new MutableJsonDocument(new GeoPoint(1, 2));
+            json.a = new GeoPoint(1, 2);
 
             Assert.AreEqual("{\"a\":{\"type\":\"Point\",\"coordinates\":[1,2]}}", json.ToString());
         }

--- a/sdk/core/Azure.Core/tests/DynamicData/JsonDataTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/JsonDataTests.cs
@@ -2,27 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Text.Json;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
     public class JsonDataTests
     {
-        //[Test]
-        //public void CanCreateFromJson()
-        //{
-        //    var jsonData = DynamicJsonTests.GetDynamicJson("\"string\"");
-
-        //    Assert.AreEqual("\"string\"", jsonData.ToJsonString());
-        //}
-
-        //[Test]
-        //public void CanCreateFromNull()
-        //{
-        //    var jsonData = new JsonData(null);
-        //    Assert.AreEqual(JsonValueKind.Null, jsonData.Kind);
-        //}
-
         [Test]
         public void DynamicCanConvertToString() => Assert.AreEqual("string", JsonAsType<string>("\"string\""));
 
@@ -105,44 +91,35 @@ namespace Azure.Core.Tests
             Assert.AreEqual(true, (bool)jsonData.nested.nestedPrimitive);
         }
 
-        //[Test]
-        //public void EqualsProvidesValueEqualityPrimitives()
-        //{
-        //    Assert.AreEqual(new JsonData(1), new JsonData(1));
-        //    Assert.AreEqual(new JsonData(true), new JsonData(true));
-        //    Assert.AreEqual(new JsonData(false), new JsonData(false));
-        //    Assert.AreEqual(new JsonData("hello"), new JsonData("hello"));
-        //    Assert.AreEqual(new JsonData(null), new JsonData(null));
-        //}
+        [Test]
+        public void CanRoundTripSerialize()
+        {
+            dynamic orig = DynamicJsonTests.GetDynamicJson(
+                """
+                {
+                    "property" : "hello"
+                }
+                """);
 
-        //[Test]
-        //public void EqualsAndNull()
-        //{
-        //    Assert.AreNotEqual(new JsonData(null), null);
-        //    Assert.AreNotEqual(null, new JsonData(null));
-        //}
+            void validate(dynamic d)
+            {
+                Assert.IsTrue(d.property == "hello");
 
-        //[Test]
-        //public void JsonDataInPOCOsWorks()
-        //{
-        //    JsonData orig = new JsonData(new
-        //    {
-        //        property = new JsonData("hello")
-        //    });
+                int count = 0;
+                foreach (dynamic item in d)
+                {
+                    count++;
+                }
 
-        //    void validate(JsonData d)
-        //    {
-        //        Assert.AreEqual(JsonValueKind.Object, d.Kind);
-        //        Assert.AreEqual(d.Properties.Count(), 1);
-        //        Assert.AreEqual(d.Get("property"), "hello");
-        //    }
+                Assert.IsTrue(count == 1);
+            }
 
-        //    validate(orig);
+            validate(orig);
 
-        //    JsonData roundTrip = JsonSerializer.Deserialize<JsonData>(JsonSerializer.Serialize(orig, orig.GetType()));
+            dynamic roundTrip = JsonSerializer.Deserialize<DynamicData>(JsonSerializer.Serialize(orig, orig.GetType()));
 
-        //    validate(roundTrip);
-        //}
+            validate(roundTrip);
+        }
 
         private T JsonAsType<T>(string json)
         {

--- a/sdk/core/Azure.Core/tests/DynamicData/JsonDataTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/JsonDataTests.cs
@@ -94,12 +94,12 @@ namespace Azure.Core.Tests
         [Test]
         public void CanRoundTripSerialize()
         {
-            dynamic orig = DynamicJsonTests.GetDynamicJson(
+            dynamic orig = new BinaryData(
                 """
                 {
                     "property" : "hello"
                 }
-                """);
+                """).ToDynamicFromJson();
 
             void validate(dynamic d)
             {


### PR DESCRIPTION
If you call JsonSerializer.Serialize() on a JsonDocument in net461, it will add a `RootElement` member to the top-level JSON object, which is incorrect because `RootElement` is not a member in the underlying JSON.  This behavior was changed in later releases of JsonSerializer.  This causes serialization of DynamicData to fail when it calls through to JsonSerializer.Serialize() on a JsonDocument type.

This PR fixes this issue by creating the JSON buffer from the reader via JsonDocument without passing it through JsonSerializer.

