### PR TITLE
[Event Hubs Processor] Prepare for May Release

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -88,7 +88,7 @@
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.25" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.8.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.9.0" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.9.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.14.1" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.13.1" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.2.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.10.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.9.1 (2023-05-09)
 
 ### Bugs Fixed
 
-### Other Changes
+- Removed the 30 second cap applied when opening AMQP links; this allows developers to fully control the timeout for service operations by tuning the `TryTimeout` as appropriate for the application.
 
 ## 5.9.0 (2023-04-11)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.10.0-beta.1</Version>
+    <Version>5.9.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.9.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs Processor package for the May release. 

# WARNING

This cannot merge until the Event Hubs core package release for May (v5.9.1) has been completed.