### PR TITLE
Update minimum test version

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -125,8 +125,8 @@
     <IsPackable>false</IsPackable>
     <!-- List newest targets first so that recordings are made with latest, running tests from editor runs latest, etc. -->
     <RequiredTargetFrameworks>net7.0;net6.0</RequiredTargetFrameworks>
-    <!-- Also test net461 on Windows. -->
-    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(RequiredTargetFrameworks);net461</RequiredTargetFrameworks>
+    <!-- Also test net462 on Windows. net461 is out of support as of 4/2022 and is not supported in version 4.4.x and beyond of NUnit3TestAdapter. -->
+    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(RequiredTargetFrameworks);net462</RequiredTargetFrameworks>
     <!-- But only build snippets for the latest. -->
     <RequiredTargetFrameworks Condition="'$(BuildSnippets)' == 'true'">net7.0</RequiredTargetFrameworks>
   </PropertyGroup>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -99,8 +99,8 @@
     <None Condition="Exists('$(MSBuildProjectDirectory)/../CHANGELOG.md')" Include="$(MSBuildProjectDirectory)/../CHANGELOG.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
-  <!-- Add App.config to enable server GC in net461 perf and stress projects -->
-  <ItemGroup Condition="('$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true') and '$(TargetFramework)' == 'net461'">
+  <!-- Add App.config to enable server GC in net462 perf and stress projects -->
+  <ItemGroup Condition="('$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true') and '$(TargetFramework)' == 'net462'">
     <None Include="$(RepoRoot)/common/PerfStressShared/App.config" />
   </ItemGroup>
 

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -54,7 +54,7 @@ jobs:
         Windows_NetFramework:
           Pool: "azsdk-pool-mms-win-2022-general"
           OSVmImage: "windows-2022"
-          TestTargetFramework: net461
+          TestTargetFramework: net462
         Windows_Net60:
           Pool: "azsdk-pool-mms-win-2022-general"
           OSVmImage: "windows-2022"

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -15,10 +15,10 @@
         "Pool": "azsdk-pool-mms-ubuntu-2004-general",
         "TestTargetFramework": "net7.0"
       },
-      "Windows2022_NET461": {
+      "Windows2022_NET462": {
         "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
-        "TestTargetFramework": "net461"
+        "TestTargetFramework": "net462"
       },
       "Windows2022_NET7.0": {
         "OSVmImage": "windows-2022",

--- a/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix-integration.json
+++ b/eng/scripts/splittestdependencies/tests/expectOutputs/expect-matrix-integration.json
@@ -20,10 +20,10 @@
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net6.0"
       },
-      "windows2022_NET461": {
+      "windows2022_NET462": {
         "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
-        "TestTargetFramework": "net461"
+        "TestTargetFramework": "net462"
       },
       "macos-11_NETCore3.1": {
         "OSVmImage": "macos-11",

--- a/eng/scripts/splittestdependencies/tests/inputs/sync-platform-matrix.json
+++ b/eng/scripts/splittestdependencies/tests/inputs/sync-platform-matrix.json
@@ -20,10 +20,10 @@
         "Pool": "azsdk-pool-mms-win-2022-general",
         "TestTargetFramework": "net6.0"
       },
-      "windows2022_NET461": {
+      "windows2022_NET462": {
         "OSVmImage": "windows-2022",
         "Pool": "azsdk-pool-mms-win-2022-general",
-        "TestTargetFramework": "net461"
+        "TestTargetFramework": "net462"
       },
       "macos-11_NETCore3.1": {
         "OSVmImage": "macos-11",

--- a/sdk/appconfiguration/CONTRIBUTING.md
+++ b/sdk/appconfiguration/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Properly supporting recorded tests does require a few extra considerations. All 
 
 The easiest way to run the tests is via Visual Studio's unit test runner.
 
-You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net461`.
+You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net462`.
 
 The recorded tests are run automatically on every pull request. Live tests are run nightly. Contributors with write access can ask Azure DevOps to run the live tests against a pull request by commenting `/azp run net - appconfiguration - tests` in the PR.
 

--- a/sdk/core/Azure.Core.Expressions.DataFactory/tests/DataFactoryElementTests.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/tests/DataFactoryElementTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Core.Expressions.DataFactory.Tests
 
             public override int GetHashCode()
             {
-#if NET461_OR_GREATER
+#if NET462
                 return X.GetHashCode() ^ Y.GetHashCode();
 #else
                 return HashCode.Combine(X, Y);
@@ -583,7 +583,7 @@ namespace Azure.Core.Expressions.DataFactory.Tests
         {
             var dfe = DataFactoryElement<double>.FromLiteral(DoubleValue);
             var actual = GetSerializedString(dfe);
-#if NET461_OR_GREATER
+#if NET462
             Assert.AreEqual("1.1000000000000001", actual);
 #else
             Assert.AreEqual(DoubleJson, actual);
@@ -1058,7 +1058,7 @@ namespace Azure.Core.Expressions.DataFactory.Tests
         {
             var dfe = JsonSerializer.Deserialize<DataFactoryElement<double>>(DoubleJson);
             var actual = GetSerializedString(dfe!);
-#if NET461_OR_GREATER
+#if NET462
             Assert.AreEqual("1.1000000000000001", actual);
 #else
             Assert.AreEqual(DoubleJson, actual);

--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
-    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net47'" />
+    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net47'" />
     <!-- 
       Explicit references to pull in patched versions of ASP.NET Core packages
     -->

--- a/sdk/core/Azure.Core/perf/DynamicObjectBenchmark.cs
+++ b/sdk/core/Azure.Core/perf/DynamicObjectBenchmark.cs
@@ -14,7 +14,7 @@ namespace Azure.Core.Perf
 {
     [MemoryDiagnoser]
     [SimpleJob(RuntimeMoniker.NetCoreApp31, baseline: true)]
-    [SimpleJob(RuntimeMoniker.Net461)]
+    [SimpleJob(RuntimeMoniker.Net462)]
     [SimpleJob(RuntimeMoniker.Net60)]
     public class DynamicObjectBenchmark
     {

--- a/sdk/core/Azure.Core/perf/EventSourceBenchmark.cs
+++ b/sdk/core/Azure.Core/perf/EventSourceBenchmark.cs
@@ -14,7 +14,7 @@ using BenchmarkDotNet.Jobs;
 namespace Azure.Core.Perf
 {
     [MemoryDiagnoser]
-    [SimpleJob(RuntimeMoniker.Net461)]
+    [SimpleJob(RuntimeMoniker.Net462)]
     [SimpleJob(RuntimeMoniker.Net60)]
     public class EventSourceBenchmark
     {

--- a/sdk/core/Azure.Core/tests/BinaryDataSerializationTests.cs
+++ b/sdk/core/Azure.Core/tests/BinaryDataSerializationTests.cs
@@ -293,7 +293,7 @@ namespace Azure.Core.Tests
         [Test]
         public void SerailizeUsingJsonFormattedStringForDictOfBinaryData()
         {
-#if NET461
+#if NET462
             var expected = File.ReadAllText(GetFileName("JsonFormattedStringDictOfBinaryDataNet461.json")).TrimEnd();
 #else
             var expected = File.ReadAllText(GetFileName("JsonFormattedStringDictOfBinaryData.json")).TrimEnd();

--- a/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonEnumerableTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonEnumerableTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        [Ignore("BinaryOperation fails to bind in net461.")]
+        [Ignore("BinaryOperation fails to bind in net462.")]
         public void CanConvertToIntEnumerableWithChanges_AddAssign()
         {
             dynamic jsonData = DynamicJsonTests.GetDynamicJson("[0, 1, 2, 3]");

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
@@ -28,7 +28,7 @@ namespace Azure.Core.Tests
 
         protected override HttpPipelineTransport GetTransport(bool https = false, HttpPipelineTransportOptions options = null)
         {
-#if !NET461
+#if !NET462
             if (https)
             {
                 return new HttpClientTransport(options ?? new HttpPipelineTransportOptions { ServerCertificateCustomValidationCallback = _ => true });
@@ -37,19 +37,19 @@ namespace Azure.Core.Tests
             return new HttpClientTransport(options);
         }
 
-#if NET461
+#if NET462
         // These setup and teardown actions require that entire test class be NonParallelizable.
         [OneTimeSetUp]
         public void TestSetup()
         {
-            // No way to disable SSL check per HttpClient on NET461
+            // No way to disable SSL check per HttpClient on NET462
             ServicePointManager.ServerCertificateValidationCallback += certCallback;
         }
 
         [OneTimeTearDown]
         public void TestTeardown()
         {
-            // No way to disable SSL check per HttpClient on NET461
+            // No way to disable SSL check per HttpClient on NET462
             ServicePointManager.ServerCertificateValidationCallback -= certCallback;
         }
 #endif

--- a/sdk/core/Azure.Core/tests/PemReaderTests.cs
+++ b/sdk/core/Azure.Core/tests/PemReaderTests.cs
@@ -238,7 +238,7 @@ pn29yMivL7r48dlo";
         [Test]
         public void LoadECDsaCertificate()
         {
-#if NET461
+#if NET462
             // Compatible with previous release. Goes through the LightweightPkcs8Decoder.DecodeRSAPkcs8().
             Assert.Throws<InvalidDataException>(() => PemReader.LoadCertificate(ECDsaCertificate.AsSpan(), keyType: PemReader.KeyType.RSA));
 #else

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -571,8 +571,8 @@ namespace Azure.Core.Tests
 
             await ExecuteRequest(request, transport);
 
-            // for NET461, HttpClient will include zero content-length for DELETEs
-#if NET461
+            // for NET462, HttpClient will include zero content-length for DELETEs
+#if NET462
             if (transport is HttpClientTransport &&
                 method == RequestMethod.Delete)
             {
@@ -759,7 +759,7 @@ namespace Azure.Core.Tests
             }
         }
 
-#if NET461 // GlobalProxySelection.Select not supported on netcoreapp
+#if NET462 // GlobalProxySelection.Select not supported on netcoreapp
         [NonParallelizable]
         [Test]
         public async Task DefaultProxySettingsArePreserved()

--- a/sdk/core/Microsoft.Azure.Core.Spatial/tests/Serialization/MicrosoftSpatialGeoJsonConverterTests.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/tests/Serialization/MicrosoftSpatialGeoJsonConverterTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Core.Spatial.Tests.Serialization
 
             foreach (GeographyGeoJson geographyGeoJson in GeographyGeoJsons)
             {
-                // Very strange issue when serializing on net461. If you don't pass the inputType, CanConvert receives Geography
+                // Very strange issue when serializing on net462. If you don't pass the inputType, CanConvert receives Geography
                 // as the typeToConvert, which actually needs to return false.
                 string geoJson = JsonSerializer.Serialize(geographyGeoJson.Geography, geographyGeoJson.Geography.GetType(), options);
 

--- a/sdk/devcenter/CONTRIBUTING.md
+++ b/sdk/devcenter/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Properly supporting recorded tests does require a few extra considerations. All 
 
 The easiest way to run the tests is via Visual Studio's unit test runner.
 
-You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net461`.
+You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net462`.
 
 The recorded tests are run automatically on every pull request. Contributors with write access can ask Azure DevOps to run the live tests against a pull request by commenting `/azp run net - devcenter - tests` in the PR.
 

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/tests/Azure.IoT.DeviceUpdate.Tests.csproj
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/tests/Azure.IoT.DeviceUpdate.Tests.csproj
@@ -23,7 +23,7 @@
     <Folder Include="SessionRecords\" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+  <ItemGroup Condition="$(TargetFramework) == 'net462'">
     <Reference Include="System.Web" />
   </ItemGroup>
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/perf/README.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/perf/README.md
@@ -31,7 +31,7 @@ Run the executable output of a project
 dotnet run -c Release -f <supported-framework> --no-build -p <path/to/project/file> -- [parameters needed for the test]
 ```
 
-\<supported-framework\> can be one of net7.0, net6.0, or net461. Note the -- before any custom parameters to pass. This prevents dotnet from trying to handle any ambiguous command line switches.
+\<supported-framework\> can be one of net7.0, net6.0, or net462. Note the -- before any custom parameters to pass. This prevents dotnet from trying to handle any ambiguous command line switches.
 
 You should use the scenario test class names as the first parameter that is needed for running the test.
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/Azure.Security.KeyVault.Certificates.Tests.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/Azure.Security.KeyVault.Certificates.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Several types and methods we need are implemented in net47 or above, so test our light-up features against at least net47 to make sure they work or fall back as expected. -->
-    <!-- If this changes, check that exclusionary preproc conditions like `!NET461 && !NET47` are updated in tests, samples. -->
+    <!-- If this changes, check that exclusionary preproc conditions like `!NET462 && !NET47` are updated in tests, samples. -->
     <TargetFrameworks>$(RequiredTargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -907,7 +907,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [RecordedTest]
         public async Task DownloadECDsaCertificateSignRemoteVerifyLocal([EnumValues] CertificateContentType contentType, [EnumValues] CertificateKeyCurveName keyCurveName)
         {
-#if NET461
+#if NET462
             Assert.Ignore("ECC is not supported before .NET Framework 4.7");
 #endif
             if (keyCurveName == CertificateKeyCurveName.P256K && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -972,7 +972,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [RecordedTest]
         public async Task DownloadECDsaCertificateSignLocalVerifyRemote([EnumValues] CertificateContentType contentType, [EnumValues] CertificateKeyCurveName keyCurveName)
         {
-#if NET461
+#if NET462
             Assert.Ignore("ECC is not supported before .NET Framework 4.7");
 #endif
             if (keyCurveName == CertificateKeyCurveName.P256K && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/LightweightPkcs8DecoderTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void ECDecoderPrime256v1RequiresPublicKey()
         {
-#if NET461
+#if NET462
             Assert.Ignore("ECC is not supported before .NET Framework 4.7");
 #endif
             byte[] data = Convert.FromBase64String(EcPrime256v1PrivateKeyImported);
@@ -70,7 +70,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         // Not using TestCaseSource because params too long for friendly test case rendering.
         private static void VerifyECDecoder(string key, CertificateKeyCurveName keyCurveName, string signature, string cer = null)
         {
-#if NET461
+#if NET462
             Assert.Ignore("ECC is not supported before .NET Framework 4.7");
 #endif
             byte[] data = Convert.FromBase64String(key);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/PemReaderTests.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void LoadCertificate()
         {
-#if NET461
+#if NET462
             Assert.Ignore("Loading X509Certificate2 with private EC key not supported on this platform");
 #endif
             using X509Certificate2 certificate = PemReader.LoadCertificate(s_ecdsaFullCertificate.AsSpan(), keyType: PemReader.KeyType.ECDsa);
@@ -27,7 +27,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void LoadCertificateAutomatically()
         {
-#if NET461
+#if NET462
             Assert.Ignore("Loading X509Certificate2 with private EC key not supported on this platform");
 #endif
             using X509Certificate2 certificate = PemReader.LoadCertificate(s_ecdsaFullCertificate.AsSpan());
@@ -38,7 +38,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void LoadCertificateWithPublicKey()
         {
-#if NET461
+#if NET462
             Assert.Ignore("Loading X509Certificate2 with private EC key not supported on this platform");
 #endif
             using X509Certificate2 certificate = PemReader.LoadCertificate(ECDsaPrivateKey.AsSpan(), cer: s_ecdsaCertificateBytes, keyType: PemReader.KeyType.ECDsa);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificate.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificate.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
     {
 // Need to exclude actual TFMs since SNIPPET is always passed during CIs, such that the following will fail:
 // NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || SNIPPET
-#if !NET461 && !NET47
+#if !NET462 && !NET47
         [Test]
         public void DownloadCertificateSync()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificateAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample4_DownloadCertificateAsync.cs
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
     {
 // Need to exclude actual TFMs since SNIPPET is always passed during CIs, such that the following will fail:
 // NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || SNIPPET
-#if !NET461 && !NET47
+#if !NET462 && !NET47
         [Test]
         public async Task DownloadCertificateAsync()
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/Azure.Security.KeyVault.Keys.Tests.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/Azure.Security.KeyVault.Keys.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- ECParameters is defined in netstandard2.0 but not net461 (introduced in net47). Test against net461 to make sure a TypeLoadException is not thrown when referencing JsonWebKey. -->
+    <!-- ECParameters is defined in netstandard2.0 but not net462 (introduced in net47). Test against net462 to make sure a TypeLoadException is not thrown when referencing JsonWebKey. -->
     <TargetFrameworks>$(RequiredTargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientLiveTests.cs
@@ -177,10 +177,10 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [RecordedTest]
         public async Task LocalSignVerifyRoundTrip([EnumValues(Exclude = new[] { nameof(SignatureAlgorithm.ES256K) })] SignatureAlgorithm algorithm)
         {
-#if NET461
+#if NET462
             if (algorithm.GetEcKeyCurveName() != default)
             {
-                Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net461.");
+                Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net462.");
             }
 #endif
 
@@ -254,10 +254,10 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [RecordedTest]
         public async Task SignLocalVerifyRoundTrip([EnumValues(Exclude = new[] { nameof(SignatureAlgorithm.ES256K) })] SignatureAlgorithm algorithm)
         {
-#if NET461
+#if NET462
             if (algorithm.GetEcKeyCurveName() != default)
             {
-                Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net461.");
+                Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net462.");
             }
 #endif
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/EcCryptographyProviderTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/EcCryptographyProviderTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace Azure.Security.KeyVault.Keys.Tests
 {
-#if !NET461
+#if !NET462
 
     public class EcCryptographyProviderTests
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/JsonWebKeyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/JsonWebKeyTests.cs
@@ -98,8 +98,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [TestCase(true)]
         public void ECDsaDefaultsKeyOps(bool includePrivateParameters)
         {
-#if NET461
-            Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net461.");
+#if NET462
+            Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net462.");
 #else
             using ECDsa ecdsa = ECDsa.Create();
             JsonWebKey jwk = new JsonWebKey(ecdsa, includePrivateParameters);
@@ -118,8 +118,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [TestCaseSource(nameof(GetECDSaTestData))]
         public void SerializeECDsa(string oid, string friendlyName, bool includePrivateParameters)
         {
-#if NET461
-            Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net461.");
+#if NET462
+            Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net462.");
 #else
             using ECDsa ecdsa = ECDsa.Create();
             try
@@ -148,8 +148,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void FromECDsaNoPrivateKey()
         {
-#if NET461
-            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net461.");
+#if NET462
+            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net462.");
 #else
             using ECDsa ecdsa = ECDsa.Create();
             ECParameters ecParameters = ecdsa.ExportParameters(false);
@@ -162,8 +162,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void ToECDsaNoPrivateKey()
         {
-#if NET461
-            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net461.");
+#if NET462
+            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net462.");
 #else
             JsonWebKey jwk;
             using (ECDsa ecdsa = ECDsa.Create())
@@ -181,8 +181,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [TestCaseSource(nameof(GetECDSaTestData))]
         public void ToECDsa(string oid, string friendlyName, bool includePrivateParameters)
         {
-#if NET461
-            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net461.");
+#if NET462
+            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net462.");
 #else
             byte[] plaintext = Encoding.UTF8.GetBytes("test");
             byte[] signature = null;
@@ -229,8 +229,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [TestCaseSource(nameof(GetECDSaInvalidTestData))]
         public void ToECDsaInvalidKey(string curveName, byte[] x, byte[] y, string name, bool nullOnError)
         {
-#if NET461
-            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net461.");
+#if NET462
+            Assert.Ignore("Creating ECDsa with JsonWebKey is not supported on net462.");
 #else
             JsonWebKey jwk = new JsonWebKey
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyUtilities.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyUtilities.cs
@@ -27,8 +27,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 case SignatureAlgorithm.ES256KValue:
                 case SignatureAlgorithm.ES384Value:
                 case SignatureAlgorithm.ES512Value:
-#if NET461
-                    throw new IgnoreException("Creating JsonWebKey with ECDsa is not supported on net461.");
+#if NET462
+                    throw new IgnoreException("Creating JsonWebKey with ECDsa is not supported on net462.");
 #else
                     KeyCurveName curveName = algorithm.GetEcKeyCurveName();
                     ECCurve curve = ECCurve.CreateFromOid(curveName.Oid);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysEventSourceTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysEventSourceTests.cs
@@ -171,8 +171,8 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [TestCaseSource(nameof(GetEcOperations), new object[] { false, true })]
         public async Task PrivateKeyRequiredEc(string operation, string value, Func<CryptographyClient, string, Task<object>> thunk)
         {
-#if NET461
-            Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net461.");
+#if NET462
+            Assert.Ignore("Creating JsonWebKey with ECDsa is not supported on net462.");
 #endif
 
             KeyOperation[] keyOps = new[]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/LocalCryptographyClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/LocalCryptographyClientTests.cs
@@ -384,10 +384,10 @@ namespace Azure.Security.KeyVault.Keys.Tests
         {
             switch (type.ToString())
             {
-#if NET461
+#if NET462
                 case KeyType.EcValue:
                 case KeyType.EcHsmValue:
-                    throw new IgnoreException("Creating JsonWebKey with ECDsa is not supported on net461.");
+                    throw new IgnoreException("Creating JsonWebKey with ECDsa is not supported on net462.");
 #else
                 case KeyType.EcValue:
                 case KeyType.EcHsmValue:

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/LocalCryptographyProviderFactoryTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/LocalCryptographyProviderFactoryTests.cs
@@ -64,7 +64,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Aes aes = Aes.Create();
             yield return new object[] { new JsonWebKey(aes) { Id = nameof(aes) }, typeof(AesCryptographyProvider) };
 
-#if !NET461
+#if !NET462
             ECDsa ecdsa = ECDsa.Create();
             yield return new object[] { new JsonWebKey(ecdsa, false) { Id = "ecdsaPublic" }, typeof(EcCryptographyProvider) };
             yield return new object[] { new JsonWebKey(ecdsa, true) { Id = "ecdsaPrivate" }, typeof(EcCryptographyProvider) };

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
@@ -21,8 +21,8 @@ namespace Azure.Security.KeyVault.Keys.Samples
         [Test]
         public void SignVerifySync()
         {
-#if NET461
-            Assert.Ignore("Using CryptographyClient with EC keys is not supported on .NET Framework 4.6.1.");
+#if NET462
+            Assert.Ignore("Using CryptographyClient with EC keys is not supported on .NET Framework 4.6.2.");
 #endif
 
             // Environment variable with the Key Vault endpoint.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
@@ -21,7 +21,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
         [Test]
         public async Task SignVerifyAsync()
         {
-#if NET461
+#if NET462
             Assert.Ignore("Using CryptographyClient with EC keys is not supported on .NET Framework 4.6.1.");
 #endif
 

--- a/sdk/keyvault/CONTRIBUTING.md
+++ b/sdk/keyvault/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Properly supporting recorded tests does require a few extra considerations. All 
 
 The easiest way to run and debug the tests is via Visual Studio's unit test runner.
 
-You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net461`.
+You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net462`.
 
 The recorded tests are run automatically on every pull request. Live tests are run nightly. Contributors with write access can ask Azure DevOps to run the live tests against a pull request by commenting `/azp run net - keyvault - tests` in the PR.
 

--- a/sdk/keyvault/samples/keyvaultproxy/tests/AzureSamples.Security.KeyVault.Proxy.Tests.csproj
+++ b/sdk/keyvault/samples/keyvaultproxy/tests/AzureSamples.Security.KeyVault.Proxy.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/ProgramNet461Compat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/ProgramNet461Compat.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if NET461
+#if NET462
 
 namespace Azure.Monitor.OpenTelemetry.AspNetCore.Demo
 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
@@ -226,7 +226,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AggregateException aggregateException = new AggregateException("AggregateException", new[] { innerException1, innerException2 });
 
             // Passing "AggregateException" explicitly here instead of using aggregateException.Message
-            // aggregateException.Message will return different value in case of net461 compared to netcore
+            // aggregateException.Message will return different value in case of net462 compared to netcore
             logger.LogWarning(aggregateException, "AggregateException");
 
             var exceptionData = new TelemetryExceptionData(2, logRecords[0]);
@@ -263,7 +263,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var exception = new Exception("Exception", innerexception2);
 
             // Passing "Exception" explicitly here instead of using exception.Message
-            // exception.Message will return different value in case of net461 compared to netcore
+            // exception.Message will return different value in case of net462 compared to netcore
             logger.LogWarning(exception, "Exception");
 
             var exceptionData = new TelemetryExceptionData(2, logRecords[0]);
@@ -301,7 +301,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             AggregateException rootLevelException = new AggregateException("0", innerExceptions);
 
             // Passing "0" explicitly here instead of using rootLevelException.Message
-            // rootLevelException.Message will return different value in case of net461 compared to netcore
+            // rootLevelException.Message will return different value in case of net462 compared to netcore
             logger.LogWarning(rootLevelException, "0");
 
             var exceptionData = new TelemetryExceptionData(2, logRecords[0]);
@@ -311,7 +311,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // The first exception is the AggregateException
             Assert.Equal("System.AggregateException", exceptionData.Exceptions[0].TypeName);
 
-#if NET461
+#if NET462
             Assert.Equal("0", exceptionData.Exceptions[0].Message);
 #else
             Assert.Equal("0 (1) (2) (3) (4) (5) (6) (7) (8) (9) (10) (11) (12) (13) (14) (15)", exceptionData.Exceptions[0].Message);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebApp.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebApp.csproj
@@ -14,10 +14,10 @@
     <PackageReference Include="System.Text.Encodings.Web" VersionOverride="4.5.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <!--We would prefer to use the meta package "Microsoft.AspNetCore.App" here.
     But this package targets NetCoreApp2.1, while all the dependent packages target NetStandard2.0.
-    To support net461 so we must reference the dependent packages.-->
+    To support net462 so we must reference the dependent packages.-->
     <PackageReference Include="Microsoft.AspNetCore" VersionOverride="[2.1.1, )" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" VersionOverride="[2.1.1, )" />
     <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" VersionOverride="[2.1.1, )" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/ProgramNet461Compat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/ProgramNet461Compat.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if NET461
+#if NET462
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/StartupNet461Compat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests.AspNetCoreWebApp/StartupNet461Compat.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if NET461
+#if NET462
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -15,10 +15,10 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == '2'">
     <!--We would prefer to use the meta package "Microsoft.AspNetCore.App" here.
     But this package targets NetCoreApp3.1, while all the dependent packages target NetStandard2.0.
-    To support net461 so we must reference the dependent packages.-->
+    To support net462 so we must reference the dependent packages.-->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore" VersionOverride="[2.1.1,2.2)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" VersionOverride="[2.1.1,2.2)" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == '2'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <!--We would prefer to use the meta package "Microsoft.AspNetCore.App" here.
     But this package targets NetCoreApp3.1, while all the dependent packages target NetStandard2.0.
     To support net462 so we must reference the dependent packages.-->

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
         {
         }
 
-#if !NET461
+#if !NET462
         /// <summary>
         /// This test validates that when an app instrumented with the AzureMonitorExporter receives an HTTP request,
         /// A TelemetryItem is created matching that request.

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientLiveTests.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/tests/ObjectAnchorsConversionClientLiveTests.cs
@@ -35,7 +35,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Tests
         public ObjectAnchorsConversionClientLiveTests(bool isAsync)
             : base(isAsync)
         {
-#if NET461
+#if NET462
             CompareBodies = true;
 #else
             CompareBodies = false;

--- a/sdk/resourcemanager/Azure.ResourceManager/docs/TestGuide.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/docs/TestGuide.md
@@ -81,7 +81,7 @@ In order to run the tests, the following environment variables need to be set:
 
 The easiest way to run the tests is via Visual Studio's test runner. Please note that the Visual Studio 2022 is required as one of the test target frameworks is `.NET 6.0`.
 
-You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `net462`.
+You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net462`.
 
 If you are using system environment variables, make sure to restart Visual Studio or the terminal after setting or changing the environment variables.
 

--- a/sdk/resourcemanager/Azure.ResourceManager/docs/TestGuide.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/docs/TestGuide.md
@@ -81,7 +81,7 @@ In order to run the tests, the following environment variables need to be set:
 
 The easiest way to run the tests is via Visual Studio's test runner. Please note that the Visual Studio 2022 is required as one of the test target frameworks is `.NET 6.0`.
 
-You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `dotnet test -f net461`.
+You can also run tests via the command line using `dotnet test`, but that will run tests for all supported platforms simultaneously and intermingle their output. You can run the tests for just one platform with `dotnet test -f net6.0` or `net462`.
 
 If you are using system environment variables, make sure to restart Visual Studio or the terminal after setting or changing the environment variables.
 

--- a/sdk/search/CONTRIBUTING.md
+++ b/sdk/search/CONTRIBUTING.md
@@ -61,7 +61,7 @@ The easiest way to run the tests is via Visual Studio's unit test runner.
 You can also run tests via the command line using `dotnet test`, but that will
 run tests for all supported platforms simultaneously and intermingle their
 output.  You can run the tests for just one platform with `dotnet test -f net6.0`
-or `dotnet test -f net461`.
+or `dotnet test -f net462`.
 
 The recorded tests are run automatically on every pull request.  Live tests are
 run nightly.  Contributors with write access can ask Azure DevOps to run the

--- a/sdk/search/Microsoft.Azure.Management.Search/tests/Microsoft.Azure.Management.Search.Tests.csproj
+++ b/sdk/search/Microsoft.Azure.Management.Search/tests/Microsoft.Azure.Management.Search.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/RuntimeTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/RuntimeTests.cs
@@ -10,7 +10,7 @@ namespace Azure.Storage
         [Test]
         public void RunsIn64BitProcess()
         {
-            // Large payload tests don't like 32 bit processes. It's been an issue with net461 running 32bit by default, so guarding against it.
+            // Large payload tests don't like 32 bit processes. It's been an issue with net462 running 32bit by default, so guarding against it.
             Assert.IsTrue(System.Environment.Is64BitProcess);
         }
     }

--- a/sdk/storage/CONTRIBUTING.md
+++ b/sdk/storage/CONTRIBUTING.md
@@ -111,7 +111,7 @@ The easiest way to run the tests is via Visual Studio's unit test runner.
 You can also run tests via the command line using `dotnet test`, but that will
 run tests for all supported platforms simultaneously and intermingle their
 output.  You can run the tests for just one platform with `dotnet test -f net6.0`
-or `dotnet test -f net461`.
+or `dotnet test -f net462`.
 
 The recorded tests are run automatically on every pull request.  Live tests are
 run nightly.  Contributors with write access can ask Azure DevOps to run the

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/Azure.Messaging.WebPubSub.Tests.csproj
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/Azure.Messaging.WebPubSub.Tests.csproj
@@ -24,7 +24,7 @@
     <Folder Include="SessionRecords\" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+  <ItemGroup Condition="$(TargetFramework) == 'net462'">
     <Reference Include="System.Web" />
   </ItemGroup>
 </Project>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
@@ -8,12 +8,12 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net461|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
     <WarningLevel>5</WarningLevel>
   </PropertyGroup>
 
   <!-- Reference the Client Library -->
-  <ItemGroup Condition="$(TargetFramework) != 'net461'">
+  <ItemGroup Condition="$(TargetFramework) != 'net462'">
     <ProjectReference Include="..\src\Microsoft.Azure.WebPubSub.AspNetCore.csproj" />
   </ItemGroup>
 
@@ -24,7 +24,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) != 'net461'">
+  <ItemGroup Condition="$(TargetFramework) != 'net462'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
Net461 tests are not currently running because NUnit3TestAdapter no longer targets net461 as of latest version. We updated to the latest version because it was required to be able to use with .NET 8.

Net461 is EOL as of April 2022.