### PR TITLE
[Smoke Tests] Update target frameworks

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net462</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to update the target frameworks to replace `net461` with `net462` now that the former has gone out of support.  This change has already been made to the pipeline definitions, causing failures when trying to run the smoke tests.

# References and Related

- [Pipeline failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2751912&view=logs&j=3d8d0a86-970a-5cf9-e585-d90461529d81&t=bb7b4691-10d1-55e6-5f5e-a096010de118)