### PR TITLE
Add ECDsa primitive support to Key Vault

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
@@ -398,6 +398,10 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         System.Threading.Tasks.Task<byte[]> Azure.Core.Cryptography.IKeyEncryptionKey.UnwrapKeyAsync(string algorithm, System.ReadOnlyMemory<byte> encryptedKey, System.Threading.CancellationToken cancellationToken) { throw null; }
         byte[] Azure.Core.Cryptography.IKeyEncryptionKey.WrapKey(string algorithm, System.ReadOnlyMemory<byte> key, System.Threading.CancellationToken cancellationToken) { throw null; }
         System.Threading.Tasks.Task<byte[]> Azure.Core.Cryptography.IKeyEncryptionKey.WrapKeyAsync(string algorithm, System.ReadOnlyMemory<byte> key, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual Azure.Security.KeyVault.Keys.Cryptography.ECDsaKeyVault CreateECDsa(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Security.KeyVault.Keys.Cryptography.ECDsaKeyVault> CreateECDsaAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Security.KeyVault.Keys.Cryptography.RSAKeyVault CreateRSA(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Security.KeyVault.Keys.Cryptography.RSAKeyVault> CreateRSAAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Security.KeyVault.Keys.Cryptography.DecryptResult Decrypt(Azure.Security.KeyVault.Keys.Cryptography.DecryptParameters decryptParameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Security.KeyVault.Keys.Cryptography.DecryptResult Decrypt(Azure.Security.KeyVault.Keys.Cryptography.EncryptionAlgorithm algorithm, byte[] ciphertext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Security.KeyVault.Keys.Cryptography.DecryptResult> DecryptAsync(Azure.Security.KeyVault.Keys.Cryptography.DecryptParameters decryptParameters, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -464,6 +468,16 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         public Azure.Security.KeyVault.Keys.Cryptography.EncryptionAlgorithm Algorithm { get { throw null; } }
         public string KeyId { get { throw null; } }
         public byte[] Plaintext { get { throw null; } }
+    }
+    public partial class ECDsaKeyVault : System.Security.Cryptography.ECDsa
+    {
+        internal ECDsaKeyVault() { }
+        public System.Security.Cryptography.ECDsa Key { get { throw null; } }
+        public override int KeySize { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] SignHash(byte[] hash) { throw null; }
+        public override bool VerifyHash(byte[] hash, byte[] signature) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct EncryptionAlgorithm : System.IEquatable<Azure.Security.KeyVault.Keys.Cryptography.EncryptionAlgorithm>
@@ -560,6 +574,23 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
     public partial class LocalCryptographyClientOptions : Azure.Core.ClientOptions
     {
         public LocalCryptographyClientOptions() { }
+    }
+    public partial class RSAKeyVault : System.Security.Cryptography.RSA
+    {
+        internal RSAKeyVault() { }
+        public System.Security.Cryptography.RSA Key { get { throw null; } }
+        public override string KeyExchangeAlgorithm { get { throw null; } }
+        public override int KeySize { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public override byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
+        public override System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters) { throw null; }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override void ImportParameters(System.Security.Cryptography.RSAParameters parameters) { }
+        public override byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public override bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SignatureAlgorithm : System.IEquatable<Azure.Security.KeyVault.Keys.Cryptography.SignatureAlgorithm>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
@@ -18,6 +18,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
     /// </summary>
     public class CryptographyClient : IKeyEncryptionKey
     {
+        private const string GetOperation = "get";
         private readonly string _keyId;
         private readonly KeyVaultPipeline _pipeline;
         private readonly RemoteCryptographyClient _remoteProvider;
@@ -200,6 +201,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual async Task<EncryptResult> EncryptAsync(EncryptionAlgorithm algorithm, byte[] plaintext, CancellationToken cancellationToken = default) =>
             await EncryptAsync(new EncryptParameters(algorithm, plaintext), cancellationToken).ConfigureAwait(false);
 
@@ -220,6 +222,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual EncryptResult Encrypt(EncryptionAlgorithm algorithm, byte[] plaintext, CancellationToken cancellationToken = default) =>
             Encrypt(new EncryptParameters(algorithm, plaintext), cancellationToken);
 
@@ -240,6 +243,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual async Task<EncryptResult> EncryptAsync(EncryptParameters encryptParameters, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(encryptParameters, nameof(encryptParameters));
@@ -302,6 +306,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual EncryptResult Encrypt(EncryptParameters encryptParameters, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(encryptParameters, nameof(encryptParameters));
@@ -360,6 +365,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual async Task<DecryptResult> DecryptAsync(EncryptionAlgorithm algorithm, byte[] ciphertext, CancellationToken cancellationToken = default) =>
             await DecryptAsync(new DecryptParameters(algorithm, ciphertext), cancellationToken).ConfigureAwait(false);
 
@@ -377,6 +383,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual DecryptResult Decrypt(EncryptionAlgorithm algorithm, byte[] ciphertext, CancellationToken cancellationToken = default) =>
             Decrypt(new DecryptParameters(algorithm, ciphertext), cancellationToken);
 
@@ -394,6 +401,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual async Task<DecryptResult> DecryptAsync(DecryptParameters decryptParameters, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(decryptParameters, nameof(decryptParameters));
@@ -453,6 +461,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <exception cref="CryptographicException">The local cryptographic provider threw an exception.</exception>
         /// <exception cref="InvalidOperationException">The key is invalid for the current operation.</exception>
         /// <exception cref="NotSupportedException">The operation is not supported with the specified key.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual DecryptResult Decrypt(DecryptParameters decryptParameters, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(decryptParameters, nameof(decryptParameters));
@@ -1591,6 +1600,120 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
                 throw;
             }
         }
+
+        /// <summary>
+        /// Creates an <see cref="ECDsa"/> implementation backed by this <see cref="CryptographyClient"/>.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel this operation.</param>
+        /// <returns>An <see cref="ECDsaKeyVault"/> implementation backed by this <see cref="CryptographyClient"/>.</returns>
+        /// <remarks>
+        /// The <see cref="CryptographyClient"/> will attempt to download the public key synchronously.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">This key is not of type <see cref="KeyType.Ec"/> or <see cref="KeyType.EcHsm"/>, or one or more key parameters are invalid.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual ECDsaKeyVault CreateECDsa(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(CreateECDsa)}");
+            scope.AddAttribute("key", _keyId);
+            scope.Start();
+
+            try
+            {
+                Initialize(GetOperation, cancellationToken);
+                return new ECDsaKeyVault(this, KeyMaterial);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ECDsa"/> implementation backed by this <see cref="CryptographyClient"/>.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel this operation.</param>
+        /// <returns>An <see cref="ECDsaKeyVault"/> implementation backed by this <see cref="CryptographyClient"/>.</returns>
+        /// <remarks>
+        /// The <see cref="CryptographyClient"/> will attempt to download the public key synchronously.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">This key is not of type <see cref="KeyType.Ec"/> or <see cref="KeyType.EcHsm"/>, or one or more key parameters are invalid.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual async Task<ECDsaKeyVault> CreateECDsaAsync(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(CreateECDsa)}");
+            scope.AddAttribute("key", _keyId);
+            scope.Start();
+
+            try
+            {
+                await InitializeAsync(GetOperation, cancellationToken).ConfigureAwait(false);
+                return new ECDsaKeyVault(this, KeyMaterial);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates an <see cref="RSA"/> implementation backed by this <see cref="CryptographyClient"/>.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel this operation.</param>
+        /// <returns>An <see cref="RSAKeyVault"/> implementation backed by this <see cref="CryptographyClient"/>.</returns>
+        /// <remarks>
+        /// The <see cref="CryptographyClient"/> will attempt to download the public key synchronously.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">This key is not of type <see cref="KeyType.Rsa"/> or <see cref="KeyType.RsaHsm"/>, or one or more key parameters are invalid.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual RSAKeyVault CreateRSA(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(CreateRSA)}");
+            scope.AddAttribute("key", _keyId);
+            scope.Start();
+
+            try
+            {
+                Initialize(GetOperation, cancellationToken);
+                return new RSAKeyVault(this, KeyMaterial);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates an <see cref="RSA"/> implementation backed by this <see cref="CryptographyClient"/>.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel this operation.</param>
+        /// <returns>An <see cref="RSAKeyVault"/> implementation backed by this <see cref="CryptographyClient"/>.</returns>
+        /// <remarks>
+        /// The <see cref="CryptographyClient"/> will attempt to download the public key asynchronously.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">This key is not of type <see cref="KeyType.Rsa"/> or <see cref="KeyType.RsaHsm"/>, or one or more key parameters are invalid.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual async Task<RSAKeyVault> CreateRSAAsync(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _pipeline.CreateScope($"{nameof(CryptographyClient)}.{nameof(CreateRSA)}");
+            scope.AddAttribute("key", _keyId);
+            scope.Start();
+
+            try
+            {
+                await InitializeAsync(GetOperation, cancellationToken).ConfigureAwait(false);
+                return new RSAKeyVault(this, KeyMaterial);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        private JsonWebKey KeyMaterial => _provider is LocalCryptographyProvider local ? local.KeyMaterial : null;
 
         private void ThrowIfLocalOnly(string name)
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/ECDsaKeyVault.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/ECDsaKeyVault.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Azure.Security.KeyVault.Keys.Cryptography
+{
+    /// <summary>
+    /// Provides an implementation of the ECDsa algorithm backed by Azure Key Vault or Managed HSM.
+    /// </summary>
+    public class ECDsaKeyVault : ECDsa
+    {
+        private static readonly KeySizes[] s_legalKeySizes =
+        {
+            new(minSize: 256, maxSize: 384, skipSize: 128),
+            new(minSize: 521, maxSize: 521, skipSize: 0),
+        };
+
+        private readonly CryptographyClient _client;
+        private readonly KeyCurveName? _curveName;
+
+        internal ECDsaKeyVault(CryptographyClient client, JsonWebKey keyMaterial)
+        {
+            _client = client;
+            if (keyMaterial != null)
+            {
+                _curveName = keyMaterial.CurveName;
+                Key = keyMaterial.ToECDsa();
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ECDsa"/> public key if downloaded.
+        /// </summary>
+        public ECDsa Key { get; }
+
+        /// <inheritdoc/>
+        /// <exception cref="InvalidOperationException">The key could not be downloaded so key size is unavailable.</exception>
+        /// <exception cref="NotSupportedException">Changing the key size on this read-only provider is not supported.</exception>
+        public override int KeySize
+        {
+            get => Key?.KeySize ?? throw new InvalidOperationException("Cannot download the key");
+            set => throw new NotSupportedException("Cannot change the key size");
+        }
+
+        /// <inheritdoc/>
+        public override KeySizes[] LegalKeySizes => s_legalKeySizes.Clone<KeySizes>();
+
+        /// <summary>
+        /// Computes the signature for the specified hash value by encrypting it with the private key using the specified padding.
+        /// </summary>
+        /// <param name="hash">The hash value of the data to be signed.</param>
+        /// <returns>The RSA signature for the specified hash value.</returns>
+        /// <exception cref="InvalidOperationException">The key could not be downloaded so the signature algorithm could not be determined.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public override byte[] SignHash(byte[] hash)
+        {
+            SignatureAlgorithm algorithm = GetAlgorithm();
+            SignResult result = _client.Sign(algorithm, hash);
+
+            return result.Signature;
+        }
+
+        /// <summary>
+        /// Verifies that a digital signature is valid by determining the hash value in the signature using the specified hash algorithm and padding, and comparing it to the provided hash value.
+        /// </summary>
+        /// <param name="hash">The hash value of the signed data.</param>
+        /// <param name="signature">The signature data to be verified.</param>
+        /// <returns>true if the signature is valid; otherwise, false.</returns>
+        /// <exception cref="InvalidOperationException">The key could not be downloaded so the signature algorithm could not be determined.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public override bool VerifyHash(byte[] hash, byte[] signature)
+        {
+            SignatureAlgorithm algorithm = GetAlgorithm();
+            VerifyResult result = _client.Verify(algorithm, hash, signature);
+
+            return result.IsValid;
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Key?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private Cryptography.SignatureAlgorithm GetAlgorithm() => _curveName?.SignatureAlgorithm ?? throw new InvalidOperationException("Cannot download the key");
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/EncryptionAlgorithm.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/EncryptionAlgorithm.cs
@@ -132,6 +132,14 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <inheritdoc/>
         public override string ToString() => _value;
 
+        internal static EncryptionAlgorithm FromRsaEncryptionPadding(RSAEncryptionPadding padding) => padding.Mode switch
+        {
+            RSAEncryptionPaddingMode.Pkcs1 => Rsa15,
+            RSAEncryptionPaddingMode.Oaep when padding.OaepHashAlgorithm == HashAlgorithmName.SHA1 => RsaOaep,
+            RSAEncryptionPaddingMode.Oaep when padding.OaepHashAlgorithm == HashAlgorithmName.SHA256 => RsaOaep256,
+            _ => throw new NotSupportedException($"{padding} is not supported"),
+        };
+
         internal RSAEncryptionPadding GetRsaEncryptionPadding() => _value switch
         {
             Rsa15Value => RSAEncryptionPadding.Pkcs1,

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/LocalCryptographyProvider.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/LocalCryptographyProvider.cs
@@ -22,7 +22,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
 
         public bool CanRemote { get; }
 
-        protected JsonWebKey KeyMaterial { get; set; }
+        internal protected JsonWebKey KeyMaterial { get; set; }
 
         protected bool MustRemote => CanRemote && !KeyMaterial.HasPrivateKey;
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RSAKeyVault.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RSAKeyVault.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Azure.Security.KeyVault.Keys.Cryptography
+{
+    /// <summary>
+    /// Provides an implementation of the RSA algorithm backed by Azure Key Vault or Managed HSM.
+    /// </summary>
+    public class RSAKeyVault : RSA
+    {
+        private static readonly KeySizes[] s_legalKeySizes =
+        {
+            new(minSize: 2048, maxSize: 4096, skipSize: 1024),
+        };
+
+        private readonly CryptographyClient _client;
+
+        internal RSAKeyVault(CryptographyClient client, JsonWebKey keyMaterial)
+        {
+            _client = client;
+            if (keyMaterial != null)
+            {
+                Key = keyMaterial.ToRSA();
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="RSA"/> key if downloaded.
+        /// </summary>
+        public RSA Key { get; }
+
+        /// <inheritdoc/>
+        public override string KeyExchangeAlgorithm => Key?.KeyExchangeAlgorithm;
+
+        /// <inheritdoc/>
+        /// <exception cref="InvalidOperationException">The key could not be downloaded so key size is unavailable.</exception>
+        /// <exception cref="NotSupportedException">Changing the key size on this read-only provider is not supported.</exception>
+        public override int KeySize
+        {
+            get => Key?.KeySize ?? throw new InvalidOperationException("Cannot download the key");
+            set => throw new NotSupportedException("Cannot change the key size");
+        }
+
+        /// <inheritdoc/>
+        public override KeySizes[] LegalKeySizes => s_legalKeySizes.Clone<KeySizes>();
+
+        /// <inheritdoc/>
+        /// <exception cref="InvalidOperationException">The key could not be downloaded so exporting it is not supported.</exception>
+        public override RSAParameters ExportParameters(bool includePrivateParameters) =>
+            Key?.ExportParameters(includePrivateParameters) ?? throw new InvalidOperationException("Cannot download the key");
+
+        /// <inheritdoc/>
+        /// <exception cref="NotSupportedException">Importing a key into this read-only provider is not supported.</exception>
+        public override void ImportParameters(RSAParameters parameters) => throw new NotSupportedException("Cannot import a key");
+
+        /// <summary>
+        /// Encrypts the input data using the specified padding mode.
+        /// </summary>
+        /// <param name="data">The data to encrypt.</param>
+        /// <param name="padding">The padding mode.</param>
+        /// <returns>The encrypted data.</returns>
+        /// <exception cref="NotSupportedException">The <paramref name="padding"/> is not supported.</exception>
+        /// <exception cref="RequestFailedException"></exception>
+        public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
+        {
+            EncryptionAlgorithm algorithm = EncryptionAlgorithm.FromRsaEncryptionPadding(padding);
+            EncryptResult result = _client.Encrypt(algorithm, data);
+
+            return result.Ciphertext;
+        }
+
+        /// <summary>
+        /// Decrypts the input data using the specified padding mode.
+        /// </summary>
+        /// <param name="data">The data to decrypt.</param>
+        /// <param name="padding">The padding mode.</param>
+        /// <returns>The decrypted data.</returns>
+        /// <exception cref="NotSupportedException">The <paramref name="padding"/> is not supported.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
+        {
+            EncryptionAlgorithm algorithm = EncryptionAlgorithm.FromRsaEncryptionPadding(padding);
+            DecryptResult result = _client.Decrypt(algorithm, data);
+
+            return result.Plaintext;
+        }
+
+        /// <summary>
+        /// Computes the hash value of a specified portion of a byte array by using a specified hashing algorithm.
+        /// </summary>
+        /// <param name="data">The data to be hashed.</param>
+        /// <param name="offset">The index of the first byte in data that is to be hashed.</param>
+        /// <param name="count">The number of bytes to hash.</param>
+        /// <param name="hashAlgorithm">The algorithm to use in hash the data.</param>
+        /// <returns>The hashed data.</returns>
+        /// <exception cref="NotSupportedException">The <paramref name="hashAlgorithm"/> is not supported.</exception>
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+        {
+            using HashAlgorithm algorithm = Create(hashAlgorithm);
+            return algorithm.ComputeHash(data, offset, count);
+        }
+
+        /// <summary>
+        /// Computes the hash value of a specified binary stream by using a specified hashing algorithm.
+        /// </summary>
+        /// <param name="data">The binary stream to hash.</param>
+        /// <param name="hashAlgorithm">The algorithm to use in hash the data.</param>
+        /// <returns>The hashed data.</returns>
+        /// <exception cref="NotSupportedException">The <paramref name="hashAlgorithm"/> is not supported.</exception>
+        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+        {
+            using HashAlgorithm algorithm = Create(hashAlgorithm);
+            return algorithm.ComputeHash(data);
+        }
+
+        /// <summary>
+        /// Computes the signature for the specified hash value by encrypting it with the private key using the specified padding.
+        /// </summary>
+        /// <param name="hash">The hash value of the data to be signed.</param>
+        /// <param name="hashAlgorithm">The hash algorithm used to create the hash value of the data.</param>
+        /// <param name="padding">The padding.</param>
+        /// <returns>The RSA signature for the specified hash value.</returns>
+        /// <exception cref="NotSupportedException">Hash algorithm <paramref name="hashAlgorithm"/> with <paramref name="padding"/> padding is not supported.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            SignatureAlgorithm algorithm = Cryptography.SignatureAlgorithm.FromHashAlgorithmName(hashAlgorithm, padding);
+            SignResult result = _client.Sign(algorithm, hash);
+
+            return result.Signature;
+        }
+
+        /// <summary>
+        /// Verifies that a digital signature is valid by determining the hash value in the signature using the specified hash algorithm and padding, and comparing it to the provided hash value.
+        /// </summary>
+        /// <param name="hash">The hash value of the signed data.</param>
+        /// <param name="signature">The signature data to be verified.</param>
+        /// <param name="hashAlgorithm">The hash algorithm used to create the hash value.</param>
+        /// <param name="padding">The padding mode.</param>
+        /// <returns>true if the signature is valid; otherwise, false.</returns>
+        /// <exception cref="NotSupportedException">Hash algorithm <paramref name="hashAlgorithm"/> with <paramref name="padding"/> padding is not supported.</exception>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            SignatureAlgorithm algorithm = Cryptography.SignatureAlgorithm.FromHashAlgorithmName(hashAlgorithm, padding);
+            VerifyResult result = _client.Verify(algorithm, hash, signature);
+
+            return result.IsValid;
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Key?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private static HashAlgorithm Create(HashAlgorithmName algorithm)
+        {
+            if (algorithm == HashAlgorithmName.SHA256)
+            {
+                return SHA256.Create();
+            }
+
+            if (algorithm == HashAlgorithmName.SHA384)
+            {
+                return SHA384.Create();
+            }
+
+            if (algorithm == HashAlgorithmName.SHA512)
+            {
+                return SHA512.Create();
+            }
+
+            throw new NotSupportedException($"{algorithm} is not supported");
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/SignatureAlgorithm.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/SignatureAlgorithm.cs
@@ -120,6 +120,46 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <inheritdoc/>
         public override string ToString() => _value;
 
+        internal static SignatureAlgorithm FromHashAlgorithmName(HashAlgorithmName algorithm, RSASignaturePadding padding)
+        {
+            if (padding == RSASignaturePadding.Pkcs1)
+            {
+                if (algorithm == HashAlgorithmName.SHA256)
+                {
+                    return RS256;
+                }
+
+                if (algorithm == HashAlgorithmName.SHA384)
+                {
+                    return RS384;
+                }
+
+                if (algorithm == HashAlgorithmName.SHA512)
+                {
+                    return RS512;
+                }
+            }
+            else if (padding == RSASignaturePadding.Pss)
+            {
+                if (algorithm == HashAlgorithmName.SHA256)
+                {
+                    return PS256;
+                }
+
+                if (algorithm == HashAlgorithmName.SHA384)
+                {
+                    return PS384;
+                }
+
+                if (algorithm == HashAlgorithmName.SHA512)
+                {
+                    return PS512;
+                }
+            }
+
+            throw new NotSupportedException($"Hash algorithm {algorithm} with {padding} padding is not supported");
+        }
+
         internal HashAlgorithm GetHashAlgorithm()
         {
             switch (_value)

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyCurveName.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyCurveName.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Security.Cryptography;
+using Azure.Security.KeyVault.Keys.Cryptography;
 
 namespace Azure.Security.KeyVault.Keys
 {
@@ -186,6 +187,15 @@ namespace Azure.Security.KeyVault.Keys
             P256KValue => new Oid(P256KOidValue),
             P384Value => new Oid(P384OidValue),
             P521Value => new Oid(P521OidValue),
+            _ => null,
+        };
+
+        internal SignatureAlgorithm SignatureAlgorithm => _value switch
+        {
+            P256Value => SignatureAlgorithm.ES256,
+            P256KValue => SignatureAlgorithm.ES256K,
+            P384Value => SignatureAlgorithm.ES384,
+            P521Value => SignatureAlgorithm.ES512,
             _ => null,
         };
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/EncryptionAlgorithmTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/EncryptionAlgorithmTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Cryptography;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Keys.Tests
+{
+    public class EncryptionAlgorithmTests
+    {
+        [Test]
+        public void FromRsaEncryptionPadding()
+        {
+            EncryptionAlgorithm sut = EncryptionAlgorithm.FromRsaEncryptionPadding(RSAEncryptionPadding.Pkcs1);
+            Assert.AreEqual(EncryptionAlgorithm.Rsa15, sut);
+
+            sut = EncryptionAlgorithm.FromRsaEncryptionPadding(RSAEncryptionPadding.OaepSHA1);
+            Assert.AreEqual(EncryptionAlgorithm.RsaOaep, sut);
+
+            sut = EncryptionAlgorithm.FromRsaEncryptionPadding(RSAEncryptionPadding.OaepSHA256);
+            Assert.AreEqual(EncryptionAlgorithm.RsaOaep256, sut);
+
+            Assert.Throws<NotSupportedException>(() => EncryptionAlgorithm.FromRsaEncryptionPadding(RSAEncryptionPadding.OaepSHA384));
+            Assert.Throws<NotSupportedException>(() => EncryptionAlgorithm.FromRsaEncryptionPadding(RSAEncryptionPadding.OaepSHA512));
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES256).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES256).json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1915849879/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-6ecebeda26137f64fc600549afc18134-4dc58f4e4e7867cc-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e01fa0024352aac8d036364f85577ff",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:29 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9e01fa0024352aac8d036364f85577ff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "2f906bc5-b649-4b50-9840-e56ab43c3f8a"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1915849879/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-6ecebeda26137f64fc600549afc18134-4dc58f4e4e7867cc-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e01fa0024352aac8d036364f85577ff",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-256"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "422",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:30 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "9e01fa0024352aac8d036364f85577ff",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=0;da_age=0;rd_age=0;brd_age=11270;ra_notif_age=205;dec_lev=3;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "ee1f6cee-53ae-4220-a82e-f503fb9bf6fe"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1915849879/9ee441fb718b4f5ab91ba6ac3125dacb",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-256",
+          "x": "AN4qfYrrvMhxEVcPYxrVvguMjWmhaa79O6S_-TlUuhs",
+          "y": "ztqsOqzgS2r3YZ-ewJboPS_P5mH_WFkLb7-hdzhtjWM"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346811,
+          "updated": 1679346811,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1915849879/9ee441fb718b4f5ab91ba6ac3125dacb?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2dc8bdea25a0e1e910f5aad3aa682e9a-b44174158ffdeb14-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4b44fbe4dbb47c6f2a54928810a66458",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "422",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:30 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "4b44fbe4dbb47c6f2a54928810a66458",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=0;da_age=0;rd_age=0;brd_age=11270;ra_notif_age=205;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "85d5e06a-6d9d-4f07-ab8d-ebe79baffe88"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1915849879/9ee441fb718b4f5ab91ba6ac3125dacb",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-256",
+          "x": "AN4qfYrrvMhxEVcPYxrVvguMjWmhaa79O6S_-TlUuhs",
+          "y": "ztqsOqzgS2r3YZ-ewJboPS_P5mH_WFkLb7-hdzhtjWM"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346811,
+          "updated": 1679346811,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1915849879/9ee441fb718b4f5ab91ba6ac3125dacb/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7041bf8f26f62ee493015f19151a783e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "197",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:30 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7041bf8f26f62ee493015f19151a783e",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=0;da_age=0;rd_age=0;brd_age=11270;ra_notif_age=205;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "7c6d0c31-93b9-4631-8e8b-d55778e5e630"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1915849879/9ee441fb718b4f5ab91ba6ac3125dacb",
+        "value": "zxytu5n8H0KXakJv83TjqAmw7-I8h-JDoUYNUbZg9QqDhTJ0A9jVFybQBGERiVx6dknp6kDekUf0EXj1nB1XFA"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1306283623"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES256)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES256)Async.json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1345167475/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-de4cdbc935dbbcd23224c8ffaead957e-8e7d5f855165ea5c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7daa27d521dd94abc02e938932933291",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:48 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7daa27d521dd94abc02e938932933291",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "a359360f-fd3a-4e4f-b46f-c0de54c4bb63"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1345167475/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-de4cdbc935dbbcd23224c8ffaead957e-8e7d5f855165ea5c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7daa27d521dd94abc02e938932933291",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-256"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "422",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:48 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7daa27d521dd94abc02e938932933291",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=17;da_age=17;rd_age=17;brd_age=11287;ra_notif_age=222;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "72cc703f-5a4f-4e38-a420-5e27bc67a66e"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1345167475/8a18f0ff8b9d47cc963421e0cc440af7",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-256",
+          "x": "BlUofrPm1zJdkiZTnlzsY6CWt_gXBy3NRZGqKu5majk",
+          "y": "juHRsfXaqi_YXqHyDNShDYKCTFB2gpV3Ik5WFEglF28"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346828,
+          "updated": 1679346828,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1345167475/8a18f0ff8b9d47cc963421e0cc440af7?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b8f25d5b2f20ae1b383b5e83a35499f7-068bcb3f46ace0bd-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "19405e109d7036183c7c0dc06894710f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "422",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:48 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "19405e109d7036183c7c0dc06894710f",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=17;da_age=17;rd_age=17;brd_age=11287;ra_notif_age=222;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "8b5eb178-8b7f-4031-b120-dc8b6ce95036"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1345167475/8a18f0ff8b9d47cc963421e0cc440af7",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-256",
+          "x": "BlUofrPm1zJdkiZTnlzsY6CWt_gXBy3NRZGqKu5majk",
+          "y": "juHRsfXaqi_YXqHyDNShDYKCTFB2gpV3Ik5WFEglF28"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346828,
+          "updated": 1679346828,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1345167475/8a18f0ff8b9d47cc963421e0cc440af7/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "955da5d699f08720813465fff7da03e8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "197",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:48 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "955da5d699f08720813465fff7da03e8",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=17;da_age=17;rd_age=17;brd_age=11287;ra_notif_age=222;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "75774184-2a98-464c-8ba4-518cac961f78"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1345167475/8a18f0ff8b9d47cc963421e0cc440af7",
+        "value": "uFVsnJ5bcLCwwnHa6zxyXieiAdgSOjRfc-7i9Avel1jetn4kQYqYtMGvzKXNK2XUSAijcNKJOM2O_M9vuF8jIw"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1324359456"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES384).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES384).json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/803192145/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-1c59913ceecf783443ca5eab5f35ad90-f1cd1aad474fa536-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2bc366ee6169ee0f71ac8c239de4be65",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:15 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2bc366ee6169ee0f71ac8c239de4be65",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "d9aeb50d-f455-4fc8-9f70-0e064065db0f"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/803192145/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-1c59913ceecf783443ca5eab5f35ad90-f1cd1aad474fa536-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2bc366ee6169ee0f71ac8c239de4be65",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-384"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "463",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:17 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "2bc366ee6169ee0f71ac8c239de4be65",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=234;da_age=406;rd_age=406;brd_age=11676;ra_notif_age=611;dec_lev=2;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "e73256f5-244b-4ad3-bbc1-01827115fd98"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/803192145/897e21f5a03f460bb7f3fb2d071128e6",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-384",
+          "x": "flQ5i5eysYDjx2oZrXXsAIzYUUxrJEUbgQJzjJMgTtai0aIXgM_kjYwQDvqu3o7s",
+          "y": "nfUBCGa8V5jpUhHNLMdRyStTK0Cq_qF_ls-nbvMMcQoJ1TsOS2DDKxS-bt7DiNfZ"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347217,
+          "updated": 1679347217,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/803192145/897e21f5a03f460bb7f3fb2d071128e6?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a55ca7b7128f44834f5b40d3e16795b2-b3a30503fb98202c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c6e4f778ae94be8eb91a4dfbca76e7cb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "463",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:17 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c6e4f778ae94be8eb91a4dfbca76e7cb",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=234;da_age=407;rd_age=407;brd_age=11676;ra_notif_age=611;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "ba400b0d-bee1-45ec-8a47-a154ee2f369e"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/803192145/897e21f5a03f460bb7f3fb2d071128e6",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-384",
+          "x": "flQ5i5eysYDjx2oZrXXsAIzYUUxrJEUbgQJzjJMgTtai0aIXgM_kjYwQDvqu3o7s",
+          "y": "nfUBCGa8V5jpUhHNLMdRyStTK0Cq_qF_ls-nbvMMcQoJ1TsOS2DDKxS-bt7DiNfZ"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347217,
+          "updated": 1679347217,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/803192145/897e21f5a03f460bb7f3fb2d071128e6/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "90",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a5a56acf74ba90915a87347a88b3e42b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES384",
+        "value": "1f9nVpp7ygg84bIPWVl6XNe4vPyXwL5bN_apy_4445hY3foksKpInKoljE_oBt0C"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "238",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:17 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a5a56acf74ba90915a87347a88b3e42b",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=234;da_age=407;rd_age=407;brd_age=11676;ra_notif_age=612;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "7d331d0a-21c4-4b83-850e-6dd1c05a30e5"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/803192145/897e21f5a03f460bb7f3fb2d071128e6",
+        "value": "spLNhyP3YBlDAhFQShwAnsOVrRAzmoEzeRguaAOZNoG7B3H3dNqUM0y_2bvfm0ZaiHbXBpcpYewYxh9LzINUIgPS46oqsbUdtvlQlwcbYnMi58aEDWvSZWFgyebqf8lt"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "509951747"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES384)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES384)Async.json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1558577572/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-d462c15285ecb1d9e6f714bfa7a26f2e-6a7cf6cbdefa450c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c573d92855a0401f55851fea10580822",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c573d92855a0401f55851fea10580822",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "9c72b51b-c87d-4cd7-9961-c1d12b937eb3"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1558577572/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-d462c15285ecb1d9e6f714bfa7a26f2e-6a7cf6cbdefa450c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c573d92855a0401f55851fea10580822",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-384"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "464",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c573d92855a0401f55851fea10580822",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=242;da_age=414;rd_age=414;brd_age=11684;ra_notif_age=619;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "28db541b-6dc7-418c-acdc-7beb79ced79d"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1558577572/f6a42fbf8ce2451988f43b7c8aa1350e",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-384",
+          "x": "iRhz1sJ3yy1VZzAw3QRHgj0FI_9f1TdTqhB_k4ebEhO-EzIJsT9EKLOMpMg9ykDl",
+          "y": "k9vgTxODMTVOuTNy8GyWacCykNhOm8CsN52WV44lESv5VmUR1bwB7hsLl4DMHdJh"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347225,
+          "updated": 1679347225,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1558577572/f6a42fbf8ce2451988f43b7c8aa1350e?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-58880c495d884a3a63e67b022f7e33af-e899fdc423aac09b-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a92a4a164c4021f5d4a17f736502cf00",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "464",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a92a4a164c4021f5d4a17f736502cf00",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=242;da_age=414;rd_age=414;brd_age=11684;ra_notif_age=619;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "3fd1433b-8df5-4204-be4d-6e706021159b"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1558577572/f6a42fbf8ce2451988f43b7c8aa1350e",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-384",
+          "x": "iRhz1sJ3yy1VZzAw3QRHgj0FI_9f1TdTqhB_k4ebEhO-EzIJsT9EKLOMpMg9ykDl",
+          "y": "k9vgTxODMTVOuTNy8GyWacCykNhOm8CsN52WV44lESv5VmUR1bwB7hsLl4DMHdJh"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347225,
+          "updated": 1679347225,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1558577572/f6a42fbf8ce2451988f43b7c8aa1350e/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "90",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bcb78bb6da7d111fec72eb8550e988d3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES384",
+        "value": "1f9nVpp7ygg84bIPWVl6XNe4vPyXwL5bN_apy_4445hY3foksKpInKoljE_oBt0C"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "239",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:24 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bcb78bb6da7d111fec72eb8550e988d3",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=242;da_age=414;rd_age=414;brd_age=11684;ra_notif_age=619;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "f2ebe8ec-0f88-4e83-b51b-7f08fad4c17d"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1558577572/f6a42fbf8ce2451988f43b7c8aa1350e",
+        "value": "f9p7d_e1muqECav_HpfGMqRPGfKoKiyPMHUS-8HfPoX4407SKO3OC7x1w4LcxSirIgXKXAYsWps0DCZxZ_e1iFssUKldH94T9Ypqkgp2j89u14obgdv46m-ihYWIMqy8"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1046468326"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES512).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES512).json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/268490937/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-195e800416f22002b0f506eef00a8ee4-8f5509d87ad6ba24-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d30ce3328308730f9ca77c0454506815",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:18 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d30ce3328308730f9ca77c0454506815",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "db1faa40-335b-4c7a-939c-bc439d9c4e63"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/268490937/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-195e800416f22002b0f506eef00a8ee4-8f5509d87ad6ba24-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d30ce3328308730f9ca77c0454506815",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-521"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "511",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:18 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d30ce3328308730f9ca77c0454506815",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=236;da_age=408;rd_age=408;brd_age=11678;ra_notif_age=613;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "4580c6b9-4a6b-472a-a9af-60767f960786"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/268490937/2ea1e7ed4a0b4b9f80f6e587bcd6996c",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-521",
+          "x": "AXLuvvX30I2gmGM2xhSp9jQK_4-2nU_Bmi6-KV2Kmjah5b7h7_GqKT7Ek6tVnIqXjPxwRgpkF4cav5W9bakISI8P",
+          "y": "ASrAByIPuCbxqelQE618wfJekHz5XKmTok_lXKxE6FiubOS2WMu4z3_UPMB0Vm0KO_ZZkMy9qRXJd5UUS7ESH2U3"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347219,
+          "updated": 1679347219,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/268490937/2ea1e7ed4a0b4b9f80f6e587bcd6996c?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-07d477c86c53e2efcd777be2b3931c67-29a99ff6775acec1-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1726cec0d828cda1cec605cb63cd95bb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "511",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:18 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "1726cec0d828cda1cec605cb63cd95bb",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=236;da_age=408;rd_age=408;brd_age=11678;ra_notif_age=613;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "78d52c72-3e52-446f-aa1b-5be18841ca2d"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/268490937/2ea1e7ed4a0b4b9f80f6e587bcd6996c",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-521",
+          "x": "AXLuvvX30I2gmGM2xhSp9jQK_4-2nU_Bmi6-KV2Kmjah5b7h7_GqKT7Ek6tVnIqXjPxwRgpkF4cav5W9bakISI8P",
+          "y": "ASrAByIPuCbxqelQE618wfJekHz5XKmTok_lXKxE6FiubOS2WMu4z3_UPMB0Vm0KO_ZZkMy9qRXJd5UUS7ESH2U3"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347219,
+          "updated": 1679347219,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/268490937/2ea1e7ed4a0b4b9f80f6e587bcd6996c/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "112",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e8ea0db847bd4239fb278a53405ef627",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES512",
+        "value": "UN6JJ5l_H1uyu4FGSvFnITdF9d72SZ5LdQpMlMHBjOVvSdRSu1RCCQ-cV9iUvoXa73rGt2VceFGgTV2ypykpoQ"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "286",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:18 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e8ea0db847bd4239fb278a53405ef627",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=236;da_age=408;rd_age=408;brd_age=11678;ra_notif_age=613;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "1cc3d8e5-9adc-492d-974b-3623330f844d"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/268490937/2ea1e7ed4a0b4b9f80f6e587bcd6996c",
+        "value": "AGMPUKZBbL9IY5VJ68OTrugQvkCFWHNzO6oUbTRqUhwUPz8wM0vLubt-gYrFy9goM5xzaP9c-KJi5e_db9tNzufKAcBoQmVrqtSkCfteKutEliueXEq3Y62lKUxon-hHPlBKpLuUqLkZK8Wu54HT2uLlvYDq9x5tHHK0jyfD1ebeokCA"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "465603015"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES512)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateECDsaSignVerify(ES512)Async.json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1897617588/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-b80c9a886057c9a08fad3afdd29492b0-376912184fd75f0e-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dba2d162ccf03a233222cff9768c7797",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:26 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dba2d162ccf03a233222cff9768c7797",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "ceaa4eee-8479-4fef-a7a9-c926eb8b231c"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1897617588/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-b80c9a886057c9a08fad3afdd29492b0-376912184fd75f0e-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dba2d162ccf03a233222cff9768c7797",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-521"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "512",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:26 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "dba2d162ccf03a233222cff9768c7797",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=243;da_age=416;rd_age=416;brd_age=11686;ra_notif_age=621;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "87e2c06a-61d5-4688-9f49-62593fca110d"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1897617588/e4205904f3e24365940f888590f8b9cd",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-521",
+          "x": "ATo7sRx2iSm5-kPRn4LcWmVm5tYdfKdl-np8ln7QKJsuc9Hir_mR5G3dQ02Ryt0AAYCyGDMFYE30_yu_JELxpV2C",
+          "y": "AUDEMKNzeRUqbpu2ZpGhHzZGEYuG7DKGGE5zVrajaNkZcvP7ukpIWSeUadOJnZf2lMOZ5-4XrYw3pRcsadzFBZUx"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347227,
+          "updated": 1679347227,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1897617588/e4205904f3e24365940f888590f8b9cd?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fcabbf7b95e5fc625a1bfec0db1bd66f-798c3c24e4f33f5d-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0059626550f579a0cf3b751956e8771e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "512",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:26 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "0059626550f579a0cf3b751956e8771e",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=243;da_age=416;rd_age=416;brd_age=11686;ra_notif_age=621;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "00173515-4912-418f-b1e3-22a0173e1e30"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1897617588/e4205904f3e24365940f888590f8b9cd",
+          "kty": "EC",
+          "key_ops": [
+            "sign",
+            "verify"
+          ],
+          "crv": "P-521",
+          "x": "ATo7sRx2iSm5-kPRn4LcWmVm5tYdfKdl-np8ln7QKJsuc9Hir_mR5G3dQ02Ryt0AAYCyGDMFYE30_yu_JELxpV2C",
+          "y": "AUDEMKNzeRUqbpu2ZpGhHzZGEYuG7DKGGE5zVrajaNkZcvP7ukpIWSeUadOJnZf2lMOZ5-4XrYw3pRcsadzFBZUx"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679347227,
+          "updated": 1679347227,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1897617588/e4205904f3e24365940f888590f8b9cd/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "112",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d8be0116ac3ca0e453a6cd455a7fc736",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES512",
+        "value": "UN6JJ5l_H1uyu4FGSvFnITdF9d72SZ5LdQpMlMHBjOVvSdRSu1RCCQ-cV9iUvoXa73rGt2VceFGgTV2ypykpoQ"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "287",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:20:26 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d8be0116ac3ca0e453a6cd455a7fc736",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=244;da_age=416;rd_age=416;brd_age=11686;ra_notif_age=621;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "dd39a016-e64e-44e5-a1d4-275daa9543bd"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1897617588/e4205904f3e24365940f888590f8b9cd",
+        "value": "AJzvcFo-OQN1JfChJrKoic3egVL7HBeNtoAvAVUtAwm9ym-3mNAx6EQSQ-IEnO0yZqkTegQbk_qpBztTvkIUtlhgAH_MEGO7jRlxdpi1_ulvDl8wiYWQWy4WdMRwyMhRftVkhM4LShYauqJ-qS_hBizODr7UXj9Gt1LtlFbobpheiIHO"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "649950165"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecrypt.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecrypt.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/475251455/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-7bc08c0f696993547eb840fa99fb2033-d7704c98658870d6-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b7f930a282ccfc1305a11fdf7ca5c22d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:41 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b7f930a282ccfc1305a11fdf7ca5c22d",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "68f81bf8-2ddb-4d41-ba6f-e42df87cfdd7"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/475251455/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-7bc08c0f696993547eb840fa99fb2033-d7704c98658870d6-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b7f930a282ccfc1305a11fdf7ca5c22d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:42 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "b7f930a282ccfc1305a11fdf7ca5c22d",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=11;da_age=11;rd_age=11;brd_age=11281;ra_notif_age=216;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "02076acc-442a-443f-8393-87692356ff10"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/475251455/0775ac8627bc42e0a9c23f1ab8e82bd9",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "l7cDD0UGZD0WkTFNF9wbDitgRj9KT5It87SxT5-0lvh8_Lg-yviRLN9zq7tchxjhZUQ8LFSVLpLwG279ZnXHI9ARMFtg_so7iCAk8VJgfPRNEYQGwaWunSeqFgJhpv8SxIbHfn-pp9_x5rr6HuvW9_tWXAgP4cVfRRJckXJlv_LZrqvJw04ygrZP6UrulfsjEcaoJeNGxhRe4_rSoeLQi7cbYHp4_k_ibOcmtYi7P9rE-oOguY-V2g0Q2J5vqPhGsGG4NG-MbO4idADXPS1gJ9gimggCNzo8F52gWAab2Ve8vc6eAQ1ca6HuAVzLc0IRF50dVSVf1xy1DfpbZRDFvQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346822,
+          "updated": 1679346822,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/475251455/0775ac8627bc42e0a9c23f1ab8e82bd9?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-88b99105c14efafd07900c8437bd5964-90d584d37812ae20-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f92ecdd0e63f07fb567761184cfff0d3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:42 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "f92ecdd0e63f07fb567761184cfff0d3",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=11;da_age=11;rd_age=11;brd_age=11281;ra_notif_age=216;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "7835e9bf-08e1-4635-b822-59cf95c8f819"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/475251455/0775ac8627bc42e0a9c23f1ab8e82bd9",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "l7cDD0UGZD0WkTFNF9wbDitgRj9KT5It87SxT5-0lvh8_Lg-yviRLN9zq7tchxjhZUQ8LFSVLpLwG279ZnXHI9ARMFtg_so7iCAk8VJgfPRNEYQGwaWunSeqFgJhpv8SxIbHfn-pp9_x5rr6HuvW9_tWXAgP4cVfRRJckXJlv_LZrqvJw04ygrZP6UrulfsjEcaoJeNGxhRe4_rSoeLQi7cbYHp4_k_ibOcmtYi7P9rE-oOguY-V2g0Q2J5vqPhGsGG4NG-MbO4idADXPS1gJ9gimggCNzo8F52gWAab2Ve8vc6eAQ1ca6HuAVzLc0IRF50dVSVf1xy1DfpbZRDFvQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346822,
+          "updated": 1679346822,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/475251455/0775ac8627bc42e0a9c23f1ab8e82bd9/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a92ef795dd7418fdfc2b652ea895dbd9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "OKLGLs_i2HD1t78pYMzeyKQ1WbB41wXnYIz_gnY3x_msqV7adQInAG3vE9Y0YrbONr8tdQoLUm7MnaZP-NFjC6DBKqc4E4bQrBEPY_7oyzoGQxTAug1x9xuGUBu3qoJoL-Tg5ashh6HXNf2b_Mnvpqbs6T2DXz4HiUY_uiU4sx0yHo_XBqxDi8GuWH628D9Bd7-Ek0nd4hJ0xM6jQRaMHbk9o7slbvJoeoMBl97W0UOR8PZ8YIKn2h5i7RNIuL-h_7QcRP6kxJWBc6_ttQFJmBklDnxz4WtH3QHYe6f_rBhOzVHfhll9qb-Tng5FeaiHU1ZW_0qhvAQ-EbmIos776g"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "146",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:42 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a92ef795dd7418fdfc2b652ea895dbd9",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=11;da_age=11;rd_age=11;brd_age=11281;ra_notif_age=216;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "10664d28-0b52-4549-ab13-bfa0a0ef8fec"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/475251455/0775ac8627bc42e0a9c23f1ab8e82bd9",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1267646208"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecryptAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecryptAsync.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/490982763/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-2c5a91bd137633b049af46feb4095cf5-41b42dad485f16ad-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6b0ca838d9920a75656291fe4b65497b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:58 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6b0ca838d9920a75656291fe4b65497b",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "9dd7d451-cefb-435e-b3a4-85353af92c1d"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/490982763/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-2c5a91bd137633b049af46feb4095cf5-41b42dad485f16ad-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6b0ca838d9920a75656291fe4b65497b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:58 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6b0ca838d9920a75656291fe4b65497b",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=27;da_age=27;rd_age=27;brd_age=11297;ra_notif_age=232;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "e2a41657-4ce4-440b-a735-09f7a1c20123"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/490982763/1c1c6ded330e4848b25e8de7b573e84e",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "sVk_rjTc5KcsC399kxgGIagm4ArLUcEucyr6Wnk2xI0HxKYC_qE6hny_m9r558H3Ne6aW59MRxVI5R7svtvgUcnTpFZ608bRrf5ghuaI-5CtfJLKuQ5aK_UcoeEC4zfOIndgbJerkepIzC46XBFfhufD9X2LtpfBae9mxezDEZU1WZM3u_4EUD0K_hK0Gb8d4HrhBNk6IsqkqKqPzbgHCOFJi3pKqJq5g7xNY3tRdwPUzhIcjr3xh6jAMM9e84emPrj48KRanpjjWtkoSJ9jRIEhllbmiOhZaD_gz6jaiG6f_3WaT-5RigYj_RnQ9e4ytvgCz8VLWmBA_VzwkG3_bQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346838,
+          "updated": 1679346838,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/490982763/1c1c6ded330e4848b25e8de7b573e84e?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3dec3f7d89a840f1684fa32b53aac71a-25c9ab4b791a3ca9-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bda62138727e967d06cf11580256ca5f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:58 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bda62138727e967d06cf11580256ca5f",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=27;da_age=27;rd_age=27;brd_age=11297;ra_notif_age=232;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "b8764250-644e-47bb-bfeb-c4b03bbfe8e1"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/490982763/1c1c6ded330e4848b25e8de7b573e84e",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "sVk_rjTc5KcsC399kxgGIagm4ArLUcEucyr6Wnk2xI0HxKYC_qE6hny_m9r558H3Ne6aW59MRxVI5R7svtvgUcnTpFZ608bRrf5ghuaI-5CtfJLKuQ5aK_UcoeEC4zfOIndgbJerkepIzC46XBFfhufD9X2LtpfBae9mxezDEZU1WZM3u_4EUD0K_hK0Gb8d4HrhBNk6IsqkqKqPzbgHCOFJi3pKqJq5g7xNY3tRdwPUzhIcjr3xh6jAMM9e84emPrj48KRanpjjWtkoSJ9jRIEhllbmiOhZaD_gz6jaiG6f_3WaT-5RigYj_RnQ9e4ytvgCz8VLWmBA_VzwkG3_bQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346838,
+          "updated": 1679346838,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/490982763/1c1c6ded330e4848b25e8de7b573e84e/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3cdc94889333b589e4608e1f10c7cc76",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "JOA4N18xMEcMZwWujxqQM5nkY0n8cNAjNf6CFiOW0g1hshIXM3nQQibH2pbzDOx4nkHu8QSK_htPJ5uamD7REeYT7riJojw9FHALFYW6wv4SIe3kmXq6Iv-p9bMz92bgDUTIdHtR4ECghFxMZ50HaQABGiq33sjfvgqVpeWDZlLw8okKHNLCxEZCwJv08gqdpzwPKbonCegxfRScwZeugu04HN7x3m_hE1s9PltvUt1097IADn60pCp_i09SWN1lTldqQ1-2wYcyfLWbS94KC5aHF2ZnBWJDGJHDPW8NMSSZM7UkXTsmpSAFc1dbEEIYtvZa1yTfEpm9iKrpgcs2_Q"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "146",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:58 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3cdc94889333b589e4608e1f10c7cc76",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=27;da_age=27;rd_age=27;brd_age=11297;ra_notif_age=232;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "efe8d176-1bbf-4115-b1c3-89b3c24c4fed"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/490982763/1c1c6ded330e4848b25e8de7b573e84e",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1336955895"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecryptRemote.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecryptRemote.json
@@ -1,0 +1,182 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/170217492/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-ed35bf22bddada182e26dd66de2fa8e9-8d4d26c2d7b23227-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fe6108d06f7f597ccb07f843b4449fdf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fe6108d06f7f597ccb07f843b4449fdf",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "02e07de5-3dfa-4350-abe5-fc9de3703405"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/170217492/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-ed35bf22bddada182e26dd66de2fa8e9-8d4d26c2d7b23227-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fe6108d06f7f597ccb07f843b4449fdf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "fe6108d06f7f597ccb07f843b4449fdf",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=12;da_age=12;rd_age=12;brd_age=11282;ra_notif_age=217;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "6a5857b0-47f4-4de5-8a47-ce472b1350ca"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/170217492/0cb575e5579a4026ab8a28f14b4a0f5a",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "nAh-gdx_KmN11iuQoytB7fvUQgFMGCGH7RDtPbIOvVG4DcbXoub-K8g1TdKi8iaeCXf0HlxVoqyMNX_oeLJVCeZPyYaHGVJxIq1m6ZUFj5HwZND000mkbt2A6-qUHNwaM8ribtj8hCBsKwyvdl2NuY_PxHK1jovMMba3xgM_suUBZMemoDy6-d_gWh1GUjyyg8ZH4INmM6p-pnyFto2hiz0AOyMGOked97Rw9w4iWV00AoQxvwoeIwt6MR2zhOKSSs5sTQAsLnKQDrkdY3ClYmk9GQS8by-Wa3QuYtF-SpA5zu96DDhhQHAIFqnRxnWR0br5WG65yt7p14Qk5uirQQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346823,
+          "updated": 1679346823,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/170217492/0cb575e5579a4026ab8a28f14b4a0f5a/encrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a6f6090e43750212e98b4fc62e742fe4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "452",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a6f6090e43750212e98b4fc62e742fe4",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=13;da_age=13;rd_age=13;brd_age=11282;ra_notif_age=217;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "81150ad3-b886-4dfd-bff4-454957d37b00"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/170217492/0cb575e5579a4026ab8a28f14b4a0f5a",
+        "value": "dntAKAlfhygC9G0w3LRTzk_-XETA6iHu2fFVXutASvCFvk8OubyVJa5EihuF-vO952kpc9ptAyv4y58XXy3tDZwF44wIhosnmUI6QMxqWD-cTuNCHVe1-dJzjz81UDut8IUJTjJuUJaZDLPoVL6-hBMkz8qLHiG43pCmif_iaBD7JRY_ooMcFXlI--G3b6wTY84sRuZnz38ugF0aHQ6rF5Cx3lzmbUNmf5ziX3k22wCAhqi41LWio3I_Xv5pG1hiSCFiyxFb41vdk4Bv8Lan2ZzAS-HHz0qFIfuKbqPoP5qofrUuXvtKq2Xz4UlIh7ORxRCFIMPJAfahokB0ubi0HQ"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/170217492/0cb575e5579a4026ab8a28f14b4a0f5a/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a8e3c2801d49c25119a192a2a7993b0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "dntAKAlfhygC9G0w3LRTzk_-XETA6iHu2fFVXutASvCFvk8OubyVJa5EihuF-vO952kpc9ptAyv4y58XXy3tDZwF44wIhosnmUI6QMxqWD-cTuNCHVe1-dJzjz81UDut8IUJTjJuUJaZDLPoVL6-hBMkz8qLHiG43pCmif_iaBD7JRY_ooMcFXlI--G3b6wTY84sRuZnz38ugF0aHQ6rF5Cx3lzmbUNmf5ziX3k22wCAhqi41LWio3I_Xv5pG1hiSCFiyxFb41vdk4Bv8Lan2ZzAS-HHz0qFIfuKbqPoP5qofrUuXvtKq2Xz4UlIh7ORxRCFIMPJAfahokB0ubi0HQ"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "146",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:43 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7a8e3c2801d49c25119a192a2a7993b0",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=13;da_age=13;rd_age=13;brd_age=11282;ra_notif_age=217;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "41cd661d-0578-4e05-be14-e09308b96a69"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/170217492/0cb575e5579a4026ab8a28f14b4a0f5a",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "681253258"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecryptRemoteAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSAEncryptDecryptRemoteAsync.json
@@ -1,0 +1,182 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/2135075809/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-d57d7b817308928295365e56595d4c93-ed4f3f2442eac03b-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "14a21579217f664572a17956d64bc8b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:59 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "14a21579217f664572a17956d64bc8b5",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "aa6ca630-740b-4b33-9b80-17414469c6f8"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/2135075809/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-d57d7b817308928295365e56595d4c93-ed4f3f2442eac03b-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "14a21579217f664572a17956d64bc8b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "711",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:00 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "14a21579217f664572a17956d64bc8b5",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=29;da_age=29;rd_age=29;brd_age=11299;ra_notif_age=234;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "57dc2321-9aa1-4834-8a76-d8f09e216431"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/2135075809/63e36e56ff6a40f1ab5ab93b00d42873",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "v2CAXs0SYVLh8i1kTa5qYWYCk5OlOpwZrZXM4wzP7yZ-hZ5SnHbFUuD5d3VWaERct0PYUSAtSyZJC9zMd7OML5pdlpDL5G44SQiKykQUh0E8qYim0Yc5SmC3DesyFrf0ok6I1ByX03rC_fFk-i6aKCnTLQF3F124Ymt4X7LM5zu8uBp0YVtUpLDfo5NKmgPD4ylAf2Z9sFp6BSql_AEfgLe4M87ipDCCWvgDVQVdr8wfhajBq03-nUm1ABYA488rJ8GAAihmc3EQCV8q8DkMQnVSGrYBtVSVNks66cQpdWcx9UgQMIYIqfYqCRhN3TmL-5g90JoORwft0FT5DzBP4Q",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346840,
+          "updated": 1679346840,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/2135075809/63e36e56ff6a40f1ab5ab93b00d42873/encrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "13d6b198410898134c0ea07acbdc184a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "453",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:00 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "13d6b198410898134c0ea07acbdc184a",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=29;da_age=29;rd_age=29;brd_age=11299;ra_notif_age=234;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "eaed650f-f5b8-4ddb-b8a8-62a1e5f0c0a2"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/2135075809/63e36e56ff6a40f1ab5ab93b00d42873",
+        "value": "s_8-D4P7x4q37h9Y0gnm9_7mwWOg2F2wNfBOUs-H8rt5obrqXk3T_5K2pLBn3AJL6zUhlKLj79oSaPPLcr1mN8gWqIbp_z__FgT6jaUYV44uhJFT8U7PO0S9yaZAn7yN1djm4AMY7MexhFBu7BKrl7qmv1p1f5LnARgYNqWe-ADyUtDAiLg6KOgRdUNgi9xj4mJsJXK9Uwsqa1zJFiIasiOtXw7ZEhiMJcy7au4-xQ9YIBFRrv1GBips7BbI0vjmHnA2mi5YPfxHvXzbzfYLwCn4-SF87oPMFvb-jkrUFIQKHJAthJLp9DQsinCnyuYLD5YJSyUk0N0wZw6e27tBEA"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/2135075809/63e36e56ff6a40f1ab5ab93b00d42873/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7e2eb8f9fce421aefc5bd92ba85614c4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "s_8-D4P7x4q37h9Y0gnm9_7mwWOg2F2wNfBOUs-H8rt5obrqXk3T_5K2pLBn3AJL6zUhlKLj79oSaPPLcr1mN8gWqIbp_z__FgT6jaUYV44uhJFT8U7PO0S9yaZAn7yN1djm4AMY7MexhFBu7BKrl7qmv1p1f5LnARgYNqWe-ADyUtDAiLg6KOgRdUNgi9xj4mJsJXK9Uwsqa1zJFiIasiOtXw7ZEhiMJcy7au4-xQ9YIBFRrv1GBips7BbI0vjmHnA2mi5YPfxHvXzbzfYLwCn4-SF87oPMFvb-jkrUFIQKHJAthJLp9DQsinCnyuYLD5YJSyUk0N0wZw6e27tBEA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "147",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:00 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "7e2eb8f9fce421aefc5bd92ba85614c4",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=29;da_age=29;rd_age=29;brd_age=11299;ra_notif_age=234;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "6dc050e1-4a28-4a62-ae9f-0f04a64b0e76"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/2135075809/63e36e56ff6a40f1ab5ab93b00d42873",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "220833239"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerify.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerify.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/710192663/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-c54f66fe00e4bbb53ca56a85b428286d-35709a42b192baf0-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "16fe1b6b2ed2b7a44a4e1455861fd770",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "16fe1b6b2ed2b7a44a4e1455861fd770",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "287e9735-376f-4add-8870-9ecdd4843987"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/710192663/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-c54f66fe00e4bbb53ca56a85b428286d-35709a42b192baf0-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "16fe1b6b2ed2b7a44a4e1455861fd770",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "16fe1b6b2ed2b7a44a4e1455861fd770",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=14;da_age=14;rd_age=14;brd_age=11284;ra_notif_age=219;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "61444591-2523-4769-b188-7fd6816b16e3"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/710192663/99bc3479a9074536b9e749fab92553ad",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "0LGllMSLMOhz4hcutYL0tQqTaWhlMHXtKpeVz92WY577E9bnRdy6Ap5eFGVRGyuVz8be5RZFOxlQBdkqZBxszM7hlDURAZmPEik_3kEIDc11KmIccCZaJQggvJNG3vuRY15pH5Z8-z0CGRTMfG_9IbXvBxWNUA_w4dWiW1u_ACD1uISXd2nRy6SK4I-KWSrn80xqLxLeTL4x3UNDvfNhDj2eUh8OgVUFFfCcsHYo31_ak02UpvMpAH_qfmua2sZHFfiFHsITkr3Pv23e2L6RjVCCjvHnHkGihNcB5htTfpE1u-jwmzcO1usW7RZ19LrOVQNEsiYip8Mo1qSBe1UXGQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346825,
+          "updated": 1679346825,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/710192663/99bc3479a9074536b9e749fab92553ad?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-adc1c917787a95525926cd1dc178093f-dfcb14c7f00572b9-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "59e640e4ddbfa8a2d2d8ad0d685a2eb2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "59e640e4ddbfa8a2d2d8ad0d685a2eb2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=14;da_age=14;rd_age=14;brd_age=11284;ra_notif_age=219;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "b5124cd6-7187-4047-92f4-8333c10dd79b"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/710192663/99bc3479a9074536b9e749fab92553ad",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "0LGllMSLMOhz4hcutYL0tQqTaWhlMHXtKpeVz92WY577E9bnRdy6Ap5eFGVRGyuVz8be5RZFOxlQBdkqZBxszM7hlDURAZmPEik_3kEIDc11KmIccCZaJQggvJNG3vuRY15pH5Z8-z0CGRTMfG_9IbXvBxWNUA_w4dWiW1u_ACD1uISXd2nRy6SK4I-KWSrn80xqLxLeTL4x3UNDvfNhDj2eUh8OgVUFFfCcsHYo31_ak02UpvMpAH_qfmua2sZHFfiFHsITkr3Pv23e2L6RjVCCjvHnHkGihNcB5htTfpE1u-jwmzcO1usW7RZ19LrOVQNEsiYip8Mo1qSBe1UXGQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346825,
+          "updated": 1679346825,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/710192663/99bc3479a9074536b9e749fab92553ad/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "08918ff4d1585ae3ab69171cb30e1725",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "452",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:45 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "08918ff4d1585ae3ab69171cb30e1725",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=14;da_age=14;rd_age=14;brd_age=11284;ra_notif_age=219;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "0c7d2309-39d0-44eb-a33d-2b129fc3c13d"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/710192663/99bc3479a9074536b9e749fab92553ad",
+        "value": "zD3rrfViCjtFqAQtBoyKrpzLzsG8-rO9pz-RnyFDp2RIRfwE8lwdoneLXzhcjCvrXVfqBAoRC0_IQYYtOtdPU2DW5ZMwINPjtn0TJ925xkODgP8SyF4TBCKHmFmKgixDCK3qHStjk_-7l1tPPwuyJWytnU58dQ9fOzVASEo5D5OhGQUHXjuf2TUyCZdymq7vSaHAYrFqaLqMSe8vajU5AJ3o9DGB6wG8zgmsQcRtxOh8GSMssuq81IiHNuLlzZgsmk5uMHS4ZgcQVCqK33Nj1bhVSB6wJ26YKjLOZHdMbLm0s0QYTXHrCgBRboEyJuHhup2vFUiCxcbyFvNFXCLtwQ"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1273378195"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerifyAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerifyAsync.json
@@ -1,0 +1,198 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/298645756/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-2d94c9cb9a79efdd5c634182f7187982-459786604b6721dc-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e6d86cc77f09536298a6dba940866972",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:01 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e6d86cc77f09536298a6dba940866972",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "f195de38-fe0a-4ea1-b4f0-7a82fe8058cd"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/298645756/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-2d94c9cb9a79efdd5c634182f7187982-459786604b6721dc-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e6d86cc77f09536298a6dba940866972",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:01 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e6d86cc77f09536298a6dba940866972",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=31;da_age=31;rd_age=31;brd_age=11300;ra_notif_age=235;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "b92d328b-bfc3-42f5-a6d3-bbf922c57132"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/298645756/7490cb223824461b8dbdbe801263b69c",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "wymmMxkQo4r7UOUBdWKf5P-GA80MqAzQe3s0T_Wk95hqj_Thm5Yjg4K9anjbGzq4mW5EzHDak_68Foqa8qs3YJFjJ_siQf6ZbHaQLmCupFIC7M7ukALLbAKZG-uCgZdmcbFFt9_j20SRJAZFxSE9p7hLcBQqAABtcrIn0vZDnk5UEEsCtXMqK73hlUj96vDm3-Gcapo2DNwktMAsKVbzFaQdIvPdSbQrpQcH4myeXYhte5DFuHNGZJU7eT7ZUyAUBgyLFU5vZZZAcddYcIwRgmTPMlbyc57Q8EfUT4kCyUm3Lm9L0DFJBOlFFKE5r5h970A_aIhfiMJhGdVZW7a97Q",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346842,
+          "updated": 1679346842,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/298645756/7490cb223824461b8dbdbe801263b69c?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-494eaa55a78761d50987420b7b16a73e-03d116c9c7f9ba9f-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "069b7560e61aa71436b20b2931290a29",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:01 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "069b7560e61aa71436b20b2931290a29",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=31;da_age=31;rd_age=31;brd_age=11300;ra_notif_age=235;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "08cd419b-b866-4abf-bbb5-003b8f12faa3"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/298645756/7490cb223824461b8dbdbe801263b69c",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "wymmMxkQo4r7UOUBdWKf5P-GA80MqAzQe3s0T_Wk95hqj_Thm5Yjg4K9anjbGzq4mW5EzHDak_68Foqa8qs3YJFjJ_siQf6ZbHaQLmCupFIC7M7ukALLbAKZG-uCgZdmcbFFt9_j20SRJAZFxSE9p7hLcBQqAABtcrIn0vZDnk5UEEsCtXMqK73hlUj96vDm3-Gcapo2DNwktMAsKVbzFaQdIvPdSbQrpQcH4myeXYhte5DFuHNGZJU7eT7ZUyAUBgyLFU5vZZZAcddYcIwRgmTPMlbyc57Q8EfUT4kCyUm3Lm9L0DFJBOlFFKE5r5h970A_aIhfiMJhGdVZW7a97Q",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346842,
+          "updated": 1679346842,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/298645756/7490cb223824461b8dbdbe801263b69c/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a66e6325f4549d73c935806860dba5b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "452",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:01 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a66e6325f4549d73c935806860dba5b5",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=31;da_age=31;rd_age=31;brd_age=11300;ra_notif_age=236;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "810f4e92-0d8f-4fa4-863e-513cccc66cf3"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/298645756/7490cb223824461b8dbdbe801263b69c",
+        "value": "FCKFUX5cv7Y6mvTpA6_0ypHRHpWCn6JB8_t0HiPrvZ_BpEDb9SMud6Fj5o_g024YxBtqL02D3zjhC5SQ6W3zfgh9e_0Lh7ZAE5YPyVFMNS-CvEQd0DqQWq8m0PTwKC3wiLmp46tbVEaeq_xpSwjyLzd8ERCEhWsiRSSuh8mOuylfEzNxhh8-DGXk7vl8_HO0Evl7wVHjqsPOIiGm4B1SlBlnhB44Tr2WIUpEP7DFRjaUaPwThBLZxb5jtMvqvPsiXkLbzW7P4JsMml5lDdgJol87WYLi8HiDkAyOxsQSAUkC6CXAHkVlUkdciZxJqTxtr8oSJY6rQNqB-QYQ5aKCvw"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1954161714"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerifyRemote.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerifyRemote.json
@@ -1,0 +1,182 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/912413408/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-ae08dc081790d5da1d03d85de06406a6-8c768a0137930dfc-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "32f2550bb0e17f6c034ea085d1761467",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:46 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "32f2550bb0e17f6c034ea085d1761467",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "8925a214-8747-46ff-a597-cd95191b5a6e"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/912413408/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-ae08dc081790d5da1d03d85de06406a6-8c768a0137930dfc-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "32f2550bb0e17f6c034ea085d1761467",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "710",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:46 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "32f2550bb0e17f6c034ea085d1761467",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=16;da_age=15;rd_age=15;brd_age=11285;ra_notif_age=220;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "84b88f04-8256-49bb-b0b4-f817b951690d"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/912413408/3957ab93314542418b5ec6b3e69b9229",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "zsIK8aTaiSRK6wePXHbh8i42EpG-9Xl8mUoZvEVSn-8DITUf9Puyuyfu3Yag0SqJNyxM8pybGi4jxRTxYpUWk5lca_AErA2YzIabl8keFH2qzns77LJCfS7hAKrvcXrJ565tRcxJepBNQzr_wnx5z8OtJkjwKldeNotfzifR0NDROjp7QLQBDZsZY1yMQ3U93PWybvECWOLcLuNmuJ1Z2dAVS8ubvoBZ3MvK4obeYGNzdFDNwsBAxjSmVT9nxpWK2WI5it_A8GdYzOUhRbAPt1PEFUS1GzcBtRwRdc7QNkYXDwgn-XknXtb9D0TPmxInZa1flNjjt1shZlbax5bCpQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346826,
+          "updated": 1679346826,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/912413408/3957ab93314542418b5ec6b3e69b9229/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6cd21a7fed2ca928ea2e5cd71fb44edf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "452",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:46 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "6cd21a7fed2ca928ea2e5cd71fb44edf",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=16;da_age=16;rd_age=16;brd_age=11285;ra_notif_age=220;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "2a8231fc-0d12-4078-87f1-f5c597a512cc"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/912413408/3957ab93314542418b5ec6b3e69b9229",
+        "value": "abA9zEZht-AgGWbZOQ4TD46qBouNy-yPjQnFifo-g3f2gdTiYhw_aSGXBSTHlxtUXm04_Hp5SYjUGlKkk3IrE23nuSWfp7TkVVxFsnOLL_vAJwaFQkiLakEkdsuSFGeGSmc0kiFz_GZUhiL7iRqW8K_nOufb6xqRNJGeGy_sHixxa_QaRqngxue3Dq0cfa3qW3GcMrDaMwznjlVjlNFLqByNhkeoNwcTIGxaNwfUqn7AVbVyu-bPh6Og_OgOLxu2LJOdsP_Yvot26JeHYgTO6SJm_cvsnNec2rPqFfhivISv2HPhVDAI0yf-drOtOEl5q4fU8aCDY__RY9xfw3XajA"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/912413408/3957ab93314542418b5ec6b3e69b9229/verify?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "423",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d57ba76f3bf9afa5e08b2e47428af43f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "digest": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA",
+        "value": "abA9zEZht-AgGWbZOQ4TD46qBouNy-yPjQnFifo-g3f2gdTiYhw_aSGXBSTHlxtUXm04_Hp5SYjUGlKkk3IrE23nuSWfp7TkVVxFsnOLL_vAJwaFQkiLakEkdsuSFGeGSmc0kiFz_GZUhiL7iRqW8K_nOufb6xqRNJGeGy_sHixxa_QaRqngxue3Dq0cfa3qW3GcMrDaMwznjlVjlNFLqByNhkeoNwcTIGxaNwfUqn7AVbVyu-bPh6Og_OgOLxu2LJOdsP_Yvot26JeHYgTO6SJm_cvsnNec2rPqFfhivISv2HPhVDAI0yf-drOtOEl5q4fU8aCDY__RY9xfw3XajA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "14",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:13:46 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d57ba76f3bf9afa5e08b2e47428af43f",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=16;da_age=16;rd_age=16;brd_age=11285;ra_notif_age=220;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "73a08207-4dfc-4405-a112-84ee09aaad0c"
+      },
+      "ResponseBody": {
+        "value": true
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1941363556"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerifyRemoteAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/CryptographyClientLiveTests/CreateRSASignVerifyRemoteAsync.json
@@ -1,0 +1,182 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1633119932/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-b8c624c189c9f073ca78225cff978833-d65d8db271e2d40c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd998f173a360d79af84ab2aeee4a298",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bd998f173a360d79af84ab2aeee4a298",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "c811cf71-afe8-49e4-beb5-3b9fe069fd75"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1633119932/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-b8c624c189c9f073ca78225cff978833-d65d8db271e2d40c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd998f173a360d79af84ab2aeee4a298",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "711",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "bd998f173a360d79af84ab2aeee4a298",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=32;da_age=32;rd_age=32;brd_age=11302;ra_notif_age=237;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "9cf2f506-0ca5-47c9-971a-e067673cbdad"
+      },
+      "ResponseBody": {
+        "key": {
+          "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1633119932/31865916d7414ebc86ab2578118c3a0a",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "xsw48ZcuUqYAFs8Kld3v6O9a6KxMI1evs71C6kp8TXkOap_pLegKCGEEppZhN_TTH9-fl58dd9HOV328pSuCjokr9JZnYwaIXI5cjUmlIgTseE7VTpk6rMSQNpR3ELXR3kH1S9XoOu8sQtVS5LH4qtmtXXjla12tiyNpQGK4NEZ3ighc0Ve8ikXfPRvmChlUQptznKFYplXpRK28YtfYcaZwf1JayXzcIi3Ppa659kZihVpF1BKmjtt0aDBewdDB1TqirMmYzmz8-MAJKI19cI7O_QeYXU3egl59F5G5X3djw7hwie7b5orNnU4tvhL2xh-RykXKMrevHKSfdrSstQ",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1679346843,
+          "updated": 1679346843,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7,
+          "exportable": false
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1633119932/31865916d7414ebc86ab2578118c3a0a/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "88fd9eb2ab705823e19f810f764e45bb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "453",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "88fd9eb2ab705823e19f810f764e45bb",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=32;da_age=32;rd_age=32;brd_age=11302;ra_notif_age=237;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "37689c43-5460-4332-b397-ef10202d2661"
+      },
+      "ResponseBody": {
+        "kid": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1633119932/31865916d7414ebc86ab2578118c3a0a",
+        "value": "V5Z2YVLfcO7qCrv5dHxwdScoPoWgCmsYJlEJxCN9lrW_eBZTa1FJaGfHmKbGljdB3_y5yhvIrOfoDOghmf531RSBd0u90Ea-xEcCA728ukHjL208O0hmt2IDA3Rdd9vmNS7lVzdvgq5pmWgH4gjTj0sjn8RZ7ZbFanPFJbpASQE2StmY7k6tjBYgHOHoETz6mGYAWsp6E9wlzeD_2IjtwQNMgo3xk9XOaj3jkMjFWgyVcuGA6QcCZXjqJW85GvIBs6su8zWsb0i6B45Dcwbq1L_3spLPkiUZhgCJjlmG6KvQlh71nYxDP_J_m7r2wF2RooQARh99J60zakpg0NrXmg"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cec.vault.azure.net/keys/1633119932/31865916d7414ebc86ab2578118c3a0a/verify?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "423",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1bc28f4b5a4ce341ff5d830028b0ac0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "digest": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA",
+        "value": "V5Z2YVLfcO7qCrv5dHxwdScoPoWgCmsYJlEJxCN9lrW_eBZTa1FJaGfHmKbGljdB3_y5yhvIrOfoDOghmf531RSBd0u90Ea-xEcCA728ukHjL208O0hmt2IDA3Rdd9vmNS7lVzdvgq5pmWgH4gjTj0sjn8RZ7ZbFanPFJbpASQE2StmY7k6tjBYgHOHoETz6mGYAWsp6E9wlzeD_2IjtwQNMgo3xk9XOaj3jkMjFWgyVcuGA6QcCZXjqJW85GvIBs6su8zWsb0i6B45Dcwbq1L_3spLPkiUZhgCJjlmG6KvQlh71nYxDP_J_m7r2wF2RooQARh99J60zakpg0NrXmg"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "14",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 20 Mar 2023 21:14:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "c1bc28f4b5a4ce341ff5d830028b0ac0",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-rbac-assignment-id": "a5f833ad-c23d-51cf-b384-a8bd5df75286",
+        "x-ms-keyvault-rbac-cache": "ra_age=32;da_age=32;rd_age=32;brd_age=11302;ra_notif_age=237;dec_lev=1;",
+        "x-ms-keyvault-region": "westus",
+        "x-ms-keyvault-service-version": "1.9.736.1",
+        "x-ms-request-id": "4c4042dc-4714-4895-9c56-e31a20d83ccf"
+      },
+      "ResponseBody": {
+        "value": true
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://tcac7e9c41ef52cec.vault.azure.net/",
+    "RandomSeed": "1340549826"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES256).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES256).json
@@ -1,0 +1,174 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1900083373/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-9abc7738e84765d5a9da6a261367f2d8-d466e10752c097e0-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a68de6bb3abb4eecd05d8d2e4455bcde",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "2adfcde4-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "0"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1900083373/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-9abc7738e84765d5a9da6a261367f2d8-d466e10752c097e0-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a68de6bb3abb4eecd05d8d2e4455bcde",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-256"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "434",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "2b1a40aa-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "371"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346855,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346855
+        },
+        "key": {
+          "crv": "P-256",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1900083373/40a4814a3c164d89066fdc46e33d445d",
+          "kty": "EC-HSM",
+          "x": "iOu1BMVbtlqUM2n-4Bdj4U_WaifvQjPfMZwmwMq-WU4",
+          "y": "s2sgGIJUMiZ4ZCY8uZV1tMl5UXRzlwOHHElPmsufsrM"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1900083373/40a4814a3c164d89066fdc46e33d445d?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8d94ed7390f79fe9c8a1e8223183504b-01b908c188f56bef-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76d33f28ddcd2f980accc2f745bb61a7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "434",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "2b5e6b36-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "29"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346855,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346855
+        },
+        "key": {
+          "crv": "P-256",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1900083373/40a4814a3c164d89066fdc46e33d445d",
+          "kty": "EC-HSM",
+          "x": "iOu1BMVbtlqUM2n-4Bdj4U_WaifvQjPfMZwmwMq-WU4",
+          "y": "s2sgGIJUMiZ4ZCY8uZV1tMl5UXRzlwOHHElPmsufsrM"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1900083373/40a4814a3c164d89066fdc46e33d445d/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "10ce80f9dedb2798009cc983c263fec3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "219",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "2b6d9016-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "8"
+      },
+      "ResponseBody": {
+        "alg": "ES256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1900083373/40a4814a3c164d89066fdc46e33d445d",
+        "value": "mS0qjjo7Nb4LFLrwMYWtkjTxoUbEiIeix-ikmQn3mDzSUdlVPCUGe20t9Hc503KH-5ZGAbkrhDYts9rSJlH9zA"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "247342584"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES256)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES256)Async.json
@@ -1,0 +1,174 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/180019265/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-2091ba42f7cdb863992b82d27a635235-dd661c6c1cfd997a-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "60f9a8c4c5f7ebea97859c48c4d00b31",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "368b6874-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/180019265/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-2091ba42f7cdb863992b82d27a635235-dd661c6c1cfd997a-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "60f9a8c4c5f7ebea97859c48c4d00b31",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-256"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "433",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "36a8b654-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "220"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346874,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346874
+        },
+        "key": {
+          "crv": "P-256",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/180019265/1b4e6d3a54340c04aeb4b5ca85463d63",
+          "kty": "EC-HSM",
+          "x": "JfgpEQpHcFlRMEXUO9c-96DFa4qjhR0Qt5YmDXW0MIE",
+          "y": "vQ_J3sm-SuAJU5BYhFZpeothUc9SjAFT917sRtYoQek"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/180019265/1b4e6d3a54340c04aeb4b5ca85463d63?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-469aa1fc402ab4c69dc1cf99651c43b2-aef91ecb82c167c1-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7cb667e877746f68219ec4c7c210d0ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "433",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "36d56fe6-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "26"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346874,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346874
+        },
+        "key": {
+          "crv": "P-256",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/180019265/1b4e6d3a54340c04aeb4b5ca85463d63",
+          "kty": "EC-HSM",
+          "x": "JfgpEQpHcFlRMEXUO9c-96DFa4qjhR0Qt5YmDXW0MIE",
+          "y": "vQ_J3sm-SuAJU5BYhFZpeothUc9SjAFT917sRtYoQek"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/180019265/1b4e6d3a54340c04aeb4b5ca85463d63/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "57c0ce56887acc1954b46919375a0bb9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "218",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "36e3500c-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "8"
+      },
+      "ResponseBody": {
+        "alg": "ES256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/180019265/1b4e6d3a54340c04aeb4b5ca85463d63",
+        "value": "UaFqUa-QOVuMqEYN-_Zn98L-_F4UucUke2k1vh-xX3v9vfHHAWP6WmGI2_TaDUztBnkOGsxtjezyEBNGoJrMKg"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "1658691470"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES384).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES384).json
@@ -1,0 +1,174 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/57065190/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-11f9681c89a70e904aff69010f5f8e48-5c391f420734f17b-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "010e1b85121b70a212f9c1d05804744d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "0c6f17ce-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/57065190/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-11f9681c89a70e904aff69010f5f8e48-5c391f420734f17b-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "010e1b85121b70a212f9c1d05804744d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-384"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "474",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "0cad8284-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "312"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347233,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347233
+        },
+        "key": {
+          "crv": "P-384",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/57065190/df7cc0e1fbae0b8ea34e327127c149f1",
+          "kty": "EC-HSM",
+          "x": "fzmIrTI3ePTE7V9Wkb1XFGaIayiOLnmj3w2Tz9uFSiyTf8HO2GiToLgqs3LDAcz1",
+          "y": "sVGLW7WDbaV8zEqp3cmev6qY6gSPw-Lm9QL-XdPsQ0LNP0GGCZjqgMt-_xb5Pj-0"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/57065190/df7cc0e1fbae0b8ea34e327127c149f1?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-425556b2b213636e8225bb626b0bf23b-29b0d814ce2c7b89-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "30d0420b47d3d5dfec50cab719d3248f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "474",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "0ceb4cd6-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "29"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347233,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347233
+        },
+        "key": {
+          "crv": "P-384",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/57065190/df7cc0e1fbae0b8ea34e327127c149f1",
+          "kty": "EC-HSM",
+          "x": "fzmIrTI3ePTE7V9Wkb1XFGaIayiOLnmj3w2Tz9uFSiyTf8HO2GiToLgqs3LDAcz1",
+          "y": "sVGLW7WDbaV8zEqp3cmev6qY6gSPw-Lm9QL-XdPsQ0LNP0GGCZjqgMt-_xb5Pj-0"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/57065190/df7cc0e1fbae0b8ea34e327127c149f1/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "90",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6a33c8ac9ab43fe8277db4ea4e34bd53",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES384",
+        "value": "1f9nVpp7ygg84bIPWVl6XNe4vPyXwL5bN_apy_4445hY3foksKpInKoljE_oBt0C"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "259",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "0cfa7fd0-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "12"
+      },
+      "ResponseBody": {
+        "alg": "ES384",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/57065190/df7cc0e1fbae0b8ea34e327127c149f1",
+        "value": "hqwaehyL3_-Nj1SDHKoJj0p8jviFCSGwZ8WOkq-VHg114rIdQDqutJjDHUaREutOdUnrp2G5tPk0_RMSQhg0SYDU5HUW4NtUVOCLuOtXTUa3MA7KLRWpVUW1PlouQxrs"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "1772879522"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES384)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES384)Async.json
@@ -1,0 +1,174 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1959886305/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-ec0e3d97b8fa3bafb6db7c6a88ae896c-6b1a23d79deb2138-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "140133bf06af44312037a9cbe04634b3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "1216ff20-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1959886305/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-ec0e3d97b8fa3bafb6db7c6a88ae896c-6b1a23d79deb2138-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "140133bf06af44312037a9cbe04634b3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-384"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "476",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "123ba014-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "269"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347243,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347243
+        },
+        "key": {
+          "crv": "P-384",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1959886305/ddf24b22a7384dd892ce698257e23f1c",
+          "kty": "EC-HSM",
+          "x": "nUiL6g1XjBoAaGUbrjoEAllux9jsw_sQctEB9lpwkJeyhZWn5KtybHNu74U4Vzfk",
+          "y": "K00aUk7HG7E9AYMkcl-dnTlnk3CEJDKpfghxgd_1hw2D8kTz0c7EUy0KH5GSJwL9"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1959886305/ddf24b22a7384dd892ce698257e23f1c?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-84b71827bee13df8b6f4ac5685e05054-e3a2f939cfd2ac53-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8d9ade017f8c46894aefa9f5b0f48a7b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "476",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "128f7ba8-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "30"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347243,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347243
+        },
+        "key": {
+          "crv": "P-384",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1959886305/ddf24b22a7384dd892ce698257e23f1c",
+          "kty": "EC-HSM",
+          "x": "nUiL6g1XjBoAaGUbrjoEAllux9jsw_sQctEB9lpwkJeyhZWn5KtybHNu74U4Vzfk",
+          "y": "K00aUk7HG7E9AYMkcl-dnTlnk3CEJDKpfghxgd_1hw2D8kTz0c7EUy0KH5GSJwL9"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1959886305/ddf24b22a7384dd892ce698257e23f1c/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "90",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "80bfce692dc2dfdf45113db592ae4ac7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES384",
+        "value": "1f9nVpp7ygg84bIPWVl6XNe4vPyXwL5bN_apy_4445hY3foksKpInKoljE_oBt0C"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "261",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "129ee19c-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "12"
+      },
+      "ResponseBody": {
+        "alg": "ES384",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1959886305/ddf24b22a7384dd892ce698257e23f1c",
+        "value": "T5_fm_HWlEfb4mog25x0SOfT8IdnnWkHB57phkDDbvVcbOS4VYsuq3T-qBk4WTiCuPonyVro8N3ZvczgNZu7GMk81e7Mkpnm8s4Xk6jSKLWCv0JHYZ6AXEF_TR3vrmoF"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "316354751"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES512).json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES512).json
@@ -1,0 +1,174 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878649416/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-513d4378fedbd63f15c2e7b363758548-06f930e8addd47ab-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2982ee39bd21721ef5a05abf47e8720f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "0dbde02e-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878649416/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-513d4378fedbd63f15c2e7b363758548-06f930e8addd47ab-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2982ee39bd21721ef5a05abf47e8720f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-521"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "524",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "0de44c0a-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "464"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347235,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347235
+        },
+        "key": {
+          "crv": "P-521",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878649416/b177ab3d3536492aaa1042d0d0e290b3",
+          "kty": "EC-HSM",
+          "x": "AJLGJYs2XB9Wtgf-fA09vUjh3QlycIyVVTLDk79AaiMPFMTwCBHVqWRNja7XLvXp5S4TYPPyaIK0RABubfnOfrc1",
+          "y": "AC7yhTACbTluOzHLaX8IcuLnpZvEvEl56EeczOidcBRMo8_4JTlx-Av6sF54kgZRghLEtO3EkArlfnfVAPMc8ybb"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878649416/b177ab3d3536492aaa1042d0d0e290b3?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9a41bdfb9e7eeb1674840995a43e6212-a29b682887a5d14a-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b2f140fa5ca5c81b20435c42a15792ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "524",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "0e3675ac-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "31"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347235,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347235
+        },
+        "key": {
+          "crv": "P-521",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878649416/b177ab3d3536492aaa1042d0d0e290b3",
+          "kty": "EC-HSM",
+          "x": "AJLGJYs2XB9Wtgf-fA09vUjh3QlycIyVVTLDk79AaiMPFMTwCBHVqWRNja7XLvXp5S4TYPPyaIK0RABubfnOfrc1",
+          "y": "AC7yhTACbTluOzHLaX8IcuLnpZvEvEl56EeczOidcBRMo8_4JTlx-Av6sF54kgZRghLEtO3EkArlfnfVAPMc8ybb"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878649416/b177ab3d3536492aaa1042d0d0e290b3/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "112",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2e7335663be24265b9852f32a5a1512a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES512",
+        "value": "UN6JJ5l_H1uyu4FGSvFnITdF9d72SZ5LdQpMlMHBjOVvSdRSu1RCCQ-cV9iUvoXa73rGt2VceFGgTV2ypykpoQ"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "309",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "0e46817c-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "36"
+      },
+      "ResponseBody": {
+        "alg": "ES512",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878649416/b177ab3d3536492aaa1042d0d0e290b3",
+        "value": "AEEnW8PgLIKh-OGM7qEx-0o9srZo3fAnhLPXFMUfQiTAYoLxO-aSeNywaMhEImdSAciJWImWr3aeL49a2Qtou0koAJvHgS2Su18KwfzhgaT1uiMj3_pxLumxoGPeG4miu4n3DLoetFZMyzFuDI-oz4Fg2S47c-1JQ6CMZazGVQQJq5KP"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "57175103"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES512)Async.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateECDsaSignVerify(ES512)Async.json
@@ -1,0 +1,174 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1428848987/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-67e9bbddbd1db7291ce2b92fcfb0f6de-cfc9e73d8dcad9b6-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9d4dcd42e04cf6b51bd101ea59f632c4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "135fbb24-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1428848987/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "26",
+        "Content-Type": "application/json",
+        "traceparent": "00-67e9bbddbd1db7291ce2b92fcfb0f6de-cfc9e73d8dcad9b6-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9d4dcd42e04cf6b51bd101ea59f632c4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "EC",
+        "crv": "P-521"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "524",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "13768246-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "333"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347245,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347245
+        },
+        "key": {
+          "crv": "P-521",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1428848987/9f0a823f1e6a08669e07702eee8239f4",
+          "kty": "EC-HSM",
+          "x": "AMaV9Qp02dLTuz6EFLEK7pe4UoT1UDJ9yeynteNy9QIUWKGTdXDcJNsCdKFeQYlK0chWvB-yj6I3uwevA5wTUp_V",
+          "y": "AO6z4rQHuoeyh-qYvqVfiEyu3K29geT22PB5Ctu7Bu98lWWXaca5ZEFkHGles-9BMfaSlHz23BXSrJEOIL_SuQnh"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1428848987/9f0a823f1e6a08669e07702eee8239f4?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-18c391126c435c0140ce247d79aadc03-aff77505de8dd8e4-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0f568cd110f378e2fa7e300a5d736ec4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "524",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "13b68e90-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "32"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679347245,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679347245
+        },
+        "key": {
+          "crv": "P-521",
+          "key_ops": [
+            "verify",
+            "sign"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1428848987/9f0a823f1e6a08669e07702eee8239f4",
+          "kty": "EC-HSM",
+          "x": "AMaV9Qp02dLTuz6EFLEK7pe4UoT1UDJ9yeynteNy9QIUWKGTdXDcJNsCdKFeQYlK0chWvB-yj6I3uwevA5wTUp_V",
+          "y": "AO6z4rQHuoeyh-qYvqVfiEyu3K29geT22PB5Ctu7Bu98lWWXaca5ZEFkHGles-9BMfaSlHz23BXSrJEOIL_SuQnh"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1428848987/9f0a823f1e6a08669e07702eee8239f4/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "112",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "55034ade36a345bcc31911a11a267b8f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "ES512",
+        "value": "UN6JJ5l_H1uyu4FGSvFnITdF9d72SZ5LdQpMlMHBjOVvSdRSu1RCCQ-cV9iUvoXa73rGt2VceFGgTV2ypykpoQ"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "309",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "13c6f4ce-c765-11ed-818c-0022488dd761",
+        "x-ms-server-latency": "36"
+      },
+      "ResponseBody": {
+        "alg": "ES512",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1428848987/9f0a823f1e6a08669e07702eee8239f4",
+        "value": "AAUCG03aDJZSidw-AWs37sGPyutPYPFoGjXlpLjqygS6NQbPDm4eKjkm-9PV30VN93eYh7MpTRn2S7lP_K-Nf9sYABLqnVSHXTOP6G0iueS5G9-vhEoRR5TqvLRvatQBy2zSJ-hy7zHaQsWUu_weL37f4Seg3rqFtsWyKklzUyjMjY0-"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "708815306"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecrypt.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecrypt.json
@@ -1,0 +1,179 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1955397630/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-9d06fb5993ede3ae2af8b16a18bda33c-289982eae7f8252a-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a384a496fe8e8fdda3d04283bf0057f6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "32147e34-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1955397630/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-9d06fb5993ede3ae2af8b16a18bda33c-289982eae7f8252a-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a384a496fe8e8fdda3d04283bf0057f6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3236f054-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "189"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346867,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346867
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1955397630/d3e41ec82ff24ab5a070040230dda2cb",
+          "kty": "RSA-HSM",
+          "n": "vMgLz0gPudW_w0afTZD7LCDrqlg8eKVD3rDxoCxRXwgQAD09eVuJ63eYK_ojP7ZOUTr5ZwN3hUP1WSe_o0v6vDz5HRIsCAOk5hCnl4fXCUnNH2xPrcVY1Y4DTijgMTRHzBKke1zDATQqwV0sOaAdWK8uwHs8pDcdF5iBYJ_W9JfdME0qTpKysqoAPCUNWL7SsAfdE4ayOIwzXIZ2Z-RCuQ_7OamecIZbsya0UHohJ5hPIp85xksHpCvG7PycEyqT41GakL1gYhe9zw8CptAEpFrJwKqP5bixK1NUzpLDCFTUsG489gQy1x8AHyA2XRfyCBMxNFCDPwx37tbIKMfgxw"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1955397630/d3e41ec82ff24ab5a070040230dda2cb?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-14f8fff636c5c08dfd54f02c8895b0b8-9b9232d4ac447acd-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd0ae7522226f8446d9366e69dc06daa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "325f34ce-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "30"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346867,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346867
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "verify",
+            "sign",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1955397630/d3e41ec82ff24ab5a070040230dda2cb",
+          "kty": "RSA-HSM",
+          "n": "vMgLz0gPudW_w0afTZD7LCDrqlg8eKVD3rDxoCxRXwgQAD09eVuJ63eYK_ojP7ZOUTr5ZwN3hUP1WSe_o0v6vDz5HRIsCAOk5hCnl4fXCUnNH2xPrcVY1Y4DTijgMTRHzBKke1zDATQqwV0sOaAdWK8uwHs8pDcdF5iBYJ_W9JfdME0qTpKysqoAPCUNWL7SsAfdE4ayOIwzXIZ2Z-RCuQ_7OamecIZbsya0UHohJ5hPIp85xksHpCvG7PycEyqT41GakL1gYhe9zw8CptAEpFrJwKqP5bixK1NUzpLDCFTUsG489gQy1x8AHyA2XRfyCBMxNFCDPwx37tbIKMfgxw"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1955397630/d3e41ec82ff24ab5a070040230dda2cb/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6798220270c241d560d8d9068e325c56",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "LymzBfkaX5DY5Fd-DuC9Sztres22y_KNlHrPIpEtwkvzFcKUFX5vqH2Fb1a7jDtThLhMrZDPBPCHWqXc_5RLtQJKoJf1U_GpP_dF9M1fl5KG-Jbv-FjLYsgxoFxfaHSkkspKQrGOY68jGi4V4J5UlvstULRQ_YVqCDJiK8z3lkfKrN5VsHjgU1aI3tEnTnCHnXzsFKqj3d13VFSlcmYsxnsc5lMA-OyJtxLndN9XHam7gHXHGeKQu__YGLzlF5eDdA0Ysh7nIRfHD6tuOElbhz1WZIgvNdhsqCkXkVW3_20pr5J93LxGyQyBVnJd-OdwF2e6Zyjy3LRZqHbBHBzw7w"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "176",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "326e8870-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "3"
+      },
+      "ResponseBody": {
+        "alg": "RSA-OAEP-256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1955397630/d3e41ec82ff24ab5a070040230dda2cb",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "655358630"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecryptAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecryptAsync.json
@@ -1,0 +1,179 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1501195290/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-07ded7b7cb789d52136cf092a41c8126-663fde0f0c9d9e0b-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3d5da9b2b778908935ec96bc6647d715",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "3d77ad0a-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "0"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1501195290/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-07ded7b7cb789d52136cf092a41c8126-663fde0f0c9d9e0b-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3d5da9b2b778908935ec96bc6647d715",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3d984aec-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "187"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346886,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346886
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1501195290/2460559642cc0b26b2f905bf22d73285",
+          "kty": "RSA-HSM",
+          "n": "4zwFD635LC6xmAce0A_uMxqhqvLFr21CqObrpflEQcWYpYfy2Ho17AOfCWFV6fbdZyBuVw3LXAMi0KSWSORewxWmmIFblnLQS-h1r-SRyvvp3QIvWrMG9s0uegn8L9jh7egYuMoERftpGAvwRhQgiZ4cB0ADIeNFfXGNH73wlxITRuVcryRO7tmoXrUk3nRiLi8cLoBKr3PFWIe0cFJkrDhOg4_l9T4ZYrvbxTG5ySXb7bQ6_OJyguE1tq0SrdELZoSvl8g0cTfmclZaGDaHgtwfEUP3yJp7HqOnjsKuAzwJnVKNT6tHRIBjuTDmpZZz70v-QehMPBrjiMyBJKg1vw"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1501195290/2460559642cc0b26b2f905bf22d73285?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c845a153ecc3522551e99bcc171fe02e-f27bc12ee6e79e67-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9deaf27ca03cbd28f6d613575af487b6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3dc03002-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "31"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346886,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346886
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "verify",
+            "sign",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1501195290/2460559642cc0b26b2f905bf22d73285",
+          "kty": "RSA-HSM",
+          "n": "4zwFD635LC6xmAce0A_uMxqhqvLFr21CqObrpflEQcWYpYfy2Ho17AOfCWFV6fbdZyBuVw3LXAMi0KSWSORewxWmmIFblnLQS-h1r-SRyvvp3QIvWrMG9s0uegn8L9jh7egYuMoERftpGAvwRhQgiZ4cB0ADIeNFfXGNH73wlxITRuVcryRO7tmoXrUk3nRiLi8cLoBKr3PFWIe0cFJkrDhOg4_l9T4ZYrvbxTG5ySXb7bQ6_OJyguE1tq0SrdELZoSvl8g0cTfmclZaGDaHgtwfEUP3yJp7HqOnjsKuAzwJnVKNT6tHRIBjuTDmpZZz70v-QehMPBrjiMyBJKg1vw"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1501195290/2460559642cc0b26b2f905bf22d73285/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5f373f791f304edb86df8d380a80e9e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "X6BmO_MJ4E0RP0OphRr42h8YVujzz7uEkvuPoJH1uUdoopMxaOkwkdKa86w6s4HYLLFXGsTcoyS49_Zvcq5Qq9CSX-t_6iUnalyKOA5CanBfk7nN8F45CxVEosm0IgdRqn7R3RhTr157m18EjqyXkPYVTJuzuRPvWLB4v6fNQD8vmPikUrl-OLaOVmsjyxTP9uuwgGTYdK_ht2kQmAhqkndlcdEK5Z2kPbNMRWhDv1KirVvviVeQZVau9eYcy6OJKJ6UH4QHdy-Q5ljdK0NnikRRj0zx9Bj53U2j7UNR2gZSMS_V4cZBcZ75AWC4FHT71jLameR16yOT-dx52bLmDA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "176",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3dcf5ff0-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "2"
+      },
+      "ResponseBody": {
+        "alg": "RSA-OAEP-256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1501195290/2460559642cc0b26b2f905bf22d73285",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "1114632"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecryptRemote.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecryptRemote.json
@@ -1,0 +1,163 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/859341917/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-589044a7306d9076a4690ff0d059ba2b-cb38ad2ca4a4fca6-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2886b0fc2820dd60005db9047ea2a257",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "332ba4b4-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/859341917/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-589044a7306d9076a4690ff0d059ba2b-cb38ad2ca4a4fca6-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2886b0fc2820dd60005db9047ea2a257",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "722",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3345ab48-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "180"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346868,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346868
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/859341917/f911ab41bbd90305ab41f96636bfc226",
+          "kty": "RSA-HSM",
+          "n": "jSR7rcS1CFsjHBTaLXxnbZ2HkYQEq-Vozk0H7-iqZ37HHXxmDul4-O_9pU1JIRQyBn-ZGMIro4QSy9lEFjWjn8m33m2AQ_SoswDvVhHL2MoqlwUmcdFWxVtFciMGp4XYwxrLGkKNtMDuPZc-z4Q9me3ufkjv0BaHneUjqEb3uaA5o4SSp5dU5RO7KCXx00S4_UcqVksr9kp1aNVuM6hDeXJHC7LnBjKn-9Gx6yNYuUGgvljyeSOLMtHf_uHB1juROH2I1Y-VV6RSw_DgHavSnLGpAO5loV7bP-mF178UrXmu_eCxihh36yQnYGi_aO7NixnEYfE0R-xiTJntgAdwCw"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/859341917/f911ab41bbd90305ab41f96636bfc226/encrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "de3e12562c5f599354a2168ec80a2c94",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "481",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "336f53da-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "29"
+      },
+      "ResponseBody": {
+        "alg": "RSA-OAEP-256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/859341917/f911ab41bbd90305ab41f96636bfc226",
+        "value": "DLcdSxTQTUhCVQ4z2Upfgvr1nm2I0JpBBU6EGxtf-mJcJBekAIhk3ElG-MrFNfIC1t5FV9JVjPGE_pX9ZXb0Jp9fhxq2rLKVf5k0Ph0-tW8ng6n5fJWBACf_vB1YDQ8PkV6uE3Yw9J-YNaX94jmDUyJYghiQGIkt2bD4ESPq7c_dnhtIxu2Q4686250MMR9bkrtbD5SSa-EtNlworhH31bjIBJ-AUnFnFwWEI9x-z3mONYBvMsC1Vept_bijE2Ey8IdjnfIVGqhzITnHCHWPGeW1wQmBLHaJb1lL69MLYHhCk4AEfwWhcCZfkPcJWcEvrMdvssayyjq68w6wB97wXw"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/859341917/f911ab41bbd90305ab41f96636bfc226/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "56ab5ce3dc4f77a95066cae3d5935677",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "DLcdSxTQTUhCVQ4z2Upfgvr1nm2I0JpBBU6EGxtf-mJcJBekAIhk3ElG-MrFNfIC1t5FV9JVjPGE_pX9ZXb0Jp9fhxq2rLKVf5k0Ph0-tW8ng6n5fJWBACf_vB1YDQ8PkV6uE3Yw9J-YNaX94jmDUyJYghiQGIkt2bD4ESPq7c_dnhtIxu2Q4686250MMR9bkrtbD5SSa-EtNlworhH31bjIBJ-AUnFnFwWEI9x-z3mONYBvMsC1Vept_bijE2Ey8IdjnfIVGqhzITnHCHWPGeW1wQmBLHaJb1lL69MLYHhCk4AEfwWhcCZfkPcJWcEvrMdvssayyjq68w6wB97wXw"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "175",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "337ded82-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "2"
+      },
+      "ResponseBody": {
+        "alg": "RSA-OAEP-256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/859341917/f911ab41bbd90305ab41f96636bfc226",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "724127588"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecryptRemoteAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSAEncryptDecryptRemoteAsync.json
@@ -1,0 +1,163 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1973643906/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-84ad5cd48225baf063a0280d4ce171ac-ffcfcb4a15ab648c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c221fa9ab1d569cc3860ce3d6b87ccfc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "3e8b9b84-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1973643906/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-84ad5cd48225baf063a0280d4ce171ac-ffcfcb4a15ab648c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c221fa9ab1d569cc3860ce3d6b87ccfc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3ea659b0-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "182"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346888,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346888
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1973643906/e710c5b3812002178101921831497a4e",
+          "kty": "RSA-HSM",
+          "n": "iwhNG_xZWgVh9pMDLhhsPTff5UKLtUvUnHS5RkXEbXs4UuFQHkUXmYb2fq-nwmo-WvWAquUhCVHOmVvjDQH3G-j232NMalY88pHzLmmClkenpnyC0U2wknkoxLuTyrsvgwJch9RHhKUbwuX03nMHs388RzKxgaPx0xk-58w9sGP3nOsfWUK4suK6QGpYrSkgdn8uvR8w7qGAUE-rs06uy-1Oq3ZNV1gKIgxcCVH32qeJ04A3aqzzSTruz7lxQOhNrWwo5IIxsBKy32v-Sw_FIPbQ7PUefWEdQG4CS6TC_rsYBrn86Gbj8p9LuI51XZ-n2u4Dt3JEt8yVDqIiDseB2Q"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1973643906/e710c5b3812002178101921831497a4e/encrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c789945bed17f97e6301908462b53b49",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "482",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3ecd6f14-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "26"
+      },
+      "ResponseBody": {
+        "alg": "RSA-OAEP-256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1973643906/e710c5b3812002178101921831497a4e",
+        "value": "RHhtrikZcb0xM7F-d5EuH7ByldKfCV54dyr3lHklGXfkEs9tSSEalEL_WGS4dZBF8Kel95cAFOcB1I_aJD4rTKfsfp4jEdctHQXB_gwxcbGbAIMkXHN6bErFga6AErbSE-8ISKv007P4slnjjpR-mJy7Q2_WYwbXlBqTswHV-HCj_pH9mkUgd-_O6jZclyVhl70aADDv6raITI-ZHbnEduh_V0z3hLevAQlxV6ydmLTHEHEwr-RBm43NJ4R9Y3Lj2ClV-IJdpAt-t5Lcq-DOume6YfTJEivC5GOmKw3-JiWx0hLegovxRQgUjD4vQbyVJtyHFe1ZAoDgeQqlBNv5gg"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1973643906/e710c5b3812002178101921831497a4e/decrypt?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cdd1bc17765f8a40f288b81572f3f408",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "RSA-OAEP-256",
+        "value": "RHhtrikZcb0xM7F-d5EuH7ByldKfCV54dyr3lHklGXfkEs9tSSEalEL_WGS4dZBF8Kel95cAFOcB1I_aJD4rTKfsfp4jEdctHQXB_gwxcbGbAIMkXHN6bErFga6AErbSE-8ISKv007P4slnjjpR-mJy7Q2_WYwbXlBqTswHV-HCj_pH9mkUgd-_O6jZclyVhl70aADDv6raITI-ZHbnEduh_V0z3hLevAQlxV6ydmLTHEHEwr-RBm43NJ4R9Y3Lj2ClV-IJdpAt-t5Lcq-DOume6YfTJEivC5GOmKw3-JiWx0hLegovxRQgUjD4vQbyVJtyHFe1ZAoDgeQqlBNv5gg"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "176",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3edc2fa4-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "3"
+      },
+      "ResponseBody": {
+        "alg": "RSA-OAEP-256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1973643906/e710c5b3812002178101921831497a4e",
+        "value": "QSBzaW5nbGUgYmxvY2sgb2YgcGxhaW50ZXh0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "392050101"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerify.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerify.json
@@ -1,0 +1,179 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/193981637/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-b10973a7131cc301781d21c140cb1717-d3182da4f199a883-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3baa7ec9baf6138eb112eb9ca6e00d5d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "343a3bfe-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "0"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/193981637/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-b10973a7131cc301781d21c140cb1717-d3182da4f199a883-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3baa7ec9baf6138eb112eb9ca6e00d5d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "722",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "345be0ce-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "185"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346870,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346870
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/193981637/c594ef0436e9408c009895ce08237536",
+          "kty": "RSA-HSM",
+          "n": "tNzhBlWj5ilSWUsG2Z-58YNs5pv6cz9JZ6vaStYsmPo9mSa_dLZbNMLp57vtPdmX6AB-P_qWmGhVildfhQ-96rO24HoBzAm_M9g89peuzkvkTPwAR1UiP6sLO15WYLubXHW5E96NdRTgy_X5I2n3rGIAFv8zo9Zt_oe15c5sS3uASb8GS1GpZ5ToKOKk3dhwzooOfPbJJnPmDACmCVnMeBgEXb54Qf580fGvYghXJDOUMuEWpttm2ikBHIOm4D_gtuSxesipMknvtDvTG5mKrTA3Opcd3FbkaWL5hGEZ8p0WS4F5BRriNpFyZzJv2EXqtlJY0y9KWwXHHvHkIFSr-Q"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/193981637/c594ef0436e9408c009895ce08237536?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4e4a56ac4b91d5341ff2fe377b2d0331-b7f1703eae658abe-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7322339ddd8319140463b302237b9ca9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "722",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "34824e1c-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "29"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346870,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346870
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "verify",
+            "sign",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/193981637/c594ef0436e9408c009895ce08237536",
+          "kty": "RSA-HSM",
+          "n": "tNzhBlWj5ilSWUsG2Z-58YNs5pv6cz9JZ6vaStYsmPo9mSa_dLZbNMLp57vtPdmX6AB-P_qWmGhVildfhQ-96rO24HoBzAm_M9g89peuzkvkTPwAR1UiP6sLO15WYLubXHW5E96NdRTgy_X5I2n3rGIAFv8zo9Zt_oe15c5sS3uASb8GS1GpZ5ToKOKk3dhwzooOfPbJJnPmDACmCVnMeBgEXb54Qf580fGvYghXJDOUMuEWpttm2ikBHIOm4D_gtuSxesipMknvtDvTG5mKrTA3Opcd3FbkaWL5hGEZ8p0WS4F5BRriNpFyZzJv2EXqtlJY0y9KWwXHHvHkIFSr-Q"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/193981637/c594ef0436e9408c009895ce08237536/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "81a65a67dbd0b08b520c3ef7c9d4e1f6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "474",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "34912b30-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "3"
+      },
+      "ResponseBody": {
+        "alg": "PS256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/193981637/c594ef0436e9408c009895ce08237536",
+        "value": "W7sQOSMCQ7uQvurweWtb3zHGmjnSO8mzDezMSRtHvJQuGwuRgq35b0hyrYq0SvjuI4Gs5GzadKaO5BGgujtOVU1xVfs_GiGF0KAc9gddgngraW5tgbzii1CHUBe5sXLVFFHUHTPvHfMck9bx6A8hGYSCKMzg03-i4mPLVXs973g_bzWvAXbYBaCpMVO9O6YSygLVKLEZckg4FY7yOmdyQyZEFyYNeu02Nphw1D0jIpNdSISOqZlmH4cjfMCdNKDzpRZQ2kPk1GjnE00ngQ0aFScCkn5cctAlVBVDhqgR8F6H451lGyFR5ZLy5SB79U4pBfotUJAWv6XP3tyexcd4gw"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "1674426902"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerifyAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerifyAsync.json
@@ -1,0 +1,179 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878279522/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-3a7092591936b45a70f203409967bbc2-f4000922b5422f7c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dbefaca3db8ec714947e2863bdff52a0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "3f987772-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878279522/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-3a7092591936b45a70f203409967bbc2-f4000922b5422f7c-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dbefaca3db8ec714947e2863bdff52a0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3fbcd090-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "183"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346889,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346889
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878279522/313021b5a1aa0c3210f1342b8cea28fd",
+          "kty": "RSA-HSM",
+          "n": "mkGLLkVUYc3YcEEdzPJwmuzYk3BpNwW0FqZ1mXU_ATU4DKUROZhXknz9fKxyP8r_gaGV-wumPsG21TzlLXq7hRvw6d6-c5ZWfKXycHikr9X4RX1fsFr4RZ3c65bh83tj9J11WNnAUVhdtg4CJoKPa1FlrByJVY9-YbINwEb_TwII1f5wPzEm_MUaGQ05R9XsE6HIhVRWrRRMW5-FCchtHuUoVoY4TxI_Os-bTg9NAG4IiHuD7mPnIbT_JISOjh0OqTMoN2T8oAZ_sqidmHTWAalcoAJq18nIywxue9V4XM7WW6Sx8niMFhLgBNzHWPE-hCBLDvojPhqGVgotzt2mWQ"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878279522/313021b5a1aa0c3210f1342b8cea28fd?api-version=7.4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6b42ffb46b773fe803e1baad0dff866f-8a2f923b60e2a015-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1910fce079b02b0f0604d10fda13fabf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-build-version": "1.0.20230312-1-12e5b134-feb-lkg",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3fe3c07e-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "29"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346889,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346889
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "verify",
+            "sign",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878279522/313021b5a1aa0c3210f1342b8cea28fd",
+          "kty": "RSA-HSM",
+          "n": "mkGLLkVUYc3YcEEdzPJwmuzYk3BpNwW0FqZ1mXU_ATU4DKUROZhXknz9fKxyP8r_gaGV-wumPsG21TzlLXq7hRvw6d6-c5ZWfKXycHikr9X4RX1fsFr4RZ3c65bh83tj9J11WNnAUVhdtg4CJoKPa1FlrByJVY9-YbINwEb_TwII1f5wPzEm_MUaGQ05R9XsE6HIhVRWrRRMW5-FCchtHuUoVoY4TxI_Os-bTg9NAG4IiHuD7mPnIbT_JISOjh0OqTMoN2T8oAZ_sqidmHTWAalcoAJq18nIywxue9V4XM7WW6Sx8niMFhLgBNzHWPE-hCBLDvojPhqGVgotzt2mWQ"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878279522/313021b5a1aa0c3210f1342b8cea28fd/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "98b01e2c4f6492c4667be4046b9e3109",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "475",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "3ff31cc2-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "3"
+      },
+      "ResponseBody": {
+        "alg": "PS256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1878279522/313021b5a1aa0c3210f1342b8cea28fd",
+        "value": "WqFT1vpxGCZDTDxJualhYOlHUC-tyzKzLPJdsV1gN8yqZM2yo5JmuKPIbva3ht-iKj9kS3VR2PTGeznCeFtsrD3fgahyrWtsRVFRved5ae-0gO9uiBbZsf3cqWicShIOS6PsrcY-w0xF8gzQ1taqEcfWkAGGYTpwglUgxxkxaSWYnsnuFJSsdNSbo29KhqPS-nAlIKWb6aCQpGsGc83VNcw_ShLnuJZOJ8EU56w0bUh47hcTs7U-SOqsX8vNiZD2nLgrjNj-d9SiilABM4excg8XPIiIywTipkpXyJ9_xOxkJwp5PLraLDbmwsYq57hlh9qHK5lL-GhQw_Vz27KvnQ"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "1380065710"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerifyRemote.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerifyRemote.json
@@ -1,0 +1,164 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1202015358/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-1ba9a5c7376d5953280c747cd050f928-a927afa4b8479af9-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "512a42a46aac3489ef90daa23e4b8bb1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "354bc9f4-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "1"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1202015358/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-1ba9a5c7376d5953280c747cd050f928-a927afa4b8479af9-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "512a42a46aac3489ef90daa23e4b8bb1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "723",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "356a4672-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "193"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346872,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346872
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1202015358/1a5a6b564ded4113a0ce0fe6f2552340",
+          "kty": "RSA-HSM",
+          "n": "qRo9wDVguxylyJRou7mDTV3o215uVKpGwT2CJFxcPrU1RGxaVIxX8BXbl97Ou80Q-u_hvOsuRCb8hWqgTwhkGNTS5vZEmvHJqGsdD-CnQp59wqY9DU8_b_IWHI-8kfa1yeX8-U4AMltviLFxStNw5HOqXLNxbP6gr0yolPb5EPJAXmh3ylMEWWRIT6Es0JujW4uuq_h6G-XFiwC7mBS739N6m19syqNVxTYfH7wC33ZreXqtT7ZP951-hPo1b3egxSY4sYVWlAo1F32I1ML1_vwVMmjrKBuCWlMmd3UlawiTs5pzDLu--gbYF6k34HTK8oEwbzL1nsI0lTvmAPgzbw"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1202015358/1a5a6b564ded4113a0ce0fe6f2552340/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4812fff869cff38742db18a58584dc2f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "475",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "35923b50-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "32"
+      },
+      "ResponseBody": {
+        "alg": "PS256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1202015358/1a5a6b564ded4113a0ce0fe6f2552340",
+        "value": "L5jnPEU1UQvLgaUPW8iXJ0ZhJcgdF9lzwHTLyg5Ve_9ZQwT6DKF72GYVtKoZXxOZWLKJzKuW_YhevshcEJCq9olGBfqSGc38I_jLvuj6FWfqvF3Jk-gmT5XwvGfzL19dulPNmsa9OiPn-sxRg083-j4LQcm5H8J2vl-RizOkAbIo7pa80ej-Wa6-wBSMTrWVwmFKIJoqBtpCYQSBFcwOCVdDESlwQR9IqHBRe-XAcevevTh123gOlzjBOnYbN4ajSQrrN9QbQsj_c_bABC-UJWy9uB02oKb61kyeZPuMP7jSlia9BET4mNIgLo8fcjCkBfcSzPo0k9RvKUpb9iE6cw"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1202015358/1a5a6b564ded4113a0ce0fe6f2552340/verify?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "423",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7ddeff2d24401a2b19ebe7d7bba8235f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "digest": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA",
+        "value": "L5jnPEU1UQvLgaUPW8iXJ0ZhJcgdF9lzwHTLyg5Ve_9ZQwT6DKF72GYVtKoZXxOZWLKJzKuW_YhevshcEJCq9olGBfqSGc38I_jLvuj6FWfqvF3Jk-gmT5XwvGfzL19dulPNmsa9OiPn-sxRg083-j4LQcm5H8J2vl-RizOkAbIo7pa80ej-Wa6-wBSMTrWVwmFKIJoqBtpCYQSBFcwOCVdDESlwQR9IqHBRe-XAcevevTh123gOlzjBOnYbN4ajSQrrN9QbQsj_c_bABC-UJWy9uB02oKb61kyeZPuMP7jSlia9BET4mNIgLo8fcjCkBfcSzPo0k9RvKUpb9iE6cw"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "135",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "35a25508-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "0"
+      },
+      "ResponseBody": {
+        "alg": "PS256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/1202015358/1a5a6b564ded4113a0ce0fe6f2552340",
+        "value": true
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "1646811457"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerifyRemoteAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/ManagedHsmCryptographyClientLiveTests/CreateRSASignVerifyRemoteAsync.json
@@ -1,0 +1,164 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/454306228/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "traceparent": "00-096efc48eb2d100c65e6f198f71f8989-5f908f7b45defb04-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9dcc9b57f5f4c7ee2dd90d39aa3170a8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "40b3c0bc-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "0"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/454306228/create?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-096efc48eb2d100c65e6f198f71f8989-5f908f7b45defb04-00",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9dcc9b57f5f4c7ee2dd90d39aa3170a8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "RSA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "722",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "40c6b780-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "189"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1679346891,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1679346891
+        },
+        "key": {
+          "e": "AQAB",
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/454306228/7a3ac28dfe3c4beb0c3f1c721f1776b4",
+          "kty": "RSA-HSM",
+          "n": "igMw7o0c3hm6hJqAaIufNd34K5i2GLDd0shB2wzITMSQVWLwe_JrZgLz72f9JycPTeMG0wLeYUgxzY6p-wVr1XW7h_CsbAy8sdW64ACgi629myNB7a1DS6RBTGrJc1ABzI6CnWfx8UPBQzmQV4Ip51fovl1LaFbUCFy6Su7yJK3dqhD4qNtg2f1lN5mUYfvoxv1EvYisy-3b5NqmTnYwJuLkLqScJO336ZqmcMnyLBLO4_yV4Zq9z_OHu0y6eaZFH6c_8C-SuicpwWDDbH47siuIQoJsRR5p-d2NGL5YyA43rMYpfBVDbiZsQnh1nBaGvxDLJ5TnzPA4JdHdlH7mkQ"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/454306228/7a3ac28dfe3c4beb0c3f1c721f1776b4/sign?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "69",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2a6724fa85a9f552f92a17cb3384168a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "value": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "474",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "40edd7ac-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "33"
+      },
+      "ResponseBody": {
+        "alg": "PS256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/454306228/7a3ac28dfe3c4beb0c3f1c721f1776b4",
+        "value": "XzN7ddxYZPWYbWTMWPIDzEMsotUNTvjsGmi9QnLGVeyBENp26_BRZAqe8t_Gb1fWaLfUVroZ2gGiQZ2oEGZYPiv24Ur2YI1hTkMJHHpYrMRinsgS3ywIRNFmiKfSnzzJ5Qgl0CSx_4cWsr2nWUHXbJi_zM7vh9WE-Q4EASRpOySMnMA255KGWtlkyNy-4d2Wk_S_JvHXyCCm4E94VM3CaJLjVTEHXfjlhR7B1HuOkmxoASgspo8M9JJO6VnRXx-puCf__a9HTDFlACkz6hYJfK48CAhQxNMuPG4t8GoZsKec9Kssx9ppF_kKFGVkt_wf0EpKC6eKiDyPXqtSWpN7Qw"
+      }
+    },
+    {
+      "RequestUri": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/454306228/7a3ac28dfe3c4beb0c3f1c721f1776b4/verify?api-version=7.4",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "423",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Security.KeyVault.Keys/4.6.0-alpha.20230320.1 (.NET 7.0.4; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "232388ebaa64299e9001451fa66a97e5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "alg": "PS256",
+        "digest": "YPMYCWi4F5iB0VeftRDvoh3NWmgJncjBwLa45jptbxA",
+        "value": "XzN7ddxYZPWYbWTMWPIDzEMsotUNTvjsGmi9QnLGVeyBENp26_BRZAqe8t_Gb1fWaLfUVroZ2gGiQZ2oEGZYPiv24Ur2YI1hTkMJHHpYrMRinsgS3ywIRNFmiKfSnzzJ5Qgl0CSx_4cWsr2nWUHXbJi_zM7vh9WE-Q4EASRpOySMnMA255KGWtlkyNy-4d2Wk_S_JvHXyCCm4E94VM3CaJLjVTEHXfjlhR7B1HuOkmxoASgspo8M9JJO6VnRXx-puCf__a9HTDFlACkz6hYJfK48CAhQxNMuPG4t8GoZsKec9Kssx9ppF_kKFGVkt_wf0EpKC6eKiDyPXqtSWpN7Qw"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "134",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=24.16.18.89;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "northcentralus",
+        "x-ms-request-id": "40fcacbe-c764-11ed-965b-000d3acfa62b",
+        "x-ms-server-latency": "0"
+      },
+      "ResponseBody": {
+        "alg": "PS256",
+        "kid": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/keys/454306228/7a3ac28dfe3c4beb0c3f1c721f1776b4",
+        "value": true
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_MANAGEDHSM_URL": "https://tcac7e9c41ef52cechsm.managedhsm.azure.net/",
+    "RandomSeed": "446431448"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/Extensions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/Extensions.cs
@@ -1,12 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Azure.Security.KeyVault
 {
     internal static partial class Extensions
     {
+        public static T[] Clone<T>(this T[] source)
+        {
+            if (source is null)
+            {
+                return null;
+            }
+
+            T[] clone = new T[source.Length];
+            Array.Copy(source, clone, source.Length);
+
+            return clone;
+        }
+
         public static bool IsNullOrEmpty<T>(this ICollection<T> source) => source is null || source.Count == 0;
     }
 }


### PR DESCRIPTION
This is a follow-up of #33186 to add ECDsa support since it'll be removed from that PR and we'll focus only on RSA. That PR also had RSA improvements mixed with ECDsa, so I wanted to push it all.