### PR TITLE
[WebPubSubClient] Fix the issue that connectionId is not set

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
@@ -82,7 +82,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         /// <summary>
         /// The connection ID of the client. The ID is assigned when the client connects.
         /// </summary>
-        public string ConnectionId { get; }
+        public string ConnectionId => _connectionId;
 
         // Some exposed properties for testing
         internal IWebSocketClientFactory WebSocketClientFactory { get; set; }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientEventsHandlerTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientEventsHandlerTests.cs
@@ -91,6 +91,7 @@ namespace Azure.Messaging.WebPubSub.Client.Tests
             var connArg = await connectedTcs.Task.OrTimeout();
             Assert.AreEqual("conn", connArg.ConnectionId);
             Assert.AreEqual("user", connArg.UserId);
+            Assert.AreEqual("conn", client.ConnectionId);
 
             var serArg = await serverMessageTcs.Task.OrTimeout();
             Assert.NotNull(serArg.Message);


### PR DESCRIPTION
# Contributing to the Azure SDK

#35299

Fix the issue that public ConnectionId property is not set.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
