### PR TITLE
[ForDiscussion] How to serialize common .NET types?

### DIFF
--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.JsonConverters.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.JsonConverters.cs
@@ -24,7 +24,8 @@ namespace Azure.Core.Dynamic
                     throw new JsonException($"Failed to read 'string' value at JSON position {reader.Position}.");
 
                 // From: https://github.com/Azure/autorest.csharp/blob/d835b0b7bffae08c1037ccc5824e928eaac55b96/src/assets/Generator.Shared/TypeFormatters.cs#L130
-                return DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                DateTime dateTimeValue = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                return dateTimeValue.ToUniversalTime();
             }
 
             public override void Write(

--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.JsonConverters.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.JsonConverters.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Azure.Core.Dynamic
+{
+    public partial class DynamicData
+    {
+        // From: https://github.com/Azure/autorest.csharp/blob/d835b0b7bffae08c1037ccc5824e928eaac55b96/src/assets/Generator.Shared/TypeFormatters.cs#L14
+        private const string RoundtripZFormat = "yyyy-MM-ddTHH:mm:ss.fffffffZ";
+
+        private class DynamicDataDateTimeConverter : JsonConverter<DateTime>
+        {
+            public override DateTime Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                string? value = reader.GetString() ??
+                    throw new JsonException($"Failed to read 'string' value at JSON position {reader.Position}.");
+
+                // From: https://github.com/Azure/autorest.csharp/blob/d835b0b7bffae08c1037ccc5824e928eaac55b96/src/assets/Generator.Shared/TypeFormatters.cs#L130
+                return DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+            }
+
+            public override void Write(
+                Utf8JsonWriter writer,
+                DateTime dateTimeValue,
+                JsonSerializerOptions options)
+            {
+                // From: https://github.com/Azure/autorest.csharp/blob/d835b0b7bffae08c1037ccc5824e928eaac55b96/src/assets/Generator.Shared/TypeFormatters.cs#LL19C84-L23C11
+                string value = dateTimeValue.Kind switch
+                {
+                    DateTimeKind.Utc => ((DateTimeOffset)dateTimeValue).ToUniversalTime().ToString(RoundtripZFormat, CultureInfo.InvariantCulture),
+                    _ => throw new NotSupportedException($"DateTime {dateTimeValue} has a Kind of {dateTimeValue.Kind}. Azure SDK requires it to be UTC. You can call DateTime.SpecifyKind to change Kind property value to DateTimeKind.Utc."),
+                };
+                writer.WriteStringValue(value);
+            }
+        }
+
+        private class DynamicDataDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+        {
+            public override DateTimeOffset Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                string? value = reader.GetString() ??
+                    throw new JsonException($"Failed to read 'string' value at JSON position {reader.Position}.");
+
+                // From: https://github.com/Azure/autorest.csharp/blob/d835b0b7bffae08c1037ccc5824e928eaac55b96/src/assets/Generator.Shared/TypeFormatters.cs#L130
+                return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+            }
+
+            public override void Write(
+                Utf8JsonWriter writer,
+                DateTimeOffset dateTimeValue,
+                JsonSerializerOptions options)
+            {
+                // From: https://github.com/Azure/autorest.csharp/blob/d835b0b7bffae08c1037ccc5824e928eaac55b96/src/assets/Generator.Shared/TypeFormatters.cs#L29
+                string value = dateTimeValue.ToUniversalTime().ToString(RoundtripZFormat, CultureInfo.InvariantCulture);
+                writer.WriteStringValue(value);
+            }
+        }
+
+        private class DynamicDataTimeSpanConverter : JsonConverter<TimeSpan>
+        {
+            public override TimeSpan Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                string? value = reader.GetString() ??
+                    throw new JsonException($"Failed to read 'string' value at JSON position {reader.Position}.");
+
+                // From: https://github.com/Azure/autorest.csharp/blob/feature/v3/src/assets/Generator.Shared/TypeFormatters.cs#L137
+                return TimeSpan.ParseExact(value, "c", CultureInfo.InvariantCulture);
+            }
+
+            public override void Write(
+                Utf8JsonWriter writer,
+                TimeSpan timeValue,
+                JsonSerializerOptions options)
+            {
+                // From: https://github.com/Azure/autorest.csharp/blob/feature/v3/src/assets/Generator.Shared/TypeFormatters.cs#L37
+                string value = timeValue.ToString("c", CultureInfo.InvariantCulture);
+                writer.WriteStringValue(value);
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
@@ -22,10 +22,15 @@ namespace Azure.Core.Dynamic
     [JsonConverter(typeof(JsonConverter))]
     public sealed partial class DynamicData : IDisposable
     {
-        internal static JsonSerializerOptions DefaultSerializerOptions = new JsonSerializerOptions()
+        internal static JsonSerializerOptions DefaultSerializerOptions = new()
         {
             PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = {
+                new DynamicDataDateTimeConverter(),
+                new DynamicDataDateTimeOffsetConverter(),
+                new DynamicDataTimeSpanConverter()
+            }
         };
 
         private static readonly MethodInfo GetPropertyMethod = typeof(DynamicData).GetMethod(nameof(GetProperty), BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonTests.cs
@@ -1057,6 +1057,7 @@ namespace Azure.Core.Tests
                 NullableProperty = null,
                 CharProperty = 'a',
                 DateTimeProperty = DateTime.UtcNow,
+                DateTimeOffsetProperty = DateTimeOffset.UtcNow,
                 TimeProperty = DateTime.UtcNow.TimeOfDay
             };
 
@@ -1164,6 +1165,7 @@ namespace Azure.Core.Tests
             public int? NullableProperty { get; set; }
             public char CharProperty { get; set; }
             public DateTime DateTimeProperty { get; set; }
+            public DateTimeOffset DateTimeOffsetProperty { get; set; }
             public TimeSpan TimeProperty { get; set; }
 
             public override bool Equals(object obj)
@@ -1185,6 +1187,7 @@ namespace Azure.Core.Tests
                     NullableProperty == obj.NullableProperty &&
                     CharProperty == obj.CharProperty &&
                     DateTimeProperty == obj.DateTimeProperty &&
+                    DateTimeOffsetProperty == obj.DateTimeOffsetProperty &&
                     TimeProperty == obj.TimeProperty;
             }
         }


### PR DESCRIPTION
When we serialize different ["primitive" BCL types](https://github.com/dotnet/runtime/tree/main/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value), we have the option to use JsonSerializer defaults for serialization, or write the values in a way that is consistent with .NET model type formatters.

Addresses https://github.com/Azure/azure-sdk-for-net/issues/35944
- [ ] DateTime considerations - what Azure formats are supported in JsonSerializer.Deserialize and should we customize to support more out of the box?
  - [ ] Round-trip DateTime - how do you know what format to re-serialize into if a DateTime is assigned?