### PR TITLE
[Storage] [DataMovement] Fix to prevent empty/default strings to be passed as paths for Local Storage Resources

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fix to prevent empty strings or null to be passed as paths for `LocalFileStorageResource` and `LocalDirectoryStorageResourceContainer`.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalDirectoryStorageResourceContainer.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using Azure.Core;
 using Azure.Storage.DataMovement.Models;
 
 namespace Azure.Storage.DataMovement
@@ -40,6 +41,7 @@ namespace Azure.Storage.DataMovement
         /// <param name="path"></param>
         public LocalDirectoryStorageResourceContainer(string path)
         {
+            Argument.AssertNotNullOrWhiteSpace(path, nameof(path));
             _path = path;
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalFileStorageResource.cs
@@ -64,6 +64,7 @@ namespace Azure.Storage.DataMovement
         /// <param name="path"></param>
         public LocalFileStorageResource(string path)
         {
+            Argument.AssertNotNullOrWhiteSpace(path, nameof(path));
             _path = path;
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Storage.DataMovement.Models;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
@@ -40,6 +41,19 @@ namespace Azure.Storage.DataMovement.Tests
                 Assert.AreEqual(path, storageResource.Path);
                 Assert.AreEqual(ProduceUriType.NoUri, storageResource.CanProduceUri);
             }
+        }
+
+        [Test]
+        public void Ctor_Error()
+        {
+            Assert.Catch<ArgumentException>( () =>
+                new LocalDirectoryStorageResourceContainer(""));
+
+            Assert.Catch<ArgumentException>(() =>
+                new LocalDirectoryStorageResourceContainer("   "));
+
+            Assert.Catch<ArgumentException>(() =>
+                new LocalDirectoryStorageResourceContainer(default));
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
@@ -82,6 +82,19 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        public void Ctor_Error()
+        {
+            Assert.Catch<ArgumentException>(() =>
+                new LocalFileStorageResource(""));
+
+            Assert.Catch<ArgumentException>(() =>
+                new LocalFileStorageResource("   "));
+
+            Assert.Catch<ArgumentException>(() =>
+                new LocalFileStorageResource(default));
+        }
+
+        [Test]
         public async Task ReadStreamAsync()
         {
             // Arrange


### PR DESCRIPTION
Fix to prevent empty strings or `null` values to be passed as paths for `LocalFileStorageResource` and `LocalDirectoryStorageResourceContainer`.