### PR TITLE
[Storage][DataMovement] Fixed `ContinueOnFailure` not being respected

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 - Fix to prevent empty strings or null to be passed as paths for `LocalFileStorageResource` and `LocalDirectoryStorageResourceContainer`.
+- Fixed `ErrorHandlingOptions.ContinueOnFailure` not be respected.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
@@ -254,10 +254,16 @@ namespace Azure.Storage.DataMovement
         /// <returns>The task to wait until the cancellation has been triggered.</returns>
         internal async Task TriggerCancellationAsync()
         {
-            if (!_cancellationToken.IsCancellationRequested)
+            // If stop on failure specified, cancel entire job.
+            if (_errorHandling == ErrorHandlingOptions.StopOnAllFailures)
             {
-                _dataTransfer._state.TriggerCancellation();
+                if (!_cancellationToken.IsCancellationRequested)
+                {
+                    _dataTransfer._state.TriggerCancellation();
+                }
+                _dataTransfer._state.ResetTransferredBytes();
             }
+
             // Set the status to Pause/CancellationInProgress
             if (StorageTransferStatus.PauseInProgress == _dataTransfer.TransferStatus)
             {
@@ -270,7 +276,6 @@ namespace Azure.Storage.DataMovement
                 // It's a cancellation if a pause wasn't called.
                 await OnTransferStatusChanged(StorageTransferStatus.CancellationInProgress).ConfigureAwait(false);
             }
-            _dataTransfer._state.ResetTransferredBytes();
         }
 
         /// <summary>


### PR DESCRIPTION
We were not checking the `ErrorHandlingOptions` when an individual job part failed meaning that a failing job part would cancel the entire job, regardless of the error handling option was selected. This change adds the check to only cancel the rest of the job if `ErrorHandlingOptions.StopOnAllFailures` is specified.