### PR TITLE
Add support for custom attributes and serviceVersion attribute from resource object to include in telemetry items.

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Added service version and custom attributes specified on the resource object to the published telemetry.
+* Added inclusion of OpenTelemetry Resource service version and custom attributes to the published telemetry for logs, traces, and metrics.
   ([#35487](https://github.com/Azure/azure-sdk-for-net/issues/35487))
 
 ### Breaking Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,21 +1,11 @@
 # Release History
 
-## 1.0.0-beta.12 (Unreleased)
+## 1.0.0-beta.11 (Unreleased)
 
 ### Features Added
 
 * Added service version and custom attributes specified on the resource object to the published telemetry.
   ([#35487](https://github.com/Azure/azure-sdk-for-net/issues/35487))
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-## 1.0.0-beta.11 (Unreleased)
-
-### Features Added
 
 ### Breaking Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features Added
 
 * Added inclusion of OpenTelemetry Resource service version and custom attributes to the published telemetry for logs, traces, and metrics.
+  Inclusion of custom attributes can be enabled or disabled by using a new AzureMonitorExporterOptions property (IncludeResourceCustomAttributes),
+  which defaults to false.
   ([#35487](https://github.com/Azure/azure-sdk-for-net/issues/35487))
 
 ### Breaking Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+## 1.0.0-beta.12 (Unreleased)
+
+### Features Added
+
+* Added service version and custom attributes specified on the resource object to the published telemetry.
+  ([#35487](https://github.com/Azure/azure-sdk-for-net/issues/35487))
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.11 (Unreleased)
 
 ### Features Added

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -15,6 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public string? ConnectionString { get { throw null; } set { } }
         public Azure.Core.TokenCredential? Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
+        public bool IncludeResourceCustomAttributes { get { throw null; } set { } }
         public string? StorageDirectory { get { throw null; } set { } }
         public Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion Version { get { throw null; } set { } }
         public enum ServiceVersion

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>An OpenTelemetry .NET exporter that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry Exporter</AssemblyTitle>
-    <Version>1.0.0-beta.12</Version>
+    <Version>1.0.0-beta.11</Version>
     <PackageTags>Azure Monitor OpenTelemetry Exporter ApplicationInsights</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>An OpenTelemetry .NET exporter that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry Exporter</AssemblyTitle>
-    <Version>1.0.0-beta.11</Version>
+    <Version>1.0.0-beta.12</Version>
     <PackageTags>Azure Monitor OpenTelemetry Exporter ApplicationInsights</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -36,6 +36,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public ServiceVersion Version { get; set; } = LatestVersion;
 
         /// <summary>
+        /// If set to true, then custom attributes specified on the associated Resource
+        /// will be included in the properties of telemetry items of the type processed
+        /// by this exporter (e.g., logs, traces, or metrics).
+        /// </summary>
+        public bool IncludeResourceCustomAttributes { get; set; } = false;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AzureMonitorExporterOptions"/>.
         /// </summary>
         public AzureMonitorExporterOptions() : this(LatestVersion)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -15,11 +15,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
+        private readonly bool _includeResourceCustomAttributes;
         private AzureMonitorResource? _resource;
         private bool _disposed;
 
         public AzureMonitorLogExporter(AzureMonitorExporterOptions options) : this(TransmitterFactory.Instance.Get(options))
         {
+            _includeResourceCustomAttributes = options.IncludeResourceCustomAttributes;
         }
 
         internal AzureMonitorLogExporter(ITransmitter transmitter)
@@ -40,7 +42,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey);
+                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey, _includeResourceCustomAttributes);
                 if (telemetryItems.Count > 0)
                 {
                     exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _instrumentationKey = transmitter.InstrumentationKey;
         }
 
-        internal AzureMonitorResource? LogResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? LogResource => _resource ??= ParentProvider?.GetResource().UpdateAttributes();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<LogRecord> batch)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _instrumentationKey = transmitter.InstrumentationKey;
         }
 
-        internal AzureMonitorResource? MetricResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? MetricResource => _resource ??= ParentProvider?.GetResource().UpdateAttributes();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Metric> batch)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -15,11 +15,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
+        private readonly bool _includeResourceCustomAttributes;
         private AzureMonitorResource? _resource;
         private bool _disposed;
 
         public AzureMonitorMetricExporter(AzureMonitorExporterOptions options) : this(TransmitterFactory.Instance.Get(options))
         {
+            _includeResourceCustomAttributes = options.IncludeResourceCustomAttributes;
         }
 
         internal AzureMonitorMetricExporter(ITransmitter transmitter)
@@ -44,7 +46,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 // even if there are no items in batch
                 if (batch.Count > 0)
                 {
-                    var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, MetricResource, _instrumentationKey);
+                    var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, MetricResource, _instrumentationKey, _includeResourceCustomAttributes);
                     if (telemetryItems.Count > 0)
                     {
                         exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -15,11 +15,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private readonly ITransmitter _transmitter;
         private readonly string _instrumentationKey;
+        private readonly bool _includeResourceCustomAttributes;
         private AzureMonitorResource? _resource;
         private bool _disposed;
 
         public AzureMonitorTraceExporter(AzureMonitorExporterOptions options) : this(TransmitterFactory.Instance.Get(options))
         {
+            _includeResourceCustomAttributes = options.IncludeResourceCustomAttributes;
         }
 
         internal AzureMonitorTraceExporter(ITransmitter transmitter)
@@ -40,7 +42,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, TraceResource, _instrumentationKey);
+                var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, TraceResource, _instrumentationKey, _includeResourceCustomAttributes);
                 if (telemetryItems.Count > 0)
                 {
                     exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _instrumentationKey = transmitter.InstrumentationKey;
         }
 
-        internal AzureMonitorResource? TraceResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? TraceResource => _resource ??= ParentProvider?.GetResource().UpdateAttributes();
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Activity> batch)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -103,7 +103,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 foreach (var attribute in _resource.CustomTags)
                 {
-                    properties.Add(attribute.Key, attribute.Value);
+                    properties[attribute.Key] = attribute.Value;
                 }
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 
 using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
@@ -95,12 +97,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             SetResourceSdkVersionAndIkey(resource, instrumentationKey);
         }
 
+        public void SetResourceCustomAttributes(AzureMonitorResource? _resource, IDictionary<string, string> properties)
+        {
+            if (_resource != null)
+            {
+                foreach (var attribute in _resource.CustomTags)
+                {
+                    properties.Add(attribute.Key, attribute.Value);
+                }
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetResourceSdkVersionAndIkey(AzureMonitorResource? resource, string instrumentationKey)
         {
             InstrumentationKey = instrumentationKey;
             Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName;
             Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance;
+            Tags[ContextTagKeys.AiCloudRoleVer.ToString()] = resource?.RoleVersion;
+            Tags[ContextTagKeys.AiApplicationVer.ToString()] = resource?.RoleVersion;
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion;
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using Azure.Core;
+
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal class AzureMonitorResource
@@ -8,5 +11,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal string? RoleName { get; set; }
 
         internal string? RoleInstance { get; set; }
+
+        internal string? RoleVersion { get; set; } = "Unknown";
+
+        internal IDictionary<string, string> CustomTags { get; } = new ChangeTrackingDictionary<string, string>();
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     internal interface ITransmitter : IDisposable
     {
         /// <summary>
-        /// Sent telemetry and return the number of items Accepted.
+        /// Send telemetry and return the number of items Accepted.
         /// </summary>
         ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken);
         string InstrumentationKey { get; }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -24,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private static readonly ConcurrentDictionary<int, string> s_depthCache = new ConcurrentDictionary<int, string>();
         private static readonly Func<int, string> s_convertDepthToStringRef = ConvertDepthToString;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey, bool includeResourceCustomAttributes)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
@@ -41,7 +41,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             BaseType = "ExceptionData",
                             BaseData = new TelemetryExceptionData(Version, logRecord),
                         };
-                        telemetryItem.SetResourceCustomAttributes(resource, ((TelemetryExceptionData)telemetryItem.Data.BaseData).Properties);
+
+                        if (includeResourceCustomAttributes)
+                        {
+                            telemetryItem.SetResourceCustomAttributes(resource, ((TelemetryExceptionData)telemetryItem.Data.BaseData).Properties);
+                        }
                     }
                     else
                     {
@@ -50,7 +54,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             BaseType = "MessageData",
                             BaseData = new MessageData(Version, logRecord),
                         };
-                        telemetryItem.SetResourceCustomAttributes(resource, ((MessageData)telemetryItem.Data.BaseData).Properties);
+
+                        if (includeResourceCustomAttributes)
+                        {
+                            telemetryItem.SetResourceCustomAttributes(resource, ((MessageData)telemetryItem.Data.BaseData).Properties);
+                        }
                     }
 
                     telemetryItems.Add(telemetryItem);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -41,6 +41,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             BaseType = "ExceptionData",
                             BaseData = new TelemetryExceptionData(Version, logRecord),
                         };
+                        telemetryItem.SetResourceCustomAttributes(resource, ((TelemetryExceptionData)telemetryItem.Data.BaseData).Properties);
                     }
                     else
                     {
@@ -49,6 +50,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             BaseType = "MessageData",
                             BaseData = new MessageData(Version, logRecord),
                         };
+                        telemetryItem.SetResourceCustomAttributes(resource, ((MessageData)telemetryItem.Data.BaseData).Properties);
                     }
 
                     telemetryItems.Add(telemetryItem);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
@@ -24,14 +24,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 {
                     try
                     {
-                        telemetryItems.Add(new TelemetryItem(metricPoint.EndTime.UtcDateTime, resource, instrumentationKey)
+                        var telemetryItem = new TelemetryItem(metricPoint.EndTime.UtcDateTime, resource, instrumentationKey)
                         {
                             Data = new MonitorBase
                             {
                                 BaseType = "MetricData",
                                 BaseData = new MetricsData(Version, metric, metricPoint)
                             }
-                        });
+                        };
+
+                        telemetryItem.SetResourceCustomAttributes(resource, ((MetricsData)telemetryItem.Data.BaseData).Properties);
+                        telemetryItems.Add(telemetryItem);
                     }
                     catch (Exception ex)
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/MetricHelper.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         private const int Version = 2;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorMetrics(Batch<Metric> batch, AzureMonitorResource? resource, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorMetrics(Batch<Metric> batch, AzureMonitorResource? resource, string instrumentationKey, bool includeResourceCustomAttributes)
         {
             List<TelemetryItem> telemetryItems = new();
             foreach (var metric in batch)
@@ -33,7 +33,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             }
                         };
 
-                        telemetryItem.SetResourceCustomAttributes(resource, ((MetricsData)telemetryItem.Data.BaseData).Properties);
+                        if (includeResourceCustomAttributes)
+                        {
+                            telemetryItem.SetResourceCustomAttributes(resource, ((MetricsData)telemetryItem.Data.BaseData).Properties);
+                        }
+
                         telemetryItems.Add(telemetryItem);
                     }
                     catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -11,7 +11,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         private const string s_AiSdkPrefixKey = "ai.sdk.prefix";
 
-        internal static AzureMonitorResource? UpdateRoleNameAndInstance(this Resource resource)
+        internal static AzureMonitorResource? UpdateAttributes(this Resource resource)
         {
             if (resource == null)
             {
@@ -29,6 +29,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     case SemanticConventions.AttributeServiceName when attribute.Value is string _serviceName:
                         serviceName = _serviceName;
                         break;
+                    case SemanticConventions.AttributeServiceVersion when attribute.Value is string _serviceVersion:
+                        resourceParser.RoleVersion = _serviceVersion;
+                        break;
                     case SemanticConventions.AttributeServiceNamespace when attribute.Value is string _serviceNamespace:
                         serviceNamespace = $"[{_serviceNamespace}]";
                         break;
@@ -36,7 +39,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         resourceParser.RoleInstance = _serviceInstance;
                         break;
                     case s_AiSdkPrefixKey:
-                        SdkVersionUtils.SdkVersionPrefix = attribute.Value.ToString();
+                        SdkVersionUtils.SdkVersionPrefix = attribute.Value?.ToString();
+                        break;
+                    default:
+                        if (attribute.Value != null)
+                        {
+                            resourceParser.CustomTags.Add(attribute.Key, attribute.Value.ToString());
+                        }
                         break;
                 }
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
@@ -24,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             [StandardMetricConstants.DependencyDurationInstrumentName] = StandardMetricConstants.DependencyDurationMetricIdValue,
         };
 
-        internal AzureMonitorResource? StandardMetricResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? StandardMetricResource => _resource ??= ParentProvider?.GetResource().UpdateAttributes();
 
         internal StandardMetricsExtractionProcessor()
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -45,6 +45,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                                 BaseType = "RequestData",
                                 BaseData = new RequestData(Version, activity, ref activityTagsProcessor),
                             };
+                            telemetryItem.SetResourceCustomAttributes(resource, ((RequestData)telemetryItem.Data.BaseData).Properties);
                             break;
                         case TelemetryType.Dependency:
                             telemetryItem.Data = new MonitorBase
@@ -52,6 +53,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                                 BaseType = "RemoteDependencyData",
                                 BaseData = new RemoteDependencyData(Version, activity, ref activityTagsProcessor),
                             };
+                            telemetryItem.SetResourceCustomAttributes(resource, ((RemoteDependencyData)telemetryItem.Data.BaseData).Properties);
                             break;
                     }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private const int Version = 2;
         private const int MaxlinksAllowed = 100;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorTrace(Batch<Activity> batchActivity, AzureMonitorResource? resource, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorTrace(Batch<Activity> batchActivity, AzureMonitorResource? resource, string instrumentationKey, bool includeResourceCustomAttributes)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
@@ -45,7 +45,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                                 BaseType = "RequestData",
                                 BaseData = new RequestData(Version, activity, ref activityTagsProcessor),
                             };
-                            telemetryItem.SetResourceCustomAttributes(resource, ((RequestData)telemetryItem.Data.BaseData).Properties);
+
+                            if (includeResourceCustomAttributes)
+                            {
+                                telemetryItem.SetResourceCustomAttributes(resource, ((RequestData)telemetryItem.Data.BaseData).Properties);
+                            }
                             break;
                         case TelemetryType.Dependency:
                             telemetryItem.Data = new MonitorBase
@@ -53,7 +57,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                                 BaseType = "RemoteDependencyData",
                                 BaseData = new RemoteDependencyData(Version, activity, ref activityTagsProcessor),
                             };
-                            telemetryItem.SetResourceCustomAttributes(resource, ((RemoteDependencyData)telemetryItem.Data.BaseData).Properties);
+
+                            if (includeResourceCustomAttributes)
+                            {
+                                telemetryItem.SetResourceCustomAttributes(resource, ((RemoteDependencyData)telemetryItem.Data.BaseData).Properties);
+                            }
                             break;
                     }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -18,7 +18,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string expectedMessage,
             IDictionary<string, string> expectedMessageProperties,
             string? expectedSpanId,
-            string? expectedTraceId)
+            string? expectedTraceId,
+            bool resourceObjectPresent = true)
         {
             Assert.Equal("Message", telemetryItem.Name); // telemetry type
             Assert.Equal("MessageData", telemetryItem.Data.BaseType); // telemetry data type
@@ -27,9 +28,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
             var expectedTagsCount = 3;
 
+            if (resourceObjectPresent)
+            {
+                expectedTagsCount += 2;
+            }
+
             if (expectedSpanId != null && expectedTraceId != null)
             {
-                expectedTagsCount = 5;
+                expectedTagsCount += 2;
 
                 Assert.Equal(expectedSpanId, telemetryItem.Tags["ai.operation.parentId"]);
                 Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
@@ -70,7 +76,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(3, telemetryItem.Tags.Count);
+            Assert.Equal(5, telemetryItem.Tags.Count);
             Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
             Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
@@ -100,7 +106,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(4, telemetryItem.Tags.Count);
+            Assert.Equal(6, telemetryItem.Tags.Count);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
             Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
             Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
@@ -138,11 +144,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            var expectedTagsCount = 4;
+            var expectedTagsCount = 6;
 
             if (activityKind == ActivityKind.Server)
             {
-                expectedTagsCount = 6;
+                expectedTagsCount += 2;
 
                 Assert.Contains("ai.operation.name", telemetryItem.Tags.Keys);
                 Assert.Contains("ai.location.ip", telemetryItem.Tags.Keys);
@@ -221,7 +227,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(3, telemetryItem.Tags.Count);
+            Assert.Equal(5, telemetryItem.Tags.Count);
             Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
             Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -318,7 +318,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                     { "string", "Hello, World!" },
                     { "intArray", "1,2,3" } },
                 expectedSpanId: spanId,
-                expectedTraceId: traceId);
+                expectedTraceId: traceId,
+                false);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -261,7 +261,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 RoleName = "roleName",
                 RoleInstance = "roleInstance"
             };
-            var telemetryItem = LogsHelper.OtelToAzureMonitorLogs(new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count), logResource, "Ikey");
+            var telemetryItem = LogsHelper.OtelToAzureMonitorLogs(new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count), logResource, "Ikey", false);
 
             Assert.Equal(type, telemetryItem[0].Data.BaseType);
             Assert.Equal("Ikey", telemetryItem[0].InstrumentationKey);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricHelperTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 RoleName = "testRoleName",
                 RoleInstance = "testRoleInstance"
             };
-            var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(new Batch<Metric>(metrics.ToArray(), 1), metricResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(new Batch<Metric>(metrics.ToArray(), 1), metricResource, "00000000-0000-0000-0000-000000000000", false);
             Assert.Single(telemetryItems);
             Assert.Equal("MetricData", telemetryItems[0].Data.BaseType);
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItems[0].InstrumentationKey);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void NullResource()
         {
             Resource? resource = null;
-            var azMonResource = resource!.UpdateRoleNameAndInstance();
+            var azMonResource = resource!.UpdateAttributes();
 
             Assert.Null(azMonResource);
         }
@@ -24,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DefaultResource()
         {
             var resource = CreateTestResource();
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.UpdateAttributes();
 
             Assert.StartsWith("unknown_service", azMonResource?.RoleName);
             Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
@@ -34,7 +34,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceNameFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.UpdateAttributes();
 
             Assert.Equal("my-service", azMonResource?.RoleName);
             Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
@@ -44,7 +44,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceInstanceFromResource()
         {
             var resource = CreateTestResource(serviceInstance: "my-instance");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.UpdateAttributes();
 
             Assert.StartsWith("unknown_service", azMonResource?.RoleName);
             Assert.Equal("my-instance", azMonResource?.RoleInstance);
@@ -54,7 +54,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceNamespaceFromResource()
         {
             var resource = CreateTestResource(serviceNamespace: "my-namespace");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.UpdateAttributes();
 
             Assert.StartsWith("[my-namespace]/unknown_service", azMonResource?.RoleName);
             Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
@@ -64,7 +64,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceNameAndInstanceFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.UpdateAttributes();
 
             Assert.Equal("my-service", azMonResource?.RoleName);
             Assert.Equal("my-instance", azMonResource?.RoleInstance);
@@ -74,7 +74,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceNameAndInstanceAndNamespaceFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service", serviceNamespace: "my-namespace", serviceInstance: "my-instance");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.UpdateAttributes();
 
             Assert.Equal("[my-namespace]/my-service", azMonResource?.RoleName);
             Assert.Equal("my-instance", azMonResource?.RoleInstance);
@@ -91,7 +91,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-            _ = resource.UpdateRoleNameAndInstance();
+            _ = resource.UpdateAttributes();
 
             Assert.StartsWith("pre_", SdkVersionUtils.s_sdkVersion);
 
@@ -106,7 +106,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var sdkVersion = SdkVersionUtils.s_sdkVersion;
 
             var resource = ResourceBuilder.CreateDefault().Build();
-            _ = resource.UpdateRoleNameAndInstance();
+            _ = resource.UpdateAttributes();
 
             Assert.NotNull(SdkVersionUtils.s_sdkVersion);
             Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);
@@ -127,7 +127,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-            _ = resource.UpdateRoleNameAndInstance();
+            _ = resource.UpdateAttributes();
 
             Assert.NotNull(SdkVersionUtils.s_sdkVersion);
             Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.UpdateAttributes();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
@@ -72,7 +72,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.UpdateAttributes();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
@@ -98,7 +98,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.UpdateAttributes();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
@@ -293,7 +293,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.UpdateAttributes();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(Dns.GetHostName(), telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
@@ -313,7 +313,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(null, null, "serviceinstance");
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.UpdateAttributes();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("serviceinstance", telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TraceHelperTests.cs
@@ -240,7 +240,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
             var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000-0000-0000-0000-000000000000", false);
 
             Assert.Equal(2, telemetryItems.Count());
             Assert.Equal("Exception", telemetryItems[0].Name);
@@ -277,7 +277,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
             var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000-0000-0000-0000-000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000-0000-0000-0000-000000000000", false);
 
             Assert.Equal(2, telemetryItems.Count());
             Assert.Equal("Message", telemetryItems[0].Name);
@@ -310,7 +310,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
             var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000 - 0000 - 0000 - 0000 - 000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000 - 0000 - 0000 - 0000 - 000000000000", false);
 
             Assert.Single(telemetryItems);
             Assert.Equal("Request", (IEnumerable<char>)telemetryItems[0].Name);
@@ -343,7 +343,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Batch<Activity> batch = new Batch<Activity>(activityList, 1);
             var traceResource = new AzureMonitorResource();
 
-            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000 - 0000 - 0000 - 0000 - 000000000000");
+            var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, traceResource, "00000000 - 0000 - 0000 - 0000 - 000000000000", false);
 
             Assert.Single(telemetryItems);
             Assert.Equal("Request", telemetryItems[0].Name);


### PR DESCRIPTION
This PR introduces the inclusion of both the serviceVersion schema attribute and any custom attributes added to an OpenTelemetry resource that is associated with any telemetry to the TelemetryItem data properties.

NOTE:  I tried adding them to the AdditionalProperties dictionary present in the base class of MonitorDomain so that all telemetry types inheriting from it would get it, but it still didn't show up in app insights (need someone to help me understand why).  So, instead I had to cast to the derived type of each type of telemetry and write it into the Properties dictionary. That made them show up.

I also assigned the serviceVersion to both AiCloudRoleVer and AiApplicationVer (I only noticed a "Application Version" in app insights show up and not a "Role Version"). These will default to "Unknown" if not specified.

I have not created or updated any unit tests or integration tests to specifically test out custom attributes on resources, but did make sure existing ones were adjusted to still run and pass (updated expected tag counts for two new version fields). I did not run the integration tests.

This is in response to issue https://github.com/Azure/azure-sdk-for-net/issues/35487.

UPDATE 05/05/2023:  I have verified that integration tests pass as well.