### PR TITLE
[Event Hubs] Temporarily resolve version conflict

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
+    <!--ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" / -->
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary

The focus of these changes is to resolve a temporary version conflict resulting from project references to the core and processor, where the processor has an explicit reference to the core package on NuGet.

# References and Resources

- [Build failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2761935&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=45862c6e-83c5-515f-73e2-e7009eff9f9b) _(Microsoft Internal)_