### PR TITLE
[Communication][PhoneNumbers] Remove if statement from tests that don't need it

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
@@ -284,9 +284,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public async Task GetPurchasedPhoneNumbersNextPage()
         {
-            if (SkipPhoneNumberLiveTests)
-                Assert.Ignore("Skip phone number live tests flag is on.");
-
             var client = CreateClient();
             var purchasedPhoneNumbers = client.GetPurchasedPhoneNumbersAsync();
 
@@ -330,9 +327,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public async Task GetTollFreeAreaCodes()
         {
-            if (SkipPhoneNumberLiveTests)
-                Assert.Ignore("Skip phone number live tests flag is on.");
-
             string[] expectedAreaCodes = { "888", "877", "866", "855", "844", "800", "833", "88" };
             var client = CreateClient();
 
@@ -347,9 +341,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public async Task GetGeographicAreaCodes()
         {
-            if (SkipPhoneNumberLiveTests)
-                Assert.Ignore("Skip phone number live tests flag is on.");
-
             var client = CreateClient();
             var availableLocalities = client.GetAvailableLocalitiesAsync("US");
             await foreach (PhoneNumberLocality firstLocality in availableLocalities)
@@ -367,9 +358,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public async Task GetCountries()
         {
-            if (SkipPhoneNumberLiveTests)
-                Assert.Ignore("Skip phone number live tests flag is on.");
-
             List<string> countriesResponse = new List<string>();
             string[] expectedCountries = { "US", "CA" };
             var client = CreateClient();
@@ -390,9 +378,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public async Task GetLocalities()
         {
-            if (SkipPhoneNumberLiveTests)
-                Assert.Ignore("Skip phone number live tests flag is on.");
-
             var client = CreateClient();
 
             var localities = client.GetAvailableLocalitiesAsync("US");
@@ -406,9 +391,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public async Task GetLocalitiesWithAdministrativeDivision()
         {
-            if (SkipPhoneNumberLiveTests)
-                Assert.Ignore("Skip phone number live tests flag is on.");
-
             var client = CreateClient();
             var availableLocalities = client.GetAvailableLocalitiesAsync("US");
             await foreach (PhoneNumberLocality firstLocality in availableLocalities)
@@ -427,9 +409,6 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public async Task GetOfferings()
         {
-            if (SkipPhoneNumberLiveTests)
-                Assert.Ignore("Skip phone number live tests flag is on.");
-
             var client = CreateClient();
 
             var offerings = client.GetAvailableOfferingsAsync("US");


### PR DESCRIPTION
Currently some tests were not running as part of the pipeline, removing the:
            if (SkipPhoneNumberLiveTests)
                Assert.Ignore("Skip phone number live tests flag is on.");

Should allow them to run properly as part of the pipeline, and this tests did not need that condition to run.