### PR TITLE
[AzureMonitorExporter] Add _OTELRESOURCE_ metrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 
@@ -28,7 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _instrumentationKey = transmitter.InstrumentationKey;
         }
 
-        internal AzureMonitorResource? LogResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? LogResource => _resource ??= ParentProvider?.GetResource().CreateAzureMonitorResource(_instrumentationKey);
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<LogRecord> batch)
@@ -43,6 +42,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey);
                 if (telemetryItems.Count > 0)
                 {
+                    if (LogResource?.MetricTelemetry != null)
+                    {
+                        telemetryItems.Add(LogResource.MetricTelemetry);
+                    }
                     exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
                 }
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Threading;
 using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using OpenTelemetry;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
@@ -28,7 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _instrumentationKey = transmitter.InstrumentationKey;
         }
 
-        internal AzureMonitorResource? TraceResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? TraceResource => _resource ??= ParentProvider?.GetResource().CreateAzureMonitorResource(_instrumentationKey);
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Activity> batch)
@@ -43,6 +42,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, TraceResource, _instrumentationKey);
                 if (telemetryItems.Count > 0)
                 {
+                    if (TraceResource?.MetricTelemetry != null)
+                    {
+                        telemetryItems.Add(TraceResource.MetricTelemetry);
+                    }
                     exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
                 }
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -11,6 +11,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class MetricsData
     {
+        private const string azureMonitorResourceKey = "_OTELRESOURCE_";
+
         public MetricsData(int version, Metric metric, MetricPoint metricPoint) : base(version)
         {
             if (metric == null)
@@ -32,6 +34,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     Properties.Add(new KeyValuePair<string, string>(tag.Key, tag.Value.ToString().Truncate(SchemaConstants.MetricsData_Properties_MaxValueLength) ?? "null"));
                 }
             }
+        }
+
+        public MetricsData(int version) : base(version)
+        {
+            IList<MetricDataPoint> metricDataPoints = new List<MetricDataPoint>();
+            MetricDataPoint metricDataPoint = new MetricDataPoint(azureMonitorResourceKey, 0);
+            metricDataPoints.Add(metricDataPoint);
+            Metrics = metricDataPoints;
+            Properties = new ChangeTrackingDictionary<string, string>();
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MetricsData.cs
@@ -36,6 +36,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             }
         }
 
+        /// <summary>
+        /// This constructor is used only for creating resource metrics with the name "_OTELRESOURCE_".
+        /// </summary>
+        /// <param name="version">Schema version.</param>
         public MetricsData(int version) : base(version)
         {
             IList<MetricDataPoint> metricDataPoints = new List<MetricDataPoint>();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal class AzureMonitorResource
@@ -8,5 +10,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal string? RoleName { get; set; }
 
         internal string? RoleInstance { get; set; }
+
+        internal TelemetryItem? MetricTelemetry { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry.Resources;
@@ -26,6 +27,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             string? serviceName = null;
             string? serviceNamespace = null;
 
+            if (instrumentationKey != null && resource.Attributes.Count() > 0)
+            {
+                metricsData = new MetricsData(Version);
+            }
+
             foreach (var attribute in resource.Attributes)
             {
                 switch (attribute.Key)
@@ -44,9 +50,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         continue;
                 }
 
-                if (instrumentationKey != null && attribute.Key.Length <= SchemaConstants.MetricsData_Properties_MaxKeyLength && attribute.Value != null)
+                if (metricsData != null && attribute.Key.Length <= SchemaConstants.MetricsData_Properties_MaxKeyLength && attribute.Value != null)
                 {
-                    metricsData = metricsData ?? new MetricsData(Version);
                     // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
                     metricsData.Properties.Add(new KeyValuePair<string, string>(attribute.Key, attribute.Value.ToString().Truncate(SchemaConstants.MetricsData_Properties_MaxValueLength) ?? "null"));
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
@@ -24,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             [StandardMetricConstants.DependencyDurationInstrumentName] = StandardMetricConstants.DependencyDurationMetricIdValue,
         };
 
-        internal AzureMonitorResource? StandardMetricResource => _resource ??= ParentProvider?.GetResource().UpdateRoleNameAndInstance();
+        internal AzureMonitorResource? StandardMetricResource => _resource ??= ParentProvider?.GetResource().CreateAzureMonitorResource();
 
         internal StandardMetricsExtractionProcessor()
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private const int Version = 2;
         private const int MaxlinksAllowed = 100;
 
-        internal static List<TelemetryItem> OtelToAzureMonitorTrace(Batch<Activity> batchActivity, AzureMonitorResource? resource, string instrumentationKey)
+        internal static List<TelemetryItem> OtelToAzureMonitorTrace(Batch<Activity> batchActivity, AzureMonitorResource? azureMonitorResource, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
@@ -29,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 try
                 {
                     var activityTagsProcessor = EnumerateActivityTags(activity);
-                    telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, resource, instrumentationKey);
+                    telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, azureMonitorResource, instrumentationKey);
 
                     // Check for Exceptions events
                     if (activity.Events.Any())

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Traces/TraceDemo.cs
@@ -26,6 +26,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Traces
                 { "service.name", "my-service" },
                 { "service.namespace", "my-namespace" },
                 { "service.instance.id", "my-instance" },
+                { "foo", "bar" }
             };
 
             var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -69,7 +69,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems?.Single();
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Message").Single();
 
             TelemetryItemValidationHelper.AssertMessageTelemetry(
                 telemetryItem: telemetryItem!,
@@ -129,7 +129,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems?.Single();
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Exception").Single();
 
             TelemetryItemValidationHelper.AssertLog_As_ExceptionTelemetry(
                 telemetryItem: telemetryItem!,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -67,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.Single();
+            var telemetryItem = telemetryItems.LastOrDefault()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -121,7 +121,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.Single();
+            var telemetryItem = telemetryItems.LastOrDefault()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -169,7 +169,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.Single();
+            var telemetryItem = telemetryItems.LastOrDefault()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -216,7 +216,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.Single();
+            var telemetryItem = telemetryItems.LastOrDefault()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -259,9 +259,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ASSERT
             metricReader.Collect();
-            Assert.True(telemetryItems.Count == 1);
-            Assert.True(telemetryItems.TryTake(out var telemetryItem));
-            this.telemetryOutput.Write(telemetryItem!);
+            Assert.True(telemetryItems.Count == 2);
+            var telemetryItem = telemetryItems.LastOrDefault()!;
+            this.telemetryOutput.Write(telemetryItem);
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedMetricDataPointName: asView ? "MyUpDownCounterRenamed" : "MyUpDownCounter",
@@ -269,9 +269,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedMetricDataPointValue: -2,
                 expectedMetricsProperties: new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" } });
 
+            // Clear the telemetryItems bag.
+            while (telemetryItems.TryTake(out _))
+            { }
+
             metricReader.Collect();
-            Assert.True(telemetryItems.Count == 1);
-            Assert.True(telemetryItems.TryTake(out telemetryItem));
+            Assert.True(telemetryItems.Count == 2);
+            telemetryItem = telemetryItems.LastOrDefault()!;
             this.telemetryOutput.Write(telemetryItem!);
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem!,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -67,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.LastOrDefault()!;
+            var telemetryItem = telemetryItems.Last()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -121,7 +121,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.LastOrDefault()!;
+            var telemetryItem = telemetryItems.Last()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -169,7 +169,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.LastOrDefault()!;
+            var telemetryItem = telemetryItems.Last()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -216,7 +216,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.LastOrDefault()!;
+            var telemetryItem = telemetryItems.Last()!;
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
@@ -260,7 +260,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             metricReader.Collect();
             Assert.True(telemetryItems.Count == 2);
-            var telemetryItem = telemetryItems.LastOrDefault()!;
+            var telemetryItem = telemetryItems.Last()!;
             this.telemetryOutput.Write(telemetryItem);
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem!,
@@ -275,7 +275,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             metricReader.Collect();
             Assert.True(telemetryItems.Count == 2);
-            telemetryItem = telemetryItems.LastOrDefault()!;
+            telemetryItem = telemetryItems.Last()!;
             this.telemetryOutput.Write(telemetryItem!);
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem!,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -67,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.First(); // TODO: Change to Single(). Still investigating random duplicate export which only repros on build server.
+            var telemetryItem = telemetryItems.Where(x => x.Name == "RemoteDependency").First()!;
 
             TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
                 telemetryItem: telemetryItem,
@@ -113,7 +113,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var telemetryItem = telemetryItems.First(); // TODO: Change to Single(). Still investigating random duplicate export which only repros on build server.
+            var telemetryItem = telemetryItems.Where(x => x.Name =="Request").First()!;
 
             TelemetryItemValidationHelper.AssertActivity_As_RequestTelemetry(
                 telemetryItem: telemetryItem,
@@ -246,7 +246,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(activityTelemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(activityTelemetryItems);
-            var activityTelemetryItem = activityTelemetryItems.First(); // TODO: Change to Single(). Still investigating random duplicate export which only repros on build server.
+            var activityTelemetryItem = activityTelemetryItems.Where(x => x.Name == "RemoteDependency").First()!;
 
             TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
                 telemetryItem: activityTelemetryItem,
@@ -257,7 +257,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             Assert.True(logTelemetryItems?.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(logTelemetryItems!);
-            var logTelemetryItem = logTelemetryItems?.Single();
+            var logTelemetryItem = logTelemetryItems?.Where(x => x.Name == "Message").First()!;
 
             TelemetryItemValidationHelper.AssertMessageTelemetry(
                 telemetryItem: logTelemetryItem!,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricsDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricsDataTests.cs
@@ -184,5 +184,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Throws<ArgumentNullException>(() => new MetricsData(Version, null, metricPoint));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
+
+        [Fact]
+        public void InitializesResourceMetricsAndProperties()
+        {
+            var metricsData = new MetricsData(Version);
+            Assert.Single(metricsData.Metrics);
+
+            var metricDataPoint = metricsData.Metrics[0];
+            Assert.Equal("_OTELRESOURCE_", metricDataPoint.Name);
+            Assert.Equal(0, metricDataPoint.Value);
+            Assert.Empty(metricsData.Properties);
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Net;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry.Resources;
 using Xunit;
 
@@ -11,30 +12,37 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 {
     public class ResourceExtensionsTests
     {
-        [Fact]
-        public void NullResource()
+        private const string InstrumentationKey = "00000000-0000-0000-0000-000000000000";
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(InstrumentationKey)]
+        public void NullResource(string? instrumentationKey)
         {
             Resource? resource = null;
-            var azMonResource = resource!.UpdateRoleNameAndInstance();
+            var azMonResource = resource!.CreateAzureMonitorResource(instrumentationKey);
 
             Assert.Null(azMonResource);
         }
 
-        [Fact]
-        public void DefaultResource()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(InstrumentationKey)]
+        public void DefaultResource(string? instrumentationKey)
         {
             var resource = CreateTestResource();
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
 
             Assert.StartsWith("unknown_service", azMonResource?.RoleName);
             Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
+            Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
         }
 
         [Fact]
         public void ServiceNameFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.CreateAzureMonitorResource();
 
             Assert.Equal("my-service", azMonResource?.RoleName);
             Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
@@ -44,7 +52,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceInstanceFromResource()
         {
             var resource = CreateTestResource(serviceInstance: "my-instance");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.CreateAzureMonitorResource();
 
             Assert.StartsWith("unknown_service", azMonResource?.RoleName);
             Assert.Equal("my-instance", azMonResource?.RoleInstance);
@@ -54,7 +62,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceNamespaceFromResource()
         {
             var resource = CreateTestResource(serviceNamespace: "my-namespace");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.CreateAzureMonitorResource();
 
             Assert.StartsWith("[my-namespace]/unknown_service", azMonResource?.RoleName);
             Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
@@ -64,7 +72,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceNameAndInstanceFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.CreateAzureMonitorResource();
 
             Assert.Equal("my-service", azMonResource?.RoleName);
             Assert.Equal("my-instance", azMonResource?.RoleInstance);
@@ -74,7 +82,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void ServiceNameAndInstanceAndNamespaceFromResource()
         {
             var resource = CreateTestResource(serviceName: "my-service", serviceNamespace: "my-namespace", serviceInstance: "my-instance");
-            var azMonResource = resource.UpdateRoleNameAndInstance();
+            var azMonResource = resource.CreateAzureMonitorResource();
 
             Assert.Equal("[my-namespace]/my-service", azMonResource?.RoleName);
             Assert.Equal("my-instance", azMonResource?.RoleInstance);
@@ -91,7 +99,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-            _ = resource.UpdateRoleNameAndInstance();
+            _ = resource.CreateAzureMonitorResource();
 
             Assert.StartsWith("pre_", SdkVersionUtils.s_sdkVersion);
 
@@ -106,7 +114,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var sdkVersion = SdkVersionUtils.s_sdkVersion;
 
             var resource = ResourceBuilder.CreateDefault().Build();
-            _ = resource.UpdateRoleNameAndInstance();
+            _ = resource.CreateAzureMonitorResource();
 
             Assert.NotNull(SdkVersionUtils.s_sdkVersion);
             Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);
@@ -127,13 +135,82 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-            _ = resource.UpdateRoleNameAndInstance();
+            _ = resource.CreateAzureMonitorResource();
 
             Assert.NotNull(SdkVersionUtils.s_sdkVersion);
             Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);
 
             // Clean up
             SdkVersionUtils.s_sdkVersion = sdkVersion;
+        }
+
+        [Fact]
+        public void SdkPrefixIsNotInResourceMetrics()
+        {
+            // SDK version is static, preserve to clean up later.
+            var sdkVersion = SdkVersionUtils.s_sdkVersion;
+            var testAttributes = new Dictionary<string, object>
+            {
+                {"foo", "bar" },
+                { "ai.sdk.prefix", "pre_" }
+            };
+
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
+            var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
+
+            Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
+
+            var monitorBase = azMonResource.MetricTelemetry.Data;
+            var metricsData = monitorBase.BaseData as MetricsData;
+
+            var metricDataPoint = metricsData?.Metrics[0];
+            Assert.Equal("bar", metricsData?.Properties["foo"]);
+            Assert.False(metricsData?.Properties.ContainsKey("ai.sdk.prefix"));
+
+            // Clean up
+            SdkVersionUtils.s_sdkVersion = sdkVersion;
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(InstrumentationKey)]
+        public void MetricTelemetryHasAllResourceAttributes(string? instrumentationKey)
+        {
+            var testAttributes = new Dictionary<string, object>
+            {
+                {"service.name", "my-service" },
+                {"service.namespace", "my-namespace" },
+                {"service.instance.id", "my-instance" },
+                { "foo", "bar" }
+            };
+
+            var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
+            var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
+
+            Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+
+            if (instrumentationKey != null)
+            {
+                Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
+                Assert.Equal(3, azMonResource.MetricTelemetry.Tags.Count);
+                Assert.NotNull(azMonResource.MetricTelemetry.Data);
+
+                var monitorBase = azMonResource.MetricTelemetry.Data;
+                var metricsData = monitorBase.BaseData as MetricsData;
+
+                Assert.NotNull(metricsData?.Metrics);
+
+                var metricDataPoint = metricsData?.Metrics[0];
+                Assert.Equal("_OTELRESOURCE_", metricDataPoint?.Name);
+                Assert.Equal(0, metricDataPoint?.Value);
+
+                Assert.Equal(4, metricsData?.Properties.Count);
+
+                Assert.Equal("my-service", metricsData?.Properties["service.name"]);
+                Assert.Equal("my-namespace", metricsData?.Properties["service.namespace"]);
+                Assert.Equal("my-instance", metricsData?.Properties["service.instance.id"]);
+                Assert.Equal("bar", metricsData?.Properties["foo"]);
+            }
         }
 
         /// <summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
@@ -115,7 +115,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             tracerProvider?.ForceFlush();
 
             Assert.NotEmpty(telemetryItems);
-            Assert.Equal(100F, telemetryItems.LastOrDefault()!.SampleRate);
+            Assert.Equal(100F, telemetryItems.Last()!.SampleRate);
         }
 
         [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/SampleRateTests.cs
@@ -115,7 +115,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             tracerProvider?.ForceFlush();
 
             Assert.NotEmpty(telemetryItems);
-            Assert.Equal(100F, telemetryItems.First().SampleRate);
+            Assert.Equal(100F, telemetryItems.LastOrDefault()!.SampleRate);
         }
 
         [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
@@ -54,7 +54,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Standard Metrics + Resource Metrics.
             Assert.Equal(2, metricTelemetryItems.Count);
 
-            var metricTelemetry = metricTelemetryItems.LastOrDefault()!;
+            var metricTelemetry = metricTelemetryItems.Last()!;
             Assert.Equal("MetricData", metricTelemetry.Data.BaseType);
             var metricData = (MetricsData)metricTelemetry.Data.BaseData;
             Assert.True(metricData.Properties.TryGetValue(StandardMetricConstants.RequestSuccessKey, out var isSuccess));
@@ -107,7 +107,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Standard Metrics + Resource Metrics.
             Assert.Equal(2, metricTelemetryItems.Count);
 
-            var metricTelemetry = metricTelemetryItems.LastOrDefault()!;
+            var metricTelemetry = metricTelemetryItems.Last()!;
             Assert.Equal("MetricData", metricTelemetry.Data.BaseType);
             var metricData = (MetricsData)metricTelemetry.Data.BaseData;
             Assert.True(metricData.Properties.TryGetValue(StandardMetricConstants.DependencySuccessKey, out var isSuccess));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
@@ -51,9 +51,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             meterProvider?.ForceFlush();
 
-            Assert.Single(metricTelemetryItems);
+            // Standard Metrics + Resource Metrics.
+            Assert.Equal(2, metricTelemetryItems.Count);
 
-            var metricTelemetry = metricTelemetryItems.Single();
+            var metricTelemetry = metricTelemetryItems.LastOrDefault()!;
             Assert.Equal("MetricData", metricTelemetry.Data.BaseType);
             var metricData = (MetricsData)metricTelemetry.Data.BaseData;
             Assert.True(metricData.Properties.TryGetValue(StandardMetricConstants.RequestSuccessKey, out var isSuccess));
@@ -103,9 +104,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             meterProvider?.ForceFlush();
 
-            Assert.Single(metricTelemetryItems);
+            // Standard Metrics + Resource Metrics.
+            Assert.Equal(2, metricTelemetryItems.Count);
 
-            var metricTelemetry = metricTelemetryItems.Single();
+            var metricTelemetry = metricTelemetryItems.LastOrDefault()!;
             Assert.Equal("MetricData", metricTelemetry.Data.BaseType);
             var metricData = (MetricsData)metricTelemetry.Data.BaseData;
             Assert.True(metricData.Properties.TryGetValue(StandardMetricConstants.DependencySuccessKey, out var isSuccess));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.CreateAzureMonitorResource();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
@@ -72,7 +72,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.CreateAzureMonitorResource();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
@@ -98,7 +98,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.CreateAzureMonitorResource();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("RemoteDependency", telemetryItem.Name);
@@ -293,7 +293,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource();
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.CreateAzureMonitorResource();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal(Dns.GetHostName(), telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
@@ -313,7 +313,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var resource = CreateTestResource(null, null, "serviceinstance");
 
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
-            var traceResource = resource.UpdateRoleNameAndInstance();
+            var traceResource = resource.CreateAzureMonitorResource();
             var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000");
 
             Assert.Equal("serviceinstance", telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
 
             // Assert
             Assert.True(telemetryItems.Any(), "test project did not capture telemetry");
-            var telemetryItem = telemetryItems.Single();
+            var telemetryItem = telemetryItems.LastOrDefault()!;
             this.telemetryOutput.Write(telemetryItem);
 
             AssertRequestTelemetry(

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
 
             // Assert
             Assert.True(telemetryItems.Any(), "test project did not capture telemetry");
-            var telemetryItem = telemetryItems.LastOrDefault()!;
+            var telemetryItem = telemetryItems.Last()!;
             this.telemetryOutput.Write(telemetryItem);
 
             AssertRequestTelemetry(


### PR DESCRIPTION
This pull request updates the exporter to convert all resource attributes to metric telemetry with a name of `_OTELRESOURCE_`, which now includes all resource attributes as custom dimensions. The `_OTELRESOURCE_` metric is included in every transmission to the Application Insights ingestion service, enabling the storage of resource objects in a new `AppResources` LA table. Below is a sample telemetry payload to demonstrate these changes.

Please note that this is a work in progress and the `AppResources` table may not be available at this point. As a result, `_OTELRESOURCE_` will be available in metrics blade..

```json
{
   "name":"Metric",
   "time":"2023-05-05T20:05:02.6710627Z",
   "iKey":"00000000-0000-0000-0000-000000000000",
   "tags":{
      "ai.cloud.role":"[my-namespace]/my-service",
      "ai.cloud.roleInstance":"my-instance",
      "ai.internal.sdkVersion":"dotnet7.0.5:otel1.4.0:ext1.0.0-alpha.20230505.1"
   },
   "data":{
      "baseType":"MetricData",
      "baseData":{
         "metrics":[
            {
               "name":"_OTELRESOURCE_",
               "value":0
            }
         ],
         "properties":{
            "service.name":"my-service",
            "service.namespace":"my-namespace",
            "service.instance.id":"my-instance",
            "foo":"bar"
         },
         "ver":2
      }
   }
}
```

The `AppResources` table can be used with a join operation with other tables in Application Insights. For example, the `AppResources` table can be joined with the `AppRequests` table to gain insights into the application's resource usage.