### PR TITLE
fix openwrite with caller-provided crc

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTransferValidationTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTransferValidationTests.cs
@@ -93,6 +93,18 @@ namespace Azure.Storage.Blobs.Tests
             [Values(Constants.KB)] int streamBufferSize,
             [Values(512)] int dataSize)
             => await base.OpenWriteSuccessfulHashComputation(algorithm, streamBufferSize, dataSize);
+
+        [Test]
+        public override async Task OpenWriteSucceedsWithCallerProvidedCrc(
+            [Values(Constants.KB)] int dataSize,
+            [Values(Constants.KB, 512)] int bufferSize)
+            => await base.OpenWriteSucceedsWithCallerProvidedCrc(dataSize, bufferSize);
+
+        [Test]
+        public override async Task OpenWriteFailsOnCallerProvidedCrcMismatch(
+            [Values(Constants.KB)] int dataSize,
+            [Values(Constants.KB, 512)] int bufferSize)
+            => await base.OpenWriteFailsOnCallerProvidedCrcMismatch(dataSize, bufferSize);
         #endregion
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ef82c651-d607-4b4f-681c-bb342d29e9e9?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6a9b1b250ed4b217768f9d64224e7fbe-e021ab950a0067e0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "b21d9e62-2dd3-4789-b2c2-7c67ba0eff49",
+        "x-ms-date": "Tue, 09 May 2023 19:59:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:40 GMT",
+        "ETag": "\u00220x8DB50C7ED9674D0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b21d9e62-2dd3-4789-b2c2-7c67ba0eff49",
+        "x-ms-request-id": "1fcbc0b0-701e-0034-02b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ef82c651-d607-4b4f-681c-bb342d29e9e9/test-blob-96c4f4e3-f132-f54c-b305-b76cdd9f5cc4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fa229d7bcfba819f51d5ec424c039afd-bde79d91cf8493fe-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e777945c-cacb-9688-f03c-6aa64cfe76a9",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:40 GMT",
+        "ETag": "\u00220x8DB50C7EDA77B93\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e777945c-cacb-9688-f03c-6aa64cfe76a9",
+        "x-ms-request-id": "1fcbc135-701e-0034-7bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ef82c651-d607-4b4f-681c-bb342d29e9e9/test-blob-96c4f4e3-f132-f54c-b305-b76cdd9f5cc4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3496418cf611ecaf6176893f3473f735-16816367bccaf084-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "490f0c84-7428-c6f8-d6a8-2e1cf1d38127",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:40 GMT",
+        "ETag": "\u00220x8DB50C7EDAE7F6E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "490f0c84-7428-c6f8-d6a8-2e1cf1d38127",
+        "x-ms-request-id": "1fcbc17a-701e-0034-3bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ef82c651-d607-4b4f-681c-bb342d29e9e9/test-blob-96c4f4e3-f132-f54c-b305-b76cdd9f5cc4?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EDAE7F6E\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3f210a3b-2def-0d81-0038-994a0ec295a6",
+        "x-ms-content-crc64": "eLvSL6XBoFk=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "hhC1wyPjxnezE4qEuQIeDZau0o8LNhYOWm5GxF2rtFaE08YcpMLpftim/sCiBI6wo27RDDtvPVD6p2i0nAEaB14zAOU7AWnUxVO3ZDdVa1XgliHu2qgbFJZ2IvxZNOLWjPZhbwSpdKEF/Ufnt9kYpDsT1AXgKy22GOtPxd9sepBx4dhA9PxQNiKA6N1hM128XX7BRmDc9mDJq1cZWq7CmYK3dtYB168/w53jYENQVeSNkmdgqzQvlOp3d0ilNtxzvk9aqr2Gu4bOgYLD\u002BZYdeVZyi8dHYe1Oh\u002BHriWBnmozAcKHz9asmB9fhkSmxbJtUWv3yMqsULFxhDCLcmjElZ\u002Bb2Aon0KoSqTITwZc/DnBtGly9idGjhrENFkeiISmymuypDumkSYC95R\u002BYmJMaMnXAHlgMBw/N\u002BFVVFrpicIgEXSqqlgOGxMzf/6SyCuoh9uPN4gbRppPg3xKUTzbGX3SXkD9ob5xyOVWLMAdrG/FvNx/alI6BNrqWybrw8nWaFaAsGnautYdHW6SxSnaIdcMdJRgW78rmFlmA0aXlgUbf7RpnOwF6vH2Ulzjl0\u002BxEClP308ldhynZSgAdKefhXdph0V1YJT7BomiaglSN/EZtPMtR8a15gmnsjfD9XZaZtzVih/6S6\u002BUVNi1gxwDRS0m9r\u002B0cj2wo5FLzb5dJwETR/M8jL3hH3lTiPLt8GL9lG0arP62pfSfJNZ\u002Bvn3hNy3HojsY1shvRddGUOk6wqM\u002BXjlBQooCXKIOnWfXYmD7YkHFJl4n1L2Uq2cnYEUbVFIzQGA0r/SjtUWZGklgh9NmWv6XdaxVFnl7rKci6uxs40kFpCIAtrJdIXEInsp0NBODsRVGc\u002B613jnmyPNNgMpZLCbwauOxZZQ8OkQrTHe/B3iDnynXFn9aX9X4Gf3PH6Cmr2KTc8k/0luBGkmaioGyN8F6yeGgghW3phsdyUumfSqThK0VG4OvU7zOVgwlv8VENeI8REW/Bh1c692\u002BIhkf2q0fBwXkrRxNy3Y00jwJgeZFyYNZaijU5H6PuC\u002Bl8SGjvntvFri/X5jF/njfiiPhQ2n3aFiVtnB0ShKHZOTsl9pEgSPAqnstlnn6k3uv9VpanmTFvojZDggK6syWJ\u002Bqj2VaumvkAEKjuydHumyL01ETIPMZwJulRe3Mrxb\u002Buh26PRrolAWpRSo3L1uSm6nLVBhaH3fsUI7J9TS915FrpQEJzX1Roz9LaZuJItEAEuoEARr\u002BpFrljexMHt7RK22Yy4paiI5sefDZDrWcY239yaJKeZa2bQDmJD\u002BQxYRgen5uMFdGpYobl8dp5ZWlCWp\u002BjhU8RrGXIl5JtGRO27QsuJQ3bnLWtyQYbuHPTEdrANrVA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EDB8B723\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "3f210a3b-2def-0d81-0038-994a0ec295a6",
+        "x-ms-content-crc64": "eLvSL6XBoFk=",
+        "x-ms-request-id": "1fcbc1c1-701e-0034-7cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ef82c651-d607-4b4f-681c-bb342d29e9e9?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0eb8bd1112e0cddf4e23d7abc1ca560f-f77f4caac2b6f70f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e7e097de-41b1-4338-f963-fb1b776d11f3",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e7e097de-41b1-4338-f963-fb1b776d11f3",
+        "x-ms-request-id": "1fcbc1f9-701e-0034-2db0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "809575367",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-6a2a1cd9-4c15-9401-4c16-6060c8ff6d77?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0420ef0ad0711cfb88e5390376eb09cf-ce91f6f6129f4d05-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "88134daa-e56c-020d-9c4b-35ee92e31da3",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EECFD7DD\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "88134daa-e56c-020d-9c4b-35ee92e31da3",
+        "x-ms-request-id": "1fcbc9b1-701e-0034-2cb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-6a2a1cd9-4c15-9401-4c16-6060c8ff6d77/test-blob-e2cf4644-e9e4-38b0-bc56-12efc1efcf8d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-876dfa6cf297043a0ecc2ed82506bdbf-70a93c04deac86dd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "8b235282-8a12-4bd6-5d14-01c0dcc5afc5",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EED98CD4\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8b235282-8a12-4bd6-5d14-01c0dcc5afc5",
+        "x-ms-request-id": "1fcbca09-701e-0034-7fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-6a2a1cd9-4c15-9401-4c16-6060c8ff6d77/test-blob-e2cf4644-e9e4-38b0-bc56-12efc1efcf8d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-593702906857da2c2e79aa1e78256dcf-479a666df4fd653b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "6f6cf273-44cc-e77a-5f6a-463f1b30e3ee",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EEDFF488\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6f6cf273-44cc-e77a-5f6a-463f1b30e3ee",
+        "x-ms-request-id": "1fcbca2c-701e-0034-1eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-6a2a1cd9-4c15-9401-4c16-6060c8ff6d77/test-blob-e2cf4644-e9e4-38b0-bc56-12efc1efcf8d?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EEDFF488\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea4dfb1b-3f59-94f8-9c1e-870b2fa10c24",
+        "x-ms-content-crc64": "Uwc5blqfydE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "BkAC6cvamQ31DC8UmFPTcm1rtXrr5ApW0VCqApc4i1fjEKaA178p0LQGkl\u002B1\u002BWlJeMKAJi6jtyI1qxd7MJd1vIHXMIisUpquQuXG5VGqodfmYIrUuGUpQFiESyynrp8ckNXe3sngnCUn0uRI3NLQiglAlM8MoQQcre8wKAduBpNFqVR7zMMOBcRlrOWA4WSGtMAiZxnPEO/RwjDZsHQductQAjJ\u002BVL5GMY8Lp/Qem8yLqXNGS596dplkqgmSNVRPR/MaMN4xCF8C2zWKxGn7sidkTgcA1m4r1oyZGam1tPw6u18ABGvtWqEURG9q77IwafjiLuZNT3CF7llSl\u002B62TSc5TwgJ\u002Bq27dvRl7JL\u002Bwebaaa\u002Bx0oUV7WzuexYRm8KyXvdIMKCpJm5KJrjy6GPehyxzdy4\u002BBHqiI2KcG36Xqtoxso6atpBGMENBZqzNIwQID/TpnSOUdFl9pg09DQrws3vdwDXVQ9CbLUfr/Z3N1ABekwuJrQy2nT40HQ\u002BDCCM4ULMw72LOM8sjTW/cqXa7r9EN33n\u002BZgVuJyL3oCXBGCUjsqzqnOSdj2A/Zl\u002Bd2vTHeW4\u002BdiiqOequwsg/15OmYjVKuPbJ0RLsb1AZvgCl0U0uLye3gqH8eXnCO9ocXbjMmQMqUiH9/qdcUQbYkHrqCPB7Eadr7uCUTj59B5U30BKYTCX8e38rMDF/WzCaI\u002Bn\u002B1zLqoEwRYKojlQPigPYSJIH0QERV7Y1wT\u002BB17JOv\u002BStVfi9iTS/Fhut62eV7Sa86bTavpuKkqemleVBrm3QXc5zYjALHr9dSLrlY2hSo9QYwOn5dAFNIsdRGvdTeWut2Y2VIo7ytc71fXHcoTM7V/IRKOmD1uXNJkNstgfICdNTO4neuYFFKg8fB/aPbH2UFcMFPkx\u002BKgKny/xPhf/LLXOijWmlXJpwyALeZNLzQbnB2KBAxs\u002BC1Q2HNvGE\u002BaATV9qC6N8T7rkkkHZNn8UztIpCialfhmqkI7hYIiWo79JezxD4bFTare3nGDJZMTVIU4JrQm/6s81v3skmu8iTf6Sj8tCwO0Qxa9\u002B/dG40TvKDD9KjPalmZBtDiJGLs/YlV5iJtUJglBg\u002BNdqMOz9jN4/ao6v17EH/PY65cK62qbfpmiDRrpWsHnu2ZQvS1ijb4FEBsQxKL2dajnu3qydpi4wipqEejYj2KoEwQ4s2KGth3YxZsPinn2q9dyAd\u002BHdQSN17sC\u002BHvVLIC4aLGe/YIGIQUc2bE9aXews6XRpo2C4N3/atvng73hw5kaVyGIF\u002B4VK\u002BDaqluTkG5DUkTWA4XzNUeT31LmXp1HOtXX4xIV6Fu3/HrsqHaCK5ptZHE5C8ATJyGZ9HhbLs0Dk29F\u002B\u002B1cA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EEE6833E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "ea4dfb1b-3f59-94f8-9c1e-870b2fa10c24",
+        "x-ms-content-crc64": "Uwc5blqfydE=",
+        "x-ms-request-id": "1fcbca4c-701e-0034-3db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-6a2a1cd9-4c15-9401-4c16-6060c8ff6d77?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9c987e22c303c6ed29fe8dacc60e69e6-d452e2ea6e13d2fc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "20247d2b-f8e3-5595-1daf-8a92759edcd0",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "20247d2b-f8e3-5595-1daf-8a92759edcd0",
+        "x-ms-request-id": "1fcbca97-701e-0034-05b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "327396359",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-67bee6057e364a3f6370af2c430e911d-5854b182d115e79b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a2d6297e-ac15-b93e-bc22-742499fed152",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EDD0B611\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a2d6297e-ac15-b93e-bc22-742499fed152",
+        "x-ms-request-id": "1fcbc274-701e-0034-20b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-15c2da24c519adf6a1c26ee442201ddd-c0f704f3084930da-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "9792fb80-809b-1c3d-ad5d-6d2f785a8972",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EDD8E48E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9792fb80-809b-1c3d-ad5d-6d2f785a8972",
+        "x-ms-request-id": "1fcbc2a6-701e-0034-4db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8fd4e1c9fd0fa58181f77ba08fcaa7b2-718ce7a9437d88bd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "28f07782-6109-0673-dd09-7d6756218c18",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EDE47B94\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "28f07782-6109-0673-dd09-7d6756218c18",
+        "x-ms-request-id": "1fcbc309-701e-0034-29b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EDE47B94\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "00accf19-616a-9e68-1254-91058b89b7a3",
+        "x-ms-content-crc64": "7elEq7a8xyM=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "B6555ecCvK\u002BelE2dnAeW/n81d8E2DKnmABLgl8bGBOPAJXv4nirMe2wmA4BfoB20i3alZIcQG/oEkuXVIiXp2I9p3HeMnWBUaPtUEAkoh1/1KwtQIKBcsAqA9AtF91lHPSvx9cSlKO4VUPuLuwrx2wuF4PcZmLfuDCttC6lUD3GiDdPdN5GbTwIdOtCl0PX/jxgAwBZhLaRzAuiYNxxEwEGK6a43E6N56ZD0/F3nSTw2bnyQVE9aQN8uajWoAxfl2HmPGudHyHs=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EDF087BD\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "00accf19-616a-9e68-1254-91058b89b7a3",
+        "x-ms-content-crc64": "7elEq7a8xyM=",
+        "x-ms-request-id": "1fcbc364-701e-0034-7db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EDF087BD\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "864ef75b-8b74-35ae-0922-2cac7fd1ec81",
+        "x-ms-content-crc64": "B/eZDRMSAJY=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "dYbWhW0wRoy4rGHJoLRs8S\u002BozgipbtDleQ4k41cuVO\u002BmARvNeNXTrujdfPyiTUUkDZ3rPni/0ga18AxeDGI0iVhyI56YnnlZ1R8gy/HUQyvJANa6QxV25i8UGIjJdaKFqPKjLyqmi24kkWlYnwYU4azhlQuMekZD/D1vhIbwkGB9miL/MBQBInVnlbKrHUco/zbb6OCX\u002BS6sYDPtNgfoMwAJ2wTjFbCY4HKWJOWTl971R4RPFaiA5aH0UtDhE\u002BttfmKxoUFCROo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EDFA4A55\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "200",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "864ef75b-8b74-35ae-0922-2cac7fd1ec81",
+        "x-ms-content-crc64": "B/eZDRMSAJY=",
+        "x-ms-request-id": "1fcbc3b7-701e-0034-46b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EDFA4A55\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "94a9eed8-303b-042f-2e38-f242d8f0f1cf",
+        "x-ms-content-crc64": "Ko8oev9Cg\u002Bg=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "hkIHbQHUSRjJVPfvg5keV4n1Y\u002B/C37fMhiimguL1nbMCmcjSoBLkzas5B4wc/OrlRFkYTN9VJ6aLO\u002BbYLsY207ZE7OnQS7d2EJZDidgqr4o9wD6I3VHUrXIhRmUrC57lAzPW2A8BFfiioTtIEZ7NYYtcm22HrfZlcD52rgRSSwT3XoWlVNd6O6tG5jsVi5vUVOXZznAwXlU9cGjQimbzUFY2UbMYKA2z4l/CQce6T\u002BSjolofeHyUxgAvZ\u002BRvqbFFUpXl3znouys=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE0063EC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "400",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "94a9eed8-303b-042f-2e38-f242d8f0f1cf",
+        "x-ms-content-crc64": "Ko8oev9Cg\u002Bg=",
+        "x-ms-request-id": "1fcbc3ed-701e-0034-78b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE0063EC\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "90d30d12-5827-9c45-00ea-8094bfdf3b40",
+        "x-ms-content-crc64": "s326N6bk0Rw=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2CXsEG4cjoIggy3nC9TX2aGKs\u002BnAKUQ5rn3uMdVwq7rnL0dTkINY46Hlw\u002Bx7yTl\u002BvQw9rzXRaq/hsmHwLlytsNhzANyNhEgdMdBH22VXveVEcHPIMvuFFcSXct0iZ7RENxMUCMlc8TnDIH1kio9JifV8rL7o5H3c7eoX9RJr\u002B8obAqNRQ7Uc5386BBJ\u002BIIs1Tujopbv2XFOWOBreRPsnWCSzSYfr\u002BEY/X8Q\u002Brt9rXs1e4qcpglUPJKZQuwubPaKDEqzuytcESVU=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE062F6A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "600",
+        "x-ms-blob-committed-block-count": "4",
+        "x-ms-client-request-id": "90d30d12-5827-9c45-00ea-8094bfdf3b40",
+        "x-ms-content-crc64": "s326N6bk0Rw=",
+        "x-ms-request-id": "1fcbc41a-701e-0034-21b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE062F6A\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ca2fcd47-601d-33a8-561b-5f194c41eaf6",
+        "x-ms-content-crc64": "VfwptYDM6tU=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "oqhF9retcyvZTIBiVP7VzqQk4Js9O6QiIrubM32T9lqYUYbaDxht\u002BN2QMU69Py4U1h8msiOtGGcDI9P8ET\u002BuRlYlygN3\u002B7\u002BLt\u002Be\u002BrAlWZeKMh11dbUM26jgf1uxFcOad4ur3l3UrnNtgm/o772tdrb7xb4riUNkS79/KWCTSRkYBIcoeXs1sYeqB/dFI\u002B/vMwSktUwFcu5ER5aiWYUS2jVS0Os6hPk/whA6gYFIHyfPj/Zf6pfJFpGU5DXkl1v\u002Bmy3B9lMAtK4I=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE0C700B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "800",
+        "x-ms-blob-committed-block-count": "5",
+        "x-ms-client-request-id": "ca2fcd47-601d-33a8-561b-5f194c41eaf6",
+        "x-ms-content-crc64": "VfwptYDM6tU=",
+        "x-ms-request-id": "1fcbc441-701e-0034-46b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf/test-blob-672015d1-5224-0ae8-fa02-5d70249bf90f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE0C700B\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f14d0e11-70af-ea23-e733-50105101c0d6",
+        "x-ms-content-crc64": "WMeHK0B\u002BXic=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2j3O8rxbPgobtLJjrLzoYm6VaGgx1suu",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE15E48C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "1000",
+        "x-ms-blob-committed-block-count": "6",
+        "x-ms-client-request-id": "f14d0e11-70af-ea23-e733-50105101c0d6",
+        "x-ms-content-crc64": "WMeHK0B\u002BXic=",
+        "x-ms-request-id": "1fcbc480-701e-0034-7eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-303289eb-132f-3c8a-168f-e9f6ea0dafbf?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e85b42f1f314bcd0eb1902818b62e793-1dfad0c10547b94c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3d07565b-f8f4-8e46-ef03-b422f9e711f1",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3d07565b-f8f4-8e46-ef03-b422f9e711f1",
+        "x-ms-request-id": "1fcbc4bc-701e-0034-36b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "411750282",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-dd3b5d5ae64da07162058893cb26269d-2fa8899501c3b939-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "6f128a34-5881-907b-eb7f-85810a76b826",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EEF9C7DA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6f128a34-5881-907b-eb7f-85810a76b826",
+        "x-ms-request-id": "1fcbcad5-701e-0034-41b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5b1ed1c9c04d3e1850c8fc2243bee470-67792aa2257f0e7d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0cb9f58e-41d1-19d4-4a49-d0d2aa06e848",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF015A4F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0cb9f58e-41d1-19d4-4a49-d0d2aa06e848",
+        "x-ms-request-id": "1fcbcb0c-701e-0034-74b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9ef7dfe06918c59aec27130239b13bb7-1a810b2ec37edcf1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "c49f0090-bc7e-fa3c-5d5c-362367e26fed",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF079AEE\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c49f0090-bc7e-fa3c-5d5c-362367e26fed",
+        "x-ms-request-id": "1fcbcb31-701e-0034-17b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF079AEE\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a9426870-2367-20c9-b2c0-1d44aeb80016",
+        "x-ms-content-crc64": "cCK6bMlxrZA=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "uPDhkXeDe0DlOwdVEUrT7ivpdZIiTd13BNo9te3L/6CRD3JJixQUsQ/SikZRJn6hq5dVIQAmA2oTao2cRsVSGjtnwwLXimMX1MODUMOXJt1cmwpWdt6fawsHNSCHd2tJf28K6mJ7ySAzPkw8orOnfESvP6q7/KNcx1f2z1RCj11YOdBTjDx64dHpIjiSY8hYYLnc2DjBjoPMriIKhPrM8a7v5GjiVO8INF7Y0tlrymSPnm\u002BaZbcllqtNh94Zb1zXHTGJo35fdgs=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF0DB488\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "a9426870-2367-20c9-b2c0-1d44aeb80016",
+        "x-ms-content-crc64": "cCK6bMlxrZA=",
+        "x-ms-request-id": "1fcbcb50-701e-0034-35b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF0DB488\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "feb22d35-c6a0-a786-66e3-ce7d67aefb61",
+        "x-ms-content-crc64": "NdxuLbAH1z8=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ytSj2em8qWDkvnvmijGL98pNvZTNEO/EAgC0qOIm5S8nY9CRE0ut76Mm\u002BlrzdkzrpZHZMaLhPrnl3tfoBwF\u002BvdlMvidh\u002BuR\u002Bn83wphaU0IuzyQJQTbSMRSQXrDRzxeiiqD2Bp7cliqutWpHV8ZiiUA1LNT3\u002BLXAkwHgCSk6vCtrkTv7ZEynTjj9Xo/IjtlSMdFsmKJCqo3rMXOY/I0Bc/VC28KKZyTzkd6f\u002Bpol9AQkjdtXyieJKOaqEDLdDlGr\u002B\u002Bqaibcay8qo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF1617BC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "200",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "feb22d35-c6a0-a786-66e3-ce7d67aefb61",
+        "x-ms-content-crc64": "NdxuLbAH1z8=",
+        "x-ms-request-id": "1fcbcb8d-701e-0034-6cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF1617BC\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "810f1d49-0106-8575-4a03-5a598aaca55e",
+        "x-ms-content-crc64": "FRP8DHZ4m80=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "HkKw6az98E9a3Rutamp0bWu29xW8haHjPACr49uUQ3GDKtNGMWGNrZO9XGV5vZOQMTQBD7rd7pmhzaysUQxzxpqpKT\u002BWLTwJKUqC/yg7an5sG7KnkjO3pTw6pWS04VyGSZbLz5NU\u002BQP39\u002BZvW\u002B5xZmMuQDZazDNm8oQDXIjXVEfu\u002B7WRb5vqFyGur5tNR0pOyT8BhqEmLH1jZdwPUZ17IKKegV843/fIRCgUrB2YGKs5tJNJ1s6myM84Lgm\u002B2saEMo/4r8XrFek=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF1CF48F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "400",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "810f1d49-0106-8575-4a03-5a598aaca55e",
+        "x-ms-content-crc64": "FRP8DHZ4m80=",
+        "x-ms-request-id": "1fcbcbb9-701e-0034-14b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF1CF48F\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4933426b-7a9f-505b-8844-69af0b728e91",
+        "x-ms-content-crc64": "NtjXhU4Vw7U=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "SDlBeBGAYMpMMdacCTJJ0/e5kP\u002Bw7QlpYY95jp9o5U6fqQGdjS22T9hjvI0EKnsARSS4C1sWOVov1xeCBtEr5EuH/V8xrEbJA0AmTDB8ZTYUeEh7sNnziHCmbbUWNEgGONhBfC0bz5je7gga7\u002B0qs3LgbY2JsDNxlHTvij\u002BRs8/4IBNXOukJ\u002BamwncHR2JmCfLlDNca6fYilz\u002Be4K0RYTDs4Is/Z0niI1nPk2BJxn7vabQ6GTX0IPaKKsmoBUM5kWFCFmLbKqao=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF25F3F4\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "600",
+        "x-ms-blob-committed-block-count": "4",
+        "x-ms-client-request-id": "4933426b-7a9f-505b-8844-69af0b728e91",
+        "x-ms-content-crc64": "NtjXhU4Vw7U=",
+        "x-ms-request-id": "1fcbcc01-701e-0034-5bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF25F3F4\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "47ee8fd4-5b78-7fbe-ed8b-22195a9dc2ef",
+        "x-ms-content-crc64": "57d7OSLxT9U=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "QLpeUtaldTMvK969NtL/vi/kLE4fDoaGpX\u002BAwuwHBRDDZEWTHrZn/RV/OtZyEC6FUMdo0Z1aijIz2K1WJLJHKCbN\u002BtKMbJ95fS85n9OwE5RQ\u002BnIknjRzadkTX0UIENhiOBGwpRZc\u002BOQn71NtIOpegsUYBilAIorxWpD4eQxacG1X12fBAG1\u002B9AGN/K7gBUjutNx/8AquIRWHvkqFY3/XzX7mFkmDnYJXmhEosyXcEVVICsUw2oBiqLZROkIj\u002BJGCtS8v\u002Be7/ahc=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF2B715C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "800",
+        "x-ms-blob-committed-block-count": "5",
+        "x-ms-client-request-id": "47ee8fd4-5b78-7fbe-ed8b-22195a9dc2ef",
+        "x-ms-content-crc64": "57d7OSLxT9U=",
+        "x-ms-request-id": "1fcbcc2d-701e-0034-04b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e/test-blob-b1d6ad9f-6a2a-4822-618f-952dba38c80e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF2B715C\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7cdb32e8-4783-3419-7ff8-4134ab142b33",
+        "x-ms-content-crc64": "\u002Bi6VL5z17JE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "WihV\u002BIZt76us9T1Yuqfz/oNtkjJiPzSi",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF35D008\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "1000",
+        "x-ms-blob-committed-block-count": "6",
+        "x-ms-client-request-id": "7cdb32e8-4783-3419-7ff8-4134ab142b33",
+        "x-ms-content-crc64": "\u002Bi6VL5z17JE=",
+        "x-ms-request-id": "1fcbcc85-701e-0034-56b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1e4533b3-47a0-0e75-5bd1-74aa1d35bd5e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-601f6491949f728f05a37c0847e5d903-8f7a783341eea663-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2730a57c-46c1-c26b-15a4-6ca2bdd6f100",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2730a57c-46c1-c26b-15a4-6ca2bdd6f100",
+        "x-ms-request-id": "1fcbcca6-701e-0034-76b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1588179561",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
@@ -1,0 +1,245 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1c25b1cf-3db1-2319-02a6-088a97b63be5?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7f52a26e050a428bf6feca2ac6dcb432-811f016e93124b50-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a6fcd4fe-f339-79cc-8b1c-344e6ea50557",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:51 GMT",
+        "ETag": "\u00220x8DB50C1AAAE33D7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a6fcd4fe-f339-79cc-8b1c-344e6ea50557",
+        "x-ms-request-id": "da6c3e8b-401e-0062-70aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1c25b1cf-3db1-2319-02a6-088a97b63be5/test-blob-2e42a134-c7a2-6158-78c4-a70f22646040",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3bdd756c581d3e512532d1106b3337db-4432342f2439b7ef-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "000a4e46-d4ab-3333-0e7e-e851271ac898",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AAB5FA0E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "000a4e46-d4ab-3333-0e7e-e851271ac898",
+        "x-ms-request-id": "da6c3eba-401e-0062-1daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1c25b1cf-3db1-2319-02a6-088a97b63be5/test-blob-2e42a134-c7a2-6158-78c4-a70f22646040",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d880ed82db899f0c0943dd5dc633a9e6-08bcc389da7d21f7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d3c81306-5f5a-1194-a67e-bc01b9ef5447",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AABC3AB9\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d3c81306-5f5a-1194-a67e-bc01b9ef5447",
+        "x-ms-request-id": "da6c3edd-401e-0062-3aaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1c25b1cf-3db1-2319-02a6-088a97b63be5/test-blob-2e42a134-c7a2-6158-78c4-a70f22646040?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AABC3AB9\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "134a8e31-f552-8d3e-7e61-6e837709d870",
+        "x-ms-content-crc64": "KoMfOS3DshQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AEAx9tklUW1NtNhEr9RDqQUni8O6lawCU5wBlC0VAp5nNkSfJ6kH2IKOWIQah8m22YpJRxpBnGuULqM8JLw/OLE53XmQo4JbH7NAKzwn58zSSrqjy7uEJZnYC/gGyrTFTyDS4alQJjYH7SdmAXAvbEbWadkBm2z2tLjgt5iJVFT/etwbVAYigiSEm96THSQoqZ6yMGHaw7Oz3Czxb26dfpnSZ4aUExdAtOa1fP\u002BOYpaTtw751yTzJLcoaHjZMBK15x1FwLaelJWHcXx6JUazJHqWXbhgo6d030LPa6ueZ4PUAJXiSaHg9SJ4cmWoeP9wdEP\u002BQ9NaVEN20OFzzyjq6Ar5piWx0dvYtWiV5zFBzGZDXvdooCSveatSbHnAbCb6jolbr9LavqJnJY1rxG0RNAN6MHAwgUfmSSx5X2ViGEhBm1mn5R2TaJ9UAHqWRLU\u002BQDd1RTy2yQxCdWWmYF89BQ1FKSkTak/m5sfQ3IHMTwR3Ox8u7dMMi9FMZW\u002B37QdA",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AACEAE87\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "134a8e31-f552-8d3e-7e61-6e837709d870",
+        "x-ms-content-crc64": "KoMfOS3DshQ=",
+        "x-ms-request-id": "da6c3f42-401e-0062-18aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1c25b1cf-3db1-2319-02a6-088a97b63be5/test-blob-2e42a134-c7a2-6158-78c4-a70f22646040?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AACEAE87\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2bcf43f8-41a5-53f5-4147-8249390e9b3a",
+        "x-ms-content-crc64": "7x6xexFKGSg=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "F/ttURuLKtXnjl505e2LdSVhLiVADhc6OJ1XxgTfL/nAkMWGX/7o6xFJRl50l6XkwfBJVb7i/wjjMxh9M2PQB19ltFUoBRYneEMT98i5xaH4cwUUltk63ZC8oivma7eteD7\u002BDuJQvLzaItx7zghAKm13hcBevHGGK9fFa2LqQQ2LZn\u002BJura\u002Bp7ZIOnP8vg6HfHi9b\u002Bb2T7zNeOMLilBa7\u002BHP8GiJt2\u002B3uN0KFoH9iW3IPe/pLNInlBbDu0HTsh1l7kuSLc2l/sUIBrYI7Dk6z\u002B51Qk1hcMMPp1tRxvst4wbApCg2a1yfIj8q4CYbHqfdiOxSXW/PBH2Hg4VyUzjJ2iKwSEgRBGSS1h8NN4\u002Bc84mzdD0O24aW8KCqrufWLc8GYAUDa9ZfzIOIwIZPwszu64/8vt/6u/\u002BcGVeoZlZ8u6lQBteJmYeyVKe5hhr/Ri7TvMNX2m/vDKUGZlJ\u002Bt2UtDATd/rv1ZFEISWk3QDTkndMp1KqSJOA6YfoygzI1NJxC",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AAD9D077\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "384",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "2bcf43f8-41a5-53f5-4147-8249390e9b3a",
+        "x-ms-content-crc64": "7x6xexFKGSg=",
+        "x-ms-request-id": "da6c3f85-401e-0062-4eaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1c25b1cf-3db1-2319-02a6-088a97b63be5/test-blob-2e42a134-c7a2-6158-78c4-a70f22646040?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AAD9D077\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "338a6b56-ac39-31cb-90f5-ec77c9662472",
+        "x-ms-content-crc64": "bsYh7YVRfpM=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "jHoWIUdz3VdxT5EFt8xwIcl/VeK7mucjo53Aw\u002BEf0hTN9bS6znuLtvZSIdRPNKkuwmFptt\u002B5h/GS8n6qshp2Un18OMIXtVNN857saHkT1G7zkgF/ths1E23DKNv94APc3M9X0vzmFgwOG8NAzR93fh0Pth8Y9pxhRyRUVIx3UBKbD4uqvAJyDXz0cJpY9EVOS6m97irkw\u002BUy9YrXksGAl8uwpb2TzcIbnamjJIUBCVLfBQjiuWHot0yld8Z3mnq6dNnPqE\u002BHu37molCBQJ9fMew4\u002BIy4nd5pyO5x7VX8pAIu6LCsMWADV0mK\u002BxcRZnasRkbaP6LuAtb6ZuBhFs4p6g==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AADFC309\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "768",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "338a6b56-ac39-31cb-90f5-ec77c9662472",
+        "x-ms-content-crc64": "bsYh7YVRfpM=",
+        "x-ms-request-id": "da6c3f9b-401e-0062-63aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1c25b1cf-3db1-2319-02a6-088a97b63be5?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-684b1b9f451e0e73ac2c280b09310d96-e7a034d2dcfa9427-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cef2b379-6784-f301-6541-f1636b411b76",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cef2b379-6784-f301-6541-f1636b411b76",
+        "x-ms-request-id": "da6c3fc2-401e-0062-05aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "662467021",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
@@ -1,0 +1,245 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dced1896-544c-895d-431c-10b293e268fe?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9a1aa5a2ec5c4de30cedd03e1d4c8c3d-1f8521be0df99844-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "89e157ab-d972-1b62-091d-f6d71edcb315",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1ABC14FC3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "89e157ab-d972-1b62-091d-f6d71edcb315",
+        "x-ms-request-id": "da6c4510-401e-0062-48aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dced1896-544c-895d-431c-10b293e268fe/test-blob-cfe70b6f-4bf4-b1ca-a0f7-e7def02291e6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-12f641779c11fc924bc9bc90165ebfc3-789f9493417a4931-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a118fb8d-7a90-a382-efaa-7f27a7a04dc8",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1ABC91620\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a118fb8d-7a90-a382-efaa-7f27a7a04dc8",
+        "x-ms-request-id": "da6c4545-401e-0062-78aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dced1896-544c-895d-431c-10b293e268fe/test-blob-cfe70b6f-4bf4-b1ca-a0f7-e7def02291e6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8f0d70958fed8ac80aa2adc591a72df5-8390e1e276fc7d2a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "f5507ac7-f00a-8955-c2a2-e9e4303c5146",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1ABD23C8C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f5507ac7-f00a-8955-c2a2-e9e4303c5146",
+        "x-ms-request-id": "da6c45a5-401e-0062-56aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dced1896-544c-895d-431c-10b293e268fe/test-blob-cfe70b6f-4bf4-b1ca-a0f7-e7def02291e6?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1ABD23C8C\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2c607fac-5850-adbe-0eb9-c75840818f6b",
+        "x-ms-content-crc64": "w6uzPBVR6is=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "sQsTjpRqZ38vfoW7e7ZOEGGLBjwA3oxVGpfxjiAQUXnewvUuHyzxQe9iWvNTpp9Sz\u002BV2k9V2FNN/vnT9eNhfHi0M3LjBH/A1mcVMnoSYAXP3n786mr2jaK4ir2G388kXAzvGR8rmka/1QfkQKXVO57wBBdgYJIRvaHQKn3COfaX7NZtI0bqpEQ0QRVnEkz4408iktu7w/t63V95V3PI/ZsNTFfPaBRUCV/TLCN4qq9U20cun6ce3Cja8kXrbVDUb0N6WcH1KXs2zol75Jfb/jKwJHwoml3z8nAq9HXSaJwO/rzcAlDpX63P\u002B9EdoveVAvQTO0TQq9ThhmdNzjUFYGHtbOna\u002B//hxsjOWJ6M1lN8lfF9vzFXOlLr\u002Bnvpm5F0ypdvLDIJvgr0MXR8AlM2VLAX0TRHh6UwmjKa7v2H9Cs3WZIHHaYdctvmiY281zQDtaXL1cpZMULyPpX/cs8JcDlJSKi9LzcJ9mJcXP4Xd8L\u002BmzlbvB5g2ihPFOMQHfwI3",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1ABD8F24A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "2c607fac-5850-adbe-0eb9-c75840818f6b",
+        "x-ms-content-crc64": "w6uzPBVR6is=",
+        "x-ms-request-id": "da6c45d7-401e-0062-07aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dced1896-544c-895d-431c-10b293e268fe/test-blob-cfe70b6f-4bf4-b1ca-a0f7-e7def02291e6?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1ABD8F24A\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b0382522-24dc-6ff6-a153-41a3de192213",
+        "x-ms-content-crc64": "SuCnR4tpZNE=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "RVUc46LQoZyveNn/NBE3srXANuRsbQa6G6AbhpT9dRiU4PkwwAwc1S26P4\u002B\u002BNlUCjoYPRkkdy9hOYsgCtRoHsQLBa1QYBvGopGC3si52\u002B\u002BRKGfgO7i/OdhQh4V5EGSASso2N/csA6oeVZ6LpZhmq12bjt5si\u002BcPT8vQ/9iSSY4pApf\u002Bg6f4YSS9weIeM5RD7dwn4YWKE77nJugrXwfNiAwMXqMAZCe5nym1ssoA8Rg3kQ38amQIou7VF1i70QYg7DXWDdTxP4W0akZf0GD05jXP88n10R2oB7u0K1DLAcojlMaQLuNHQlGIRAAhrNKN4C0m6\u002BE8Lx8ULgoZPRA07Wh4OD\u002BeZLtSiLF0bYkdilrpJksjpBXo52mneADZKgFBU1qXpXCW83910GMvx72R\u002BqOzLBrJEUVWj1TV9ui2eV6sNxoyieDmVjLPqdO2uR\u002BoFYFdKfnqeEIRPRYfwPySv1sAg4ynY2zCyNnn\u002BWd1o9I1KeFrWU9gxb7YHUzKypU2P",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1ABDFA80C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "384",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "b0382522-24dc-6ff6-a153-41a3de192213",
+        "x-ms-content-crc64": "SuCnR4tpZNE=",
+        "x-ms-request-id": "da6c4606-401e-0062-34aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dced1896-544c-895d-431c-10b293e268fe/test-blob-cfe70b6f-4bf4-b1ca-a0f7-e7def02291e6?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1ABDFA80C\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b35a8c1-de49-778f-aaa9-21d76cff41ee",
+        "x-ms-content-crc64": "QjZb74l5btE=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Op0sjmPALIQml0gBn7am51H5pcbJ2YLn73Rz0Ij\u002B/5Erbx4/O2YpiUvVr7uQMND/YWvhuf\u002BHxWEaRZ7vTVz8KJi21S\u002BYZ6vqzxt69CnGVr\u002Bkc28cHEaRpKq9JPbHOjzv2Ycj2lqgZ/rA9unkDNE4VO7fStnt4AtRJDGF2kK0I5XfixqionxkAwx1WyZdrZfZhNAI5\u002B9iAvl70rUoG4y3DNNUBYC2lrFxekfNeITl83eZq1VxqzulfIkhJs/GPOh/vU9SCagWI\u002B4flm2olIl0ld8\u002Bj282RmCYroj3lG/hqz5eTbs0k\u002BrPg4hnUhTN/ej/rJDwiK14SXbuulsfH49/PQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1ABEA2DCC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "768",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "1b35a8c1-de49-778f-aaa9-21d76cff41ee",
+        "x-ms-content-crc64": "QjZb74l5btE=",
+        "x-ms-request-id": "da6c4647-401e-0062-6daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dced1896-544c-895d-431c-10b293e268fe?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8daa7c14914be515af0e3fc378e6b9fd-1289ba1ecef778e2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "36e1e69d-07e3-eac9-fd8d-46e09cc192dd",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "36e1e69d-07e3-eac9-fd8d-46e09cc192dd",
+        "x-ms-request-id": "da6c4678-401e-0062-1aaa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1418150777",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-59967be9-68f1-dd4c-5802-69a172d456eb?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d6fe2fc7b9a1743a258e02918e0026f8-1c7b5d539ebba7aa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "7f920f1a-25f5-3c79-04a2-8a2cc87a6a9a",
+        "x-ms-date": "Tue, 09 May 2023 19:14:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:51 GMT",
+        "ETag": "\u00220x8DB50C1AA6EC340\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7f920f1a-25f5-3c79-04a2-8a2cc87a6a9a",
+        "x-ms-request-id": "da6c3cb7-401e-0062-45aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-59967be9-68f1-dd4c-5802-69a172d456eb/test-blob-cde0a05d-2ec9-371d-61a8-8c49d396f870",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d268ac8fd808e49ada8ababa215fb5fb-90b351a22c37bbaf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3ace0faa-d745-df52-3473-cc5d3e6fb0a4",
+        "x-ms-date": "Tue, 09 May 2023 19:14:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:51 GMT",
+        "ETag": "\u00220x8DB50C1AA846A10\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3ace0faa-d745-df52-3473-cc5d3e6fb0a4",
+        "x-ms-request-id": "da6c3d4b-401e-0062-49aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-59967be9-68f1-dd4c-5802-69a172d456eb/test-blob-cde0a05d-2ec9-371d-61a8-8c49d396f870",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2cd43d2e539165aff483b52d7c139550-70ebd4f539716d4e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "c49fa20e-bec7-512b-d5d9-014cda8ed69d",
+        "x-ms-date": "Tue, 09 May 2023 19:14:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:51 GMT",
+        "ETag": "\u00220x8DB50C1AA8CCD48\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c49fa20e-bec7-512b-d5d9-014cda8ed69d",
+        "x-ms-request-id": "da6c3d7b-401e-0062-77aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-59967be9-68f1-dd4c-5802-69a172d456eb/test-blob-cde0a05d-2ec9-371d-61a8-8c49d396f870?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AA8CCD48\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9c4e6374-ecd0-cddc-9b02-4d3df8ecdd25",
+        "x-ms-content-crc64": "otF6AHp4B2o=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ZbZi/lxr9W5nCCrvgQ/k\u002Bo7ah2NB1/VRs8BgrPDmxLSWTNdC\u002B3YxrhkkGOz6ibr0vpCe7fIHWI7AEEqcC0l\u002BgER2WDQ3of4XqdlJHb4JVikFa\u002B1fSNfBj/RJgeorlaLQpZeohDCFvByRh0QZvTrPt7kglqBbHjhstclA7iAT6xM2eHgnYNL5gK7RzcCSp9G5eskwC/4CdYdeO89nRM78fZsw40TCp1bnJxbxilB32g33h3NW4uAVMwPwyCQDkTvg1U8lYcSN9tJySeToEes25mHBcLxapZu7G69B0d8x5JXaEbUAUnhJapCh45n7LSIYuuHDQSF\u002BhS\u002B0aUYUSyTzQGVODf81NZTpeAYsucEBv\u002B6NKBf9bqJ0XIuFS\u002BgxNR5sraI0rR8i4oRN2skaUsxts6pYhyMN9dLC2bF0sOqrt0LovwsfzBLOakaSsJPYWQm/F5g\u002B2a37XrjQcdNurjKaoSOGMpLBTuaYiRzde0U\u002B6n\u002BotZhSbd2U7GFTTls\u002BYLwT\u002BA5wUSd2/cmxplCRHuNykYdTxviZSDRF8UUxbv\u002BLWShfyYI3zphYMbfPoMaNA85\u002B4L3T65rDebDZKl/hRY/JJkwnMlRgOsLv\u002BpRByqdtuO52s41Bt26Om0/SXaQ4d\u002BwoBXp6ZdF6Hab75PAFgq8IbHFxapIBh27emJYFjdwet4KoGcQt81Id/JXnRtN\u002BiRmgyvEyxg1aJn4LnMw7dI/J3SxtXWnq2ngeU238GkCbXw98ZcPr6/B1TvJGIlaF4ogGHWmmECuwte94E3OgXQs9cDy9vg/L3vE8\u002BA92pLgimHHk9vzX9E7jzK/Tcth91PDmCLEayCN4Oj93ahgcORE2VnoBu2cPZnzt2fJf92sZvyMfkJsHB9BNbLu8YIk2x5KdnRxdexmI16I1LO8xGELUXar1/al1L06qs0\u002BrUgXytxJfwlpPvEMJlrj50tvgHFN56ALfQcnpKG3NssfK3IWcQnXd0VbnhaFm62bxfF1zyZf8MmkDE3ZIdpntggl8P7ozXI9lA0r8kmNgeFVi96sPWekvzqobmC//lFq8\u002BgKY6qysvSDODsVM/6AGo5sg5X7u3SgfTHEQF8NfZm7vP5hgyI2ptjqLQUsj484KFPWU3q/czhzaeJ06nKZcbqdWXcAHptoNdy5EYpzd/GmiBQLNy4i/E3B7hlDvbhqTL9KjzIYOAm4bh2aAl2uA/Hw0l5ajjqMfl0lPjB\u002BKHQgUsTPJOS/jlAOTskQhPnwF\u002B4nTu9aD8KAvhDU8vnZOkGlea\u002BY3tsJMUQOSD9te/ljNSpCWtmIxkcCSmrX6ptWNRCLaw9OWzUTGh2nT8ODF0Ibcb3TluNkHLNolpBwNUqotBcq4hA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:51 GMT",
+        "ETag": "\u00220x8DB50C1AA98163F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "9c4e6374-ecd0-cddc-9b02-4d3df8ecdd25",
+        "x-ms-content-crc64": "otF6AHp4B2o=",
+        "x-ms-request-id": "da6c3de0-401e-0062-56aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-59967be9-68f1-dd4c-5802-69a172d456eb?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4c1ef4b5cb1f7e1d14a3924480a2468b-e13d2e8ae75905a4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76d793dd-3a3f-aecd-cafd-d6a12995b7e9",
+        "x-ms-date": "Tue, 09 May 2023 19:14:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76d793dd-3a3f-aecd-cafd-d6a12995b7e9",
+        "x-ms-request-id": "da6c3e16-401e-0062-09aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "719175826",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4bc997fe-4fa0-2b56-e0df-9f8e2c251497?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-585eb14ccd54b567a839981117261810-704c700d09db0fff-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c64fd8cf-1a59-904c-8cb3-a929c7e2aca1",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1AB6EF63C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c64fd8cf-1a59-904c-8cb3-a929c7e2aca1",
+        "x-ms-request-id": "da6c42a9-401e-0062-2daa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4bc997fe-4fa0-2b56-e0df-9f8e2c251497/test-blob-55cf0b5d-6d63-0355-eefe-8989c53900d4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5bb98be49866ee1182ccb71a0ce5255c-06cb78534eec4ede-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0172a18f-c24f-f098-7b68-6beca417064b",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1AB7731B3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0172a18f-c24f-f098-7b68-6beca417064b",
+        "x-ms-request-id": "da6c42ea-401e-0062-63aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4bc997fe-4fa0-2b56-e0df-9f8e2c251497/test-blob-55cf0b5d-6d63-0355-eefe-8989c53900d4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d28ccfdc0b0cdc7a5a0c17f0fefac60a-7ffb60af0ef385a0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "23fa7cae-fec6-9c85-5288-d85442c169cc",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1AB811B43\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "23fa7cae-fec6-9c85-5288-d85442c169cc",
+        "x-ms-request-id": "da6c4302-401e-0062-79aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4bc997fe-4fa0-2b56-e0df-9f8e2c251497/test-blob-55cf0b5d-6d63-0355-eefe-8989c53900d4?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AB811B43\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "283e4e67-e31c-4685-228f-c6baad8d6c9c",
+        "x-ms-content-crc64": "ofq2v4jKsgE=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "7HcuLxBGKbYU1EjrSAj4buixvlTVTT4INBsvhp5ZLSAIZWK7QsfdiK\u002BYsoXSYEiEuzpAFiNYy545Jfv1F6MYuqcn4uKlPCwg0zalPJu5NdTTqspjGBb9sJnEghzM53ALgPfdq35l338OIELts48CgPAmImzYtKGQKjFJ4boPU\u002BvFmbyj24pVbctLVfjUD/0KwQEspcUEM8tVTIBMHP3E/8xWKBnSX6Rl0LShjF\u002BpvBo0Ph\u002B44q0mwWXwTY8JCVDNhlYrfefjOGFdx9QRYqZsrJBmF97dDB0fMGaz4hEVW8dj0wUJfj8zUAa\u002BWxrYFV6/g6H\u002Bo/Jy8Ho4DEyAL1VQR2sNrY\u002BgYy5RMsfYH7ECRhsI9F5wFrjU8OKL0HHysiCwbROvy2fOHiBzrXAqmtDINsYxdzv33zGyOLysFZO8XoCmJ7GeUnqzOtY9/WhHqVYSw5mrwDrluI7i/JKrIQmNt0/whHIeKuNLfT1kuuLIa45lmlL5EJ5FwG8jvFXoCBnNsEYZViXj9Ji2YEP9gP2rGZEDRYa2lKawq8MD\u002B26NYnUklwqcrhRpgqa5Qq9aRz9xd6LE5cOSFhufaKth4PgqKP3O2enzD2p8mcLg/VH2VWODkYPLyX2xkoDu/EZpB6KtjhqxjG5WfWc3R0sAsRjKqBJH3k51X16AHEdoBBIkE5IgM282RMn1LRMblIExseBoJFQzIilTNy\u002B7MXAn7XhVEjS5336pk2NJUrA6WcrdTmpmAOC\u002B8fBozPtAexNYzUCaxoFMeNJivpHw6tB5Gd1k3uIGwOyYliFDUBKCaRhQ8IRwn5NIkNWYA0JOzgcg77Md25wwUg1TAjBgCCi/31V5n/lMCXlKHE4NbbyqSccZI2BeZY17H553HJ1j54es2CTs1S4N1OY60r9OI\u002BRQqbhoRuXHYXrI/X9b1e3b5zTHYJWYvXSYC056JJLOLfy5JnLl\u002BqGh5XepJNevsv/5XuuLhsNPt\u002BtEzzqXTT3o\u002Bc\u002BDoa569uySJXse7pmc6VlPgcWmQqY5am\u002BGoSpmCpc6wSoHKxFRfmj\u002B\u002BGFIMchRp\u002BbhSMx3QbYpSjc\u002B81XCLBvj4y1vlL1H/QJcqEpF8DimNPlEhMHLwoBz3uHZEooSPMtGZE2b4hMomkrJG5ls5Fn\u002Bl75cfqdZGCGs\u002B7Xcbet3Smt\u002B/ozrC1HmG\u002Bp3AafnB/qH23rMtr4k7Ewr7uddTCxfUtAt7eXNE4xsdWK84RZ6xfS7VJJwq5OtWhI/vxxqic\u002B\u002BGK/WuhkVusjuX0BbZws2sSnzofia7qY9f5PSjlNvAuyT/slmpArbpZnJgktSUfIGCA3zd\u002BfXJCkJmDuFQix0flxUyGlBzw0eGPte0Gxa6i2hzA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1AB8F22F3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "283e4e67-e31c-4685-228f-c6baad8d6c9c",
+        "x-ms-content-crc64": "ofq2v4jKsgE=",
+        "x-ms-request-id": "da6c4361-401e-0062-50aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4bc997fe-4fa0-2b56-e0df-9f8e2c251497?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-45416657b36b984f751a61eb396fe68a-ecfe651bc4274862-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3ed835d-4182-8caf-d6a3-3715700f5b31",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3ed835d-4182-8caf-d6a3-3715700f5b31",
+        "x-ms-request-id": "da6c43f9-401e-0062-54aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1907433277",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-cddc8095-9cca-d414-1ae6-8a823117c8ab?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2bf68848fcdd245bba5abc25da1dfcf3-f71ae02baf3d49ca-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e76df521-4b9c-ce19-864b-f9ed9bcf31f6",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE295049\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e76df521-4b9c-ce19-864b-f9ed9bcf31f6",
+        "x-ms-request-id": "1fcbc4d8-701e-0034-4fb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-cddc8095-9cca-d414-1ae6-8a823117c8ab/test-blob-a7b04661-90d5-ebf8-f3bc-6ca3bd6de12f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c892844e40f9763c46f0fb337b8801dc-64c44a4a50f2e4a8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4195f9e0-eb06-677e-dc43-a89c8e6c77b4",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE3130B7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4195f9e0-eb06-677e-dc43-a89c8e6c77b4",
+        "x-ms-request-id": "1fcbc4f8-701e-0034-68b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-cddc8095-9cca-d414-1ae6-8a823117c8ab/test-blob-a7b04661-90d5-ebf8-f3bc-6ca3bd6de12f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6f4fb3717c50f4833be8c6a79a9f6e02-1e5d95d168695852-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "c3c2c094-9fd7-9429-7f76-4c5c42428e75",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE39BAF6\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c3c2c094-9fd7-9429-7f76-4c5c42428e75",
+        "x-ms-request-id": "1fcbc53b-701e-0034-1fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-cddc8095-9cca-d414-1ae6-8a823117c8ab/test-blob-a7b04661-90d5-ebf8-f3bc-6ca3bd6de12f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE39BAF6\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ce08b5db-b3a9-2edc-a327-e74125703424",
+        "x-ms-content-crc64": "T6luf1k9pcM=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "6/LwBo2b97SFIcoQKreOo\u002BUbYTuq4A//EGq9D\u002BgNHzOJe3FShfnihf64YnqACaPPvFYHgG31TAvj8fUj3ufMeAKXhq5FOx3rOdw88X6UfwfG7lORBp/Fky9mb5QEv6YX7Op36IL1iYA4G0eQuFqNTnHuXPCUOnFj0fJ/3syI53o2JQWTHJaE0GTTWepYNdvU2CEiFmK1g7F4FBePdqq0sDTMWZJV\u002BTHbaouMwOGHC5sXqgarZdEXgKJTGwh/9Fq5H6i2i9xIf97vR6zWKcLQ8Ql7eMukCUpitdjwAd4pXHUx0qE40IC/zysnux4lQFfggyn/A3yOFBZeU9UDWH0Axuo2pVYgmCGIu6igfU0sPXSBD360KVj5or2L2nyqvHetJvUz7psAv\u002BsIdkjT7pfIMRVhgUj/S5ySPAOZlL2k3v4x8lZY\u002BE7ZgU\u002BTrLMPJrMmw6hmSTourttYobKXZistZJhKovxBcDnGiAD4a5/pghZQc9EUPZXDAkN6/1ecQRokZUcaxYO25FJvoME6NkM8bx6bR/NZGCcDhp\u002B5xnHhKkbm1AVXzrySmY5\u002BpZ3UicwAPo84APkmyk0gFz/k/R7hjXV6VGI95KBiCa5l2nOJL/3TuYfhqSlMvwm4N7d9rptvnRcnWTVpwlru1vdLwO/ZluhCEESX/\u002BRMLZRYhK3p5FoS9j1cYtXIafYs89MxAf4Z3qDPO55X150y2iugET2tBfGcOcqyfTQSeaZOagwRGiyVP6YNGqm8ux6fKoeqJ1i4f\u002B3hlMg0Z2FrvMH3CGyRIb//CtGXoOpI4H2sElKsaFJOleseMIZkYdhEoV3nxbKxDgnIqhyGIN8DmLRKh1QOvlRvqXOBcvA5mqn5U/6MYRrL\u002BgNJ5L01x3QMG5fRGtmDNeIJeBw/MJwYjhBzjM3gdjeaf4xRxNqXOeH\u002BdFdZaIDPdh0bg\u002Bj\u002Bi8pnMVaswTqnLKRgNppNMnAIcj46QbtFviaQpBawxPNOnPPC6ZOD6nemV0iy\u002BTHlgkSsEhGqw0oOInIwHB0k9mexEZqni0jdhYfHlOpzksX0qiLSBLLhpNips8cgU81ZgmDhAeeWPvf7z42J4y9gm4\u002BsO3H7UfK1z23B/deBvDG6bRGJkpDeXmwr1jQkWMCpSRg3cxhcXjBuKzJ51EAfeRJbz3Yd1gj/zt0E0Hq9kHasF7S/SkkZXg7gG2ZeZYksC1wiyIlKjHIPOKU7V461sJu7zLyLYC/IQnBnPbuioGhT2MQdmsjtYotCsBKj3geAKmrLo5nMoastWYYY4062bZc8537JlxbTzWowSK8dJGRp5xJR1v3PhjcZ8EBC1X49jEJ6Z/aIt5JT\u002BNUvnFj7DzQhrvw8ZJaabQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:41 GMT",
+        "ETag": "\u00220x8DB50C7EE4133E6\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "ce08b5db-b3a9-2edc-a327-e74125703424",
+        "x-ms-content-crc64": "T6luf1k9pcM=",
+        "x-ms-request-id": "1fcbc557-701e-0034-36b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-cddc8095-9cca-d414-1ae6-8a823117c8ab?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-941791e995c272894aef8b6c266aa809-20b325c3f69294ba-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8c814280-bf3a-e1cb-8e2b-131cd9b348bb",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8c814280-bf3a-e1cb-8e2b-131cd9b348bb",
+        "x-ms-request-id": "1fcbc57b-701e-0034-55b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "164353026",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8c1f22bd-f0ce-770e-c9f7-d207d7409ab0?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-74a763a797b762ac4b500c46d6b72396-f0201aa37b4180f1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "94e6bad5-6972-be24-e7b4-c2af7e7c67f3",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF4285EB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "94e6bad5-6972-be24-e7b4-c2af7e7c67f3",
+        "x-ms-request-id": "1fcbccd9-701e-0034-26b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8c1f22bd-f0ce-770e-c9f7-d207d7409ab0/test-blob-982ac599-90c9-05d0-c8fa-8ffac1671a3f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e7758ff90897fa0d18fcef0c0cb232ac-600efa75a848acd8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3c3a0d26-2bca-d94b-a8b7-019b29b21d78",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF49CA4C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3c3a0d26-2bca-d94b-a8b7-019b29b21d78",
+        "x-ms-request-id": "1fcbcd17-701e-0034-5fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8c1f22bd-f0ce-770e-c9f7-d207d7409ab0/test-blob-982ac599-90c9-05d0-c8fa-8ffac1671a3f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bf5b8d76389ae9205042ccd855577dcb-ba4761ed8ab8cc76-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b4d3f102-de2c-0775-2a41-ca30af989b46",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF511C37\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b4d3f102-de2c-0775-2a41-ca30af989b46",
+        "x-ms-request-id": "1fcbcd52-701e-0034-16b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8c1f22bd-f0ce-770e-c9f7-d207d7409ab0/test-blob-982ac599-90c9-05d0-c8fa-8ffac1671a3f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF511C37\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "37987861-69de-b64b-7a6d-6e90665838f9",
+        "x-ms-content-crc64": "/BKLVWsN4eA=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "YIp1HoSFsHdmuE1Xk4r6F8NpMRxaBT6ZuBhAWoMM6MMPaiTyPRXkUApuLrkczCtduqrsFEtKmVtL22ZrRFb0Ws\u002BKSChmB9quhOAS69eFfezt46DYH9R3xNDJp2GueQyzetPpkoQC97LQPpBqOK6Exl55fmG2Gzv7EoNXnGB4/wrUXnADm\u002Bpo6uztCOFEDYwiReADNfuq/F\u002BY7YAAqlpSVz6Fldk9gCpzEZN1yBJZtwT3NVeAdcoPKWEQa65qaD\u002BRm7Giv3iy5cS1jyNoNTRMPjZ8CHUC0eF0dWt3LBV8CalT4y1ht/iLRU\u002BTyuWmp/QtxCx47V/Kj8nPLUkNOrivOIZ5FFIG64c98MMlbwb8zs53SWjoBBtJiVNjkomvfgqX45JfLJKhJ9mlOv2cpCDC0l96lfFQxzRqL4v\u002Bolj\u002BjnG4jot0nKE71SKPQ8kdreQzob8pNOkZRhxd9PwHooWApqyL4xWUTTa\u002BP7/PwYNqTIKmygGY1FqIn0huF6ekNDKdDpwdkcnPn1OJavUpSoWY8qd6YNiD6NFRA0TNJTaOGgqMMbLnTbu41yutD2llX1XC1ST/KdRaGSbKy46FAXkc\u002BlDqnBjSsaXswYms1tho7KTuCk8SjvA2MhiMHIEsMtWxkBUZesI98CR/E2dKrUJNYt/ql/cpCmtgtGr/RpQjv4\u002Bz\u002BkXDTnHhsBorknuI64TVPrqiQpveiIapuMZYPqqPW1PYlrL9ihNtCObc/njw18jlKQfagX3z1XK/GZariXJwmzYosFTR2LSmNTq0AYoOueD9chSitdrV5MBAPnB9wX9zbGJByCdzE1FSM0tDPtTosGC1rhZdzeVcUsuUkZlDKXO6QZQnzPG5iV/DUIKOkqXsV40PxxNpFZ995HVc34K3DgnYiP1AwONv\u002ByS3mn1izb8lpzkMNGFgUSv1quh7XarcDEF5tgqorJapn8vvsnshGhe2NjdIq9qneDbRShb79J552o486Re0ffujYpSVcJ\u002Bw04/QxCZylGBm0j7T1mF/rastddft5TEAAbk7pUlGEQeXIXeHKi94B0Ut1RfY4aaaI7ToaPvHw\u002B1e0MNsNu8XIMA3PLXq\u002BIJ8tG6RwBAaJyAToYGUXagMz16JKVpsC9BWFbRWoaTxsCoxbLSMNgLdQ6mjWZVtg8MYKmxWYM8oD6idO6pbw4V7IfFXY/D0f5lbq\u002BWwybI76ZLwPnY4mk9bCFwL7/pXgYAjJzejFR/TI6vT\u002B7XpeEb2YVEYa4UPQ4eh\u002B1qT6I\u002BeAypljKF6l9NyHRrLZJ\u002BacY8VFY6pPxb7FOSwAhrFPzobNfeKhOule8l\u002Bpk1qRN7nB4rKfdMB9cQUaXi9ypW5rd7gry\u002BnD\u002BykcA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF5735D0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "37987861-69de-b64b-7a6d-6e90665838f9",
+        "x-ms-content-crc64": "/BKLVWsN4eA=",
+        "x-ms-request-id": "1fcbcd89-701e-0034-49b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8c1f22bd-f0ce-770e-c9f7-d207d7409ab0?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-07110848fa2bb06ded7a216b5ae4e1fc-fa20b2cb8bd62c93-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "37ce5d6e-64ff-e868-c54a-465def3c8e2c",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "37ce5d6e-64ff-e868-c54a-465def3c8e2c",
+        "x-ms-request-id": "1fcbcd9e-701e-0034-5cb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2066996695",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-48e0971278c8a42130d619add1ab67eb-55366051bdc646f8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d8175142-c5d5-5ed0-63d7-6534336de7c1",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EE68E7EE\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d8175142-c5d5-5ed0-63d7-6534336de7c1",
+        "x-ms-request-id": "1fcbc664-701e-0034-1eb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-38cbba5f776f1917eca52f6c6c808bd6-d9b4a87176529028-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d451c5ed-d87f-8356-9dce-f5cc9919d485",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EE70EF6A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d451c5ed-d87f-8356-9dce-f5cc9919d485",
+        "x-ms-request-id": "1fcbc6ab-701e-0034-5db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4e42177802ea04c046da103988d7d828-ebf3650ef053c3a1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4e971519-3895-48a2-9d7c-244e82d71fbc",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EE77A526\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4e971519-3895-48a2-9d7c-244e82d71fbc",
+        "x-ms-request-id": "1fcbc6dd-701e-0034-0bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE77A526\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "84b329a4-8582-cff0-a6ca-3723acf46e0b",
+        "x-ms-content-crc64": "tgGxmv4nQbc=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "4bZq4bFpy1oBGTq5uFhLzF6lqFVilxEULWjKVTlMYQwTje3waGpH2YW817uLF6YKi5jWjsSSXkmlVrNInnYhtLgtpSprW2T0Xc/PpcBViRXCv8mgdtNIgS\u002BjSxG2/joOmyIDXXJ7njAz4TD1wrmIT82dht6tgD7k5ST7yBBTPV\u002BVwQqeUSujRyGZbZSjU792GvtDGHhbYRrkHnhOf9Yg4KTRXwGu6v2i\u002Bj69ExOpQZJkha4UDyXmOV/wujOzVcdKeYzw0vO9xy8=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EE88E0B9\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "84b329a4-8582-cff0-a6ca-3723acf46e0b",
+        "x-ms-content-crc64": "tgGxmv4nQbc=",
+        "x-ms-request-id": "1fcbc762-701e-0034-08b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE88E0B9\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "59aafc43-9b23-8539-2142-8d13b5dd6f8d",
+        "x-ms-content-crc64": "8drn5gwaFwk=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/aEeOZ1NBzrc5en6KAvQfuolob0wyu6kd3Kahrhvn6e9fhZuB62cEeh/Vs1szSJtu3HnzRsJ/zOyecIqsoCCbUZBPKn1Ync9iZDVsHQhN6lQLctGh9GLs37ju43qcV5o/OmGKpF5eFj6qkOLNE6\u002BkUIY2oW1O\u002BV1togrEafqUhcxbLOLmg0Y17VyTN2N/38vJClL0pfZs8EDEXMITWaxEFgsWsibM/c0AAPPQu8H57cJ\u002B\u002B19n4CAV7jyh4iZD4lOwDuFYaW2lPA=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EE8E371A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "200",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "59aafc43-9b23-8539-2142-8d13b5dd6f8d",
+        "x-ms-content-crc64": "8drn5gwaFwk=",
+        "x-ms-request-id": "1fcbc793-701e-0034-33b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE8E371A\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b0e00667-1449-69e8-fc5a-172068da7737",
+        "x-ms-content-crc64": "YvS/g\u002BFCmss=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "MRbRkwlw0fwqvP9SeDNx16sCD6isb5vweoCBs4KFElJn/UyIruxOSCCLXtwPNtaNyq22oqfsRMJ64RmI7h55pKqs63vn6Cm\u002BtMeHIBC\u002B4EOq9OnVz2\u002Bre7iJDc3TxVkCErkyY0tapuGE9\u002B3fZCOxvADV3fo0pNQ6AW/DXdpc6\u002B9uhA5Xi333UE4HUNiCyxaU11HM/edezW3k\u002BGHbl0gGKAv\u002Bcd8VWjCD3Y2sLVP8tzVZLoaJj\u002B4HD7agcpMbHLgGACjMg1o3f3w=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EE9B2D7F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "400",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "b0e00667-1449-69e8-fc5a-172068da7737",
+        "x-ms-content-crc64": "YvS/g\u002BFCmss=",
+        "x-ms-request-id": "1fcbc7f6-701e-0034-0cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EE9B2D7F\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aeac2eba-bffc-dd44-fdeb-b333e7a34561",
+        "x-ms-content-crc64": "zM2BVxxmVWU=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "IEkfWbKgGehALIJpwX2YHfZhKHTonWfB1aYsKy802iGvCWhGz65dFoaJU\u002B\u002BZT0SDj6\u002BN\u002BA4Kk4PhXYQMdO64DFFgubgUUk5IBBLtX0p3J4ViqJuApuITpHXlZHEqUaGY0UaeOZWLbj1hRPT8HDQ5ajX\u002BqctTOGVvTRRCL\u002B3cHrJwVY0D2e7v1jpdHmHtFohAq/o7K6fVRJjgLuuBSD9QhSZBi8emNpBHDtOR9hkDgTaMAYTzoPILmhD1IqsCbo36DZk7rIvAmnU=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EEA2F484\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "600",
+        "x-ms-blob-committed-block-count": "4",
+        "x-ms-client-request-id": "aeac2eba-bffc-dd44-fdeb-b333e7a34561",
+        "x-ms-content-crc64": "zM2BVxxmVWU=",
+        "x-ms-request-id": "1fcbc82c-701e-0034-40b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EEA2F484\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3966b18e-c82d-4c3a-f965-6205ff705c94",
+        "x-ms-content-crc64": "tIHh9Hh1s94=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "afQd00ROft2ttfRHulzkMzbwtrET5USfRZbogMjVq8tnD4ms1TdWwnZF/U15RkCwtQd1mgroYYSvfY6uZf4U1wkp36vTN17\u002BmvQ7zuf3Jv9WOMrAXxHBfq0E/VipqFx3MCZEUGaU3X6pd/8VrZKduFaOVy0zU3f3Z2D9zjkGVfKXw53BstaZwlpMF\u002BgRq9EaZ0UBG1AuRNyuTOgFlg5EoyENfen13AWA9JXS5jyP5ryP42b0BDqhaX/BEmbtkytLCHTGAy3nJYs=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EEB58F66\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "800",
+        "x-ms-blob-committed-block-count": "5",
+        "x-ms-client-request-id": "3966b18e-c82d-4c3a-f965-6205ff705c94",
+        "x-ms-content-crc64": "tIHh9Hh1s94=",
+        "x-ms-request-id": "1fcbc8bf-701e-0034-49b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7/test-blob-c8de8669-e2c8-a78e-bddb-b58413e60d21?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EEB58F66\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "35a4e8ac-0b3c-4733-feb0-8112c567b4f1",
+        "x-ms-content-crc64": "P5bNGg8mNfE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "P4Amu1tdoB9mK3azqE\u002Be52wUajTJn5Jg",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "ETag": "\u00220x8DB50C7EEC03C37\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "1000",
+        "x-ms-blob-committed-block-count": "6",
+        "x-ms-client-request-id": "35a4e8ac-0b3c-4733-feb0-8112c567b4f1",
+        "x-ms-content-crc64": "P5bNGg8mNfE=",
+        "x-ms-request-id": "1fcbc91a-701e-0034-1db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b3ae83f9-07b4-f327-9fa9-9eeba67970e7?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-051336bd4d00f8279282cd20db98906e-0fe8dc15defecbd3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1758b080-27cc-ab57-8744-f484cedbcd5a",
+        "x-ms-date": "Tue, 09 May 2023 19:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1758b080-27cc-ab57-8744-f484cedbcd5a",
+        "x-ms-request-id": "1fcbc949-701e-0034-49b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2131793103",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-df1054b61918633a1744f2e788d88d67-8f1a7f20b6d5932e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "584f7316-908f-74c2-ef82-c0a41e865a5c",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF657209\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "584f7316-908f-74c2-ef82-c0a41e865a5c",
+        "x-ms-request-id": "1fcbcdc9-701e-0034-03b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bc1d51f8e0ccccd86e5c4340e037eac0-ebd5ff341ba5cacf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "278de192-0423-f195-b19d-0a43616592ee",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:43 GMT",
+        "ETag": "\u00220x8DB50C7EF7C1D7E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "278de192-0423-f195-b19d-0a43616592ee",
+        "x-ms-request-id": "1fcbce50-701e-0034-03b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6a2119e7bd0e6fd684dea54891a582d0-904ddf3154828efb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1b10e0cd-e17e-d27f-21ed-25a2a3f82368",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EF832152\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1b10e0cd-e17e-d27f-21ed-25a2a3f82368",
+        "x-ms-request-id": "1fcbce78-701e-0034-2ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF832152\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "80758e13-7655-be6f-fa22-f518bcd53d99",
+        "x-ms-content-crc64": "N2u7Ra/uTp4=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "SICyqKvJpCyT8ukF8SVBA4XZLSUH2EqVuvl9teo2cN3w3SEcy3mkTM8ixJ2mvYPKQLweRFg0VXA2He2yTO9CXIEMFRQDJTgLNeFW5BOt7v12s3UtFyyEu4ex5q6M8gDf4GgbmqhuxhuEEg933nFciC7wPJh5FERVh1mMUj6Kf0LgdgOrkVRUB\u002BxaqAUdDdwWVF1/m7ZnZssjxhJO4nPc\u002BZPMl2dtsffamzSsH2s/N3p9df7gC\u002BOMeBA3h8pBBiR5fa5xUXZ1qaI=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EF89B00E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "80758e13-7655-be6f-fa22-f518bcd53d99",
+        "x-ms-content-crc64": "N2u7Ra/uTp4=",
+        "x-ms-request-id": "1fcbce97-701e-0034-45b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF89B00E\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "158eaf01-a382-6f13-f758-6e7e1eebf394",
+        "x-ms-content-crc64": "BBYkQkUW8PE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ZqQAgbtGX\u002BSPmNFtdfzurz8eVjUqLJmUEDOivc3mBAfMW3pm4wq8ydeiO6g1twOBwMIRVx5zeDoLbHGIpKIWqJPJoBmCiMw0Yo1dh/DwXlgvIP0L1a3pWOJAW3aZMyQ1jJMUbBbp/jf13PSRFfFJGg0ZWYOlCtLm4Eg3Qi1Vmy5oKPpd2/JBRSHFFfm4WELx9kBpgNqgj4HALovOsrwKoEDGKO327D8a1xNh4PXZLogFRUvt6xtTx5h5nK1nc5Jlu3W48S9V\u002Bgo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EF8FA29C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "200",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "158eaf01-a382-6f13-f758-6e7e1eebf394",
+        "x-ms-content-crc64": "BBYkQkUW8PE=",
+        "x-ms-request-id": "1fcbceca-701e-0034-75b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF8FA29C\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0d167773-2846-cd16-659c-a8ccb25c9af0",
+        "x-ms-content-crc64": "e4UQQZ7n8os=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AE\u002Bpxj6vjOb/A8htcR20JXJgVH1PkrJjgfwkfyE8WLBKQOyccY2J6ey2rWOqJfOdwZN/zwB9u26cRUVBigzFw6oXIjAxF7Pl12uQmORPuFwJh76NvYmwzYV9/yxHR17g8Oq5kwPDbKnfmfeV7SKKTYzpOANONwUgZlSqsxeGnZAMr6j6lSVYRRoUriSRG99j87KgXg5bkbjkmCyuGLmRWPtniD16kLdmkPPpOYnhj0t1R8Bl5j\u002BBsB7vFf35qixgg1UpKpKh6WI=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EF960A4B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "400",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "0d167773-2846-cd16-659c-a8ccb25c9af0",
+        "x-ms-content-crc64": "e4UQQZ7n8os=",
+        "x-ms-request-id": "1fcbcee5-701e-0034-0db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EF960A4B\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a70a64e5-e5d4-454e-e551-44fba2844156",
+        "x-ms-content-crc64": "I3KiJz2l16A=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\u002BjnOG3JXLwMJ4TjR\u002BCtyu\u002BbXH4p6um3lxoi2M7hkuNNeXWuscWY\u002BxsAR8xdxW2dX421Eu4Je6D/L6FTpoPtLpChlcpvAxUp/mFjKacdVdGogX1BLIP1RAHUr4IgSVCXExk/vDOnMlh0ixCIpk394dXPpyUGqAIMrFHImlOTBbUQyBaJ4ZmiBU8gzKFzaJ2z2s2oVKIvkGsbLw/h2pgE4YFfe9o3c/w8LZ3V4d9cnUewGL\u002BF5rES4TuvbrKJvC63H\u002BscE\u002BzDeGbM=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EFA0900F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "600",
+        "x-ms-blob-committed-block-count": "4",
+        "x-ms-client-request-id": "a70a64e5-e5d4-454e-e551-44fba2844156",
+        "x-ms-content-crc64": "I3KiJz2l16A=",
+        "x-ms-request-id": "1fcbcf0f-701e-0034-34b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EFA0900F\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4de74ef0-f351-871b-cf1f-6980beeb14d9",
+        "x-ms-content-crc64": "eBB7Akhy5Q8=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "WwnAFWyj76NyC3B2IL60EiWoogFSbJxcyLF8DyJVuycWLR6jhKLiSOwJL2OaNqY8E/LWiDsYYO5tY027J9\u002BBHU9IYPOgEY6DxloUST04wZEKP/swfzPr/cwwNSBUJyEMiBEUUtWznAJkUsHhAxexNaK8sOfkUJ4cXGMmb9ttLp84CMErJG\u002B7VqP5zCxxCfm1fgB\u002BmHY5KDdz9/VyjCwn9iQiqftVhhEyAFlE64RyqlJpcfHa7pUo/9\u002BKtyx5Scl20dUHTmD9YPg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EFA76CE3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "800",
+        "x-ms-blob-committed-block-count": "5",
+        "x-ms-client-request-id": "4de74ef0-f351-871b-cf1f-6980beeb14d9",
+        "x-ms-content-crc64": "eBB7Akhy5Q8=",
+        "x-ms-request-id": "1fcbcf49-701e-0034-65b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da/test-blob-ae19cd8f-5b6a-6bf1-11f8-eba2fc0b09a2?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7EFA76CE3\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "540afc84-f39d-2d04-9700-d718b9b7b0a5",
+        "x-ms-content-crc64": "MZb3CFIdHMY=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "70uYHPU9swBNogkbO0wIj/qpG8vO5Lm3",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EFAD1155\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "1000",
+        "x-ms-blob-committed-block-count": "6",
+        "x-ms-client-request-id": "540afc84-f39d-2d04-9700-d718b9b7b0a5",
+        "x-ms-content-crc64": "MZb3CFIdHMY=",
+        "x-ms-request-id": "1fcbcf66-701e-0034-7db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-4c816ed7-2b50-df8e-82a7-2944995630da?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7eb0e11dda4ac4dcca3ee2ea8b45feed-56fba2f92d41b288-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c2fcd49f-bfe0-663b-0877-b5952d0a0775",
+        "x-ms-date": "Tue, 09 May 2023 19:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c2fcd49f-bfe0-663b-0877-b5952d0a0775",
+        "x-ms-request-id": "1fcbcf8a-701e-0034-1cb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "884870174",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
@@ -1,0 +1,245 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9269f485-0281-d0bb-e10d-f8693bd3a8cf?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ece010e4755428d947b69356f4fe05c5-fbc71334eab564aa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d1303ab0-0997-8502-cb8a-1b7fb7407040",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AB206CB5\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d1303ab0-0997-8502-cb8a-1b7fb7407040",
+        "x-ms-request-id": "da6c40f4-401e-0062-21aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9269f485-0281-d0bb-e10d-f8693bd3a8cf/test-blob-5e6d9a5c-b5a0-7089-b17f-ed12b0bcc291",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-febb06ee99ca1726d53530c899ad87fd-c09a846225280919-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "f3fb66b5-1845-7de9-3a02-ee9f45e942f2",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AB285A0F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3fb66b5-1845-7de9-3a02-ee9f45e942f2",
+        "x-ms-request-id": "da6c411a-401e-0062-44aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9269f485-0281-d0bb-e10d-f8693bd3a8cf/test-blob-5e6d9a5c-b5a0-7089-b17f-ed12b0bcc291",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b25aad938ce36a1e2175d41493c72d91-d860f5d791dbfd8c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "495c68e4-cec0-274c-a3de-8cf390614308",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AB31CE87\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "495c68e4-cec0-274c-a3de-8cf390614308",
+        "x-ms-request-id": "da6c4153-401e-0062-78aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9269f485-0281-d0bb-e10d-f8693bd3a8cf/test-blob-5e6d9a5c-b5a0-7089-b17f-ed12b0bcc291?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AB31CE87\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dcba2829-f88c-9531-f0fe-02436e974c38",
+        "x-ms-content-crc64": "GQTQsTWPC9I=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "zq8IBWXHW3pUz2uRcEMKQUCguAGj1jhkCnVlA\u002B8g4uZ/UakVl8fx6d\u002B1fcedcRWHgNk/FodvnPd3o/rwYVeLM\u002B2FER6a9ap5r88h7llwxplf3YMV4cteELSxnvPMAYeHKUnaGGD27Ysvxme3Ta6eB91hkITUdlIiJgFq6Fe2rK1ImsUQlq44aPD45htkp8IGE5YWanADs7P3t/JfjAQ0eBm6b7PpjXAvKSeT25A2vX4/ZNXAoEI8ReYSGd672dzsxG0CqjgOHYUm50FJb9ciwPpzICgudNjWfSnM1nSRc09LpxciNBNGMEZPmbkA89UP71nkSLmzvVCVKywOQUYRlHPx/ce/AIvmLO/h39oe1opTvecbrSqWmOrHjQnnN\u002B4APgVFDvUNT\u002B/N/RzJ0d11dlWiuoRe9uZJW2Xd\u002BHKC//QA4KHU2ceURW74Ta8OzMYMURa0RH1qokce/LOQMFZ8S/4nyPE8oJ2NDXQVZqk3O46e0Kdbzrp3lT5ZttwTAxUX",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AB3D6589\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "dcba2829-f88c-9531-f0fe-02436e974c38",
+        "x-ms-content-crc64": "GQTQsTWPC9I=",
+        "x-ms-request-id": "da6c4190-401e-0062-31aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9269f485-0281-d0bb-e10d-f8693bd3a8cf/test-blob-5e6d9a5c-b5a0-7089-b17f-ed12b0bcc291?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AB3D6589\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "68ca4818-66a7-607c-da99-69c5f11e4b43",
+        "x-ms-content-crc64": "oi4ywcXD9uY=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ewGx5gPV0LB5JjYIVTye58Ek8l\u002BvIX1EsDKy4urAegpf/uqnhlSLyQD24qiDbkABu88b7xG1aFqEbDbQIu3GuKssqVdR92FtmSlfuT/UwEHysCcbpYr5qZaQIhkduqYTMCn8V8XpsMNurlbnVq4br6z13nLFqxMhM//AwdVHT9\u002BDTIkV2Gl7CABjrPc0EVPndXJsJ9s0TYUW2yPGKO7uJl52ZAolBddDetZxYf4c7CGr2Uxi2ycDT/4D//1FtN8RdYaYvaxJwW\u002BaKa0EwuyG\u002Bu4BGk\u002Bii0s2chULIQbZ/cX3X\u002Bx3gy51YRjcx7F6/owSfQQPQ5mQb\u002Bk7YUqWPZ9pwSvoDWL/D3a/jLg3xsSZvHOJ\u002BaQByrorZvADOyLj3iR4cgaGkvEpEm2OT7bgWakloqTXDUT7aPZxvKZy/NNU266UvlO9EyqCX\u002BY2cnsDSg1G3pl9DNDffQkQFNVKthaaOXMITJpVZ496VK1dxPV7bnKZKx4518/dtUFJrf5VOKjQ",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1AB4C577A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "384",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "68ca4818-66a7-607c-da99-69c5f11e4b43",
+        "x-ms-content-crc64": "oi4ywcXD9uY=",
+        "x-ms-request-id": "da6c41db-401e-0062-76aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9269f485-0281-d0bb-e10d-f8693bd3a8cf/test-blob-5e6d9a5c-b5a0-7089-b17f-ed12b0bcc291?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AB4C577A\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "262b4282-e3cd-3b91-e84e-d02e153dffe8",
+        "x-ms-content-crc64": "4qU4nxJtDUM=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nDkH\u002Bv5z8XYKArgigbgUlKVjsYv4YGKkK5ZYC7qQJRsFjSe8dHNzJTqnL9QWujOINRhY8Ycd1zzWYs9nG\u002BW8ed2cHfSRVyAy74tRUDCNjXBjz9aiNzOU57Xr5hGkDApU67b3ep0/9973JgL7zIcLSNReA0sPGkKpCDU\u002BpnEPjeOB/GV6lhPTJNj3qhAxmBsu3508RQi\u002BRNF0TXFnAFFs55kees8hkbLBi99zF28xeG8ZD8bT00jbwreTBkiibCOGi8J3Eh5LDE7re7ooSy1hQtUCTfCLmBRQQ7cYjotpHx\u002B77IysuWVRzgN46FiOsneKMsNynx4z\u002B/KuJs5mM37Cgg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "ETag": "\u00220x8DB50C1AB530D3F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "768",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "262b4282-e3cd-3b91-e84e-d02e153dffe8",
+        "x-ms-content-crc64": "4qU4nxJtDUM=",
+        "x-ms-request-id": "da6c41ff-401e-0062-17aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9269f485-0281-d0bb-e10d-f8693bd3a8cf?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cd57c871b4cb5f4e9af40ba31dcde13b-175ad2de4d13251e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af426479-25f2-ee76-8f84-5ee64b4d95e8",
+        "x-ms-date": "Tue, 09 May 2023 19:14:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "af426479-25f2-ee76-8f84-5ee64b4d95e8",
+        "x-ms-request-id": "da6c4228-401e-0062-3daa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2060742754",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
@@ -1,0 +1,245 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3622e217-ba22-4929-f592-a76f7ffc2eff?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8666ded3603276df3be2c1c513c0dd46-d787b1413ee14f6d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "104bc239-9e9b-52bb-8c34-2fa5316b69b1",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC288DC0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "104bc239-9e9b-52bb-8c34-2fa5316b69b1",
+        "x-ms-request-id": "da6c47d6-401e-0062-59aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3622e217-ba22-4929-f592-a76f7ffc2eff/test-blob-af742e4c-5857-e063-3187-ad39504bafe6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0961315ed0cca6f835ffdbc1ec745791-d0cd3dfa4eb440cb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0a88dbe0-818d-07f9-9442-413672c6bd72",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC32019E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a88dbe0-818d-07f9-9442-413672c6bd72",
+        "x-ms-request-id": "da6c4815-401e-0062-14aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3622e217-ba22-4929-f592-a76f7ffc2eff/test-blob-af742e4c-5857-e063-3187-ad39504bafe6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-255194b605605329d79c26aa500bb0fc-dd0d8e0b9c2d94b1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "745907e3-a5c2-cc58-3e44-e1669ac28d20",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC3BC42B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "745907e3-a5c2-cc58-3e44-e1669ac28d20",
+        "x-ms-request-id": "da6c484d-401e-0062-49aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3622e217-ba22-4929-f592-a76f7ffc2eff/test-blob-af742e4c-5857-e063-3187-ad39504bafe6?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AC3BC42B\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6a53cddc-496c-35b0-b081-d2c71e4ed671",
+        "x-ms-content-crc64": "5JCJ/GRTXhU=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nX9hCXukZrMDnZYaQWZJCa8nNb2xHmPObwTusjM5VDOfxiWAitkElVuYDP4HoRAm6yb1CTarAH8bk5l2tbR/yUhjenpAyH/WIqBiGRFlxs30yMYNQ0r988amZfY/jd\u002BnGEK1pCaV5SOmH\u002BeVSedttczMguztcYb\u002BZYe0mmKIlpTAuwDOsCKmXuKjZiNiZ6reOK8qcwvzuaa8tj6f4EvAHolS1I7mnwWpJSQJSQtim/3d1WKzXiOJzQFZEvnkB32X40iaEJMb95mqgE3n6XCbWhpAwQvoDb9lyQeNjYwLxR2mcWXCx4tqwd3ICN7VouSRvrjfpEVyr9aINEaMjmoMn7owQHcK2JKO1QAtHwThkCci\u002B87ULCHXNMKPOZJF3jJzvGkjpWFthuUlUM5FRY/Rp6QfaZKbN3OZWAy0ep//SffNumObvevFtXXpr9tSku8zvZLtJnWf14T2iUxVuAxGJQfXd4srNum5WrMdsYiXR8Ydgb0MESOBLuLfpDSeb/xp",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC48456F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "6a53cddc-496c-35b0-b081-d2c71e4ed671",
+        "x-ms-content-crc64": "5JCJ/GRTXhU=",
+        "x-ms-request-id": "da6c4896-401e-0062-08aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3622e217-ba22-4929-f592-a76f7ffc2eff/test-blob-af742e4c-5857-e063-3187-ad39504bafe6?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AC48456F\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cc890272-226f-1ab4-ff9e-c2edc0d2c2d7",
+        "x-ms-content-crc64": "1caae4aqAuw=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "o4nUehpjB4aoNMvBgiX7XkKGODdOORPjVUmoTJG1G\u002Bq3tA7/w8yruXk2ZN1XwKu940byFzbFGmp18CXRu7v18xjhCs0X/Jt123\u002B\u002BGNQ2jJWd62lLwwO08ZqjitKn2f29QXHEdrbepuerfDy2BgKVP2SQNNBSqS8VLBgzc3LIzgGCAdZjcRXev0WBn0bH/eqXDUtuF6UtapdBr0meqjJ04q46NAUrMs1OsXSL0ArpTS4tm2UnWrdcVJY/IcHLQBQSDb2YjMnlbNt9H2UwopqNV2EacA/NTYj23uBv7BALg3FgeMNMUcFlSC6KqTtSK7H7sclfsNAFRL80oa7pdYDKcZz0zynWQAagtSfgQ6RMpLIudDpHq9KgWzMEGK8TfNOuwDifXVuIJHHCv/uoJAEa5/37uwFGgsXJU3T10ihXjDhUMoNsrUdWpk/JhOzW\u002BDYx6TCyF8HSaD1y1QrnklJIazLCU/J\u002Brjq1pRSxfP7Z81o9xOj4pHV3gslF\u002Bdc8bxP9",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC4E8614\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "384",
+        "x-ms-blob-committed-block-count": "2",
+        "x-ms-client-request-id": "cc890272-226f-1ab4-ff9e-c2edc0d2c2d7",
+        "x-ms-content-crc64": "1caae4aqAuw=",
+        "x-ms-request-id": "da6c48bf-401e-0062-2baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3622e217-ba22-4929-f592-a76f7ffc2eff/test-blob-af742e4c-5857-e063-3187-ad39504bafe6?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AC4E8614\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b55576e-09c4-c502-f3b7-85432f178f9b",
+        "x-ms-content-crc64": "0nLkmfdGJUk=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "gBi5E6REszr1/HKsIOs\u002BmeKvqc5pUMa9S9EoOLVieTYBtPvmH9\u002B2\u002BRCuAqgCy2LeB1/1jcVFkzBR\u002B8jTG3qFk4M8q2vvWHkC\u002BLC9u00eu4BvSjFVbOtwuyHLlCQW492WKG8kxR/27q/m8pQViNjiMj9IY9FILyaYy\u002B9KI8NV7BXSJpLe\u002BvVgeFuCb3lWWzJI6WHkzX8MTflJjPkvrMvrkAZ/Q2FFBDhK6Ot2xr\u002BsQXC8ATpicB6WxdiZlW37MMuQlt5z1xjRA\u002BQomuWUlYc5nEqJcquQiSDo6H2Jq27LTrcf5i/gOWpY6/1WOdU4AjBRYPgicr0g/w2\u002Biu6bSFd2XQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC55D7FF\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "768",
+        "x-ms-blob-committed-block-count": "3",
+        "x-ms-client-request-id": "1b55576e-09c4-c502-f3b7-85432f178f9b",
+        "x-ms-content-crc64": "0nLkmfdGJUk=",
+        "x-ms-request-id": "da6c48ed-401e-0062-56aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3622e217-ba22-4929-f592-a76f7ffc2eff?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-401602c73c0c300c62a88bc69dcbf468-b49cc3e12122abb1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "687e5239-a67c-3713-616a-1d3ac6babab1",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "687e5239-a67c-3713-616a-1d3ac6babab1",
+        "x-ms-request-id": "da6c4943-401e-0062-23aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1524883226",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93448e69-4b4f-9861-cf4f-ca0e4ec28636?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5b9f5b5ee09ba1eafbc67c0cd4f93235-a1e17a805fb5b7f2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0e45bd06-2a74-6700-f2cd-483f7d988a42",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AAF6F1DA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0e45bd06-2a74-6700-f2cd-483f7d988a42",
+        "x-ms-request-id": "da6c4017-401e-0062-56aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93448e69-4b4f-9861-cf4f-ca0e4ec28636/test-blob-e3e515fc-724a-63c3-7245-a73d3d8ab78c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6f37c4db9152adde628587f41016889b-520c5486369994d3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4ba2ab61-6ed0-4678-baf5-75865265b4fd",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AAFE6A0D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4ba2ab61-6ed0-4678-baf5-75865265b4fd",
+        "x-ms-request-id": "da6c404b-401e-0062-05aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93448e69-4b4f-9861-cf4f-ca0e4ec28636/test-blob-e3e515fc-724a-63c3-7245-a73d3d8ab78c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-613e02f4c466e38805d3395bf011ac15-45bbbb02f24b1d20-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "91dbecb7-6ce7-96bb-a6ea-0fd4d33e9cb8",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AB04D1BB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "91dbecb7-6ce7-96bb-a6ea-0fd4d33e9cb8",
+        "x-ms-request-id": "da6c4071-401e-0062-28aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93448e69-4b4f-9861-cf4f-ca0e4ec28636/test-blob-e3e515fc-724a-63c3-7245-a73d3d8ab78c?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AB04D1BB\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "65cef0b0-238a-bc16-2674-5a4107e0e012",
+        "x-ms-content-crc64": "YrnOoI5CrwA=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "xyhxGp1DhckgH\u002BVfwkWaQtaKB5B9eMLuPz0V7VYtpxVmR1TVHF6jwzh77VREoaWtMgZp8pD5xE9mgttgLphz8njP\u002BXrwxCZ350RXAoptqp2XaLpQxLSFbIIEb5mDQpSgCPvcdKgqvG7g8gtMosLF\u002BNc9yMbdIi7DSo3461WM9KSwt/qPkTX1batMb9GpOMnAP3bBRXrNwuXMGCoaMtAZVP1nnOrINmehSFsbkbNcGhHDN6zeyq8q4vQUwngL2jraMxvTQZzf\u002BAkPIPwfsjEyb/0YV/skOolOPbn1s3Pulm0gQF2Xidh05D\u002BjzqqyCi/D4lN684M/tviShQTi6UWVIImP/nHTmuYlo3O7gWzfnDKKMtAgc6Pp4YplBQPTkvr6Da0gIgy970hsVU8QgzWMsujSWLd0da3mpR3nbZXiURF4wXO\u002BvnklzEKIsx5T2V1V2VIbATlDhZgAOn3v1oGyiQQ\u002BmMLBzfRurIx07MGOksy/kZRCx0/XNDzavoT8NvXA1SoZFUGbkwxerFStz5jXcaewL0TtcMK0ZmOF5w5vcXaWsxeXdX2LJP2I5Br7KmWjAkzdTAaw02VnZa/dFaz97jveFhuBQPwpJQtHZYuouTv94uTCkiVv5eCxLw/NrQ5RivXeHBNKIcJQsyb7aW7Zv6x03zPHO1wVbzE60BDsW3j89dqWyZwns8Ahcd7/c3ty2HBjWc3biU\u002BYya3iD1GyY1it/nSTQ/UPTCxypcl\u002BFvu1yPefiQKqIWuK/QDvRaRubw2FUXQH3pR7Uw2haOSFGrKxLEdZEtpWA90ICUb1IAaIAza8\u002BMSGruljJDX0CbmHBONNPRhcFVwzL06X/tVOhjMGGWSuySHtKn5e9u6kYfkjgQRip\u002BLtK\u002B7ZiMh2768TFJ0C7vBU2TrCXxOa/h5tjs5Uc33R7N5RGO111EFYdzvPSuFQonMJzqjJoEfPUyzPa/n6InsxQSi/sNUC3wT5aejXyrQ8HOxbSqTVCEuXgcXApWlHXVXAngi5kfGdB\u002B\u002BjzzZf\u002BIh4k04Nn9fWWzncKC8QQTmbsgyTFiyrg4v6vUO1MjkVN4k8RxIaOb596ULP3GnCjcW2Bxwqy\u002BFbzQ/DE\u002BKTISkAx/Cl0/kmgHlNFS3q3KchOC99/yoc6myo4HoDVybc6cgZzhR5HbnLj4ej3LWzcfFooduyFSL/5N2D/PN/IylTcSxk0Q2Spxp2sm\u002BjeA629G6JmrVKKtOmGeo39iDGTGtdUGqJTqDk1frAO2OyXGvOzAeE9oh0CEdYvrciWrH5sGUERSijLaXOpMW7iu5w871/aCkZQVbj6UcjMZDpwXpIxov9rhZCK59htVHDuH1Y6Mv5ovKI4G4PIVzgfw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "ETag": "\u00220x8DB50C1AB0B877B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "65cef0b0-238a-bc16-2674-5a4107e0e012",
+        "x-ms-content-crc64": "YrnOoI5CrwA=",
+        "x-ms-request-id": "da6c409a-401e-0062-4faa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93448e69-4b4f-9861-cf4f-ca0e4ec28636?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fa8af1cb1a4e1141bf2dae568a7e2fb7-d15c181549e9cc41-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e2243257-3770-b02e-ab01-146d314c4315",
+        "x-ms-date": "Tue, 09 May 2023 19:14:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e2243257-3770-b02e-ab01-146d314c4315",
+        "x-ms-request-id": "da6c40d3-401e-0062-03aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "645320086",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
@@ -1,0 +1,171 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-68a39f08-fa59-4b30-62b2-d28b99ee4fcf?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f7f79fc8f045b6c3d9b8b85bcfa9fbe5-36849c6c9c305bac-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a815831f-bf05-b512-83b5-60e7b0edf03c",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1ABF8F955\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a815831f-bf05-b512-83b5-60e7b0edf03c",
+        "x-ms-request-id": "da6c46c3-401e-0062-61aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-68a39f08-fa59-4b30-62b2-d28b99ee4fcf/test-blob-6e27abcf-1912-3c86-093c-4b4a01877871",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d528a04d8ea0d9852f1f9878d6ef3f0a-cd8835fe0d494657-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "bb079674-e476-e9dc-422c-b28f192b9034",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC0098AA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bb079674-e476-e9dc-422c-b28f192b9034",
+        "x-ms-request-id": "da6c46fa-401e-0062-10aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-68a39f08-fa59-4b30-62b2-d28b99ee4fcf/test-blob-6e27abcf-1912-3c86-093c-4b4a01877871",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ed83818e7d254fc2cf9e85ba35d7ad47-d0cc608f053bd5d0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "6ad5cc20-bd80-e0fa-77de-ff1e7a4b8aaa",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC0B4578\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6ad5cc20-bd80-e0fa-77de-ff1e7a4b8aaa",
+        "x-ms-request-id": "da6c474d-401e-0062-5daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-68a39f08-fa59-4b30-62b2-d28b99ee4fcf/test-blob-6e27abcf-1912-3c86-093c-4b4a01877871?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1AC0B4578\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4c6ecc25-2555-33b3-80a1-bee635e82786",
+        "x-ms-content-crc64": "7pwFd85Xf1o=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "7ZbKjo7bV9Ri\u002BCwk5rgBQ/dOaxXYpsq3K9JpDNNV\u002BU5E14qzVSz1QyxBRgyT7c/LtB3wYoHaY0fLEmK7ckoADP7d4A4tTe3KWSfpl1\u002B\u002BJD4Dnli2ZZfMaXNC50LKOdHhQToNtQ3AnWcvJgha8cznDe4juNPySqZmEHaa62Wr/x9VB1YlsG4xQgHwhj\u002BOcninW9pTpoD\u002B7vaTpqWWJrIBhCbpBOl2wl2A8nXSAsRn153\u002B84\u002BLV1ieVxhfkQnImhxP7gEYpW6PMJh90rQLK\u002BwyK84HlzMidi3NSqzQFzBTt1dZgxPCTzIvb8L3DoSkkywsLGY6wQLoLHjUSlvCvxlnKRtcsafZcNyc2ChwKmeoKbZ/pOrKGPZUcVab7gTWbK\u002BpkORpSOKEUryJnunadwIQLCGkQhounBEkB0BQPoLYxWt4x5qDPuDU\u002B1EtQXoMevlUisLjMimUe/PTREGhMxQ6sdh9YbBnje1Az0fJAFuXGIxH/LPA9ZNC40unr/qfMsc985ChjxlI7f3UomLhy3qYPCy1WjdgertFO31kwN3zoZyAiw3K9ohz/g\u002B161IwYBjRD3PN6diP3HjUW1Sb4ywg4QDFYT9tzUajQlwoqo9pFdtlk7FpJbfE8K\u002BU9po01xrilQlSav7YY0EtKad7ZzHpa0Z4NlB7trxIAXCQ2derb2pBRRWFFqrcjDBvPPsPSIh9qopTu6DKZt5NCWmNSIlqgbo8OiEcY1SbnKogDHrAOLjnEi5MV7PKd942OA1BTkSmBLtA0w5mYUc2uB/2qlpkjNCwpTVaHikHcsJD5SpHWk5meQe\u002Bf2WqgLHnFZ\u002BU1M2D0aw8kagOS\u002BaROWBLI3sc7l7QkDBTpQxqBSSEcgiJc531vxN\u002BCsilVy0hLUYFX101yyZBw0ScMCuf0YuDitjdB8bDVWRnneSVKzgCMXjGZabHTqfhSK9ZWY7n3zk8Ic1VRCWAQgn4zS1CrJgLmf6z2GvlvDsx\u002B78WafvVgL6rWAlrre1SRiOczoB5n5sXTb\u002BPNAbNVmWRJEhmadgOI01vl1OOn\u002BwRYJJISe26t1wj/hs8RUu33gGj2omk7NxLjqszCgdIiK3TftN0hA141mzsQmu90d0Bt7lR68VibHS1/LtBh61U23VtaMd4Qln0KgMcuKlxjrzOMVJN9p3ocBJfv4dRN0\u002B/l2f1T2kWiXRgXMHCRbTKQ27/c1VaB\u002BTYhfe0GIPRo/O0XSBCfD5SuKjd7ZncJStelHsZUcP5ZJCDHcpxYXDxj7nNDeiTiMcwrLutfRpK\u002B1/MVoQHuFEvuvmQv1504VY3617gDhhCygy06KUITOZ2OCFqpQrs6tZnnVPvA8lpu8tkdpG7aexHiYt3Uw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC11FB38\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "4c6ecc25-2555-33b3-80a1-bee635e82786",
+        "x-ms-content-crc64": "7pwFd85Xf1o=",
+        "x-ms-request-id": "da6c476e-401e-0062-7eaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-68a39f08-fa59-4b30-62b2-d28b99ee4fcf?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3f90c02dd9fcb402aef18f34c6bdf9c9-bcb2d8b96dbdf4dd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "adf97554-3edc-9f54-d2aa-38ff26d40aa6",
+        "x-ms-date": "Tue, 09 May 2023 19:14:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "adf97554-3edc-9f54-d2aa-38ff26d40aa6",
+        "x-ms-request-id": "da6c47a5-401e-0062-2eaa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "41817028",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-42863bd7-b413-8ed2-faa0-d08deb868ad4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-796bc8a12ccf12f2964331f2af41c12e-523b4bbe059e16a3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "6e1f4137-3e42-e226-59a5-7f928c5ddfec",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EFD2549B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6e1f4137-3e42-e226-59a5-7f928c5ddfec",
+        "x-ms-request-id": "1fcbd03f-701e-0034-42b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-42863bd7-b413-8ed2-faa0-d08deb868ad4/test-blob-81503a53-a053-4ce0-2e38-4628a4688d1d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-637de35f28d13960b97a0a983fd0ca76-5bce21b7bc1cc67c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "622bcef7-3c79-d427-c087-2b3a5cef2218",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EFE027BB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "622bcef7-3c79-d427-c087-2b3a5cef2218",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbd096-701e-0034-12b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-42863bd7-b413-8ed2-faa0-d08deb868ad4/test-blob-81503a53-a053-4ce0-2e38-4628a4688d1d?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d5309551-2b3c-ada4-817f-61f305858838",
+        "x-ms-content-crc64": "RrnyJ\u002BlQSbE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "4S5fPUbRg1l\u002BOOQ7TIxo4tibVqpnHJHqWiuJ4P8qwAD4emT3t4rvZb3G7wla6pXNPZy68Qc1hcWcdeMaSKNZU3fkQ9EncCpNrPDsoSyHkG\u002BVvKJib8/5wvWfW0Kn1B0ZbJyRdafEpsxxbEUWSeSYFOVzhIsB9\u002BOo6oHciBXoptfT0jWQ9hrI0RbW8QOJ4ngRBkZcNE\u002BRGHS46Yom6B23iMZuQ3euCB7LqrN1KgXgHwcIy4HOjHKHQbnA1wyPoun4H2g9G58BYv4okImcG\u002B5v2MqCHhyc6PtT5gG97jARPAjKfQudowNoBmmDpvvo6yXLUf9CDITMXDZs6TSeRHPOFlSB0Z7i0jTGGhezGEEAa/rb8p0wzi\u002BE/iDVMLrOycL1tJCnZxmH6X/LfPFsGEP0bH45w1LVnUcl/NN9DKF691FVvWOxWQPhUwgeZVI9F\u002BXd4MM8lAZwHxdIgWpGCdzdUIWgFlrfQxN6WG9Jtzj15\u002BTtoCzePmJK5Z1MadeZmkosQRTMnQGL/ZyvwTyXJmjfUpqFWGiv/hIjVTG8k9k84L0kHXYjKUrjYqOPL3wms741bRY9E0LhfEICqUfPzmrDc\u002BB\u002BcgnxuylPofbFH8\u002BV/aFyhiXD/817Q6A0IX8CFJM4zLubp0G1RLHt7XJMG1xybKulXEdE/3QTAi5ovZqpTI1ijFMT\u002BVVgvUJ01hFbLydEwbTTXbdM9MxHiKUSTIcWQ6Hk6o4JXnJWRZ8F0CliuNMHJPvm1e/VFZiGy3GwTXC7XZNwdkWYOmJBfRcYRyOj5c/SCyiLMG2xD9T2gpMApfcuSXKW8kKNbumYpFjXvc514\u002Bai3kJILy0lvmZxorfPQNcf6f2wDPKMRJw\u002B8osV2VIFgJ\u002BsXse15hpFcDTcHMwyyWSAuNPRxNb0FZmlCTyhEOQTayEYI\u002BIPagLjapu\u002BsCfQDCknlCF\u002BNLzIuEguD9zdpGBPyLGqGqaBcE7Q7lk7NWRy1f0TenzDlDdlT2uZ4VolBcY7b\u002Bh2JfGDpSPTrkVijYLjuzrfyinjjDN5Rcs7547zq\u002BiT/8Z7\u002B68Lj9VY7\u002BbxAsHotSYfRjucV\u002BK1/OAmSL2V3wJdz427Z7\u002BK0zpUi5xMiEIJUjJo1GSs9qjjxv/P5EcYww/jlDMzLU5mlHIBSMtGaXSeHfaLLAuesNnl16HAu\u002B7zPMiMaPQP1STkAj/xq63cnV2LMcdQjJcEReNZTlaspdmEDgwDuQB/jkfSpynLrAUrCDlENYonoq8xhyMRtYbNN1xmbZyh2eNcC6J/fuVtOZjdLUYcaHBOXGxc0jHdbtjBBG/MZT9pii5V5ynoqCPJw06KNIg/sc7sGBEwRAaxf5zKvnp1oNRZc6MXxg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d5309551-2b3c-ada4-817f-61f305858838",
+        "x-ms-content-crc64": "RrnyJ\u002BlQSbE=",
+        "x-ms-request-id": "1fcbd0f6-701e-0034-6bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-42863bd7-b413-8ed2-faa0-d08deb868ad4/test-blob-81503a53-a053-4ce0-2e38-4628a4688d1d?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7EFE027BB\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c7e95aec-4dbf-8ddc-a41c-1ec08a751df4",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7EFF4BE19\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c7e95aec-4dbf-8ddc-a41c-1ec08a751df4",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbd109-701e-0034-7db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-42863bd7-b413-8ed2-faa0-d08deb868ad4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dc9bb53305a69e0bb3ae6ec75f569685-3444229f027ff5a0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aa06dafd-c09c-7978-585f-c57628b180f0",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aa06dafd-c09c-7978-585f-c57628b180f0",
+        "x-ms-request-id": "1fcbd128-701e-0034-1ab0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "835208371",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1f48ae0c-181b-69ba-74a2-9b2c46f0b2ec?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0d42b15729cbef1697905bc767593ec0-49e8aa2080d7a17d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "38f8e193-0a19-6d58-72f6-1c84aab62096",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "ETag": "\u00220x8DB50C7F0F4FEAF\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38f8e193-0a19-6d58-72f6-1c84aab62096",
+        "x-ms-request-id": "1fcbd650-701e-0034-4eb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1f48ae0c-181b-69ba-74a2-9b2c46f0b2ec/test-blob-22ee7e23-6ae0-b10c-ded6-a4c318451e32",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-297b4129161981094fd8fa3d832a7b0a-84579e84050c0718-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "02a2a071-d7a3-4bcf-0822-e43c1d587231",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "ETag": "\u00220x8DB50C7F10F5342\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "02a2a071-d7a3-4bcf-0822-e43c1d587231",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbd6f2-701e-0034-5eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1f48ae0c-181b-69ba-74a2-9b2c46f0b2ec/test-blob-22ee7e23-6ae0-b10c-ded6-a4c318451e32?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "77529d09-1ba2-7d8f-1f90-4cb39a9abcdb",
+        "x-ms-content-crc64": "Nzptn/kyok0=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "oXTA3xHbIKiJ1RwU4eXr2\u002BBBmWT4etJGwKIKeEegx0vmoDIJ2OFIt8FPrkTuQ4uMCkGjaR27nieheh9u0ahh6Q3RLUGz4gP\u002B\u002BOGjqMuOV3wWfW0G/F4uKgILaF3C2eYZ7sU2HRZK2Sg9pHA7GPVcEiKjWFM6WuyvogI\u002Bp3qlPB76iroFWDpmy6RFyFjt8hIMr1U7H4GT35PZhnoTCzGumGdRQY47VrrnPYyu9JKTwbDwMvgkaR2dZ6smK9HAUr9yly/wm7GE0ViaU\u002BL05OoARcTJI9k5iS9KtNniFCroJ\u002BrMPFxjoyX/bGCfiRU7qILAJeYM9i/lOQ4ApufXobwusiz3KKiOnaKfybd5mf8ZDgtXIu5E3DC75gNOY/0\u002BKMqkcdfoRIDaMohDbSx4bJ8O5pfcgH/N6dX8PEGkPzqlYKHs1CcoMMqLfO9mAW4DQ3ljQHxlYadL1ogB7Ag\u002BNfJNngyKi5h35rXMUAOPZ\u002Bhn\u002BPjHQf\u002B9P/76oP6fJkPCTEf9GGNheLfh7FnGmBGkvG\u002BfmvQPd/Tzj14NkOqZ2L9xCgS8kk6FBX9A5VWl96btVuSO/4tPs9VTCYgEU\u002BfNRxOaVI4M6CohGpR0zpGeTZi3HzoFC9g0IlcvaIjFgLGXc55BC6IY4W26beX22uRDtLzwTTStxzw7ZjI33H\u002BhW5nj3FvzXUL2nz7MS57yPUdy67TM1TN96qthBaVw4ATuGBFLE/2JUFZ5\u002Ba714HyeSSnqxPHL1YZmZfKvkVichr453jKMpilK6ZpdUtuFhwovw7x8hRwTIkOL5K0L2b/\u002B3XPvuwFJEaL/oNtWboOq4d7of82cIACiJrvvAcF7Pw/bXnVolcwI5bEZfOVBvbTA4APPI1rxYrxyTZVGWhDgg2HLeg8OQkwR35kcgqMaYGkGLyG\u002Bqxu16fy49Uc2woqgOfiEdUKlsZ22vUPA1d8YV\u002BwsPyvvIdhFFpASVUwE2x0Pe0mqlusmYX2DB\u002B7Y9BQdn55aCoJfsRcgP1\u002Byk1xRsuImsVmWbcEBBd6ubBrqbSF79bWuqtCar8kxilaLdM4gMlULsUO6hjHcWQSksEX9NtI9Np6mogcRiwGPZONqdZEPjTrE3rvewW6E0VHM9v\u002BENFOETj4weo9N\u002BSVBKyJNcuNylCILOFcWX3UvItC2RZUBCzCQ5SdT3xOqduWVnJVLNl9tWWHcefv7bu7JAFi\u002BlrOQPx/yvYy8H7QPYMJygMLf5OtxSew0JZI0lHc4it\u002B6698xBVx2WXjSsTqszRg5iO0s6htsTU3HWxqMvSgVg5XVVHTiQHtlaIpynpeyiFd6\u002BwyKDKDDTp6SaqlC6ZxQvS2l1nijV0hxxoGR\u002Ba\u002B1FdPDEsIcig==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "77529d09-1ba2-7d8f-1f90-4cb39a9abcdb",
+        "x-ms-content-crc64": "Nzptn/kyok0=",
+        "x-ms-request-id": "1fcbd756-701e-0034-39b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1f48ae0c-181b-69ba-74a2-9b2c46f0b2ec/test-blob-22ee7e23-6ae0-b10c-ded6-a4c318451e32?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F10F5342\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "80337836-fa06-bb8f-5034-c9e435470a0d",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "ETag": "\u00220x8DB50C7F1223C32\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "80337836-fa06-bb8f-5034-c9e435470a0d",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbd79c-701e-0034-78b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1f48ae0c-181b-69ba-74a2-9b2c46f0b2ec?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-aaf3576dbe1427faa27504362c8cc5f0-072366fbf67c9734-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "217da0f7-3b67-c5d5-f51e-948c1baebb5d",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "217da0f7-3b67-c5d5-f51e-948c1baebb5d",
+        "x-ms-request-id": "1fcbd7c9-701e-0034-20b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "467202616",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6a353646fcdcedca5aafa6ceeb2ee23c-89fb1c492d811fbf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "279f6e29-158d-18cb-042b-707803b596fc",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7F00850AE\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "279f6e29-158d-18cb-042b-707803b596fc",
+        "x-ms-request-id": "1fcbd179-701e-0034-63b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-deb88521fb533c47fcc57c8833cf1ed2-c09e4485234bd347-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "64cb23da-25fa-f7cf-4773-5c7a3eaa487f",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:44 GMT",
+        "ETag": "\u00220x8DB50C7F0164AEF\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "64cb23da-25fa-f7cf-4773-5c7a3eaa487f",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbd1c7-701e-0034-29b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c81522c4-f039-43f0-527b-6d3d297d731f",
+        "x-ms-content-crc64": "0d0ibiDy1lE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "UDCgzOZ1CtUzWxxpNoVO78xzGs/JzwqSXNmxyroDdQhxOeqeh2LQtGTJ9DL4YuF\u002B3YCrkJvGM4ElDnAMwz8aL\u002BUU9/2asGdpo2Vr/9vYmfr3Mu06V\u002BVsqwVpeHnyw/Ekr8RM5Grk5CwYQew2WzOlTHV1FZBS39gAp0v3MTfud\u002BB0RlAWjLSPE07AIhX5NlDRwywEfK1g0s/sTDwf7LP1KcoLwRTjj8DA5gFCkr3CBnH7JW0K6voyFHSBKj94byabyvhL7XQ77jQ=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c81522c4-f039-43f0-527b-6d3d297d731f",
+        "x-ms-content-crc64": "0d0ibiDy1lE=",
+        "x-ms-request-id": "1fcbd1db-701e-0034-3db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1bb5cb26-8094-b646-f26c-2e0f15b66e84",
+        "x-ms-content-crc64": "udkBrlUzf9g=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "bEOWrB0/ESpFyyTHReo/0NmtoGJkgEh226fHxXcZ/L83OZ6mY4b2NG8A\u002BqxLX1bfuHoUxpuLz\u002Bv7H9B2d0yzLM9kjwtMmWxSt2vyY4abKnxR6Az8BDUkq2myqkS1f70jTc3d589Kkx8Owg8vmWxlYPVUJY8/tiiZP\u002BOime4onDeuzxa4vkOsBlTs7kIm9RL9TEpOYVot45alQ6jsqPox5SXXgMlWraGyqB46Usjlc0rRpEyj2TvcgOt/E3qbwF5auwgdTnRIp58=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1bb5cb26-8094-b646-f26c-2e0f15b66e84",
+        "x-ms-content-crc64": "udkBrlUzf9g=",
+        "x-ms-request-id": "1fcbd20f-701e-0034-69b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d169137-57c7-908b-0b56-13c731fa4179",
+        "x-ms-content-crc64": "N8FJJOvsaL0=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "qJy4PPKRzr/QXhoDrY0M6fsA3taZJhfov\u002BCWwMgk1Yj9rfs8g6CNWrFUqjylWq0u/DNTdGrQBoGFz3wS\u002Bg32rIiRBQCSz2ZacoQlRXzaQ2UzaMSV0GAeLad5t7Mje1\u002BjXf20E1SsnCzM\u002BAHlqsAFq4wX35FJYdsnc9hZGRizNvckgud\u002BJS8QhsyXyNdfOIPmdAsmDJvNWfwijJ98U4IUGcEKwSfYhoVdB1jFsZgDyDpVcqQMjSpbVijrXJmPkzJJgq8WVHdbDu0=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5d169137-57c7-908b-0b56-13c731fa4179",
+        "x-ms-content-crc64": "N8FJJOvsaL0=",
+        "x-ms-request-id": "1fcbd27d-701e-0034-51b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "84d8ec7b-109f-cabc-271d-56083394341d",
+        "x-ms-content-crc64": "YLvMeLYSCPQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "hckEQwioZB/DZSbg3geLl69q/\u002B0q7M1zJXsv6O10w/pkt4fEJRhOgIc81SpsUmt7I36lDFsgw5j7kR2MeHsyT6EsfCeAx3GWG35l7ReiBtMQs8Vuz7eeQ/PuyJT7wQcLCoWJQNVE\u002B1sNDvDcu9aBWYpJfMW2w4DpjTgzkf/cm1p3WuKRGMb\u002By7hpYcHGwYgcbW4JskVCVUYFn7KdEGpbMHKWZWHz8EDES7ANTGK\u002BI8yvFySQ0\u002BkUNQSbi3kTYLpODTBOMFwnKHw=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "84d8ec7b-109f-cabc-271d-56083394341d",
+        "x-ms-content-crc64": "YLvMeLYSCPQ=",
+        "x-ms-request-id": "1fcbd2e4-701e-0034-2cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "454baa2c-bd22-b4da-2178-78458a75acda",
+        "x-ms-content-crc64": "cGERWHnkfTk=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "LkVmlDUJ5EZ85u35RcpdiIEvXFhlx7Dq9r4\u002BMXDzb4jup2KNgoAA\u002B7dE/CxzwQhD08auLMrQF2eUfJ52yrLWiXdlC51ozwYBL2GgIMqEdjS2\u002B16pREO9HZD6\u002BQbiijAEbXO1DrZq2gTArfxpL/adEAVpv89ULEQzp\u002B0Nbdb/H6Uxm7NWzmh\u002BSyBa6ZdGU\u002B2ZXekAeMpgsEAvgWbIXW0uwI1XN5NDRkKc6nOv\u002BkKs7VP/cw/s/6bb0OtyJ0wCte6yLCkJ7xtZVhY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "454baa2c-bd22-b4da-2178-78458a75acda",
+        "x-ms-content-crc64": "cGERWHnkfTk=",
+        "x-ms-request-id": "1fcbd2fe-701e-0034-43b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "88db8c74-ef48-befb-458b-8ccdd89aca9e",
+        "x-ms-content-crc64": "/k4\u002BtqfkN2g=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "pmOOVrG2/YKUEsnpXUHA53xnqNAf9Zo0",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "88db8c74-ef48-befb-458b-8ccdd89aca9e",
+        "x-ms-content-crc64": "/k4\u002BtqfkN2g=",
+        "x-ms-request-id": "1fcbd31f-701e-0034-61b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798/test-blob-9b46f81d-8418-351f-74a4-b7f0ec0555eb?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F0164AEF\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fed00501-2399-2a91-ea9b-8375ee545271",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "ETag": "\u00220x8DB50C7F0598B93\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fed00501-2399-2a91-ea9b-8375ee545271",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbd348-701e-0034-06b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dad4af00-6d71-1dc0-18fc-2a433e68f798?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-239185b8e7d8ae021bad651625c8490f-735ecd9a6d9be6eb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d2ccaff8-ccc9-6604-8232-81be5d54c234",
+        "x-ms-date": "Tue, 09 May 2023 19:59:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2ccaff8-ccc9-6604-8232-81be5d54c234",
+        "x-ms-request-id": "1fcbd35f-701e-0034-1bb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1112105482",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d868c51a09a3b55ad69e96f5c96cf8ff-10e8afcd2057f0ae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0fc34469-d90f-09fd-fcc1-92fd891b008d",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "ETag": "\u00220x8DB50C7F13B731E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0fc34469-d90f-09fd-fcc1-92fd891b008d",
+        "x-ms-request-id": "1fcbd845-701e-0034-13b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-38f788f2e340c633ff07c7627425bcc8-a3a03f9f68cce39a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a61df38d-d41f-b5cf-af95-82a97a3563b7",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "ETag": "\u00220x8DB50C7F1432CDA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a61df38d-d41f-b5cf-af95-82a97a3563b7",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbd873-701e-0034-3eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1c3eba3d-f951-6fbb-9fc2-842d0e4c4e4f",
+        "x-ms-content-crc64": "64PGPz2rtys=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Is3VUuaFfjZGX5J/H8J\u002BdZjasTqC9ZLgu7u0ENlv9LoXCbwlzRf45MWNybBHfek5QhxlrmnFCiw79ZYq0G5c1mrYZxYFWaiA4s119SzhmD7Ses68CkVQUv\u002BP6deAzRNWMPJGbxXTNOh05MycUBUAWVxYWFagoMwlhxUXdXDQ/xW6HsQ5myko/kbmRyV5tAHqj496KHS8tpAmIOcAvL53pOS24jJRxr4zMFkPulimq9MULObgVdeg/WczEnpBKEKIbqNBwtLPmMg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1c3eba3d-f951-6fbb-9fc2-842d0e4c4e4f",
+        "x-ms-content-crc64": "64PGPz2rtys=",
+        "x-ms-request-id": "1fcbd88a-701e-0034-54b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c06c3d5c-47f6-a666-1e00-7466469a27b3",
+        "x-ms-content-crc64": "Dn5odv1n8Yc=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0Uf4Gq38OIB0FOuP15dODRbkyh2zQ/EHF4dMtGXpAUSUHQ4O3oVQa/uSBS08srDWVDOs7QV7FY1V8AMlsIMbixKm\u002B7qIQC6QlF4iIT7Dy2TXdV8xPRM/GAiBuO6CKrt3dnoalbf1TRQFG1mmWfNPkiSeTjoj6k7/Z\u002BKyB4g/DWmjqqvEqDat4SdLKyG6mb8UMSbJ5NyAVIwrGy7UQ0aLxQ3vAq9Ii\u002Bnu8G0S2L4sRc0jndVidimNI1UemI0I2J3hwGYUypYPzKY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c06c3d5c-47f6-a666-1e00-7466469a27b3",
+        "x-ms-content-crc64": "Dn5odv1n8Yc=",
+        "x-ms-request-id": "1fcbd8ae-701e-0034-77b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d1d148f7-8de0-9958-443d-cd36133d7b90",
+        "x-ms-content-crc64": "VhdPqeeQGOI=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Pdvzbm17zf/WYLGmcSlP5GLfWSnyW\u002BYXzzEYWBh6NhPQLiWaNR612VGZt6cn92\u002BWFi9ot7ais\u002BH03J87Y3XmWymd1UIEtK9DKX/YWaQ\u002B79jCgUHoEn9dLnpDpVl/enbbslt9iiEskmKAJI03ylo9tezGeeI0/UmqP6fIwA5Ww68J/KZIwWW2le7eaO3xJmMgBvBsuQCTprQS0kp6ZNJTKmHdLc2z9PSHD\u002BP0VZVbuBlDqLke6QqvdlbxNe4aPDEbij6MFPiWbBI=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d1d148f7-8de0-9958-443d-cd36133d7b90",
+        "x-ms-content-crc64": "VhdPqeeQGOI=",
+        "x-ms-request-id": "1fcbd8d1-701e-0034-1ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fe6f6b62-55c8-72d2-5abd-fb507fd7a1d9",
+        "x-ms-content-crc64": "9igluiqUgDI=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\u002B\u002BWpHZ9QH7cZMTe7GDVAVi63d8G\u002BBWzTstjLV8\u002BkIK07pyIEYZLWBdJ\u002B1OkFdQNV/TbmQR6rU/Z41mvGhcjndRCJgHESPPSc4HLvPzCDzTzVdVqYvd\u002BOkFMsi4onEH8Jll/Ye/WRQ8BBSmCsuxPF9Agu8RBuTrcx\u002B\u002B8e5bFpddDy5anRq1JHQzGZV3N/4dQ/Z5aC\u002BB5um0enp38Fc10P19WQutZq80m2563e1fdEshob3n4a53yxg0lhKgTSQdDUioCe7if91XQ=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fe6f6b62-55c8-72d2-5abd-fb507fd7a1d9",
+        "x-ms-content-crc64": "9igluiqUgDI=",
+        "x-ms-request-id": "1fcbd90a-701e-0034-4fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8d399e9-7dce-6ac8-205e-c481905c8f57",
+        "x-ms-content-crc64": "QZwXaUA8rDM=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "TcwRcJDGUGL0ZeqU3/TvWN42jAnIReOl3QpKd6bD8h0JCc0ba0DzgxDHD2xXO/SVkEUQ8HHLqwfoa5OFe9m8MXLMi9Un1O2dQgn4ADV2TaEWteZgsgKsPV7FMv\u002Btbgg3C975irAebbtXc61o06rSch7ybsXyXH5wIE13YaLu8NQBwfVXfMPw\u002BEgrCD9URGqz88Dhuv9CRK5fiWlipgsZaYLYZxG1evVaAXZ9x1M/HNzjxG7iDTbVvnxH\u002BPNZjlE8EZ\u002B8e91Y/ng=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a8d399e9-7dce-6ac8-205e-c481905c8f57",
+        "x-ms-content-crc64": "QZwXaUA8rDM=",
+        "x-ms-request-id": "1fcbd951-701e-0034-11b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e666b37b-f804-820b-973e-3fbbba47db3d",
+        "x-ms-content-crc64": "8G1wFB4Le0c=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "yoa4iMV8Wx9sjX7inDZbTAOolW6CAQFz",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e666b37b-f804-820b-973e-3fbbba47db3d",
+        "x-ms-content-crc64": "8G1wFB4Le0c=",
+        "x-ms-request-id": "1fcbd97d-701e-0034-3cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2/test-blob-8717f6c5-4d7d-fff8-ebd9-86cc0f6e9fdb?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F1432CDA\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dd0649d0-a8f5-1c53-c4f8-5f15b45e2959",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "ETag": "\u00220x8DB50C7F181DA47\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dd0649d0-a8f5-1c53-c4f8-5f15b45e2959",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbd9b3-701e-0034-6fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-67ddb3a1-b697-71a1-1801-b91a7e4605a2?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f197606ddaae4fe89032d18302210ed2-e0eaea0acfd6dc6f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "71eac987-fe41-8b48-f7f6-4f6bedde4120",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "71eac987-fe41-8b48-f7f6-4f6bedde4120",
+        "x-ms-request-id": "1fcbd9e6-701e-0034-1cb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "236032714",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11191dfe-f3d2-c4e1-a51a-15b5cd6ef850?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-049618e60a0dcf4297ec873d2e01880f-1835186ab205e052-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e272a7d1-650c-3994-bf45-b95df59e9730",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "ETag": "\u00220x8DB50C1ACF55C45\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e272a7d1-650c-3994-bf45-b95df59e9730",
+        "x-ms-request-id": "da6c4c30-401e-0062-47aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11191dfe-f3d2-c4e1-a51a-15b5cd6ef850/test-blob-9d57d47d-d8af-52c2-c2cc-47ff232f5e0f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-7ff4acb24c67015506f252414cb9bc4e-c681ac15a935f128-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a2846e7f-0670-a9d3-4ee5-8cb459b6c38b",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "ETag": "\u00220x8DB50C1ACFEA937\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a2846e7f-0670-a9d3-4ee5-8cb459b6c38b",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c4c62-401e-0062-73aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11191dfe-f3d2-c4e1-a51a-15b5cd6ef850/test-blob-9d57d47d-d8af-52c2-c2cc-47ff232f5e0f?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b47f256a-bbaa-519e-2718-f50557fb3fe5",
+        "x-ms-content-crc64": "Ueuk5CwaKC8=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "R3gpMNoUMf/yv5UhviJM6XiL4yX8FkOZQ4zv1kXNZN0ZBHf/kXGvvXVy703Pc3uc\u002Bc/kabpxNDE0kO1NJFu6JFq4B7qrTVcH3CaviSb2yc8RU9116foip9BGygGEYpgat8ryF2vA8at33Y2UwaoKPscdPNF\u002BRTtglV/pZINWg3mNldJcBLJkUGEx/QttjuYlPIw6ZybHnHKPkoIL14woIVoTBizYrjkUuOtvTEcv8gZ5xCj2HBtTxvlgzHEvWHnUCdyxWYe6TY1SJa46V08qX597kRJjMQQ\u002BwEAyd\u002BHI5WBxmkJrfpl\u002Bv3eapPdtGG\u002BpNW3StMZmcdfXc5lHh9WsikBNyLwNv\u002BEG/NKbyI0N0KfRiEJz9TCZCilqkwr/Nzih7hm2H0\u002BynHaMzLf0y6hKyaLydf6TOZQPtL6SoivWBsWZ\u002Bdp0VrBXHuzL5il5pD\u002BBIMpnDcE5DrSEp2uRIPlKtcXyWtHN1nLym1cSx1Jrlg9\u002BEYJhb/gDYOsl769Fxf7y",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b47f256a-bbaa-519e-2718-f50557fb3fe5",
+        "x-ms-content-crc64": "Ueuk5CwaKC8=",
+        "x-ms-request-id": "da6c4c93-401e-0062-21aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11191dfe-f3d2-c4e1-a51a-15b5cd6ef850/test-blob-9d57d47d-d8af-52c2-c2cc-47ff232f5e0f?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "334ad050-0e36-dee0-2cf4-5e4867174229",
+        "x-ms-content-crc64": "\u002Bmvdvfcsua0=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "gDFjh0lts0pXdXJqJkZiGRFbEw536UbN7vrlp\u002BbDrNVYIEYhBw7GEF04CfmGmTqkw9We6bLvepfqlphPiAtjlMicEQb/QBIClQKwP99MRlS/QOQRJcIjaKWvNnB1dohS1HUx6YczpILDm1SvPzu3nU9Ej0cnUW8FeKlhUAmhjB55XmpqG1zNi5thTolucylp\u002BJkgMeZBKoIGK3De0lR4IQ42NeDQTYHzdwSrxgPllwV/91hwgVs3ODToY/Dr7rhH6C17Nz1JmaoXLbrilmR/IZRrXtv8CJ\u002Bz/v2r6OqRB4hLY93Wal/HNl6tWVOgVKLPaEJcgJDdS\u002BCNxzlAnbDAhSYylzKHqLY0pCd8Tq9ME6lb23\u002BnNYf3bRj8SaImhpiu7dMtbb1vSMCLJ9toYPwxQLSP5MEwGE\u002BeOykZil4UDR2PzmHbHqXs7JO/HA2rjgwcywjul6LWfdSDjjKTVb5hdxq\u002B2ZKbVSIOo/gucfxC86wd/b5WJXZ7uFGMWI9yWJbU",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "334ad050-0e36-dee0-2cf4-5e4867174229",
+        "x-ms-content-crc64": "\u002Bmvdvfcsua0=",
+        "x-ms-request-id": "da6c4cb1-401e-0062-3daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11191dfe-f3d2-c4e1-a51a-15b5cd6ef850/test-blob-9d57d47d-d8af-52c2-c2cc-47ff232f5e0f?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "86b518cc-0cb0-88af-0fd7-c6ca7c77bb3a",
+        "x-ms-content-crc64": "ZwNSDIxwbr8=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "XaXz7bR6gXbm4PSpqAvYQZuGdlj/C1GkQiFADvyTm0piWRRWTgX3onxIb0WC0g9FtBfz7OI\u002B1VFTT6qTOXJ5U0SpRk73gfKVj9PbtpsMIXAR\u002B1nln69oI4PCAv5bZGkJzxwA2IvBTTIkXl0OYh\u002B1Ri05gT4YlLOUQSLKNX7zOitp0ud/DEnlUK0nwEFSWcFkDLzRIuIr8Dtoa5do9hizMCMypJA4NjrkUzGQ8dNyQudhZSjCIhdIPuGsFqCyfVmUc48dILQwLNWB7c6xmv5n9imvBpHw8A0M6WavjB\u002BaMtXX/H1DVSEyMTlSQTVJl6TiRCB2AnfIpIKBETdOgaC25w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "86b518cc-0cb0-88af-0fd7-c6ca7c77bb3a",
+        "x-ms-content-crc64": "ZwNSDIxwbr8=",
+        "x-ms-request-id": "da6c4cc6-401e-0062-51aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11191dfe-f3d2-c4e1-a51a-15b5cd6ef850/test-blob-9d57d47d-d8af-52c2-c2cc-47ff232f5e0f?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1ACFEA937\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4e7cb5a8-bb62-7278-6c35-5fe4da3212ee",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "ETag": "\u00220x8DB50C1AD20AB2D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4e7cb5a8-bb62-7278-6c35-5fe4da3212ee",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c4cfe-401e-0062-01aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11191dfe-f3d2-c4e1-a51a-15b5cd6ef850?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dda87ceb478f96501f2ce17a470f2a4a-239a674b56222ff2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c6228736-6cfa-edd8-dac0-7d8b7e3bd4a0",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c6228736-6cfa-edd8-dac0-7d8b7e3bd4a0",
+        "x-ms-request-id": "da6c4d27-401e-0062-28aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1793658094",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8ff66b73-496b-7489-d4a5-9957306c339c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-707e66a57018611e80c1e56f4d78665c-9c8cac25d745feeb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "09090fee-3682-d8a7-eb88-33e90e1c0eaf",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1ADFB33B8\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "09090fee-3682-d8a7-eb88-33e90e1c0eaf",
+        "x-ms-request-id": "da6c51b6-401e-0062-39aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8ff66b73-496b-7489-d4a5-9957306c339c/test-blob-a959cf99-4193-2ab5-3ae0-c669e8731d45",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-99f3b5f2a6ea2f0c3ec36ba46567ef83-568cd1035d503c33-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "8fad97cd-c06f-a797-472a-e751e360eb48",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1AE040BB2\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8fad97cd-c06f-a797-472a-e751e360eb48",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c51ea-401e-0062-66aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8ff66b73-496b-7489-d4a5-9957306c339c/test-blob-a959cf99-4193-2ab5-3ae0-c669e8731d45?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "509c22fc-8ec5-22d5-c3dd-c24cea8ca3f9",
+        "x-ms-content-crc64": "8zOjsmKB/DI=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "FkqZMMpaaNGE\u002BWJzO9xWfnOuaSBjKRlPcZ02lW7\u002B7hDpX5fSvQEgk6c3hYjTM50PMrR1YLLtS\u002B0xSb8sJNJihQtSitxEg8ByjdZ5K6ORez0AJmO6iI5d\u002BxOpoXNB9G/V1f99gKjByq7zAtLcdB9JoM6BK/1vqP199I/Im\u002BFNMZlmo1ajE/qVP1y0xoa7gYbzXwGlwMhyZSwCAIsZ\u002BC/NptE5ddDJpozT7OyhuuJ3wXMJ1Tvfp3HQ9D4qoBNve0cs5x\u002B0gQu1Krl10tPc0KtJiz4YDyP07f5gaIGSngV4ZHCkdNPDwj9oVKqBatWd9COT4BXUVmwkN/ogUxmKIou0/G1iN1vYhsn/sLt4c4Mow3Rd/77vpA0EgD3Zom4m3TEfzG1oOr3Hu1pM1aawq8R295CkLCPMxFhgXrYe/uNa2NKKWaYWwIi2lURko85mVNV4YqrdgbEOUggUB9wGqbx28fzUJlIdYDcI7pfeaCGK\u002BQngppw4fFcgewaeAbisr\u002ByI",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "509c22fc-8ec5-22d5-c3dd-c24cea8ca3f9",
+        "x-ms-content-crc64": "8zOjsmKB/DI=",
+        "x-ms-request-id": "da6c520b-401e-0062-06aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8ff66b73-496b-7489-d4a5-9957306c339c/test-blob-a959cf99-4193-2ab5-3ae0-c669e8731d45?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1546c30-9bc3-f483-5670-f96fe721dd66",
+        "x-ms-content-crc64": "ALp4kxm7eVU=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "7bHRki6DWgJz1ZMZL\u002Bnmig7SJQMfPXWls6pLf15\u002BXD6qVnpvuGfbXUuaxKfDB0sdt3aq2YrpaLA8LN6DONuj9XhVb9hvd9Kn9si3hXnN4qxeLcfn1IK0we7KMoyIWCVv988ubZhzrUCkA\u002BPBMeI3bkkyJQoTuyH2oa3qpERFHp6jR46pn3QU64CHQ9Cf8o8Mk8RCVjMaXDuuOMzqiAj7XuREHulTjc/VHTmKi3hQVq8e3hGAA8driOtS\u002B2enKmJ3jOTsW9SluAX0bTn5kNDDXeEdy6r3elsd2ZX\u002BAZJoLfPXEv\u002BTZPvaeCULjJaOcvgaj52Fil63fxKIz4E\u002BprdzjD9GIn3RL/nlQlOE6\u002B7Fjmad5HH04qKUH5LtCpV5nNFul/9WSE96SV\u002BjoEgLM5Mjw0AaoMJFfqqcsQPq5CRka6WBFVTub0YXI5sRUUFaiev/yUdUXvsPKRhUuZdMj2Q7PzSiiR0/NFT6A30nMy1oQicX6xvdDw2pcuw7mrWvypM2",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1546c30-9bc3-f483-5670-f96fe721dd66",
+        "x-ms-content-crc64": "ALp4kxm7eVU=",
+        "x-ms-request-id": "da6c5227-401e-0062-22aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8ff66b73-496b-7489-d4a5-9957306c339c/test-blob-a959cf99-4193-2ab5-3ae0-c669e8731d45?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7d1ca28e-e237-3335-1d15-adbb2ce63c08",
+        "x-ms-content-crc64": "0tBferBTT\u002Bk=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "1hINuP/Ov5TzWlt\u002B5/br7HdvNaNJXS8n\u002BBcwBJqeSzjp8VwbW4knSCyG6rWyK4r2T64\u002BP5Xw7Xni5r/onbr6VA8ilfaZz5HtR\u002Bx3wnN5dM2MOrXsXwuj\u002BQTjOHTKP6tyjJWmkJWUXIAcUfipeCoFaXHyW2IFDfQDfpvxtpYcIwdBBDbd0\u002BQ39900zw4T\u002BYDa3c8C1\u002BRIbH6hohH5o6bpAC7waHPzKJaNumOE0D3m8IQbF9jHGksj\u002BJi3PDDTPVQ3S8/fIpEM5rU5dR2Aw5xBurKM3ovNIebjzW/bPOtluXwOTYRuBs3zDjEjjqQuojX7doF9Rl/Jairp/FUhManJ0w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7d1ca28e-e237-3335-1d15-adbb2ce63c08",
+        "x-ms-content-crc64": "0tBferBTT\u002Bk=",
+        "x-ms-request-id": "da6c5249-401e-0062-43aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8ff66b73-496b-7489-d4a5-9957306c339c/test-blob-a959cf99-4193-2ab5-3ae0-c669e8731d45?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AE040BB2\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "44e0f5bf-5f05-4c2e-20d5-9b064793a8e4",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1AE1CE736\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "44e0f5bf-5f05-4c2e-20d5-9b064793a8e4",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c5278-401e-0062-71aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8ff66b73-496b-7489-d4a5-9957306c339c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-33681f1d07ff64122691a5c7a369d317-c4c70277dfd7f392-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "37fc8f12-f706-a802-0823-f9e0fafdf38a",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "37fc8f12-f706-a802-0823-f9e0fafdf38a",
+        "x-ms-request-id": "da6c52b4-401e-0062-2daa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "393398949",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-00d41b72-b559-ea56-a8d9-dc8d8d1c7e34?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-127ad27f396ce2454e1bc7b39f320da1-6552dac5f3369dca-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2f69d48e-ed05-301c-32d1-8b6b1b72a254",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:54 GMT",
+        "ETag": "\u00220x8DB50C1AC6FC565\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2f69d48e-ed05-301c-32d1-8b6b1b72a254",
+        "x-ms-request-id": "da6c497d-401e-0062-59aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-00d41b72-b559-ea56-a8d9-dc8d8d1c7e34/test-blob-ac50a94c-95ec-4de4-c47e-ee9a045df7e9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-3afbabf730a40b03e86bc7ff6080d5fe-beb99d7ae84c57b6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "38b90224-3e75-a1ad-5081-e61ce77ebebc",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "ETag": "\u00220x8DB50C1ACA942D9\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38b90224-3e75-a1ad-5081-e61ce77ebebc",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c4a7d-401e-0062-3aaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-00d41b72-b559-ea56-a8d9-dc8d8d1c7e34/test-blob-ac50a94c-95ec-4de4-c47e-ee9a045df7e9?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0176bca7-bea3-8373-0512-a25cf11b4f97",
+        "x-ms-content-crc64": "iZG\u002BfvIyiIs=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vot2W/boR8I2NFoMS5hw2dM//riyTi5qzz7sWiR5hDOrFv/uWKqnpo2m\u002BdCSEOWaYLGY3HPpoXBdC4y3\u002B\u002ByevLAnYDSYgoAol1grDFVd175ZUvlz4ai/wXSPkU0e76ugCDwga6\u002BwAt4wcEQbvpUa/zTNXanzKtsHZ5/ACfEzCqetigMYPGwPqU8bQnFjpALfdJEYUJIBrd1hGAMP8Pjt/GacbjOSAsPIvrRZ1\u002Bdqo8Od4JRfG7kVq90ltiNo/7hXLUYLxzbOTXLOUJLdqNX293RAcg9kjeGsh8JWbEufX777AqqhX9yMzpMikconOAIIL76uJ42p8p9kXkBzeOAmLvDT4aYqVZiYs6N8QvwWhU7ATT2M8DgxUg8KPACcGVay\u002B2LZU1Zc3domFnPpLbCjTtjxsyujmT64oo6WIBiX\u002B5pNyUaZPTH4Y29iZtrERyVfZ\u002B4nq2YrDmIkILDHxb3BjhvZnGNpCRCn\u002BE\u002B7QDNj9FtpN7gqcE8zIbrkdRyAMJ2xode/6qrC9V7dgLMWb84uwCxVXo4Elx7LpnqohZP0JsexCZ9bpAmxp0FaTO\u002BcHLLstbTvK9IPrQq580QvGXDK6FrrZWUu0xwipLdMqkouLonIu8/fBPr1oVyVorDFgY3RkGSUsbdMvuKYzIcbwwO/isW7Zl2g6\u002BNf9cMJmDFrXSIpehnmmn3RfP3sRzhz2t5Z1RfrCRsvMKWANbv0QyWxLG5k8Ujp2fBH6epgtKOr6xvkr8IZgFQH\u002BUp0ZmTB3TjYOxrJD\u002BiWcPwnoyAwz3wB1EmfD5NimKwaXff9dXKLhguxh3mJ4twyTj/G8dwz1irOcpEbIc6ldaJtrrHxmPuJnB0Uf0gDd/JsbMFUnKbQ5obNLwLhb2Q8DBHWGzMqQbVEPFW/H1fiy/ufr7UNUdn8ncgrI2n4qCy513M2LFu/QSsMD19QEccv62QGQcCvL7s42X5q/x1LS5MpBUfkrJ6f4G2JAUF5q4wA/DgF8WZrCai4/VPdVEENwMTLJguASj/FZ2FSJS55vi3yagPlRlktvvyeLK5LwYsrfEB9roSAgLH5P4oFGOR5Pj8l6uo\u002BJ3lqnmgP4R6QeqXVJ6jt/BCpcelS6wfPKKUXJO1vJteh7VXGEg8bcZ6SaMTkL/E8i0Iue3kA7Dtym3bD97wwIVTONDlTJ\u002BkBjf9Lv4NC6vi025mrQKpeoQEZU3eYWHrhYUdvFfu36GRYLe55tCy4MLB\u002BDxwjheCqcJI4OtNyaDSFaV470tT9/PI0UxO75OzUYCPGGklevdxnxaVofq6R5cW680rOfV3bgBIp7zHM74umZNmvrE3qJ6uB0w0vlH1Eom1OAPChBuLG6pk2NM6qmtYZwg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0176bca7-bea3-8373-0512-a25cf11b4f97",
+        "x-ms-content-crc64": "iZG\u002BfvIyiIs=",
+        "x-ms-request-id": "da6c4ac9-401e-0062-7baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-00d41b72-b559-ea56-a8d9-dc8d8d1c7e34/test-blob-ac50a94c-95ec-4de4-c47e-ee9a045df7e9?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1ACA942D9\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2a7556f4-bc08-1e19-85f4-be0837658455",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "ETag": "\u00220x8DB50C1ACC92230\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2a7556f4-bc08-1e19-85f4-be0837658455",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c4b1e-401e-0062-4baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-00d41b72-b559-ea56-a8d9-dc8d8d1c7e34?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-da7c61b232c81dc1a5deb52356101310-7d6caa7684a7a5be-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9a68c6a2-25a6-578f-8c73-40c8540d12dc",
+        "x-ms-date": "Tue, 09 May 2023 19:14:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9a68c6a2-25a6-578f-8c73-40c8540d12dc",
+        "x-ms-request-id": "da6c4b73-401e-0062-17aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2078200963",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9d5f10b1-2fd1-4537-1cf4-db0f04351428?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8de991383fb864a28e9512721bfbb8ae-f9b7dca08d58d363-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "9a0373b5-9ba9-724a-e93a-8166b7839deb",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1ADCCFEAC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9a0373b5-9ba9-724a-e93a-8166b7839deb",
+        "x-ms-request-id": "da6c5089-401e-0062-28aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9d5f10b1-2fd1-4537-1cf4-db0f04351428/test-blob-5449a20f-4dce-47c4-dd2c-a1ef23397d56",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-6826b69882e53231e449d788c52b1938-fe23d76787c5d28b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "39196058-5efe-5aa8-bd90-8d296c250438",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1ADD82034\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "39196058-5efe-5aa8-bd90-8d296c250438",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c50cd-401e-0062-66aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9d5f10b1-2fd1-4537-1cf4-db0f04351428/test-blob-5449a20f-4dce-47c4-dd2c-a1ef23397d56?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c397f19f-431f-0a57-ba6d-8692bca1a8e3",
+        "x-ms-content-crc64": "plAV3WvXMO0=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "G\u002B/DexHcTODpWU8QKpABudGNWZExeX\u002BykQUYaFC/TssjGYtUnqg92SYjsVBMOUhYOMeVKikMuaFwEekLw\u002BSPKQqE7BAErRooUIBqDsgvZle9vzCIKiShF1/q5I2\u002BMRVCk4dFx0w3VIqsbNqooavYQauSTgS0B//l4tWxGcmNah5rKHtB6Z4Khmql271K\u002BXa0EaPiLOMQjouHX\u002BV3hTrBHwK7PXgvl1cNh8eZDitBm\u002Blf/Qgmqz47WprvuYm4kgAw47y7j7z9hHpL1KQbd39gRsT8GIgym3PEgOLeQN3OVPXGaStuhgwtYnmN2taaH\u002BMbj3PEvHp4/khI9w7ZHkSdfYCvVA5U8b\u002B4zrYOpMCdKWH/w7BpCZd6TmviJY79U0M18F1W6srUx52zDO3EaVmIq82t2VuTM3PoNAajccsxu3ty2bRiRj\u002BWKvsTtf2qtuQRWXrBUHnnobzqbbbEMVXRglByUZCkJmSOFq5ff352PX4hkRhRb2oBizf4eNmI0vmmQTKsOGVUbDMVMjrKhyI\u002BdC84op89gBLmcMVYrK6LBUO1uT1LyQUYzCTlOzwwNgMVugSpUDBZacEgxsef/L\u002BEii33Fc7k8qoqH9V6V0TVtjrCQvKp4rUSW1B8KwM\u002BedBkYLEPOSA1McdZfjFb3xF9Sg\u002BM3LnN26h45Lp9aMem66UEFfeTxnwZjRErUGOEt3w//\u002BDzsp0Xl4UIl1Rmt8j/spOLVskZ6YSTck\u002BnoYpE9Cw9PmnnszgI7X1yii4os9VJK53P\u002BGGzJRVbYD9Nb/b6xKMnKHhfGP9ag2hLp15War95XnbtdPvLihlTi1L5un6Hd8aLAIpc6RKddXT4aH23BfWA1BGADU\u002BnXJ5fDI2sYcjqwzCYymo1HHVjT/\u002BG0yGcnIVdeOVtB2p246Tr/dyF8ROsDaRNHjqLS7ibHb1PIIh8w3AIT\u002BjjfbzFIefGSR6Y3l7s2sV9T31K0i0t0eqtJ8IbbjpsfKEqyJDoh/1TxAGZAz5eY0bC/3TzvX26tqzRGPolqtvkLGG9wRE1lMd/9w0sk86rTsN8WG7FeL4kbxLjFm4DLhkmtdbdoaE0jWusc8ZvjiLeJso2qVJsHrOimVH/UX1YfMnzBd73zawiR8sDGQX4tOHwBfCkzITHupYjOwhPNTvuU/f9fIhE5lgdFGGGaAWuquRwDkuMtK9EK0tI05Kk0hKPFcUO\u002BjdYqx6Xh7gjQFGQdZAj3ybwYZ9HuVA8/BPFeUFO91JAoLCsF2Ms9Cz3IOr5t14CgPPsnrQlxkDnG68L0g521En\u002BUNXgdsfDw2xzT5llQkS1w/lOYlieGtlvxfuzISIegEuh\u002B2eIIQkrKdtIsnengdhqVg4VJw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c397f19f-431f-0a57-ba6d-8692bca1a8e3",
+        "x-ms-content-crc64": "plAV3WvXMO0=",
+        "x-ms-request-id": "da6c5123-401e-0062-32aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9d5f10b1-2fd1-4537-1cf4-db0f04351428/test-blob-5449a20f-4dce-47c4-dd2c-a1ef23397d56?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1ADD82034\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a8ae1e3-418e-2f19-b1c3-df3be6160935",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1ADEABB10\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a8ae1e3-418e-2f19-b1c3-df3be6160935",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c514b-401e-0062-58aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9d5f10b1-2fd1-4537-1cf4-db0f04351428?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-009d5f93ca802787883eecf308640e87-f5a9f416e9b1ff2a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "daaedd87-2d16-1355-870d-dfa214ca04a1",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "daaedd87-2d16-1355-870d-dfa214ca04a1",
+        "x-ms-request-id": "da6c5179-401e-0062-04aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1391607598",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7bfa53c7-513b-fb9f-2e67-df54a2bd578d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-13d5f49f0b8da21666055e11dfd6b229-59570cbb0a4d23d0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "73b91e3b-be00-173d-c5ae-a1f4818a365a",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "ETag": "\u00220x8DB50C7F067799A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "73b91e3b-be00-173d-c5ae-a1f4818a365a",
+        "x-ms-request-id": "1fcbd37e-701e-0034-36b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7bfa53c7-513b-fb9f-2e67-df54a2bd578d/test-blob-5be81ee7-ceb2-1708-b347-a5c7ae418e52",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-3e169ab7779c244e9013efb6c4256cee-c8076ff49f792368-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fdf0e81e-1104-4f74-760e-9ba5458b8112",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "ETag": "\u00220x8DB50C7F072400D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fdf0e81e-1104-4f74-760e-9ba5458b8112",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbd3ba-701e-0034-66b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7bfa53c7-513b-fb9f-2e67-df54a2bd578d/test-blob-5be81ee7-ceb2-1708-b347-a5c7ae418e52?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c6a86cb6-9051-bd4d-f40d-6df7a199b065",
+        "x-ms-content-crc64": "XeB4iiK\u002BzGc=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "39/AV0knbMvcxxsKTlenD8wwGYQE5IwfO0F85lqBstX7p2h0XkNlE7LulzmjM8htB5IoUHGxVftSoBwIq4VwWhVGDqbvM7CIygXRFkxTfAd4D9/HWWFjSVJtIb4nXWcsfTwkXCUhfdPioIVr3z\u002Bu/iQVj5ylqQGz48RUghHxYG2dpZkPLx/hV5EL5bjc92kSviKaEs3LhtM7cHlgzPvC8D8Xzjqlns8EMzcKmsRI1\u002BtbQsPuV06g0h7G1L\u002BmgYuWSfR5xCkubR9Tld\u002BVwewP8pmNBYo305jwd/wc38oQXbKsdFHPzxLCLNSjm8FvChAxtuIlGHsBXnVciEwtEo1VQzgs6UybQCKHy9m1lDjWgW3r6inn6kU2qxbcckbFlRlHTVeJQiDElna/nk2iS8k8hQffQSdkbVjy9j42v83bwTW/bkbgTT5MJlOyKEz3lF9Mn\u002B0/5lPx4uD/lkzijtep49wX4t2DXDjJkhvTsUUM\u002BmHe6R/fnNvizYtm4bbxaph8CURv4LKCyUO1dVM4HjCa85zrBKS4yUYBNRRSHXqB1yiDV6gBnBquWyDcKieHqa9ay\u002B4aBmXzxD/9baqeMKvIM54qtcaImVaBPKiE258feotk91GMZ9DCj5NpAy5wECt0E/aIXPTp0jKXmcq9buig3fMeOjhaPMzNaCUzH5UnESt9D8iolx2XeiUe9M4GBSCqyCY7UdbyGtYqu/TOtrOdb4eeP18f90bVh78TO0f9xmIEiFZv7L9VivXxftwpyMRxgYVGaMXBi9HfZskX3t\u002BOLPSSyS1dLYPISbVqLXhqrL/6ornCt16cQ/2Ej4b1PqwWYlHnlv6WFFMBfh8QVl1YdLkKHDwlzHWV9YYw2J390goIVMomghXAZI1lwDg/i\u002ByfKxvM6yFw8JbcUqF4ZTy2BKwUCAKSMfKkSriuvws9VmqZkayCMObomGM0SjB0SP5Rr7yMKoPqDfkpJ6FpwTGLn/s23tSPM9PFK2\u002BeXubBMAG5XQ9PsCvmr4OyWQlFf9Yyqas0PWkpwXzoxv8TS68SZ/efr2QhO\u002B7QUC9Q3NnKf6yZbLQ7jPOYkJuTZuks02PUn/ERps9xEG29ZOw52OSiHUZSet7619sDBx/JjtUEpH3Lez3nuNncJ1tHfSgGXre28Eij2ViF2scWDp6wqIKYub9vbVynu2VsdlOCslqz/ahnE56MYcskRqF10Ko7LH/Zr8RolvFaDjXjNmIFAihtYxD2SJXjC1f0Sya7Muq6MUnTqQKVSma3DARoqCpoHkR4B22ZROPq9aNsc0vKn9xLKQQZMVkm1xiqPzuQemMsjCziQyp8Ie1l6bNeKNcb7G0nHX4mT\u002B3rUjBU7wWnWXpAPw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c6a86cb6-9051-bd4d-f40d-6df7a199b065",
+        "x-ms-content-crc64": "XeB4iiK\u002BzGc=",
+        "x-ms-request-id": "1fcbd404-701e-0034-30b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7bfa53c7-513b-fb9f-2e67-df54a2bd578d/test-blob-5be81ee7-ceb2-1708-b347-a5c7ae418e52?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F072400D\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d9eea5df-bbe2-d0c1-641c-fb0fed420845",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "ETag": "\u00220x8DB50C7F08465CC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d9eea5df-bbe2-d0c1-641c-fb0fed420845",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbd432-701e-0034-5db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7bfa53c7-513b-fb9f-2e67-df54a2bd578d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5d516b8eb3affb15c217318561f8cf21-5e35838df282fb6f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fb18cd64-d7aa-bd83-54ff-d0c7a50bd46d",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fb18cd64-d7aa-bd83-54ff-d0c7a50bd46d",
+        "x-ms-request-id": "1fcbd44e-701e-0034-78b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "775147106",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-efdc6d25-3c4a-c42a-c861-6cc71892a213?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ead06c27fdc5d6160526583057037939-006c23efc06a3c76-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "4c3d7c51-2f38-8ada-eaad-3816fbd738c3",
+        "x-ms-date": "Tue, 09 May 2023 19:59:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "ETag": "\u00220x8DB50C7F1906464\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4c3d7c51-2f38-8ada-eaad-3816fbd738c3",
+        "x-ms-request-id": "1fcbda29-701e-0034-5bb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-efdc6d25-3c4a-c42a-c861-6cc71892a213/test-blob-2861366e-2f73-3ced-e893-385034076c71",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-3f7d927d44e49e1f98960a7787473d04-82d1daf3bc9976ad-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ef85e2d5-6c2f-33f8-c80a-768149be1d85",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "ETag": "\u00220x8DB50C7F1992F6B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ef85e2d5-6c2f-33f8-c80a-768149be1d85",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbda74-701e-0034-20b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-efdc6d25-3c4a-c42a-c861-6cc71892a213/test-blob-2861366e-2f73-3ced-e893-385034076c71?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "527bbcd0-7c81-a942-1551-8ce3af97253d",
+        "x-ms-content-crc64": "BPZtYtbQnzE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "8tHKKi5yXBLSCiDqATCkCsuFdpxVVds9P8aZ9tmE1vcndwdO9Gy53iAqei4P8Im5CS5LdmGcbp32jepn2GU5TjMow4koVRZey5d8KtutLk483\u002ByqOGCWiwlpWGeBUgW68Sv65iwAkbMY7KrJH0PCSF6bKvl5jhXTkjiAvv2u3XmRwTmvskchPE44kUy1zGvFpw8I5ScMQWIVJ1P0f9K2aQ4xOF4KEpUXeu2rQPzJHcXNuxfupvhRhYDWmYvzLb18gic9hJQMupR58Ws5YQBlSwmOJ8S6x8MV37LdM3gKI0wwLr3UjJgxwACCdbWNGCN/cU6BZQb4wbpkJ6XhL4cbb80eCTJDkL9xXWbEOFINiMePXcIqiL1GOG0CcGTyT5B4ZgXnbg7xPOCOEAifM4hnV5/eUtHF8eYQ2NDEQCBafg3WS9FNJRm4nSHhnHi1pgTkmxjFFP2/s3Uf15Y\u002BLPzAM5H7yee3GjKGJrSw41VuWjHL36QHlWoQFpdcLU2CeXAkIGjmud0cLYDmP\u002B1IDtAgsHxlck1XuJ4m67JQWuzkA6xEi8PsiKFUr7EkIVZ9xwjHPH3QHQcjzWjKv84rzNOTAjtABIIMMyjbEMObM5dIqSOpiB5vE\u002BWkIL5aIsjSKeLekB8aPMOFughU9QxEiJrRgRWrgUO1JO5WnOPEsRBgCefgvaJ3Lm1gJM0VGx3YYJgjiaCyJ6ieKGwww6DfwAj49OwlY8r3WVOoSlx2oAjQfTtLoShvruE/QpQ2R2rNgWPFHCcxs/zNLDBMCdxLKIhjX0Zkkx/giEYK5SE2wRHp28n5sIPhnsk\u002BfXX3IqQF9BkL0\u002BcjaO1D5JThJ87bl2oeYy4TUXcFgcB9JRaq6WWhBfAHKu0pxnLbtszvAHf6Y\u002BUK2L918aKiBlEnpkLXmPsuPyLd1G199Z28OJurFoBJgsIwoBClLBNOZSOcAh8vBB3RwMFUHY94jOMiubgH9/DQ3iR/p/fqiRIOj29J4fJ9jDR\u002B2Va/9WUztxMtg3NbRm0yyyT6r10l5zauRY0fLqvwpCyEiB2aEei/TO/jvAafs0gBFhXOgtzWWPIfEa/XE4hoPN5G1r5PmLk7O2NtQSowDpFEHhiVIiFQrTArewA55zhme4AnWd2KsX5ckkd4aRbH7gIdk/Vw0hm89iiNJBy5AlQrBsWqCbW0um2ZOY/a10QZY439G1RD9qlmamO0/YxhopDzTGJQHeRMadmH1piJ4h7kc8CPu\u002Bf/6BAcQ55S/7zgOJf/54riyUaosLF7ux8Q3IhE0InM0uap82RRNNpG\u002Bmocp54BivuTAap65ws1hC3wC2YWDS4zFGawVfQmkJRrYrVHXhSBD1KMsc7eUurbcw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "527bbcd0-7c81-a942-1551-8ce3af97253d",
+        "x-ms-content-crc64": "BPZtYtbQnzE=",
+        "x-ms-request-id": "1fcbdab8-701e-0034-5ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-efdc6d25-3c4a-c42a-c861-6cc71892a213/test-blob-2861366e-2f73-3ced-e893-385034076c71?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F1992F6B\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8cb0e22e-cb43-c803-1b1f-2d14f9a19886",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "ETag": "\u00220x8DB50C7F1ABF14A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8cb0e22e-cb43-c803-1b1f-2d14f9a19886",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbdb05-701e-0034-23b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-efdc6d25-3c4a-c42a-c861-6cc71892a213?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-56d7b21b00570ac5e3a73740c42af850-e5d30d70dabc50a0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cdb556c3-99e7-2bf9-014e-e66c500055ba",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cdb556c3-99e7-2bf9-014e-e66c500055ba",
+        "x-ms-request-id": "1fcbdb43-701e-0034-5bb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1980501500",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a8911563c9c3376af297c89e56c14d4e-bfca06afdb38d70c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "042b5d46-fd99-4b40-ae1e-defadb9916b7",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "ETag": "\u00220x8DB50C7F092C8F4\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "042b5d46-fd99-4b40-ae1e-defadb9916b7",
+        "x-ms-request-id": "1fcbd46a-701e-0034-11b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-f1639697383841105dd632ba4472e2a7-206a884353bf6292-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a3f875b5-a48d-85e1-ae5f-14e97a606851",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "ETag": "\u00220x8DB50C7F09A348F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a3f875b5-a48d-85e1-ae5f-14e97a606851",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbd47c-701e-0034-21b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4ddc62c5-f7e3-28f5-54ee-444b3604bc41",
+        "x-ms-content-crc64": "p2TITK53GO8=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Q\u002Bo1XaHbXCxzmaEEi9Py0iar9t3NEF8mz3ZJLsH\u002BXCpRxPQpoKc3agH/kABcPMDbKwvTMKI56jOKDo0rki1qdDx2ssbfyTF/c4vbzX9fypO1bgK2KyuHGNrAnpEaDNjTlRvD5Yr5\u002B2LZVLwXXRyzK0T6dSMqtEkR7pnsHiqfZGeyBzhjnOQJvHKg3NZvcLu\u002BDHJNIJa0qeHSsvfwDdw3Oe9UZFXjUI9f8bmxitdyoX7eLhG4UkTQ/V5XkertGK\u002BVaKLmGgtl2rw=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4ddc62c5-f7e3-28f5-54ee-444b3604bc41",
+        "x-ms-content-crc64": "p2TITK53GO8=",
+        "x-ms-request-id": "1fcbd495-701e-0034-37b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "182306ce-1b83-9f6d-ea76-6b8cb11f7516",
+        "x-ms-content-crc64": "v6m\u002BVVCmz3o=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "4\u002B0v3QMeCV8QeRHfy3/nq4Rn9oy\u002BpXLYCRsiNYuGcnlTVdRkFfL6QE4x2XMH0MrpuzuWpG5O/T56VtPn/NTTiQaYi3WrgpWRbLY\u002Bjcv\u002B0DlROHpQ8M4KBVeW6r4fEkN5XVBtb0RUPTilBTe4D3BzfIaalsNag5k4jYYeFZjXclpyxC97kWH1/PpBquqWUvXmIm04hHuAH9q2NeG\u002BNSigzpPdRUtB9\u002BokpZrIGNivoTuQN/Iqnu3e8qRUxFyANsbSoNxWuA2qpSs=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "182306ce-1b83-9f6d-ea76-6b8cb11f7516",
+        "x-ms-content-crc64": "v6m\u002BVVCmz3o=",
+        "x-ms-request-id": "1fcbd4c1-701e-0034-61b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2f7c8848-a3e0-8cbe-5469-197676e20deb",
+        "x-ms-content-crc64": "KSkUENNtGG0=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "gxPf4bcGAQeTpS7\u002BNnYvpv9TpuwzjqRu0/Z4/FjpLuWRx6aLDfw6nVO8ydoIyJsprbC4uQO59/VvcQ7BjgWvqXdIbG/PpJkDGAiZdsTJZgtaTk\u002BoMHTh2M\u002BxG5vteA9NDR9jv1ssWgkWtaH7IIEwpQsDZj\u002B2B3kCZpSgHYj9FaD5S2mlZqavLvRFkXrT5rhOgXaQ6hHPlwWlYFnHjDyAGZ8BAdUXij5kVDhLcHb\u002BL3/bUZwSbCuOKrNj/wZM56K3xXfb0eXiNvY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2f7c8848-a3e0-8cbe-5469-197676e20deb",
+        "x-ms-content-crc64": "KSkUENNtGG0=",
+        "x-ms-request-id": "1fcbd501-701e-0034-1cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2943cf59-45a3-da36-99f5-c88074aa6d10",
+        "x-ms-content-crc64": "l6AyYmI2MDc=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "NyuV2YMnj6cw2es6oG6sdHPXIbSLOBhslZSq/yNdmvkbpdpBlbSmjNNY1XP7aBZWymZeDcGBa/8TKUPvfJCD0z/yH/uTa96\u002BMZXgMmKlcS1\u002BVDS8/ow3mTnbLWxxtw9D1QIzCEkawl6IoNwroTmcbrcVcShbxtSzuoXCuD5xTHmGnV1gcWjkY5HVNF2vDPj/Pr60W0bn5w4tf07DWAogFlNjpQPcO/xPMQ6WhpJ2BK6Nwnl/vfEznrVOM/IaIQqHtR4KTGf0IwM=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2943cf59-45a3-da36-99f5-c88074aa6d10",
+        "x-ms-content-crc64": "l6AyYmI2MDc=",
+        "x-ms-request-id": "1fcbd55c-701e-0034-68b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a61dd038-e49f-9048-3afb-1940c051cd3a",
+        "x-ms-content-crc64": "B\u002BvsRq\u002BkzTM=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "wmUpOFFhfLZ7nzaVkKFZYi8GTo0ICjUQAw7Rc2y4RpmfdrxYx/tNVNF8d3rqdPcTxagcYKaV\u002BrgvGTRCkAhJwlmc9hnkAJo0uPm7i5K7JY4Xva7Em\u002BXyCXsEKK7GC8PJMrQhTX7dL8QO56is2W4ldPOlKtNahSdzquyd39jrbq018ljemdcQOY3qtrM9Ri8M37O6IODwb62NraORP1DrInn7ducWR9oclfBFb85zNWO8kP8kME7MRYOrUOwzf/k9/pM6QtBI9pg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a61dd038-e49f-9048-3afb-1940c051cd3a",
+        "x-ms-content-crc64": "B\u002BvsRq\u002BkzTM=",
+        "x-ms-request-id": "1fcbd5b2-701e-0034-39b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a3484b42-c78c-2c71-0e30-c3d05024ff65",
+        "x-ms-content-crc64": "0FwHmP410Zc=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2J6L76v/3hp4QNSuUMfyKy4wZGr27ugV",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a3484b42-c78c-2c71-0e30-c3d05024ff65",
+        "x-ms-content-crc64": "0FwHmP410Zc=",
+        "x-ms-request-id": "1fcbd5ce-701e-0034-54b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8/test-blob-3a7108f7-f338-7492-9a67-4c92c2dc9a83?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F09A348F\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "75fed8a0-2909-0bad-a229-73e570ab9e46",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "ETag": "\u00220x8DB50C7F0DF2294\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "75fed8a0-2909-0bad-a229-73e570ab9e46",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbd5e5-701e-0034-6bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65d16ccc-076c-060c-a92b-843c3bf814f8?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-831e5630caa2b3b7603bc9c9ada83e7f-e5e3a23b477cc594-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "78301f9a-8926-435c-63c1-c7d9bd8294a9",
+        "x-ms-date": "Tue, 09 May 2023 19:59:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "78301f9a-8926-435c-63c1-c7d9bd8294a9",
+        "x-ms-request-id": "1fcbd628-701e-0034-28b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1341599062",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8d18014ea618e283a642c21d6639eded-9fe946d0c9c32786-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2eae1b71-1ce5-f3d7-2a5a-3f18b63e3b17",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "ETag": "\u00220x8DB50C7F1BA5459\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2eae1b71-1ce5-f3d7-2a5a-3f18b63e3b17",
+        "x-ms-request-id": "1fcbdb74-701e-0034-06b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-2aaf30e14960ecaf0c79cb43077dd4fe-979dfdbfc66451b5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ff985c08-20dc-32bc-4ac5-71f34ae4df3b",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "ETag": "\u00220x8DB50C7F1C47EC3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ff985c08-20dc-32bc-4ac5-71f34ae4df3b",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbdb9d-701e-0034-2db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3277c66-8df5-e485-08c8-957701791ac5",
+        "x-ms-content-crc64": "LIH0SHiOeFU=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "B62/pR6RXkOR1vy3nOMNKoms9E9ISu34YQRwE9I200IxCAVc\u002BXTB4LxrnA4fH1ZGTBSOCknsz73Ax0QZIUpxWwK5hpPesTAV6hSS3a3e2EGtKce\u002BqMj5RTlHnDIwp75y\u002BkELZpnCaJrjeR81WfEQ4e4Ca/eDs7I6wEFZlxX\u002B5ENVIONr0nKo6sAs2i\u002Bow\u002BtINrpELTvH7kaP0aVXadGF5ZTc3zkOpQ97WYA2V9iDkfxVEWBaubYIjjKc3AHNUIHvpvWbzOSyOZE=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3277c66-8df5-e485-08c8-957701791ac5",
+        "x-ms-content-crc64": "LIH0SHiOeFU=",
+        "x-ms-request-id": "1fcbdbee-701e-0034-75b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cd8d87e2-ebbc-6146-4388-8cdf02e5efa5",
+        "x-ms-content-crc64": "pKNLMKVueK8=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "qsnUupCWbgs/qQFXcSor3dNRBnHJDq4I/0ex4ujFGKPXz6/w4k3\u002Bmy3QwSNOKn57yr34kqvIx5way7tI5YwjeZBef6F7OvqGU2tE\u002BUyKutTJNRgqzYX3DwcT1heStbahrEiT8KrcAI/Dcj9Ag85QkBDmf690\u002BKwLZ2\u002BaZ2Ti8520okwE98kp7DWIZ1tFtos4w0UGqzUHLbSbh4k7QZgq4H6hjOCCS5hHvZJ565FQxbDkYqQe20dorHWXaG9A7qucXobcoyqqtXc=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cd8d87e2-ebbc-6146-4388-8cdf02e5efa5",
+        "x-ms-content-crc64": "pKNLMKVueK8=",
+        "x-ms-request-id": "1fcbdc19-701e-0034-1db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a945327-4cec-2309-9722-1a76e19f6e19",
+        "x-ms-content-crc64": "T\u002BlIZ\u002B6MWFk=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "rb/uo41CI0vC2Fbf9AsENjnfa\u002BriKQbO592NCnMhhTmsLHEcWcQfM3QdrGiXy6hSgqZqSz/KlYO5H7ywtRjXoFMdM8eZ6Nx1wDd1xXyeNxs0OofNtzr54ZfuYjoIbn5cRgwUeZjguJnJ9IoHVdAGG\u002Bege3qRCekYI1Ewq4WibFG5GX5wib2DVILuBMKv8YzH50dSaPIDyz0i/FZGsAwTJog5TjtRlpEqHSf4ogQmaDHFacM\u002BTwRftU5BTY1nPKN12t06dqNQdVE=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a945327-4cec-2309-9722-1a76e19f6e19",
+        "x-ms-content-crc64": "T\u002BlIZ\u002B6MWFk=",
+        "x-ms-request-id": "1fcbdc43-701e-0034-41b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aeb86736-7551-8bb9-bea6-1d616974175c",
+        "x-ms-content-crc64": "CtnPDk56AaQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "tShKygsoOPuTJIFGSdXWhNqY7BBIBMPgg4PIJ\u002BzyjnTzcognuZSpJghS\u002BkO7XSwEB7WcCmRlCbFlakaIXxEPoJUMU9ZMrspF7sYH9gp/JSZWwx82VYMQjmnXwk5NIcb3QlmtrglVuFjrVhueXROm5UUfMZzx2EoR/MRtdOx7\u002BM3/ELOx0nYdAQvHS/9ncjFWMd0JLfAqBmoOm7JE6ENsb15Onk1f9RLPAjCQKYxLqYqTF0MOcsrd1ApIojbE2BnHW9ygGdPj9js=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aeb86736-7551-8bb9-bea6-1d616974175c",
+        "x-ms-content-crc64": "CtnPDk56AaQ=",
+        "x-ms-request-id": "1fcbdc72-701e-0034-6ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a40726e-bfe7-41c8-8286-0c71cf5df426",
+        "x-ms-content-crc64": "TlJPloDDod4=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "yjoqv5nc3sLxJ7HQ/138k3HKQxdS3AsqFsnNr6qQt68hCEM4oB06LWrgRJwnSMf\u002B3w2oCKDe6e4uAKnQDi4XYXABr/cZxPNTjxWtcpduAs4Bz8\u002Bd6K4PQh5VCZ90ah47yOMrJpjQ5BsZVHmKMXZWwP3azz9eennB8W3Yw7pT3yX2caqzQ9w2Meq0hJM1hBGo/kmimZrf3U5qajQr9yFgxXVTk7/MonwgpJ5UqvbljG1bMMRxsUWKF5RcSdmoCznJU74d4fBS21s=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a40726e-bfe7-41c8-8286-0c71cf5df426",
+        "x-ms-content-crc64": "TlJPloDDod4=",
+        "x-ms-request-id": "1fcbdc99-701e-0034-0eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f6f27d7a-9d34-8975-1155-f0037b9b6b38",
+        "x-ms-content-crc64": "Vf7lUE/kaZo=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "zIH1/IoyV4Tdx8/GXO8UL8l8KnBZo3iZ",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f6f27d7a-9d34-8975-1155-f0037b9b6b38",
+        "x-ms-content-crc64": "Vf7lUE/kaZo=",
+        "x-ms-request-id": "1fcbdcdd-701e-0034-4ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2/test-blob-37568b64-aac7-097c-5568-a530508d8c61?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F1C47EC3\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "52f65175-fd6a-dff2-ff33-0b0a511b33bf",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "ETag": "\u00220x8DB50C7F1F8CD77\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52f65175-fd6a-dff2-ff33-0b0a511b33bf",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbdd0f-701e-0034-77b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7d60e055-bd24-17f0-e4a3-8b666af778d2?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b2a183559dc68491ee57a2933a188220-8d8464dc4b205960-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "298dcfaa-18a4-43cd-c6fb-07120335db38",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "298dcfaa-18a4-43cd-c6fb-07120335db38",
+        "x-ms-request-id": "1fcbdd45-701e-0034-2db0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1766468723",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2bd12fba-255e-656c-7d47-e35b4c4a53a0?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bc1e54ec410e4682dad0743e6a1e084c-3264153227d868ff-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f26f3509-7b7b-1495-84bd-61dfce71d97a",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "ETag": "\u00220x8DB50C1AD683150\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f26f3509-7b7b-1495-84bd-61dfce71d97a",
+        "x-ms-request-id": "da6c4ea1-401e-0062-7caa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2bd12fba-255e-656c-7d47-e35b4c4a53a0/test-blob-93d7cdbe-2b8e-87cf-2682-ecb62c3cfd26",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-f12b1ffae23fd492df4cb778f0958633-b544f10874c1a49b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5f89deea-8c2d-58fe-6dbf-e196b9cb8e44",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "ETag": "\u00220x8DB50C1AD71093F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5f89deea-8c2d-58fe-6dbf-e196b9cb8e44",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c4ee2-401e-0062-30aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2bd12fba-255e-656c-7d47-e35b4c4a53a0/test-blob-93d7cdbe-2b8e-87cf-2682-ecb62c3cfd26?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4dcca7c3-9db3-a7f9-8b2b-92cb86488d91",
+        "x-ms-content-crc64": "7WWy9f4NBKI=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2Ug4Oy2dV3v3JQFERkBZaJapURbbYSUAP/TtYt1Y3bhAY1LD23UMa97z\u002BlV6UM5DY/hJJB/Dn3gjN/w5sPSenkhJBOLulo0gneU352bPhu4lqf7kD7iYfMTan6N50rvqVFwNMUzsVc1rKIc6jLgRVLEOEwf2uo\u002BPsIceE/bpp8oqTZIJwlShOVQxeOYxXvAMyEvxar6085rNfoDFzUHWgoG9Dz4lCJFdbdqyxEGpXVKXEUur9zwLdln4PEPT22sTWvZkdE6x5sC5lP3kAS5ZJCAuLrv2K4tEsZnlLMxOiZFun2pLROkD5SuL8WI/JnQqnxcjpK2vHC5rIMK1y7n0awtsdWLEDeA3K0iQazkoBYsku420KuTjv4I73yMmTRlxloZX07ESZpE37HllHrH1Qhs3kRAsP0AmiLbfiC28EN4uH9Sz0DLaEVT8fD5rfqDQRp0I77wJRVZGMUr6M91je9ubN//dQnHoXX\u002B7L8MBuwoVDkGQsyAhJdp9bJ/n3953",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4dcca7c3-9db3-a7f9-8b2b-92cb86488d91",
+        "x-ms-content-crc64": "7WWy9f4NBKI=",
+        "x-ms-request-id": "da6c4f24-401e-0062-66aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2bd12fba-255e-656c-7d47-e35b4c4a53a0/test-blob-93d7cdbe-2b8e-87cf-2682-ecb62c3cfd26?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "11d3538a-40fe-c591-a312-a2cee658d0a4",
+        "x-ms-content-crc64": "jhqXIK7b/3U=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "mAFi0Eeh8wQrH5I8TRWTRHVA5CSc0se7eREkYNXRAX2hRJfCn\u002BrDdBs8ZJOO5djF6Sgqp/q528Y5p1c1fZMvWh4Umwh\u002B0aWKfXAJX20zLJQ5Xnasp1mD52nQiPeTjfaHDQp1eknPRxiDnyqJr3xYBXrC\u002Bx4cg7LEkLSfrUit9\u002B95gVFivrJKahddKQgv\u002BTfteIJ90JLYaopYsOmUMJrP1ac6Dy4q9UfHd5EHvlqqlJd9sjTFMCZdoRbHCg3Jtjl9jVNg9ekJwoI6tVgA0aswrhxRF35lCqWB3W4XYus6/cFXijEHSZ\u002Btc\u002B\u002BxinrNXNBql1vwd567F4Ot3xh78WCXALeXqEd6KGR9pKOPs38qs4CerMqPSYYinHKtWWqGMoGOGorDNrOJ7273c9P7LGQEgiuX3UWWCLYxdAzUzc/69nEhAJn0Z3zMFLxbl9ayJ3AOqNY/71U8\u002BBHTksKntCKf/X1i2SvKDxuuy8iJOnDgfkycxiX4uwcc5QiHIdW6JGCa",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "11d3538a-40fe-c591-a312-a2cee658d0a4",
+        "x-ms-content-crc64": "jhqXIK7b/3U=",
+        "x-ms-request-id": "da6c4f46-401e-0062-03aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2bd12fba-255e-656c-7d47-e35b4c4a53a0/test-blob-93d7cdbe-2b8e-87cf-2682-ecb62c3cfd26?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3241979b-7b75-6592-8d33-10ceef7c8a60",
+        "x-ms-content-crc64": "TIhUls0SGy8=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vJpZUE5EQ5i7kCOMs76h8xN2C\u002B39p0J1RfQiQ\u002B5G9KZn737Vhy79V4OMPCrjjzJK5i3BQxlynBVY4wpaIQCpdZt9JcRAy2vkeLRqcGoXkrbB2FzBhLCN9VJofaMjozWC4seOZmpuChvB3ctlCCyqQVFUmEmj6PDr8C9x107IwdV\u002B6I6iiCtLU85B/6flJ\u002B0mvjxSzgrs3vnXo3Y6/DLM\u002BRz15h\u002BdCLglCUV6YulJBchCSxkSdfLKkgmUy\u002BW1EFebdAWL70HNiLWDLcXFcnwPjZ2t97AZuoQqK1QWCT3Tb/jt3u3kvhaGdcNjjkcsBCCNhD1HBximgbqBYcTttn54sA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3241979b-7b75-6592-8d33-10ceef7c8a60",
+        "x-ms-content-crc64": "TIhUls0SGy8=",
+        "x-ms-request-id": "da6c4f77-401e-0062-2faa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2bd12fba-255e-656c-7d47-e35b4c4a53a0/test-blob-93d7cdbe-2b8e-87cf-2682-ecb62c3cfd26?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AD71093F\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4f32bac0-9e17-872f-1250-1c456fde41e0",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "ETag": "\u00220x8DB50C1AD95C9CF\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4f32bac0-9e17-872f-1250-1c456fde41e0",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c4f9b-401e-0062-4faa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2bd12fba-255e-656c-7d47-e35b4c4a53a0?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-30f02984c7ef7a8844e2927ed8ed9b55-ecf841e1bc703e23-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "350dca99-3b49-c349-9e11-9d9cc93b9ac8",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "350dca99-3b49-c349-9e11-9d9cc93b9ac8",
+        "x-ms-request-id": "da6c4fe4-401e-0062-15aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1477059989",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83ee102a-bcf9-12ab-8c20-42ed306fa50c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-464310ff26d92b91352c9b5986a400dc-2e2536537045c2d1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "155e2928-f938-3082-b06a-dc5d00ae4727",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "ETag": "\u00220x8DB50C1AE5EA1BE\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "155e2928-f938-3082-b06a-dc5d00ae4727",
+        "x-ms-request-id": "da6c53dc-401e-0062-3aaa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83ee102a-bcf9-12ab-8c20-42ed306fa50c/test-blob-672903b7-e727-9044-9a13-bc4c07068a84",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-f688094fc1bb6eb3f00c8789c2d1089f-44dcd0f8b56b7120-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2ef6d918-96d3-fb46-d6eb-8648d2ab45b3",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "ETag": "\u00220x8DB50C1AE772ED8\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2ef6d918-96d3-fb46-d6eb-8648d2ab45b3",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c545c-401e-0062-2baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83ee102a-bcf9-12ab-8c20-42ed306fa50c/test-blob-672903b7-e727-9044-9a13-bc4c07068a84?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2e33d17c-5b10-07b0-a90b-237b18751bc3",
+        "x-ms-content-crc64": "wB4dDbvNsf0=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "gitQ2QOLhm41hNu\u002BCUSenMDHxQcQj9THddKGTN58afjyi\u002BRIn4Z3nKPv37QdxCdrzECdOelAFvJWiWQwBDmQuBrjy31gVfw6TyhkIa8gqbGrG3\u002Be3zAOsnTx8hYhR5dpXyeZOvipC3ZDY\u002BnA3PVCNuCzhOm68dnq1BgJbmPmGAiR\u002B8GIhm64AhAJWnxGTtZ\u002Brrs1bsKur25Or2bfn5wTXUrhL\u002BE0urBx\u002B4LZsJZdo4ZCi8CnsKpF4ktTOtYI2GJ09f0xZB71SfQLxHI/1P7X8QzfnRTcbK2gm0yV4X/ZaCIgZbuZKz5nTUHLm\u002Bw3BQ5Ne0nKKDtNl4lPkMnRYGh0MltQH29CPcXNeFDTENDAaJU\u002BR2U1Dz/n0s0ySZp1lu3YV2mQ5\u002BaeCj6E/LDreoe4jigzkhgDPiMbaU2iEPMqWOJi\u002BrlnMIGvoD0nsRKO\u002B1hFebtyQgPU1RhGdH2Y/PlKWaTOiH/OUV6mg/Lb3I0QjG31XJc4txXejiShIbsDF6RD",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2e33d17c-5b10-07b0-a90b-237b18751bc3",
+        "x-ms-content-crc64": "wB4dDbvNsf0=",
+        "x-ms-request-id": "da6c54ab-401e-0062-77aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83ee102a-bcf9-12ab-8c20-42ed306fa50c/test-blob-672903b7-e727-9044-9a13-bc4c07068a84?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "00cb3059-1678-bca2-4f2f-fb7e472c00d0",
+        "x-ms-content-crc64": "kcu2yuagldo=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3FduwHPYdihczL4Q\u002BfmKNecQo59iEqGO7/paLS\u002BiomxOmP81ocz5HOVu2\u002BtXzpQrFuvU83MF4Mm139B5fkn4uSlSwmH5VZMaFoa58za2NyFlLxdEzq74Sbc2f8L8gJ6cdiLBBAszMcBXudzsS\u002B2T/6iuE04ytOt6Wnmqw9XRHpboHH0U9DMVMv1W7BXSC/3Kon8ZTW1PacE2RqqSiW7rhZpGBC5vfwp1meBR3MfWqE573yBVuNEombO73a2IgqmPa2Z6iwfOWiN0pLOM/Y35YJ5bFqlNlc3JHWp7tKFd7BY3wnFhWx1HrYX94RQdnJslwX0PLWv/QtaZsW2cUqaCF7edVDscmASAFGkkT7S5q4DPVfIkTb6qN3\u002Bbx6qvqlreeslcf0hfCSh4jhkC2/Ii4AXszP20Xsr48xy8gdFZ0WkPRtXqXCw4b0zJq76lqFyNeOelwt1dKhz/Y4wro4hXHr2w8pUdN4PYtF2w6rILU0rALgjptA\u002BLsRy46/ifDMzD",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "00cb3059-1678-bca2-4f2f-fb7e472c00d0",
+        "x-ms-content-crc64": "kcu2yuagldo=",
+        "x-ms-request-id": "da6c54e6-401e-0062-2eaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83ee102a-bcf9-12ab-8c20-42ed306fa50c/test-blob-672903b7-e727-9044-9a13-bc4c07068a84?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e722ccc3-1ba9-034b-deef-adddf4e16604",
+        "x-ms-content-crc64": "KAXN7IilLTs=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "cowB9bXHb0FkzA2ArD9p8xBCa3SAbWqtJEF5ZEuKOaeQ7HgmCV2V\u002Bb/GhecBCgXcTvfnXaFYQwQiU9B0TQr12ZJm8L/GQ\u002BqzrHK1ueiCrBk7nBVUotwGOKl0A7WMIau00atUmxpFFQsNNLAvooobn6e3OLH1oTa2X7cWUj80JovGAeg9LRH/9YYKRm4r15UeWWQO1ej5vy90njtiL8PM2Q4kaKGi3nKWt0Iq6lrIiogh9/nbJVCjzUK4yI/VnMbCPm1gB2/0fHvyeB6lz9TVrBOzQDfK8bO9gZte6hXiwBp8Z6ztZ4MYLHt\u002B6a0y/f1u4xt7IVyO\u002BE25o4XUlpFlDw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e722ccc3-1ba9-034b-deef-adddf4e16604",
+        "x-ms-content-crc64": "KAXN7IilLTs=",
+        "x-ms-request-id": "da6c5513-401e-0062-56aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83ee102a-bcf9-12ab-8c20-42ed306fa50c/test-blob-672903b7-e727-9044-9a13-bc4c07068a84?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AE772ED8\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7bbbd0c7-180a-0426-e9a9-54e3e66a9790",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "ETag": "\u00220x8DB50C1AEAB5684\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7bbbd0c7-180a-0426-e9a9-54e3e66a9790",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c559f-401e-0062-4faa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83ee102a-bcf9-12ab-8c20-42ed306fa50c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e88c08cc01d088f3370120e3fe600259-e67876fa9e9f599e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "241675a5-eb25-c5fa-f274-8026c2a0dd7d",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "241675a5-eb25-c5fa-f274-8026c2a0dd7d",
+        "x-ms-request-id": "da6c55da-401e-0062-07aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1606481632",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e249a9a0-dca5-0375-0c70-06e13b1ecec6?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2b1b250542b0910887c9edc2df6a13ca-a654bd447306ba68-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "60523899-bef7-dbf5-37ba-8de6e402571f",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "ETag": "\u00220x8DB50C1AD30D5DB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "60523899-bef7-dbf5-37ba-8de6e402571f",
+        "x-ms-request-id": "da6c4d51-401e-0062-4eaa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e249a9a0-dca5-0375-0c70-06e13b1ecec6/test-blob-8b3354b3-2d5b-24ef-19f1-46f7e3cf4199",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-7d06300f6238705a566e900e4d5449fe-740a16e9fd4ecc9d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "99d234f9-75a5-e36f-b5ca-5cfb1a3f80f9",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "ETag": "\u00220x8DB50C1AD38C373\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "99d234f9-75a5-e36f-b5ca-5cfb1a3f80f9",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c4d8a-401e-0062-7caa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e249a9a0-dca5-0375-0c70-06e13b1ecec6/test-blob-8b3354b3-2d5b-24ef-19f1-46f7e3cf4199?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aefd5cc9-a7fc-e0f3-f68d-26ef6699d145",
+        "x-ms-content-crc64": "PdfxAkEOvzQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EFxu42nNI99P5diOkDn/8B/mSALLbc\u002BWWlVDkTRyfwe/LCynrm23yxRzEBHlZkv\u002Bup3H/bpUU6KN14kTipGq3WbRz2MMWEGxLnzuWFy9sfQJRNeXqoFNatmJGdbko0GCyDOqFJfn8WJbFs4\u002BZvpGzyaUCUa6EzLlg2SKgz5rzIs6a5AoEpxcIVJ1O5SyDwTeQ0qvUJn7yLQAxZAyXW4j70lDA/pqHbyKN\u002BfzRdeeMnRfqz/0u3zxP6LbKE0LKsTjUUtKbgsJcyWNJRixCIPdYpIb07EvLzTNUcRXj/Vvfg0jD/OLVMNpVTgZZ5ZkQDcf/ca671cStCIXfR1GsuQwHacKjfiQUQ3Osn15FcieaBGNOJEvtI62EVrQdNamIqNT6UnuWbI\u002Bj6y46z3ZmJ9aeRQLuXpSAWkYVHydv902KI/ZJSt\u002Brw9fTqjldshR3Hm7dfrCmmkpAefg1gU1odDOgcOt/3J028oFrGrRbIqgx3cD4knidI0msCRDntgJKa3YF/UFo90GR5kwve7/V5RdPw6OMr\u002BG6w01h09OMD3x\u002B4K9\u002BVWVmiSa/JqvsrafJ1iP5l7Je/fuUivozxyNuBZcP8JrQl4/yKXq9DUk1jlWlmD2vkneJ4CLz6cqrMsIDESDU3P0NOX6UB6534fByXvxkTm7l/rNfhdC33O3FBva4ufxoILGYmJ7/G4rJEj4yQUrOBqRTHVKttVbsVRyQjsC3/yf0Cj4Ky/WQJqMoVnPSRVtjNwASJZyp\u002Bmta7AOCbkyKUVLWfncMgzruwvavhV7i2g\u002BBLZfAZdlLSk\u002BS8B\u002ByDfhWXcTg/AckFnPFY2Kl\u002BjUMt9IzwQC0yiu5SvPnudMbPLU\u002BWSeZwd3IXNdj\u002BwK25ZAahnhNvgy34ZPZZ7ETPJygqiatp6ENsrX0K2QpUM7owqVjzPOazX5oRreTgFpstWB6gxDbyT4vDROCWZLojlCE8GTL72\u002BpBdyoRSEpefIbR3YD7o2\u002BDTlndP/f2LPrv/gnDtA1oMYwkb10M4QcxZNhptJcpN\u002BCxuNrZLpvyS1o/IVowmsiJeawEx0QSdm1Sm8svjGhjtsYZAfsijwLgIhPy3b\u002Bs8NoP4Dr7JGCsn0J9hpLQ0s7h23qUJ4jNVvqZFJUwH5itpZrxH6wteIJVfGK4tQhwH19VEQJFGNlRMolAUg/LbI\u002Bp39D338MStFLoPrsWFKHiGQVF6w6WWJyxr90S7RaCig/jDuUneD\u002BcMlyvbNouOy3nXjkKhYFxA3dENj/l/9dMZaSrIwXMyqDVubix5vuyk2S/O47deASOcft90zH/pjJ1YvclgxgYGpOYJMvIvyx7kaLbNrRIbu2QHLEaXvdu1hN2PIP0jRBclyDw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aefd5cc9-a7fc-e0f3-f68d-26ef6699d145",
+        "x-ms-content-crc64": "PdfxAkEOvzQ=",
+        "x-ms-request-id": "da6c4db7-401e-0062-22aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e249a9a0-dca5-0375-0c70-06e13b1ecec6/test-blob-8b3354b3-2d5b-24ef-19f1-46f7e3cf4199?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AD38C373\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd328b17-d142-56fc-bc9a-a8cc6e668926",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "ETag": "\u00220x8DB50C1AD4D0BBC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bd328b17-d142-56fc-bc9a-a8cc6e668926",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c4df7-401e-0062-5daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e249a9a0-dca5-0375-0c70-06e13b1ecec6?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-420010bc71dda68826bc10371b8d07e7-7d2b046c94d37afc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dbd7d9ae-1367-d603-3332-0534e0c3f578",
+        "x-ms-date": "Tue, 09 May 2023 19:14:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dbd7d9ae-1367-d603-3332-0534e0c3f578",
+        "x-ms-request-id": "da6c4e25-401e-0062-08aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "359207879",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-41bc3120-6cb4-f377-b537-e9531ad12db3?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ebb75e702869c6e6edb768183235c0dc-9ac1729c911ccf94-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "4baf66bb-8f3e-85ad-d944-01009b8a7ccd",
+        "x-ms-date": "Tue, 09 May 2023 19:14:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1AE317DF7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4baf66bb-8f3e-85ad-d944-01009b8a7ccd",
+        "x-ms-request-id": "da6c52fc-401e-0062-72aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-41bc3120-6cb4-f377-b537-e9531ad12db3/test-blob-625db239-e7f4-637f-c62d-f14765add6eb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-e73a38568bfac4845b21afed4418b850-8dabd5d689fb6182-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9695dd29-7c04-2385-38f6-f8872d7f5df7",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:57 GMT",
+        "ETag": "\u00220x8DB50C1AE3A55EB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9695dd29-7c04-2385-38f6-f8872d7f5df7",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c5322-401e-0062-11aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-41bc3120-6cb4-f377-b537-e9531ad12db3/test-blob-625db239-e7f4-637f-c62d-f14765add6eb?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "881d1a65-4018-abe7-6616-78d105109440",
+        "x-ms-content-crc64": "gJspe5\u002B5ego=",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "sJKaQRLdCbvOBBVD4FD/MSfWl7Qi4nWdzCsHzmNhHaH0vndg6c0A3lzzfDl5aaWJRNDYxPPHqs4d/HXn1jpYbed0TyLYn0da1rlXL2U7I2KGfoqTiFitLBOpQu1YGQcimg9SBRqDsKWIfu45cHto4tgSYFewxeSOxiIOL1xaAr2xNZRV6R5IA87kCwlqdLyYQGAVRbiwcdUrwz/4dIBILnwxiDvmEvm5yl2Jy7raJFJldu/7RLwEAcO/KiXfUI9NnNyNOeuBsS1nW3paJqUbUJ/skv2QTOm/LIZ3J\u002BjT2nnOPC/dTetm5MXClOhCqdoeo9qG8r6RvE/zzQxlCopFlIEBjOp2PgOzhq03zrgAfYKrWYMOTei7PH/f6X/eAdo7fQBnQR3wp2TW0msQWu6W8lCJubEGNkaYRU9rllSE1IXT/FC4mTxlu7EeN3p9q\u002BKQSfcuVUgpNUa5z/vNhREQUv7lPF2d3lkUI/3/5//MG5pt2k1dVX89qscK/8lAmDWfDuV8l26E8mudGjFKKU1H7LNhX6vEsvx\u002BqJKWk96P04vIX9gaT4Qs6OfiwDtO84B5wxIW3ziK21zo/u7b7l\u002BMDUalgcl1LZ0vNHbD4vLAL7URHNDMefRSPoR8MVGVUPqIVbL1qHG2BJZ156rBxvlpKM45ydGPv5RSU0NF\u002BfxLmeR8O4xAy4dDWxg6V5JJkHeKEgiDXIco\u002BZUdo1UucQuZKk3GRIttKV1H9m65VWgCCMLMu\u002Bbzxz1dVEH2IigxFekNoC1Eg0vrHemrPGYYb6QtG5qTYrYkpmIQaPBKdgc1FeCEq7Q7voV24J38SIrXROWdyQaNnrMz6PnKMxpboafhdiaFk8Pv8l0VHIEYJ17XOSQKrKwAp3ctUcK6cIpqGz/2G9FkUbEirtepd4ExGsCb8/n2UPX64c6vV0IANIHSqgFCIgyMc\u002Bdz6P7VVy/2\u002BzYCH32QdMpJ\u002BzkDtPluIXlV18x/7/e0Dn8Sg2j2JIqeuVwL/hUEQTY3\u002BCbTib7tBMaEf39idgw/TRD9fvFiU9evZPudYyNkUZWWSPbR4IXAJH6hcqQKO0NPzLAEBsJF1aVPIyTDT6CjIC7pzC0Vbm2KPFpywOAypCi4TpdyX0vTUXNRgb1g/dTe/VJ2IG8VOV5Declo0hTEHX77CgEJMcDiFnu6xOyvKj6FlMOOu4S5oxQ5L\u002BWBa35fjGQ\u002BZPPT1cyRlArzWnVxk0\u002BK4j5QNWL6QmfszwHbYKr9WzeIccVLsr73/Sd6xUifx5uV94k/DlYBQyKM5gXKtjNf9v896CGKPi9/WTg6gHweTQdlRWkhvUzghi2iv8y5LEfzGs5IYd95C7hZv7QexsOlbZn9ZHDKPQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "881d1a65-4018-abe7-6616-78d105109440",
+        "x-ms-content-crc64": "gJspe5\u002B5ego=",
+        "x-ms-request-id": "da6c5346-401e-0062-33aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-41bc3120-6cb4-f377-b537-e9531ad12db3/test-blob-625db239-e7f4-637f-c62d-f14765add6eb?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AE3A55EB\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1221edc5-d561-56df-c729-1320a0a4350a",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "ETag": "\u00220x8DB50C1AE4E7739\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1221edc5-d561-56df-c729-1320a0a4350a",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c537a-401e-0062-64aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-41bc3120-6cb4-f377-b537-e9531ad12db3?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5f121dd83c4a88c2f419d8f9ddc2394a-78b06b31b8a66d38-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "170c6bdc-82ef-37de-2664-bdbc3a7e6fc2",
+        "x-ms-date": "Tue, 09 May 2023 19:14:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "170c6bdc-82ef-37de-2664-bdbc3a7e6fc2",
+        "x-ms-request-id": "da6c53ab-401e-0062-10aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1556914200",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ce7210f1-6f0b-8a44-1abc-c4c988f509f0?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-cf044f51433cc2ee7a1d47bc51256413-22088de637110869-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d1dc474f-7e12-72ab-cc84-39c94ba2637b",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "ETag": "\u00220x8DB50C7F2088FDA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d1dc474f-7e12-72ab-cc84-39c94ba2637b",
+        "x-ms-request-id": "1fcbdd9a-701e-0034-7eb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ce7210f1-6f0b-8a44-1abc-c4c988f509f0/test-blob-66d008cb-06d3-818c-4234-4e69c351e640",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-3c82e691fb1942bd5d60a37f6c7b96ab-11d0bfebcc2d1161-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3bd8b7bf-cdc1-8d8c-8ad9-bd1129862d51",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "ETag": "\u00220x8DB50C7F21B4482\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3bd8b7bf-cdc1-8d8c-8ad9-bd1129862d51",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbddff-701e-0034-59b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ce7210f1-6f0b-8a44-1abc-c4c988f509f0/test-blob-66d008cb-06d3-818c-4234-4e69c351e640?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0caa87cf-ab79-617e-52de-3919502a7784",
+        "x-ms-content-crc64": "Ls82V7hY/jg=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "L45kwY0\u002BxsGMK/hMoY33uKO/eUEZN90EGKAQZfa6\u002BzNbUoYE/VZ2EYEaROaGXtA\u002BjIEliykhYfiwYKnsLWHK0jDE8E8H87pMSWjA/vL3frnP0th1lG8KOvCNU52tieMfT3K2wW6BNpnG2ULAYWIGueLwHVuIVT3AurZfeZ8dn7\u002BFoK5/QLxLTps/rrstSdiNh5q6vGyHl/o19ga4Ib35qTmDO8G0hnglpc6/SaeBk3De0vEFYuJS/Qi0Skq1kizeRQWBqQ4W2QEhlRedyE5Ts2KW2U/L80ZWMD64/zwubxKh4AOiAOlix/jw5M3LtTS6YZbnH7ndElG\u002BK3nPXdnE8iUE\u002B\u002BdKsbN5MxJW2w95insJ/p6lR1BZxM2x49VvkmoeK/Gnx7lMb6/jbeumhjdCRKD\u002Bxl87HqvVqzcamc3dCqGnOK8e0sPBvY7uwtlksj6Wb581ccwL4wxF0RyCMtbiBWNK/k6II3HcPQnQTFzScfj4gyouqJjVnFSi2AGnPoq4DLx1GrPvDUstWDTDOpawc18jia6stFzKdWL55UtwNP5\u002BF0CfXFdECHXeAFBkEWK\u002B8mWhhLTbDFdgqqVR9igAvCM1RCJWEBYI3oA4zbMMZmMAOvPlzrBJowvoP7Ky8xJN3kMsL8w/aOFPmaU0oj6kVERBUbw1Gu5y7KEXbdFkVupu6\u002B5v3zeWwNISljUKFQDMROptcKJWGMNVukIrKPoP60K6xbdQNHUNqpDpI4S4Z9ahSinm9uVIGNMqGiX0a5jYAqvzUFBJfBB1YMURbPQ/nVJsit3RKPRccqzjJRlPGT/4ECDZxReGV80ZcZYfN6ve633SiOG6B9m2lt6jZVf2JUeGGVzUZtc65TIPuLdePToABTqcfZBdPQlGIy454/F2IktOmR5PCoSlmKKvqk8iV1mjomAdWai2KNxSjUOpAAJAmZVsD6Qcsfq19\u002BTurpK6JMvVlkCQWcmimHBB/XxB/JegbhG6tke1hvFmZ2LEx3lJmGl302rBr0DMyXcz2rN9c/tMTUCAAG6EIA9PKvFm3tD292UTyigt3r/R7ezPgaw96PNmd3k5yZf68rJacoROZeumPeJOaanSH2\u002BArxKCtJ9jEUL9/2ZWvC7NGdd20mw6g4gAKUTJ735KlFcKuRmFeD0T92BCUGWET4CzgVDRXE0CRSyKgYtbmiLDs2sOTAMVR6CaY9oL\u002BDIie9rEFW0teDgKCHPt\u002B/eyuF0\u002Bfpz6dQN8njmwN/hy9035ZwWxloS0ljsyBEOQJ0yp56t9zXqVJwXWR3YzfUA/mBEm85PxASHZiehhx3G/7HbtBlBN9SnSZD8A2k8NgRj682syajS4uOaJo0OSNGCTF1v/RXfw8Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0caa87cf-ab79-617e-52de-3919502a7784",
+        "x-ms-content-crc64": "Ls82V7hY/jg=",
+        "x-ms-request-id": "1fcbde1e-701e-0034-74b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ce7210f1-6f0b-8a44-1abc-c4c988f509f0/test-blob-66d008cb-06d3-818c-4234-4e69c351e640?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F21B4482\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a2411f6e-21dc-55d8-94fd-21a629c46da2",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "ETag": "\u00220x8DB50C7F230EC2F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a2411f6e-21dc-55d8-94fd-21a629c46da2",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbde8a-701e-0034-5bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ce7210f1-6f0b-8a44-1abc-c4c988f509f0?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5cdd6349d58baeb8f7eec594c959efa2-8a20ba130f6bd325-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "30abf08d-d5e8-b2a7-9ff5-7047cf9b3214",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "30abf08d-d5e8-b2a7-9ff5-7047cf9b3214",
+        "x-ms-request-id": "1fcbdecb-701e-0034-15b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1274105883",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0ee621ea-fe3d-bca2-99b1-c57b90dcbd33?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fc7a1d68017e49e17b04882cdb3b90b5-9d605e24012b095d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "29b686bb-25d8-ba29-9492-f017768a4369",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "ETag": "\u00220x8DB50C7F32C7243\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "29b686bb-25d8-ba29-9492-f017768a4369",
+        "x-ms-request-id": "1fcbe620-701e-0034-3db0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0ee621ea-fe3d-bca2-99b1-c57b90dcbd33/test-blob-3b4a933e-69a4-19c3-9db5-a0726fb831d3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-455671195aeb9270bae1ef5c46d16e8f-b898b772badc290a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "01cb479d-4b3a-bc4b-1346-aaea485277bd",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "ETag": "\u00220x8DB50C7F3369CCC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "01cb479d-4b3a-bc4b-1346-aaea485277bd",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbe67a-701e-0034-0fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0ee621ea-fe3d-bca2-99b1-c57b90dcbd33/test-blob-3b4a933e-69a4-19c3-9db5-a0726fb831d3?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "27d5f49f-30ec-9f99-be95-45d37dcdd4b5",
+        "x-ms-content-crc64": "5xKBH7Q8Y1s=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "53ruzTBa5jj9tiwgHDmeUoLPvwomk1vRKeUf/sELuVjYd4GjWGDEYKB9LCH5CJ1b852Vp8o5Q1MfHKRLOud38f3TSKW3\u002B/ohCl9pqGc52CFIxAojdhKOnjQtgzu8eSa4BTojJb/4o/ijc5xr0Jrs5USCA3bdU3rrRalwiXe\u002BZJA4saMsFrNhTyARgAN1Is6aQZ73Onaw2rG/ON8VhxmA5Q4MMh73v8\u002BQIbNVy9N3diLb1kjZxioaiNbxbd3US8gGkZv1aPCvooLOZxjCWg7eSMG8OrHRph/j8apHBVLxvNXrTjo3gg0yKzPFC14RWC3IEiQcFxEWNep8EXdFaJww3KtD1gvTp8a0iQ59C5vA0Zl8f/Mt1aTE1BlQu3CW7MOWlS6zzoEi9GteZ40CmSpOvEDdyOipAgcGfgHyg\u002BtVHZxL5nVtDAIYWouIzm0WwjvvAv8wuCTb7ZInrU9/L3F/CErwt7K04K89xW5dITSZ77zGAoDrJWV4cPniRl\u002BzmCoZCMUjJQqIOyFQ8vO1fcxejb2SuC3wk\u002BPleEe40ZpQiSxDQxhudcmxPcdemzJxwvIthLihIN/9KXTiPq3D0GmH/2nGcjqz7xj04Hplkfiwc7VUi03hr2lMRRmjjDcb7m1e15zJq1C3eZSgrD9kmJd8Mcv4bkQbplD/eSwgD2Ph2PINBrpb58hknRG5QAIp6K2BJ1trIn8pQjBLyjEjlmkxv9RMV5HdIEoDlNEyYmVO1ZF/nugHdbVz48SJEB2WQAanh4Eu3JAcpAYQaI6t9t/L/fSgpPeBKUoe2XPMVBAtbVPKitvkH/gBYvrh9wwnxu3kvhIo9ZsOJl43EAMcT0/24/s74msE5t37n0L9nzI99hOG6JX9BHe4vGR9rQ/15BOq6xQR7OOB39c1LVZZEYYr\u002BRnwlWa6\u002BN6DgyYHhznNBbouUrQdKwovBAi\u002ByNYgXqrdUbP2BE\u002Bs8PI1jWm9elidZyebK7/SDs4OwJFe\u002BzAHYyR7KTaG1wBrgWHB552hcoqwIGCvhDPrCkPk50S9TvTCLipEQVAiF5AmMKldESYwbU0HrdvQWN7xkB/zoe\u002B8rTJs/7lzXDE5jgjQiFSJjvkctHr2tqEZ8tZMU7ExL3agaoN28BFsvBAczR/TAM\u002BJZwEl1ux1xfaRUw3jJwl/B16SLx7REp3or/dp2umBRvIGwuuvDFmJKqSM5ZwEiZUGnMbAQNCxuFVkPSb1C\u002BsNEA0b3GQe0PoFCAR5RC0A4yZhYj0iwAUhVQqWS88ylB\u002B4f9SP6a0x6MzLuzjMN3MnY1kAk6mu6k8I\u002BYdaiIQr0nPlwcVYcfp4MHpwVwXMVR2Wbud1MgF2CZSEhu8m12BHn\u002BjE5g==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "27d5f49f-30ec-9f99-be95-45d37dcdd4b5",
+        "x-ms-content-crc64": "5xKBH7Q8Y1s=",
+        "x-ms-request-id": "1fcbe6a1-701e-0034-34b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0ee621ea-fe3d-bca2-99b1-c57b90dcbd33/test-blob-3b4a933e-69a4-19c3-9db5-a0726fb831d3?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F3369CCC\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "534b03cd-4f7c-4cd0-6166-979fc440980e",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "ETag": "\u00220x8DB50C7F347D852\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "534b03cd-4f7c-4cd0-6166-979fc440980e",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbe6de-701e-0034-6eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0ee621ea-fe3d-bca2-99b1-c57b90dcbd33?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-434bdd2030a693644a592af18435689e-ef7cd173d91ffb7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a060d9b-8182-a738-181f-44882ad6cef2",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a060d9b-8182-a738-181f-44882ad6cef2",
+        "x-ms-request-id": "1fcbe70f-701e-0034-1ab0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "221778263",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-54dcede88f025d8f7a925b27f82b26ae-e137089d5279ca02-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "7cf8f2a7-6a51-cc60-01d5-226c007c0ed2",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "ETag": "\u00220x8DB50C7F2406071\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7cf8f2a7-6a51-cc60-01d5-226c007c0ed2",
+        "x-ms-request-id": "1fcbdf30-701e-0034-72b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-7bd828182ba99634a77b2380e7a2c398-cf46a52d26e1d1bd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "166abb9a-a694-83c3-bf2b-d3e0794d7d45",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "ETag": "\u00220x8DB50C7F2490482\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "166abb9a-a694-83c3-bf2b-d3e0794d7d45",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbdf8d-701e-0034-46b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8a9d36f5-e1fb-c85b-e2b8-7f98df14b134",
+        "x-ms-content-crc64": "qheQl5dOQfk=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "mGZj5Bi\u002BOg3dN2bw1zusZJFdquFdCggWkUJks99bTkGMhGbGxa3I6LfqnxoEb/TGKL3aotEsdI1dTVPWWoYtgugkZFLV5p/klcEpcmvtESFNnosigKxvXw/ZaHda8o4xvR0y4Aui8EIe9gwQAwIicDwxiLz7CgE8tARC/H4niqMz\u002BLVOuzAWq61JBIqfX1wNtvg7KGnRNrIb9iwGX/TD9mxp3QtM07QMGtwPsgZ3nFSoNUWG62E5YcEDMsUEEEy4hQ0eNYJRwOM=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8a9d36f5-e1fb-c85b-e2b8-7f98df14b134",
+        "x-ms-content-crc64": "qheQl5dOQfk=",
+        "x-ms-request-id": "1fcbdfda-701e-0034-11b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "42ebb9e8-f3af-064a-0515-bc341cc2d6ff",
+        "x-ms-content-crc64": "TheEB1R9RPw=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Qy8OjMKEq6RZ114qrz0KCi97SUmh7wcKkFYs\u002BFln0ld0YkK8U6yePVeNbCyxIglIAhMFBgd3QVQnBPxsV7JL8QUHtUz6TreC3QzxE4LbWG5M5PZFYctP/SDulU6wMuWlQnonqmy8TbRbgyn7hS3RS6uNH3O8BZA5uLcsDLlo0qomTNEItK0Bj5ZB6d6iU3fyHEmiIxJy6Dzp7fK0kEH687B\u002B1TlcyJf\u002Bi4/cehuylmRAOe9wxa6YtGSUH8a7Tf9VRvYtJH4\u002BllQ=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "42ebb9e8-f3af-064a-0515-bc341cc2d6ff",
+        "x-ms-content-crc64": "TheEB1R9RPw=",
+        "x-ms-request-id": "1fcbe061-701e-0034-04b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "25af329b-6e29-d684-bf1d-c2baafe7e19f",
+        "x-ms-content-crc64": "l2v5Ocn3vAE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "saSXgpVtIDdWjnRXUootAuYg1cep0UI\u002BkIc0JYVy5QGjm74gFhUf9nPoby3YpwO8yCs9XWnOquBiWfINOfux5KhytLfLDOvQAd5UwWEVZeiEd1xaNIeY1PDevrwjEb14NouEZfNM8Ls/bVuLeul\u002BTPQJiMGeV68g2t/G7E4urfAg24vVkP/1OIagGscsDVoHX3HIGoj82d7cZIsUhQNtEMBrap5dqbz0FFA6/T3n9M2Ev43cZZNnJAKt\u002BStz4bOCMgkHwKK8qbY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "25af329b-6e29-d684-bf1d-c2baafe7e19f",
+        "x-ms-content-crc64": "l2v5Ocn3vAE=",
+        "x-ms-request-id": "1fcbe0c1-701e-0034-60b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea996204-b012-90d6-3699-9d31b88dda33",
+        "x-ms-content-crc64": "HAyEJ/YwWl0=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "tdQGOMHcofRwvo/FdpGrLARGm7CwkIAynbjKM\u002BA0K8gW1iaRjS5jJgsEu7VR7QyhXtq7WyD4BiRT05sIEW4UO5PGr6BqGZ/V43Wkq9TL4a\u002BsKdQFeM\u002BnHdACPrmTWhWd74Aiiz1rNkU65XirU1pPiPLrXOeZDsPDH5LQaNvlQohgB7xUqFVyQPOPy5JX/Ml1srbHqP0tBOC9Xmurm81pVKPvSkyd\u002B9\u002BceBzzCkMwbCPIWrYlHpmLMgPbl0rqx6QlJXbuZ7F917Y=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ea996204-b012-90d6-3699-9d31b88dda33",
+        "x-ms-content-crc64": "HAyEJ/YwWl0=",
+        "x-ms-request-id": "1fcbe10d-701e-0034-2bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4cb634f6-f74d-2c8d-2c53-c67f23cdb5e3",
+        "x-ms-content-crc64": "hL6T/0q6tKE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "1isv4Dn5nIzyR\u002BJBFkQ2CmQXScJjlbGxeM3kzUEFckuC/07yaqr5CT8LV6LlYw/gQOQCmTMVU0F6fWhrFc9K7NWWvxf2RJ\u002B6HkCDWD0OzBW\u002BA4xdAtgYbKwMeOxBjfRvwGvNTqT36vxESHrzkvoEa7FTrBFC7er8flJq6cuzeJFME5jSQX5xxxmQGLpeJNmxCAw67eDiLNKA0M9RjQEwkc/pp35iMikz4uX3sdUwnll4ueC/eIuwaefFUXGuHzkYYIfqdX1bT9Y=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4cb634f6-f74d-2c8d-2c53-c67f23cdb5e3",
+        "x-ms-content-crc64": "hL6T/0q6tKE=",
+        "x-ms-request-id": "1fcbe177-701e-0034-0db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "833ae08d-8ed7-c7e5-fb3e-b0404fc0b766",
+        "x-ms-content-crc64": "IUOUu6nUHpU=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "4wcK\u002But6/VAydtnTIHAYRDg9l5zguIXD",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "833ae08d-8ed7-c7e5-fb3e-b0404fc0b766",
+        "x-ms-content-crc64": "IUOUu6nUHpU=",
+        "x-ms-request-id": "1fcbe20f-701e-0034-14b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759/test-blob-71dc0a69-b580-6c7e-c800-3f374666f7ef?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F2490482\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "42f20409-3293-f80c-108a-455a98b9a061",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "ETag": "\u00220x8DB50C7F2A23AE6\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "42f20409-3293-f80c-108a-455a98b9a061",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbe252-701e-0034-52b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2486a50f-2e8c-d83a-8e23-3e52d3558759?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1738e640330e780bbbc738877315b223-41e89147c18309d4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4a37920e-74ce-5ad2-c447-419885ca1381",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4a37920e-74ce-5ad2-c447-419885ca1381",
+        "x-ms-request-id": "1fcbe296-701e-0034-06b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "867138187",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7de300260cb59139c4a2f57423a6daf3-903632265eeb521d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "595f9718-a537-fdf0-d346-7ddf51581109",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "ETag": "\u00220x8DB50C7F3697238\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "595f9718-a537-fdf0-d346-7ddf51581109",
+        "x-ms-request-id": "1fcbe7c1-701e-0034-3ab0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-e04c4b83d85e7c93505c10359c4c21b5-f007a11aa588d4c8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e8d8e203-95af-13fa-fe67-6d8a71712faa",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "ETag": "\u00220x8DB50C7F371EF5C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e8d8e203-95af-13fa-fe67-6d8a71712faa",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbe7eb-701e-0034-62b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e5e5c514-d9d2-c295-ea75-01e26644eae5",
+        "x-ms-content-crc64": "3rOLmNJn/FQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "XTtxy25FzSr6aNqcdsYCHsyYE4WA7\u002BZdWQQ8Znrde\u002BLO1Qo9jSko0so1X8/LU4YNQ18TuUWMiW5VE3FpCWawHe33zqC8xZGib0C6So8XkgZ9LyMbysGdQUyb6Hm4v8ljhULi1IXmUX7NcEkF0T7ePYFr69pDlFIrWoxTIN0X6rB2V8VNNb2Al96kTVl4l3AOvar4TNPvH/Dvtnr4kjChtoWZj3l4kQjD6lP8nkf5s8IcRWMyH53chjfVXn5DhwStA5fU3gf2lSs=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e5e5c514-d9d2-c295-ea75-01e26644eae5",
+        "x-ms-content-crc64": "3rOLmNJn/FQ=",
+        "x-ms-request-id": "1fcbe81e-701e-0034-0fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab76dec1-498b-16d8-271a-d5e01dc2f557",
+        "x-ms-content-crc64": "jSk/j6uPNE4=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ojRhf/OAqPYDt9xNzG6W57wIQaMziX9jT06bsCXUuyWvN5DrPFyStyxne4yqt\u002BCVAOwh/rXy\u002BBi0/jCl5fjRLvy3npXdq6tgdop2yw7zuJdtBrA4s7xwvD54Nj0r7dE0lk2Q8xhLt1RAwYgqey0KwUaZN99HmHs/R\u002BFWZXVuNIi5QjTAYsR/Ik5b9/EzRUERbXX2krby7P3RUKs29FHf0oz/cTn4SV6BGRSQ7KGJDAGgRfj/d6LSxlU27hEZSC79fCRkM9QIGCM=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ab76dec1-498b-16d8-271a-d5e01dc2f557",
+        "x-ms-content-crc64": "jSk/j6uPNE4=",
+        "x-ms-request-id": "1fcbe865-701e-0034-53b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8721dad0-3fce-a75a-f101-80c42605c67a",
+        "x-ms-content-crc64": "DEQD88zkVBA=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "FnV4oWEAXEhEqpWvWOBb6iyq48FaTGjR5pJvfCTYLZgs1OgCKTFlVdqmzW6yf6ScyXoHKSRWycoMp7vOkOAjbH38goT3WcH7RY3ns3/6H2bu07Oq0QNz1gse9YJ2lsT5g2Dxtf0gpG\u002B4C\u002BSXbhVKEodU4LwteJp6iKt52WQ/ha7J7jAeCGlpzS9D8sUe3Gf11OL6IbYHzAvGdixRp8sLeYY2zYDlKwke6hKN6YbVXKtEgwSBRGP3wSEkWJI8GCZjN3g/5w/mEKg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8721dad0-3fce-a75a-f101-80c42605c67a",
+        "x-ms-content-crc64": "DEQD88zkVBA=",
+        "x-ms-request-id": "1fcbe88a-701e-0034-75b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "420ffcbc-6da0-c589-f150-b3be7eeaf2da",
+        "x-ms-content-crc64": "vphpUwuu\u002B9M=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2Ns2pHnihPAagAwkxok1Ij4MX8DSd\u002BHR6yqxDpV0nF1yXKloLFNHPp9nd7sLApyuQxypAodQ1WH5ZbhPMHZapuOvsWrgzPXqxCAgav8lxemNA8p5y5nWIYZHbseb\u002BA0pDdHYXFAyzXYnvj5mL2th05/OwS2r4dtJ2I/kmF0tT8sT910uTWmZWzZTUQ1bcPIb5psozTbgfSv2joTATjQZ\u002BW5zUjgNM4Y2NWb2WJDN7midyLLCBYGUM3oyN7/k2A0BOlie5x25DrI=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "420ffcbc-6da0-c589-f150-b3be7eeaf2da",
+        "x-ms-content-crc64": "vphpUwuu\u002B9M=",
+        "x-ms-request-id": "1fcbe8b0-701e-0034-18b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2a072e78-83f6-1ad9-6af5-26ca4ba74344",
+        "x-ms-content-crc64": "luRIUCXhaX0=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "FfKY0OklmyifGyKFglf07N4fvtv7xlFcWfQdNy8HS\u002BS6/60S6cRJVZYOIMm2h3/iZLEJ/fsztk6hO3b1B2P4mNA\u002ByoKq4QIZ1mlE7KWHptF0O9N\u002B/U3oh0heca5OVE4zFoj4d739OIKu8CeS7sqoGZWkgMuQepqDVUI5THBUy4EaENYdji4UdwNQzw0lVph\u002BtVcZqdOCo5vtdSJ6w\u002BsSWSWld97zi4pmkAnIP6qNXf\u002Bpu5YYOyGumG07MBkMmbMXPnbof9\u002B6iyo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2a072e78-83f6-1ad9-6af5-26ca4ba74344",
+        "x-ms-content-crc64": "luRIUCXhaX0=",
+        "x-ms-request-id": "1fcbe8d0-701e-0034-37b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "50464449-c8e3-b8e3-54b2-2e241ff387cc",
+        "x-ms-content-crc64": "3GvJtHo3jKo=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "zbIYyrlk8GAYI9EIVfoeA/fecLdacVr3",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "50464449-c8e3-b8e3-54b2-2e241ff387cc",
+        "x-ms-content-crc64": "3GvJtHo3jKo=",
+        "x-ms-request-id": "1fcbe8fe-701e-0034-65b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e/test-blob-894b6c2f-e409-09df-4ad0-00e9c8abc144?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F371EF5C\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "068005a3-f361-a261-0e94-1d03c112564a",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "ETag": "\u00220x8DB50C7F3A2E332\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "068005a3-f361-a261-0e94-1d03c112564a",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbe939-701e-0034-1cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1535b621-557b-7c2e-1cc1-2f2b1cdf491e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7157e4e3be77caaab517fa9cd84d8d62-2ef7a70d2fe0f4dd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1980dbad-8072-276b-b164-73ef77b5c7e4",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1980dbad-8072-276b-b164-73ef77b5c7e4",
+        "x-ms-request-id": "1fcbe96b-701e-0034-48b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "527089832",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-97ed1e5b-44f0-335a-78b6-621bb3642031?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2c9bfe616c946654e3dd67db78991606-40bb97fd8be16b96-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e692eef5-67c4-5596-5d15-5717edff03f9",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "ETag": "\u00220x8DB50C1AF288A82\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e692eef5-67c4-5596-5d15-5717edff03f9",
+        "x-ms-request-id": "da6c5863-401e-0062-5baa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-97ed1e5b-44f0-335a-78b6-621bb3642031/test-blob-72d932e6-abd6-f4f7-2513-ae29e41cb8e0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-6d00b5c300866c355f22776890b5e07e-8252a98fca7238a0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2edf93bd-4d19-c70a-1e48-bdfe75bca48b",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "ETag": "\u00220x8DB50C1AF342160\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2edf93bd-4d19-c70a-1e48-bdfe75bca48b",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c58c7-401e-0062-33aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-97ed1e5b-44f0-335a-78b6-621bb3642031/test-blob-72d932e6-abd6-f4f7-2513-ae29e41cb8e0?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "516c0c0b-8a3c-93c7-287a-c4c6c06c9087",
+        "x-ms-content-crc64": "lES/caTyfVQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "YCNcFXRMjreu251yKOzb\u002BHmuJsTROWyTg7VxuUxZJPp5Ig41Iic/qGDbOOnKJCxwOl6dP9k\u002BJya2yZK\u002B2tRqVbei\u002BAbdptZSbn1k9gGDyV\u002BIAX/tu\u002BUhO/rnfliVgc2MceIxJysmkpSIS9Bb2jElMwAyNdlVfJnSgL0L9id\u002Bve2v14QeUaE0Ym7qZW8UxWDJwktYYkv0NvVJX6ZtGpxtCo7irAKsB\u002BFe/tJraxYqvbpdQTPbJlqhu6GP1fH7xkjRfVvhMRldHbtq\u002BWN4iMveH6LrENhokeMzQfBhHDLvYzeKme66SIuh/yR4cSz3KTLVsbZPD7Zvaet3rfAp/AGJepYr7e/dI9YWShC07x\u002B3PBi9i2t7n1SBGzACQ5qbdwIi7/eWyztD\u002BI3fOcSlunnLwHHYa3CVDdpBqtK\u002B2\u002BA7etINkQAoIXHcepPenGaP22C3N4MpwgySjeIcVCFohB2spL7xlyh4op7/\u002B/Hdt3B0ss5xB6NdEbfGewQeDM1QdPV1",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "516c0c0b-8a3c-93c7-287a-c4c6c06c9087",
+        "x-ms-content-crc64": "lES/caTyfVQ=",
+        "x-ms-request-id": "da6c5934-401e-0062-18aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-97ed1e5b-44f0-335a-78b6-621bb3642031/test-blob-72d932e6-abd6-f4f7-2513-ae29e41cb8e0?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "69f31051-5250-d64e-1f47-a07d0699a95a",
+        "x-ms-content-crc64": "MEUdkgpZkMU=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "MfinnkM3PpTkKscbtNVxp6JS9n15T5IGKhwjWpbRr4f7Z4V4zROKOsgPeOfwq8cvrGQr/X13/OJloHMnE\u002BT\u002BE3pAH0xP\u002BNqOyLy0adaqFn9U9K0xpbIJg2ujEiygYybkEWVtsIx637OKnTXBw5IMu4r00h82zW3INpvhrOat7WWW0FhwPWXy2hX6pgh8SMDYl1eiq5AHrkT3pHnwmTPN3a/QKvI6m34kAfgJPCZkS\u002B7aCRSOCkHUjyIUeJjsAkDiLMlZrB3OnfzZfqqX/XIdk1iLFY8eP9Jt\u002B5vQJSLlOP\u002B3Jw9dCp/QDGsYtYuXPZGv9\u002BU/YOywxOz27LCB/Xfa80ar39Ziv4i5uggkBYlG1b4KIC48ptcSBmIiZx3vTg/zPsJF7F27TTdchqXjjL5jrxfxd9xInU1umNlzP1hqyWv5MMfHAelhT9P33x8yL3qkv7cG/dcyqqF01lSDRw3e8rw56lz3m64tkCgIUb0tPGhfz4ChY8uUxoUmUiqU3QfF",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "69f31051-5250-d64e-1f47-a07d0699a95a",
+        "x-ms-content-crc64": "MEUdkgpZkMU=",
+        "x-ms-request-id": "da6c5978-401e-0062-51aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-97ed1e5b-44f0-335a-78b6-621bb3642031/test-blob-72d932e6-abd6-f4f7-2513-ae29e41cb8e0?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af75e1ea-2779-a237-9a86-f6579f2ceb98",
+        "x-ms-content-crc64": "yUE6ygc3Iho=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Ge1i\u002BEUerCMJ2G2vKVnjRpnrJHeNPI7wpSPW0UiDmbIgQzfPy0QjQCJcmIpe5ZwsQgyQqbiPONxfcVMhR9vahT\u002B7juYiFHtVyONVMaQDkr\u002BGqY888u/5kAtab1nwAfhHgRJLo1a2Ci2ROuDUOgY4XN\u002BTm55MnpJPwf7bx6QhZcbrDq\u002BRuO9p0J9hq7gPJVYEIhN6XGZa\u002BuOA\u002B\u002BJY2kKJb9UZ6StWpqTvKsr\u002B6/LaQJun16WRpwhgkBPMEb0MEfZd2Dzi9TsqrXtvijKbXA/wpbpGsAOc98jNuVkYipXm4hnUoRO290tffSkqIRzVxDME22sCxmDzwOBzFTziEiPmiA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "af75e1ea-2779-a237-9a86-f6579f2ceb98",
+        "x-ms-content-crc64": "yUE6ygc3Iho=",
+        "x-ms-request-id": "da6c59be-401e-0062-12aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-97ed1e5b-44f0-335a-78b6-621bb3642031/test-blob-72d932e6-abd6-f4f7-2513-ae29e41cb8e0?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AF342160\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "259344d2-f924-1be0-6fa4-b358e9b72c35",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "ETag": "\u00220x8DB50C1AF5A685B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "259344d2-f924-1be0-6fa4-b358e9b72c35",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c59e6-401e-0062-36aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-97ed1e5b-44f0-335a-78b6-621bb3642031?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-609d27224aedb618db2c0040d6b37a2f-8c4b867e905548e8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5a8458d3-c599-d374-2be6-07e28ead864b",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5a8458d3-c599-d374-2be6-07e28ead864b",
+        "x-ms-request-id": "da6c5a2b-401e-0062-73aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1853214136",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1a6befd2-187e-16da-5616-70c8d66f7414?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e42f076dc3c8b6681a0d05bca3c5fddc-eb777ca7bd781d13-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f400d5c1-22c7-b66a-949e-4946f7cb2537",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "ETag": "\u00220x8DB50C1B08A08F5\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f400d5c1-22c7-b66a-949e-4946f7cb2537",
+        "x-ms-request-id": "da6c5f9f-401e-0062-52aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1a6befd2-187e-16da-5616-70c8d66f7414/test-blob-e50543db-2501-cb39-da7b-ab146007a332",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-60f2d9346cdd83fc1e2a5dc3be306ec2-a3752526f8277f25-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "54710ed5-77ed-c8cb-0339-71d7b0212af4",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "ETag": "\u00220x8DB50C1B095C706\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "54710ed5-77ed-c8cb-0339-71d7b0212af4",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c5fe7-401e-0062-15aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1a6befd2-187e-16da-5616-70c8d66f7414/test-blob-e50543db-2501-cb39-da7b-ab146007a332?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "513e90c6-4e95-1f44-b70f-85af564f2034",
+        "x-ms-content-crc64": "hyicknh67tU=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "mUNeAkbw880\u002BtQjal3x7g2gDBgBvgE0\u002BgE1xqLtqvUZ\u002BSsRWdKsl0eIytREakB8XI8Xe88Ulxxn2IIH5fksS1PjCXEy4JA\u002B93jUePMo8JPAuWoX1jMmAWYKqYFQqLFKXIOAYWDPSX/61IBWPBotOufuQyiTFHEguQQLJDcO7k7LjhxvqI8y8W/uGP2u08FL3XKZYmWEt0QSY6hYwCFE6\u002Bo1jrH9vZJYv024pPtzceVCw0rEdY/lQtbUXUTm1i1OpS0XeUUTSiPcQKMbzBJInu3DGgDagHZaUEvfJVxJdeUcbf/KW/igM3Uq5DTozXbAi75bI7wscCS6uSj5MCTDlsq5\u002B14SfkbxIuaLs5xBcYbVGpmd8lIo8/nbE57Tpv9QZ01qLtIUrg17ZgDVoMCEeUuiJBWLIaB0kQtkO26kHXvrO0hO10KwvGyMJohRU081UppXLX7lyUWo8Z3GsHae00SE7ml4NaII8Wuo\u002BvsYJz28LuTUUO/9AW4GoeWg7gv18",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "513e90c6-4e95-1f44-b70f-85af564f2034",
+        "x-ms-content-crc64": "hyicknh67tU=",
+        "x-ms-request-id": "da6c6042-401e-0062-65aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1a6befd2-187e-16da-5616-70c8d66f7414/test-blob-e50543db-2501-cb39-da7b-ab146007a332?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2011bf1b-d9e2-e25e-913c-03cc9a5bbecc",
+        "x-ms-content-crc64": "or3xf9eH0Mg=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "VNDyGThvRz4TjwTPM5KkM5gBoGNyoJUi\u002Bz7dZO8ZANjtwmr1FrU2nHL2AKz6cCjvBEXQOeGZCbM60B75kuJP\u002BY4s4nEorh3iywTxe6DpJ4oW7WCpScf2U7i2ukWXPQqQpwcdzY62xlUn7W7dqI4TUKiT46SBpbDHNo65cfPXS476YdOYzFr8YCcKglxZGKsqommdBFllDgJWVpf//VVhT6Lg40a6eoROl4N9dyNUbh3jjs\u002BJOkc0lFLRQnbD/GLSqDK5eTVkbyflTmzW6JffAud5G26F2BVbq07z6TgOi5sgq87xmvTnfh\u002BnpOvaXau78j\u002BOSeDzTNAcXs3ncIbu1sPRtT3I7mfzkZxP3TMpgE6jOPf4gEG6LV791DsnAA6Yuc0oCadt8gPYm7dDpG6c895/QziP9laBF4jfyhkry5COtiRlAXemNUXzIOWJdojvYeBdqLzVCcJ3pvIfjifprM8ntO1KNvJm2Q7znNVx\u002BKD/72k5ziPTua1h7luFh6Yd",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2011bf1b-d9e2-e25e-913c-03cc9a5bbecc",
+        "x-ms-content-crc64": "or3xf9eH0Mg=",
+        "x-ms-request-id": "da6c606a-401e-0062-0aaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1a6befd2-187e-16da-5616-70c8d66f7414/test-blob-e50543db-2501-cb39-da7b-ab146007a332?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9694b3de-ff3e-0b51-3af4-448ef7721ca8",
+        "x-ms-content-crc64": "iMjoOwgP6Aw=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CXQVYsGbpSru9s\u002Bu4mztBq1RH5\u002B9sN6sU/s/6EiX4VJn1ZNgW5XeZEo/StdUJddAc\u002BitM2cHX1iWaQ/GW7ziVxR9RgzZjKoYcrpUfmYGVy0k/3Rf6q7qX3U6yvKGGAmOXfPC197KZ\u002Bc\u002BlMCss\u002BHyjxHholxHgm1mkuaWnsK4kVqxxiFyRIBOWZiNIVXuPayUSDrgpHasRtqGXET4NMgkhQNm\u002B\u002By/f0uQk0nEuWEXd1U6AlWI2O3jBH9G7Oc8ViTPaZtSiEK/1MnuTxEt6I15buTvvTJym60VgvZteJJjVDwk9FDFxe8Tei2MmojcthzyzX4DTZjyXc3tPAVLUlw2ig==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9694b3de-ff3e-0b51-3af4-448ef7721ca8",
+        "x-ms-content-crc64": "iMjoOwgP6Aw=",
+        "x-ms-request-id": "da6c6097-401e-0062-34aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1a6befd2-187e-16da-5616-70c8d66f7414/test-blob-e50543db-2501-cb39-da7b-ab146007a332?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1B095C706\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e6ed2404-27c6-148e-0902-c5660358d3df",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "ETag": "\u00220x8DB50C1B0BC0E03\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e6ed2404-27c6-148e-0902-c5660358d3df",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c60e7-401e-0062-7baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-1a6befd2-187e-16da-5616-70c8d66f7414?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cf99ad352419ad860523151ef0f0aaa1-8d894e6c5fd4b868-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d2893e28-3584-77e2-dd91-82c86b10cf80",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2893e28-3584-77e2-dd91-82c86b10cf80",
+        "x-ms-request-id": "da6c6113-401e-0062-1caa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "249743004",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5446a8ec-fed0-b87e-85a3-4eb47019562e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-434c00198a6e28174209056e2347ba3d-84ef50fd970bd057-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "20340719-1fc9-4b8a-94d9-9cdcdca8a115",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:58 GMT",
+        "ETag": "\u00220x8DB50C1AED08C88\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "20340719-1fc9-4b8a-94d9-9cdcdca8a115",
+        "x-ms-request-id": "da6c5649-401e-0062-6caa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5446a8ec-fed0-b87e-85a3-4eb47019562e/test-blob-4465cb8f-2c5f-ffb4-a859-4f9f4a1340f1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-40ba56490859a77c479744651d404ab1-e4e7cf171b52cd78-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2c8b06a6-7e1b-acd4-da7f-d800dc96615d",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "ETag": "\u00220x8DB50C1AF05020A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2c8b06a6-7e1b-acd4-da7f-d800dc96615d",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c5771-401e-0062-7eaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5446a8ec-fed0-b87e-85a3-4eb47019562e/test-blob-4465cb8f-2c5f-ffb4-a859-4f9f4a1340f1?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "44f9838a-1488-92d5-9230-90a562d9a970",
+        "x-ms-content-crc64": "tNbozi5Apcg=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "UcrL46\u002BzyuUwUGx0uhTI7QylmmjkNWWrksfXymqbGUC5LhglzLL5Zj1P8HmyFpCAEK7PNw05MBxlH1Ho3P96lDYsu4v7oyBZqzQrlETs\u002BHw2Vrm8zOIygP78wK1hEYk91FxChlsEhW2NdYvYDpvXeSbUsYVFvsdT\u002BTqN/uJz\u002BJqr7cDnqXIhMdFMLldXWnJiJUeGjV8D9xaV74wgd4aKGn3xLSDb78\u002Bzs4C0\u002BZBv/J7IK9ib7Go6p/WqUrrlAbpLwRTaZS1RhjZ30trfT/6FJfLtWEut7i0St4UrMZwVzrLGaTd8lZZxdqSiJBmQWlj3JCzH96hundPmx66nJlWZYQQoGebGCY9cfOGnCskUgV0tNA1wTtYJV8tkls7oyVBPCcMUaEByMBqda3vHxpIJ0UVRevJIKRIuHsEaYnPBdLKRWAEG/xkcuwPy0uNaQpE5WsSIlk5dBuCw5kl/V82n2/bINW6RAtEsNb/uVVYv09ww4AeuON1kM1EgVhnQnWM2S/bskgwiqFjyXGGPb7GJgBJsTnfG\u002BKMZZAEdcKy4XJhbuApfQkHQDjivvNx81MSgltUGY07sb1JT0y0KBTesOgDJM7amKj7QnEA\u002BFjzGnY89fdnWsfhJb0i3C28UxQgAA4Lbs6EN\u002BWyXNccNrVkWjDadzYhe1YgHf8Nu7h7OvNc3PhO56\u002BnuL4NsPnsxPMLvoH85dveAoS360zTdnwtOyXnv1W9FXaFMr50F8ZcM1kIBfk2flUbft5zmvxe1EZB4HnUCQWZTqkPd7cdae7CV7f3x3CC9rjQzEB7SXp2Klp0NjdIhCZTcrtQJwah\u002BhTvrUNEZxDVvum9BzzBHgEumU1YpTO7dc\u002BRpFC5Ms\u002B2LtIvi5g3LcNJontJi4DpjlC2IY25RVThNDtztsK8HIgeCtRqlZZk\u002B2uKEwK4bepOpBX8AxE9/Ol9TlNgw3cAiYXvL4Cofvi\u002BTSYiMzZSKMZNJRKswBl63A3u7UtDBDf0hYl8yUJpoikZQbXrH823LyGNF55kV8lsdFNyvZGxf0TuLamo1V\u002BH44Llk4Jnj7xAO8IltfCZjDHADFDu9uCba8Js\u002BO4gClnCBTAbfsRHCOiTMoXTj8lUVKF36MUKlOiiTie/9pLSHC1oY6y8gg1teQdoX8Rey9/5FKRIrB2Qu2xHeTCcixJVvRZUZygYm9KUCnPBojkkQ4ZLwuHqhXAT16g8eQjc0O31Ep6yBmCz3HzRtKGt0xk3HzWqUMQsbzuiRJOD2B7JtzmByI\u002Badj0lm\u002BJlFMzOZgCTBVnTMnwlxKdnD8HNLABeCAFoKAaJnKj4gLjhy1Zq1\u002BKO8NbE9oC5WAfkN2p7WGveBwzPYjn\u002BBWiw2rA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "44f9838a-1488-92d5-9230-90a562d9a970",
+        "x-ms-content-crc64": "tNbozi5Apcg=",
+        "x-ms-request-id": "da6c57a7-401e-0062-2faa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5446a8ec-fed0-b87e-85a3-4eb47019562e/test-blob-4465cb8f-2c5f-ffb4-a859-4f9f4a1340f1?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AF05020A\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5976d583-1d9d-7bd4-37b0-4400fd05f117",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "ETag": "\u00220x8DB50C1AF152C40\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5976d583-1d9d-7bd4-37b0-4400fd05f117",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c57d8-401e-0062-5daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5446a8ec-fed0-b87e-85a3-4eb47019562e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8dcdbb2454f941745baf42de7e5158b7-dd8a72935f825229-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8d21e4f2-4f63-75d3-8b7a-bfb2b39b1a56",
+        "x-ms-date": "Tue, 09 May 2023 19:15:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:14:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8d21e4f2-4f63-75d3-8b7a-bfb2b39b1a56",
+        "x-ms-request-id": "da6c5812-401e-0062-14aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "499374840",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2b8589af-d5ea-63dc-54d9-b54df21a818b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e6985bb9d241cd517f6c2d24683ed549-bdfac2c590d4f570-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "374e767e-0704-5e91-a452-e34ca68bd4ed",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "ETag": "\u00220x8DB50C1B0414AFB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "374e767e-0704-5e91-a452-e34ca68bd4ed",
+        "x-ms-request-id": "da6c5e44-401e-0062-1baa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2b8589af-d5ea-63dc-54d9-b54df21a818b/test-blob-5b1111c2-9168-294b-1156-82a057b23c30",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-fb71de0a95c1adf23654c5bd491daa2e-9ba94b363b4f8ba1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "59eca77a-19a5-a7b4-f390-3b6d426213de",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "ETag": "\u00220x8DB50C1B04DCC26\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "59eca77a-19a5-a7b4-f390-3b6d426213de",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c5e6c-401e-0062-3eaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2b8589af-d5ea-63dc-54d9-b54df21a818b/test-blob-5b1111c2-9168-294b-1156-82a057b23c30?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b0253f36-e2c6-778a-5e46-a9afc4082550",
+        "x-ms-content-crc64": "o7uFAzXERwI=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "sEfPFEKOBUtC1S/5jhT8d8SJz3zLSoevIeyopn/6CXAcWRcfDgDo8HAC9C7XmNCQVmyIHLxXImbAH/NW5l/MR8y\u002B3DT93GjEoN4MyFVY14kbF1ATcu2zxDewX\u002B4MkgoQNqxiGbubk3oDw3vdS1kQZ0hpOs4PuNXeChf9THx5tw7U\u002B5Go9r7NgITWD65x1nndoPimo1g8AX7Xgw6knUb9igttCU/HZ3GKm7lJOagmbTSeIKuD0xS1mPoT0XKwKeI92IWjBMwpFTiHGwee8sjVsBbZBX2berb3t3FVtJb\u002B2nHXDGEjg2hodQpz/LcMFqUyPSFc1iRkol7Oq0xb02GiiUGWx\u002BVmsiytcZBzJ33/66DLI3d0oQNNcmkCVNgcDaGp0HN2dk\u002B/y4r1r2WT8Xrgz8Csj7DqLuc\u002BSFV8Y11UkWPuylcKiHRRC1jsfvKduYHuIoUXcH3xv6KLOC36Q2csoR0BpSYj1UZLWoNX/a/0oI/TjUHYPCHm/Qu0flBHVsjxv93UmxRay0w/yxX6msHzlpeeJrYlVGT8G6cbb1b2BAS7Zj3RIAV6ecL0mXEM62NJwei4qTASy2t52H9sPlv1SMcQPzODIXaSI6z0MLvy8DBE0a1uPVvUqZrSWEiFDTpm/1Cq\u002B6wvxp9xJYWDHZqvhudPKG2thgprPJaZsMkuDRZyjTFrSPWDFQsO/RfVUYv/ItJgNuXNuHhFPr4VlRXWQhhuEZBpRD3xyxJin4nylusLmY73zdcwpNW5JQo3bn/1N7r/ZkD6lt2UbmrSaxjuUqjSCvuH33RBPmy7rx8zul2SbGfO8y\u002BrEAOwYl9sXTi8ytJhZGODbVhFvSjTP\u002Ba\u002BYbQMP/\u002BxIF55Jvr413wV1eA0/uVM0VX6D/4PiTYG2NAc8QGqXx45C6p06D5pi5bbL\u002BdInkABco9eEjAAoZYock4p2\u002BV7a3XC\u002BvM72OgXkINoM1lOvTmQG39xTE3tOWkTTHbvP6\u002BwYMRyhqRMxpqnR4Gtl2082bQUmb9mCR8o1cGKJ4tyJ1HTt9OV3DeVQ1XlygTLP6H71nPB26bvSlalSrHiwp4ONB8w2eCap/x9flVqgT8aXJUgj1AYsUyq5G198JKGs4G215XlmmbBYS92Q1xQhckWi\u002B0bwjNO9YPThvVyHLdq98vUs6qqNMEuXi0gom3vWV6kZ2WkavFOaOESEhRxTkV4C0yRe9EfbFYr7WMFLVMV4yyWzbVSxY3ahkvIlyKsvRDoqJYhXt2MhfsOeX2NSDqO/C7o2oGQJUW/t/WGVtQzfi9THIW884VOCUi6Q0wQTD0ROpv0xOKOWIJQYqboBi8m2/pNOiu10gmomtE41eL5r2q3dRw5PrpNxMQCaw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b0253f36-e2c6-778a-5e46-a9afc4082550",
+        "x-ms-content-crc64": "o7uFAzXERwI=",
+        "x-ms-request-id": "da6c5e93-401e-0062-5faa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2b8589af-d5ea-63dc-54d9-b54df21a818b/test-blob-5b1111c2-9168-294b-1156-82a057b23c30?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1B04DCC26\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0237f89b-633c-c017-aafa-a75e2262fe92",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "ETag": "\u00220x8DB50C1B0787F57\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0237f89b-633c-c017-aafa-a75e2262fe92",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c5f1b-401e-0062-56aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2b8589af-d5ea-63dc-54d9-b54df21a818b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-48411c15dd93e6ad375857c893623133-652e64f91d67031a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cb1438b9-22d1-ef14-8167-5561713e8c32",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb1438b9-22d1-ef14-8167-5561713e8c32",
+        "x-ms-request-id": "da6c5f5d-401e-0062-17aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1161688264",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a3a257f2-b225-932d-d787-c21fe3d78955?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bcbf7a8b62883c7ab305f46d1d27d48e-e1ba62d00b1a11f3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ed8e6a94-cc8e-8270-01a2-e78a6ac4c1f3",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "ETag": "\u00220x8DB50C7F2B0C4E0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ed8e6a94-cc8e-8270-01a2-e78a6ac4c1f3",
+        "x-ms-request-id": "1fcbe2ec-701e-0034-4eb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a3a257f2-b225-932d-d787-c21fe3d78955/test-blob-b3207428-e24f-f836-8e34-eb912d08df40",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-be13010b79507d0ce6d5ad1d1dbe72f5-eaa35365b9e9a84a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5deb3841-a661-d826-8186-de3b51912a10",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "ETag": "\u00220x8DB50C7F2B857B2\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5deb3841-a661-d826-8186-de3b51912a10",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbe316-701e-0034-75b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a3a257f2-b225-932d-d787-c21fe3d78955/test-blob-b3207428-e24f-f836-8e34-eb912d08df40?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f5503f01-821d-7cde-ae5f-c52bcdcf3914",
+        "x-ms-content-crc64": "Qb9r\u002BTLO5Wk=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "dPofy1P1PISzZxBZmctAID60i3lInMad9HTQLYcZ0M4KJO5YmH26ni0KOia8F\u002Bg2YcdMtTlHq9gzgtfeJQ/8mpdCT3Xc54fA\u002BexMPWGg4NyMmsvAzBuUwngVJRam23kdDp\u002BPeshyWXk/jLxM\u002B252kqH6UotDPM58rYz8xsJxGh1zLi7CEWYUGUBRgD9eSMcJn5N0q4nu2dHREsw8dpK3zXGe2cw/tIA65TlK8ruOHWXF8ycu/G6UhVVd8P6Z2KOtmrPOwG76yusSOsVPo\u002BcWQ/VndoNriNADClR34sOBoA2WnVcIwFz2yig8HMKoROFtR60JMmEgQhHiyrUagucnkJm4uQaPDYKYcaxaL2wNWsVyCZsWeG6rdVpGJfWm20dBFIsp8Irb3TkqcMC1xhOk1G/wp3hMERcqDEOrSeiN8ZVkGBrg5Go7lyth6wiu9q9HoVCFtjTO9AN0/uNHL5RQnX4rUK35xPAFtRBM6iUPfBaTZKeYBzthlSQWbOWH9GiXEE2KgqUCTt1ggAEjgQndZYLMs8rtuJZDyruI4lcKfcGotdrXhPlxkRbJOIY5PRMaOQdju0CdqVi3R7jqeWuFVQJAe8wvBeCIWyG0I4APCoynbqlQpsKACgyCID1BhxeqROKD\u002BMJH6zMn22Af6YbXqD0rQgvCNa5AwHC/reWiRtMJCd\u002BdixHKX4N1KctiYCGGqncAFkQM5w4zQzdRhz1OhJSMFd\u002BmORwrYOKHTQzj3l9OOQJtojCO/CLQakjaedhFJ6Q31ktC33Ba1bZihJoCUGXXAk474OFk/Ri91s/UUeYKQiZnqwgUDFqSEs15LHiHzhnjAneJCkfD09gyhQmghoPPV0J0mqVdwvX0qM0U6tCgNQe28U5vgDjfpNgv4odQ8YxJqtQ2EzN0hj\u002BBlWF5rugHkU8B6pU1YNcJlPbMLeBuo7dAy0D8aiHTQmoP7urXZfXvJ1A3Tgf2E0r9LH49p1hfEvKpOOOoCycuLacqJnHsMi8A3AWPN1SwSrf2/z2ilpsSr9v4LSwSRxwpCCFfzO3YEPpPPMpTz9qe\u002Be4rsgzpi5cMGHaW9AQD7pXpZi4zUH3JHe5DU1rQvt8AWjM955UQQH2JU7N3Qhv1TE40ammsaqlxYpQdpTc8O1mWlZrRxQcA2Cawqf3KUtvTTgcLm1R2VO\u002BKzIQB8ppGTBdZ4KyBJIZHNJFD\u002B8Grpg\u002B4SlcvMZ8FIEGrRviC/\u002BaLalzlcHEuUSmAxGfDMlgu3iV0SKhCFht4VMBr1t2NxTWquJFkxjWeifgtrmw4Qe7ofGfSDbY\u002BSFNAbRyxw3tL8/8xGXrHyRjw1r6vFGevPxPRgll2u7h\u002BbG89I1gZ7cZ84rttBw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f5503f01-821d-7cde-ae5f-c52bcdcf3914",
+        "x-ms-content-crc64": "Qb9r\u002BTLO5Wk=",
+        "x-ms-request-id": "1fcbe340-701e-0034-1ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a3a257f2-b225-932d-d787-c21fe3d78955/test-blob-b3207428-e24f-f836-8e34-eb912d08df40?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F2B857B2\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "11398385-3541-8af2-a6dd-5d236028ad99",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "ETag": "\u00220x8DB50C7F2CE7481\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "11398385-3541-8af2-a6dd-5d236028ad99",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbe380-701e-0034-52b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a3a257f2-b225-932d-d787-c21fe3d78955?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c3254f6c1720f6aead86c3e8cdc1d48e-92a5e928fc908ad0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4aa69193-2796-5fd3-d351-cbfcc705bbba",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4aa69193-2796-5fd3-d351-cbfcc705bbba",
+        "x-ms-request-id": "1fcbe398-701e-0034-69b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "904498569",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-21b6b8fa-76dc-b546-c1e2-94d92fc2e834?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-00c8bb9c6d0d632df19578d1f1cc358c-dbb0f7e221aa0183-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "720a2018-bbf4-c0aa-ce9c-0360ea152552",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "ETag": "\u00220x8DB50C7F3B23048\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "720a2018-bbf4-c0aa-ce9c-0360ea152552",
+        "x-ms-request-id": "1fcbe9b2-701e-0034-0db0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-21b6b8fa-76dc-b546-c1e2-94d92fc2e834/test-blob-e9f13f1a-ebf1-eb5f-1601-dc1035027d2a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-9397ae1c21ce341883ac96221f89d3f5-10f9cb3496a359b0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7141a336-4cf0-3943-fa00-e3faeaa75f41",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "ETag": "\u00220x8DB50C7F3B9270B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7141a336-4cf0-3943-fa00-e3faeaa75f41",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbe9e0-701e-0034-3ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-21b6b8fa-76dc-b546-c1e2-94d92fc2e834/test-blob-e9f13f1a-ebf1-eb5f-1601-dc1035027d2a?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "91d90bd1-0bc1-e53a-1eb8-ba760f41e4b1",
+        "x-ms-content-crc64": "uoVIX53mFHk=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "S\u002BsLLIFmSRcfFzj//oFUsqgewQ63dkDR1cSaE985tNO3JXp1Aw30sdfzU9yDq8JNSFG3y1MWm9SrOle8zDU45WNlR9gH36\u002BaKQ83xCJjTSoCTcuOgeh/oYqlyci1OOShu255HWPpRWmiHaJE3tayR\u002BwtuX9qqmN65aZOYRXm5PEqlgm06jDGGQdi62RGO8Kz84HciH5lNhEK/zi8muRTvDiwGUjN/V28ZqB4B77/M6rkmm6TCVxyxV/4qur4Cn4iDi8slSF65vUkICHe7C5SCsuN2P91wLLbPlTo1VNyxFwiVfmP056JabR5b\u002Bk7lNgwpZ8fajF\u002BrU18UFfMkRChsVvFu5c1wzcsA25L/FHJoKl8ty\u002BzU1kqo6irEoJHvNik172NddhB\u002B\u002BJo8mbDM7H8s7CtUNng7V0CmxfvibC05UeWpiSTOyrQO7xNS2DyZ3D2r1/SmWz\u002Bw\u002Blfi9rBUXExswwfLIyNaHeF3BUdkqL9DzOn\u002BNlR4kzamOI6M7BQD\u002BlKHJdT0zrjaUboTL1X4DBHYnumGlmX4NHARJSpUjXGNcwr0nYKqTz5w46TaZWOg7ex8tA1qfWQsjzGk46mOhcRIRfwKw26Pbk/rVbKBHY7McHc919kkYvWmx86RBatU4l3gUd\u002Bnlep97UX9vyexa7FimHNyUK3rY\u002BLGZDtgPiikVnNUoMuvJNpMgCpTJuPONVxdbm04IlHwNO484THu3e9dWWi0XMqls7OY5ZBDWH0\u002B\u002BG6fAo/7bDPhpGwdskOonaJ7NY27GdiR97r5n3zBbNxw/ejDD9sfYe00krheh8Ev8EfuCCKvg56WDUsUwYy3IHePrPRa5U3HG5PgRocgMy/5ie81E2S5gXoKLQKQCqAgfbIAztsM1Mr6JuxOzz0XddobG3fdgg0S1iu6EPgLNxEzv8kU32RU7PTkOyx4KrI9MrdotO8oAvulLfivkoQS7u/bW080Ala1hm6DOUbg2qt5fR4A4kIhy30Nb/FrpVowkUw8XM8iyPAg8u6ApQl0hFMNNhVl0cxt\u002BVASJpKlCeEUUmg65H2cFnQt4C\u002BTYSZzmOteXm8Eir9/jmO/EOJdu6kNrFKheZ/VcN/heDHc2lgp3o2nButxz8fouxYaHQWR0GRGRfTTkh8LiO1PY1KNovQLVXIUtnT9m5xK\u002BP5J\u002B1PaD2eNVlRjVgxuW7394mx1GthhzseTfRovSOpYSNlgwY2ZtVPrAAxfqD9lphq3P7kv1Z3mJ\u002ByMRpINXg2qCs1zDZowZG0YihqMAmaIbZc/eEkxKHM7etmgzW6BnaI\u002BtV1x8piAhpsL10uDWeVFw9j7DeWEeSJaN5LAT1c\u002Blux4jU0JVns\u002BfvHuJREneCD0WwlVg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "91d90bd1-0bc1-e53a-1eb8-ba760f41e4b1",
+        "x-ms-content-crc64": "uoVIX53mFHk=",
+        "x-ms-request-id": "1fcbea20-701e-0034-77b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-21b6b8fa-76dc-b546-c1e2-94d92fc2e834/test-blob-e9f13f1a-ebf1-eb5f-1601-dc1035027d2a?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F3B9270B\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "df299513-cecd-1480-7b6c-51c2b56817c1",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "ETag": "\u00220x8DB50C7F3CDE479\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "df299513-cecd-1480-7b6c-51c2b56817c1",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "1fcbea88-701e-0034-5ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-21b6b8fa-76dc-b546-c1e2-94d92fc2e834?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7063f32a763bd5c43562a6ccfe39fe41-7c4f0d77c46cbc30-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a635425-0518-21e4-8396-cd096f94115b",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a635425-0518-21e4-8396-cd096f94115b",
+        "x-ms-request-id": "1fcbeab2-701e-0034-80b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1176284817",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9a4ae986cf2f5cd39e902e7b00c39a23-369019534917ffa8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f6e278cb-e553-06e9-3b30-48ade3c4e143",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "ETag": "\u00220x8DB50C7F2DD9A9A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f6e278cb-e553-06e9-3b30-48ade3c4e143",
+        "x-ms-request-id": "1fcbe3c3-701e-0034-0fb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-cf1b2620960955b240314e86457c0e7e-6dbe51b5f9388b79-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "285b0624-c9a8-a37a-2c21-d90d5deb3d4d",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "ETag": "\u00220x8DB50C7F2E617AA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "285b0624-c9a8-a37a-2c21-d90d5deb3d4d",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbe409-701e-0034-49b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dac3fcd6-405f-aed5-9b2e-1f33132e5487",
+        "x-ms-content-crc64": "DYkAJfAyq4U=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "f083rZlj3ej5Ll9JBlqDbyKtQ9UA88SO8\u002BVqj0GTdTkYnOs1gTcJaJr5/CSGnwDhrNiKNYELQoyKqbmz\u002BE2nZrkmMWpuTu7rpNs6BvafCFTlieNoCD\u002B3DFlfqth9VW9NUZZrX26Wcl7qn5Gl0DyV66Flzm5qP115biUQD6MVbk9r7bRgM6jmTheEfmmuEjsdyb83GIYA4hI58vFJhWO71DBBOuOHNbf4f39X5sHzy1zp80Xj3lXJaguiJkG2ncm0yak4bddYlZQ=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dac3fcd6-405f-aed5-9b2e-1f33132e5487",
+        "x-ms-content-crc64": "DYkAJfAyq4U=",
+        "x-ms-request-id": "1fcbe431-701e-0034-6db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "61377e9d-6228-c2ed-3c17-739dc6ae4af6",
+        "x-ms-content-crc64": "njvJUKWsNCg=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Bz6ZBqn8UUUmlV\u002BSHdf223fP2OUOdkLitqMcF7tehJFdsdugvMPBDlDhGiE9N5bxs131CICwhZH7tk8F3zqKyBHONWz7Vh60DcmULVshpH8NK2RdaHsQrCtKpAVzuy4WV1IPbwEq9V0\u002BQfq2G1g22hLQ\u002BLTVLF\u002BVvYhAsbEYQFGaftUIETV94jUHHieBWpDTE8nzo8N6QCrzerF56USrJgCoG52CLcncUhV\u002Bzg43E2P3bZ3oJJ2OHz2qFJaDBPnwW/gn2D7zUOU=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "61377e9d-6228-c2ed-3c17-739dc6ae4af6",
+        "x-ms-content-crc64": "njvJUKWsNCg=",
+        "x-ms-request-id": "1fcbe46e-701e-0034-26b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "949649ef-f3f7-935f-a141-d665f1087775",
+        "x-ms-content-crc64": "GAiy6DoJKCI=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ABdQrfxyHLxmToF8psMBYxr8X9cYMllOHI1yFRA7JAQct\u002BcNTOAjy45YMDSCfUqY98S\u002BQpR4zM2\u002BApFuAAarKyl9X\u002B/b8xY52JRJwAIky55D2R5MfOJvpOsZT0pPtMqHrAQLBR5avAOthWkALwzLmjbyKiboX65GDboEwaPL6iPJwRP9GMWA6Bwanvd5b3XeTrUTXIqkn01VxPhjVvtg4ppFN235zYFxckIKzcG3zZ1FJXPtuI2ZJSLGp1TNHJEhurxcMzgH5YA=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "949649ef-f3f7-935f-a141-d665f1087775",
+        "x-ms-content-crc64": "GAiy6DoJKCI=",
+        "x-ms-request-id": "1fcbe48a-701e-0034-3fb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7daeb90f-b618-affe-3b11-350f9b787f4c",
+        "x-ms-content-crc64": "nTNyWtcQcjo=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "NKLpR5nRi572Wx0xiHIpDKwRSjMmLKRVsOgSBVqaZD1A8rkWpFGLUDoIXXH\u002BYJlHkk\u002BHJr2yWgf9k5ewvoVEXPbf8JW5E2hahvn4Hc8yV1BPy3MKEz2AjpixGBC62pK0xAB7H28Djn7nLKDDuTw4yzxGYfMSOkm4XmL9CPtXn6xnQ1nOtjjgSzz0IuadvdRbeUzTc3meooq3w8AMBoaDj4z0W3bjaRQEZRW2HhdjGqGOoY\u002BuhCsyyaHPF/N31EW2cZNZqWJeeA8=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7daeb90f-b618-affe-3b11-350f9b787f4c",
+        "x-ms-content-crc64": "nTNyWtcQcjo=",
+        "x-ms-request-id": "1fcbe4b5-701e-0034-67b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3855bdbb-f95a-fe5d-0f5e-d02b32759127",
+        "x-ms-content-crc64": "U2T0yR2lyx8=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "OM8NY\u002BeEclSoH35l99QLYcGS1BRSIIyRzwCsgwlwPi8of3a0Hc/hHVzDS1hV4L\u002Bch/jo0IlkvBdCfJTn1\u002B9KN\u002BBOPHdeVkPysLe3j9UzPO9AEPwQiG6mxMNecqE6\u002BkZteBN4BqNIPTG19iDRrC1CDj\u002BkpsfyOa9xqHizAOSht7VxShbBuzVM\u002BNLLW5FO1BeWG2RhllN\u002Bej5kBl4rlD1MEz9qX2EWgVIKWK71J94dI9NgHeSAPyBh8tDYXLTXIGOUfkdR43W2gJk=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3855bdbb-f95a-fe5d-0f5e-d02b32759127",
+        "x-ms-content-crc64": "U2T0yR2lyx8=",
+        "x-ms-request-id": "1fcbe50a-701e-0034-39b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dd542029-4622-13f2-e2ae-1eb72b52544f",
+        "x-ms-content-crc64": "4M381kWWj/0=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EVc\u002BpYlSYEbjist3WMzTHwhskD0lnjI3",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dd542029-4622-13f2-e2ae-1eb72b52544f",
+        "x-ms-content-crc64": "4M381kWWj/0=",
+        "x-ms-request-id": "1fcbe539-701e-0034-68b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917/test-blob-96a9604a-3fcc-a95e-9d4b-6fe8e1bb697e?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F2E617AA\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "12015095-b320-0004-cc82-882f394be8e8",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "ETag": "\u00220x8DB50C7F31A666E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "12015095-b320-0004-cc82-882f394be8e8",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbe56f-701e-0034-1bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5c873b72-e642-08c5-2907-500e4de2e917?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7fb5c0d1943dfda83345c177f26da286-9bf7edfd94b47364-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "db21dd72-4251-252e-c6e9-5ca3f207296e",
+        "x-ms-date": "Tue, 09 May 2023 19:59:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:50 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "db21dd72-4251-252e-c6e9-5ca3f207296e",
+        "x-ms-request-id": "1fcbe5d3-701e-0034-74b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1671459389",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
@@ -1,0 +1,330 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3d001c6c0ae89797390a801e31c0c750-269e4b963bb67d7e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "eb0d823a-1992-b2bd-4ec3-b9226742ee4e",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "ETag": "\u00220x8DB50C7F3DE90EB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "eb0d823a-1992-b2bd-4ec3-b9226742ee4e",
+        "x-ms-request-id": "1fcbeb05-701e-0034-49b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-e8c889f951dfed27be371ebfb1ed7b2b-e4d22ee7365ed2bf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e8ba49c2-1297-b874-dc81-36ce0822e7e0",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "ETag": "\u00220x8DB50C7F3E6E70A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e8ba49c2-1297-b874-dc81-36ce0822e7e0",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "1fcbeb37-701e-0034-76b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1?comp=block\u0026blockid=yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "369da51a-37d8-e049-369a-cce09983fddf",
+        "x-ms-content-crc64": "IPtuqWIWj6E=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "uGZZ2o8qOYMQxOhf6Bcrlpe3Er5cAPE7qWOrQmLysJ0SCUVHHLOIEEmK284xXco3mCOKsC8w8rh1HTArf/YgHhRLTd/S43nkLgJ10SUiCkyZdKo/aABu4heM0v\u002BCXZBSar265hDrZbSppoEsuiGTUhLkkQtM4LYT3WrHRRF6YdFxImdoaCQ7rg/2lsF\u002BQSf2\u002BYDsnsuFBokGpgmlIx\u002BiL0Swupe5K\u002BnuqOP8VUr0lZtD0UyRjsMF7BzdYcIblYvvU2Z8zoePPM4=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "369da51a-37d8-e049-369a-cce09983fddf",
+        "x-ms-content-crc64": "IPtuqWIWj6E=",
+        "x-ms-request-id": "1fcbeb5d-701e-0034-17b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1?comp=block\u0026blockid=kAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "63b44533-b185-3b07-0d54-26f6a6516654",
+        "x-ms-content-crc64": "N7eMxCgAt5o=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "lv316ImwPhIRbWJR0xGhgavOe9vKJtMTVwwC43fGE7OVfvqQzhxibJ9Osa0zOhxBxfsjuRRgA3Ap4ZF8rVqaSlqvu1UXELKOaw48e3Um3x3wwB18o1qeNXqKZuyL5b5EtGdShH7HKrVJlE4GI4j7AwJzjO08Hqb/EIbajarFAoVP\u002BMcN01ueKZVoMg4MmBHxj2PqF1nRB5XAUnP47J0Lg5HItivB7S\u002Bm1WNX1OuX83h16f5G2\u002BsrfvAxTIHnpj34Xa99Q\u002BHlMKE=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "63b44533-b185-3b07-0d54-26f6a6516654",
+        "x-ms-content-crc64": "N7eMxCgAt5o=",
+        "x-ms-request-id": "1fcbeb8c-701e-0034-46b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1?comp=block\u0026blockid=WAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "54ad079a-9ace-b45a-46c7-c76b418fa9c6",
+        "x-ms-content-crc64": "pz9nSx/fDOQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "NENC9nkzqSle\u002B4MDn8Snppw3O5Chrr8vJV92Oxqwlo\u002B5XBKXqTUFvYcjIuwjOViYCNamqqqgAIWEE9AZvG4OrmTzSkOxD/1nMX0IfYvTC\u002BwH3jNDCuzkGVyME5Zk6wAZFHOHL\u002B8V5/jZPngsl4L5sQfkEt46yqR4DzHmJPxmAkV97mkYTNz88vY7astzt4HZk2GPgNki30nPDiC\u002BLsL7cjsyr6gZ4WUq6CDn/mDZBVevDJGb14JsWw8fSD27PcM0QPePQAjYwLE=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "54ad079a-9ace-b45a-46c7-c76b418fa9c6",
+        "x-ms-content-crc64": "pz9nSx/fDOQ=",
+        "x-ms-request-id": "1fcbebc0-701e-0034-73b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1?comp=block\u0026blockid=IAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e5b0d96-11a4-1286-b63d-224db1c67190",
+        "x-ms-content-crc64": "rstWLbK1A1o=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/GSYuTrh6PYIyA8hMWCbucZUmPmYJ2\u002BqXLO9aUnET9ZM4J5z6rIgLjdSNPMuoQPgXNZ6sz/HGNT17VyGI3\u002BsRHk41VDBJ88TM2rCRfJ8fLqw3A1zSZuWhMfKfvxVmgu4pvB59cyyHzQHZ4DVBNPheXGi1UZxOPreoVCJ9qnSvZlfCp8CAobu/r3YbOIawYD06AWLs8TERm31m1N7KCiLNKnndvoz33bqtNeImMwYw\u002BDQlQ6jRwrUmsMyDGcyctWVTTc4MkuFwAg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9e5b0d96-11a4-1286-b63d-224db1c67190",
+        "x-ms-content-crc64": "rstWLbK1A1o=",
+        "x-ms-request-id": "1fcbebdb-701e-0034-0db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1?comp=block\u0026blockid=6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "34d516b3-0a33-4322-342e-5aee7462084d",
+        "x-ms-content-crc64": "WoGr2B3jE0o=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "jqD/7DutoN3Xc6uTGeftnxLbNgHTD7hBAfNLlN\u002BQlUrUBRSmCudfFpEvj77GQntlSpkfcE6\u002BNX/nvetHYQz9Rt5gvhTSRpQrfB9wo3/5er545kpGcCX8FtCVvk38F7WEMUngZoRnkgME9PQuTpEA7kIsz3vBt9a5ZKhDPYdHLmRq63E2GBQ6EVNGQXswzcc\u002BlNAK0Eg5wnpyJwHcI1V7vcaPxGIgytUt8r0ne3VaiJfgBai3PF4cMSn3w/ESXu7\u002ByoO1oQllHso=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "34d516b3-0a33-4322-342e-5aee7462084d",
+        "x-ms-content-crc64": "WoGr2B3jE0o=",
+        "x-ms-request-id": "1fcbec02-701e-0034-32b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9b99c41c-3df0-995c-3586-37ed52fe8ef5",
+        "x-ms-content-crc64": "c32WD6eMxJc=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\u002Bt3eihFHBBieavsdrMSBaHKSOSgG4xqU",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9b99c41c-3df0-995c-3586-37ed52fe8ef5",
+        "x-ms-content-crc64": "c32WD6eMxJc=",
+        "x-ms-request-id": "1fcbec29-701e-0034-56b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83/test-blob-f2b029cf-e6a4-7a8e-e7de-bc5f80921fe1?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C7F3E6E70A\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b0d2c673-6dc8-525c-55f9-06996fa79621",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EkAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EWAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EIAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003E6AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "ETag": "\u00220x8DB50C7F41B0EB7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b0d2c673-6dc8-525c-55f9-06996fa79621",
+        "x-ms-content-crc64": "8YdXVk6iuj8=",
+        "x-ms-request-id": "1fcbec5d-701e-0034-08b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c7dc259f-4161-d915-0c24-cf4d416aec83?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-201351f5e527acd8d7c69ff3c1ff3188-91291098d72b0e87-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8b7abb13-de2c-7c2d-97eb-4e95dea39cd9",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8b7abb13-de2c-7c2d-97eb-4e95dea39cd9",
+        "x-ms-request-id": "1fcbecc4-701e-0034-68b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "11662559",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-705f6c6f-c792-2519-4720-ee874df32343?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-735879ddd218e589802753f1861e5a81-f48b7c93951b4e40-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2b67a788-4f51-ed06-c79c-344a0e5f8f48",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "ETag": "\u00220x8DB50C1AFE1ACEC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2b67a788-4f51-ed06-c79c-344a0e5f8f48",
+        "x-ms-request-id": "da6c5c71-401e-0062-12aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-705f6c6f-c792-2519-4720-ee874df32343/test-blob-12a2cb39-7bc8-b18d-654a-4f781cdf9f99",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-ce0e6e120f2cc7cb11ae93278e79e29f-ef8b2b92cb598fd4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "095f3a02-6885-b66a-bfb8-98a8bb932704",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "ETag": "\u00220x8DB50C1AFF0028E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "095f3a02-6885-b66a-bfb8-98a8bb932704",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c5cc0-401e-0062-56aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-705f6c6f-c792-2519-4720-ee874df32343/test-blob-12a2cb39-7bc8-b18d-654a-4f781cdf9f99?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e175ae01-957f-3b14-f86d-4b48aecaf917",
+        "x-ms-content-crc64": "/NlEkFZmDTM=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "RYHzNBSspfbCgF3531oi0wGC/6WM\u002BPInXZLS80Rf0LIJoHmBgOtX2wJwaNHxDQ1semFJjGDqu0yPzNaB2bGyYrCr7z7goFMWKiSiG48gNVCEZnnjFkNSH\u002BQs8rMU1QJRvgYgRh3PjNoNM2I8SKC9bpeG/XM3z0xsWNBas66gAVQiUFyJ/\u002B4ytdqf1uPhFtdDb4MbjtiOGe\u002B6tO1MdNgrbDENGvdDM26oU0iZmPloi0L5FkQqhXJ8kzdtz0sA5kABc2mx1PzfADsVcjuQ9YH2USirU16TAee\u002BkIa/1mQiqG0HlyWPtrZGGRYIFRI37J62d30iVZLibnGC80N1HynX8srOiF1bZppyZTpHiuzUh6ToCV/m/1LaJSmzDMNz0fnsMSJIaWNAWhDisPBYmuOFrmufjBbK8PJ382M0qFrX/pNAWljJix5Ap69PA05igopFLl5X1ETjIkEw0XUADLK2C7JcF0CKuyJNXuVmeuyjFHHZ73n7gCpPXTgXmbqoQJv9",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e175ae01-957f-3b14-f86d-4b48aecaf917",
+        "x-ms-content-crc64": "/NlEkFZmDTM=",
+        "x-ms-request-id": "da6c5d00-401e-0062-11aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-705f6c6f-c792-2519-4720-ee874df32343/test-blob-12a2cb39-7bc8-b18d-654a-4f781cdf9f99?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0da76c9b-451d-9784-2c54-7a415161448e",
+        "x-ms-content-crc64": "t0EEQMALeJM=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "mficBmpKunI7CXVffKdUjLwEJxw4uouHDLoHcyJopR5JaeH0Bg4GjzQHv3a08OCQwgz\u002Boxh\u002Bxd5tFPmwQkZQ02RXFRPFX4Wu/ZjoMfsU0hzZd7AVaQEFyqQDh/EUVkzttusSXdrNymOHT6aAlpPjWELd18uWO2piUUtuwtiTmadL\u002BnsPAnVCC6xNjhlbhDQQHy\u002BvNn\u002BBV3qBrwyPXgiK87b\u002BNZsY01XNm8sfSK1QB8wWXqOp42IoyaMAjlJosq2kwppjXE\u002BY90zZ4puzYg7MMag/eABk4Q9T1Wv4GEUDZOgde4YS7Kp9fmdXzwHHdGeUM12qKDqtP\u002BGLEIfjoN8G1n6zleeIukT\u002BwvqZDRIOi2ADY\u002BTnWTutcDukh9sjmd2HUPmDFN\u002BADHkYrGZAFDHOfIQm4Dz6H31CBSWr4zJo2ikcEb0Yi3eBgldqz6zVbVwK1gtX/bmhjDF7QA661SlHsNE8IwJztfEMpF3lkE/QbJfIoA0nEd1ve4SMnUppx60t",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0da76c9b-451d-9784-2c54-7a415161448e",
+        "x-ms-content-crc64": "t0EEQMALeJM=",
+        "x-ms-request-id": "da6c5d7e-401e-0062-01aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-705f6c6f-c792-2519-4720-ee874df32343/test-blob-12a2cb39-7bc8-b18d-654a-4f781cdf9f99?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "41aca07f-ec22-3afa-2ab3-27555cb0132f",
+        "x-ms-content-crc64": "rTISCaPpyic=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Ix/bmUlZliAZSlhbu/zhq9R28TQbIJ7zzKh\u002B5ximo9ywt2ww9NNNbgrsDceFE8CHq/F28tV4EgOA6Myh268HcqZ7qwOQsLYBKIMqLhLXbrjn9jsnMLEGN6VpsAwHq5Ja5ZohCWi89/o6dMlSTePwqXkTuuRz4EL0dXReJgCq\u002Bnzwz0l4tmRQK/9B7LvotOnCeQaS8/Gt5wVYLJT0XtD6kHpMYX6ZePMUwo7lMvOGC8CKm635FwaKQ\u002BhDH4nQXM0uRlxBnFJrKAETfTFjyLUS0iDTacIjAXh0wR6WVVhpRGXBtuyWRW9uH3Or5ZnVJ3ozMU1p/fMLC0TjzNo01dKoqg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "41aca07f-ec22-3afa-2ab3-27555cb0132f",
+        "x-ms-content-crc64": "rTISCaPpyic=",
+        "x-ms-request-id": "da6c5dae-401e-0062-2aaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-705f6c6f-c792-2519-4720-ee874df32343/test-blob-12a2cb39-7bc8-b18d-654a-4f781cdf9f99?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AFF0028E\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b0c1cb19-02b4-056b-5565-ee15a12ccd0c",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "ETag": "\u00220x8DB50C1B029809D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b0c1cb19-02b4-056b-5565-ee15a12ccd0c",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c5dd6-401e-0062-4faa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-705f6c6f-c792-2519-4720-ee874df32343?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bfea6a9224cb4159008769ea21319385-94361badf4fc2e86-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "903c77ff-62ee-257a-b8a0-5b44e6cb32be",
+        "x-ms-date": "Tue, 09 May 2023 19:15:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "903c77ff-62ee-257a-b8a0-5b44e6cb32be",
+        "x-ms-request-id": "da6c5e19-401e-0062-75aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "761906336",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
@@ -1,0 +1,234 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9fc3e9aa-36b1-4309-7e8c-1061aff973d6?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-94c7b47cf06597391b698286b87f84b2-e2a4b5eb7522f314-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5e649429-a1ae-0f18-91fb-bc3bb10cd849",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "ETag": "\u00220x8DB50C1B1323DF3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5e649429-a1ae-0f18-91fb-bc3bb10cd849",
+        "x-ms-request-id": "da6c62ff-401e-0062-56aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9fc3e9aa-36b1-4309-7e8c-1061aff973d6/test-blob-ddcdc2ac-e66a-1e80-e9ee-2ec8e382460d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-e1b84053b27dcad0461222c2c4f0416b-cfc47bedba5e75bc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "50ae9bc5-7bff-5ec5-f4bb-121d22895868",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "ETag": "\u00220x8DB50C1B13C4E98\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "50ae9bc5-7bff-5ec5-f4bb-121d22895868",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c632f-401e-0062-80aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9fc3e9aa-36b1-4309-7e8c-1061aff973d6/test-blob-ddcdc2ac-e66a-1e80-e9ee-2ec8e382460d?comp=block\u0026blockid=gAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "470322ae-f5d3-1e0d-128d-cdbd0f5459cb",
+        "x-ms-content-crc64": "4IgBIMdNrIE=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "VKFSD42a7J1RrgVnRFUj1mPDOBqVFCiOwllUk1BbY4xyqGB\u002BVRm\u002BjqjHDf\u002BbsMo71\u002BXX7dS\u002BtD94w0wzRlhN9kt59Jv1pYFJBKlxzgco8xGPGLtrg3W4tPQgBZLMikhQeRa0IrwvRjJkjukqTOY4UNA7pC2d4XLVwUCn1aDufHlgIVTwc9FVX9KJBvWMjWcN57TCkeYbspij32B8iHGRdhFvySuSR9z/5UVbE9t9STTYme3rK\u002BuTRW68TZRw2dZg95DkHcM7e6DYw6ygv568JpYso\u002B\u002BEpkol24S91vpIjgxu\u002BhxKmCtwnR1ME2g\u002B84bP/yb\u002BQzbn3FFGvkE/faWmjzSfMsSCco1qvAXRN5Ph5\u002Bj97tbTSUvWhh7LBNrqMR94poMznsHBTI2YlIYwFqW\u002BZNdZQY/O0kboyaumt22zf4rmWJAPrkgnPKFJO7XEpXB4DZ8CkO\u002BPqtQ8S9UVG5Uf5BT7Sb0VrraPMgXthJaQIyM6LanNse\u002BbVq670mJzESAM",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "470322ae-f5d3-1e0d-128d-cdbd0f5459cb",
+        "x-ms-content-crc64": "4IgBIMdNrIE=",
+        "x-ms-request-id": "da6c6348-401e-0062-17aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9fc3e9aa-36b1-4309-7e8c-1061aff973d6/test-blob-ddcdc2ac-e66a-1e80-e9ee-2ec8e382460d?comp=block\u0026blockid=AAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "006f5cb6-1186-2b94-335e-ce3b8a8b7afb",
+        "x-ms-content-crc64": "Fkc9m7ICp6Y=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "KlahyFyyY1/pc17qoSU9rCex2\u002B3rUTMlYPIPWdtTHCHk4VpA71rHh8lK5D6RsLWIfSY7wTUyINgjfGhpowmDllc8Bb/L/bzM6VMjoG31k7A9h9y0F1rrscGBHXPyXuTAx03mVKr1vIBqbtjiD39qLei3Kxstz378UVT\u002BSeBI2otuY9kfDj8FSMtbSaiCCaJBF\u002B\u002BLOjLJk/jP6QNW9nKgIpRMc6umSx\u002BosuJQ0YXVekexvTLwvJ9ZpdDhTyQ8r1JYuycUNZb3msvP44hPeMFz\u002Bm67pDlAr2X1883bxfv6bAOQ9xZdwUWxuiJmINkXCSwPblW1gAoZGAzCHkLIHNXQ1XaEv4GrFTgpCukW2Y6L3eqgy1elROv4d98Jm6ID6J5MlktikkqrY1gdjHUhAj59NkFXJ1B\u002BK5CKjEehoXqWJiFKykNCKUuf9Wj\u002BiLh213Sgi2Rhq8FOzmu71wYCCcLdhmZU1jj7Ow32uDLnf6LXFLTSARUVNXpg/PvYh1FEneul",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "006f5cb6-1186-2b94-335e-ce3b8a8b7afb",
+        "x-ms-content-crc64": "Fkc9m7ICp6Y=",
+        "x-ms-request-id": "da6c6371-401e-0062-3daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9fc3e9aa-36b1-4309-7e8c-1061aff973d6/test-blob-ddcdc2ac-e66a-1e80-e9ee-2ec8e382460d?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b3068509-59e5-1e45-0e86-a5579206e4c7",
+        "x-ms-content-crc64": "oDcLaIv3UkI=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "IAFSIgE8pFBXa/OOZk7I48NRLwisyFHr89o8I7S8sRpGQV\u002BghfKzllzEvsqH0ZWtD6ON8m3j\u002BViwZy4nAICcm7nYSCTuJ17Qnpmr5wmHYyFEjxQQLr6tYkgH8B3DjJbcKCMQr4lwvudEvVTUOBFOKQMN4nBsi2z6KuXc5zdADBIDz7/mdrSY1NAszHFq2So3uMYatqklb5y2FoSjlNawA7BC0GhSZ7JOdA6gQL/7j1G7pS9wJlZo3l8iMGAv9UD5e8jBKAjB5FATy0KbhC/duoYy6O6nP91a2fIJMDdSH3/NpsT3OmdJ\u002BcDeXFoTzFkwRHXa/AxRUjvrZ04VuLQZwQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b3068509-59e5-1e45-0e86-a5579206e4c7",
+        "x-ms-content-crc64": "oDcLaIv3UkI=",
+        "x-ms-request-id": "da6c63a7-401e-0062-70aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9fc3e9aa-36b1-4309-7e8c-1061aff973d6/test-blob-ddcdc2ac-e66a-1e80-e9ee-2ec8e382460d?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "269",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1B13C4E98\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "04329f32-c784-9e16-7893-287587a8bbd9",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "ETag": "\u00220x8DB50C1B159483C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "04329f32-c784-9e16-7893-287587a8bbd9",
+        "x-ms-content-crc64": "Z8MDRj3Ds2Q=",
+        "x-ms-request-id": "da6c63e8-401e-0062-2daa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9fc3e9aa-36b1-4309-7e8c-1061aff973d6?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7f471ff821a906c9163020c7034665f1-e2a8c74ce465b894-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f225d14f-e0d3-e143-ee18-bc9d24d601b3",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f225d14f-e0d3-e143-ee18-bc9d24d601b3",
+        "x-ms-request-id": "da6c6418-401e-0062-5caa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "997387479",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d251934f-1ee9-9d81-abea-f49499d2342e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0e1a719dac1e002e76c4302e39207add-ecd5e96e155063b8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a95c8f0a-33ef-e532-1113-73ceedde7a81",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "ETag": "\u00220x8DB50C1AF9175F3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a95c8f0a-33ef-e532-1113-73ceedde7a81",
+        "x-ms-request-id": "da6c5b07-401e-0062-40aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d251934f-1ee9-9d81-abea-f49499d2342e/test-blob-b3bf2b8e-f598-9c73-ea99-2be06df75791",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-273cadfc38de36cd77a9c22c8a234f23-877aeb907952b4e3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1ffd1624-aa8a-a373-0f9a-118583905435",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "ETag": "\u00220x8DB50C1AF9AEA47\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ffd1624-aa8a-a373-0f9a-118583905435",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c5b2e-401e-0062-63aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d251934f-1ee9-9d81-abea-f49499d2342e/test-blob-b3bf2b8e-f598-9c73-ea99-2be06df75791?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "56bc2f3a-38f9-4607-a5c3-7aeafc39a39f",
+        "x-ms-content-crc64": "JayJKPxYwbk=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "hngM0zzjmf1szsNxiA9A9G8Sigl1ij849Vk9EN1YlTD9FOzkqqelJ/VePSFvwF0C039f21NwDPs51N3jpYkgEziTdHMiW0nHbGIUFkwdyDT8Ojxe\u002BbrcjAjwqtbJwoFsPiro3Evp33c2l27wXPWuGwuo5mtMwRp9tuhqMrBy/arhp9giNezoElrEKGFM6y8TQY7LINsWH3wQaiVjfq3Hw5rDD7QcjOYewNQQh5m4Mcu4V/Ahp9zOy4dcEsrGhZOt/WTHiNx79rWorGAGBZjiVzlaqye9pRy99UQswHkcVztBYok18KjuPWE6efp8x8XvebqRbNls8FhHCpOYTjU8i1QlxaMOrWaQa27FgishQS1\u002BPUe\u002Bi\u002Bth1HIx7eYVVu4s/u2mVgEi4MxUAAFrp24tJchmGRDufQBpxPEx3b\u002BAehR/mYM9e\u002BorXFx6aorq9i0DBMgdrz3ePYDsPZIQ8QMN04bs7A3q76rdOryzcxN2fs3DLdn3YsrWoFsDUD5YGmtZbZYD/gofGRQeP3SBKspsdr7ETcMqFnG7FUuy5p5rhSBQWgZ9coDDoxPE2SJVVXaRltp/lM2nL1YkSOi\u002BbTJ2srpUMNDD7wM\u002BAKmwZT1OZb/UIVDD6/BSqSuvWCqXBDbhTiZoASWmzabXQZQj98kZ1uMo6kvissfJAYekE5fYpvtzzxcW5mSZLlOp7KlcL7FiloFHbhrr/5tfnv\u002BeAboP/5uYsCixAu9\u002Bj7v3OMYdbNLVQn0VkDfgh9B7t0dl\u002By2Zmu0NxH\u002BIsJOSyN9f88bVQTEsyb48\u002BW5kuChYNUqoGZONXp3YEKhTTJHpg8hXgJQJpnYVODFuXKB/qAxWMHtI6q9L0ZQp/DGJ2XwtUnalDTeTT4/UkuFhHwL8WWec/BwWoZkZC68A4KlFjF61QQkq2ZvVwuHrdFjN6bKSLKPK7d1gF7HdjAKHk2/mjwWCrN340oDLxzk6Ki1BSyH8bbMGep\u002BAVCpYTUyZTS9xBeRSSj3Umlki/iakJeyEm0Hgiya73xRmAlizn4U0MnkKyCRI7gDkJ9Na43x53C491LEKuMEItibQ7EjlIfrU7susmlzIO61B/GNTYfyX7SUpdsvTKXq4ARL\u002BeAK3/wbYhfWxzELRdZgEybxetVUqOP8ju6ovAMVR9JhKycKqif1cetsG5iDiVwEyz1\u002B9WUu81EADlENbqYUwX9iph6vWWUC/ATt6I1HfQGSp/DBmk5pNjfWCp/W5AdFV1odHOM9VXHYe/lgPQrDvI1PesaxUycs\u002BXPm1VLFKBQBqJEzKlwiVU6C6R5VCPkpEkoSi208kAQy7CdzVoAfE1PhXpR5kJYxKSV0LmYI2\u002Bx6vcMEtqCqxRiJADg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "56bc2f3a-38f9-4607-a5c3-7aeafc39a39f",
+        "x-ms-content-crc64": "JayJKPxYwbk=",
+        "x-ms-request-id": "da6c5b8c-401e-0062-3baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d251934f-1ee9-9d81-abea-f49499d2342e/test-blob-b3bf2b8e-f598-9c73-ea99-2be06df75791?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1AF9AEA47\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "534acccc-fdd3-183b-9079-88f73b9e8433",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "ETag": "\u00220x8DB50C1AFBC9E1C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "534acccc-fdd3-183b-9079-88f73b9e8433",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c5bd4-401e-0062-80aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d251934f-1ee9-9d81-abea-f49499d2342e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-edb4e50c80563db05d5533243427c982-d269cc5cf40ca71f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2f1eb17e-4fee-f5cb-25c2-a56da84931ed",
+        "x-ms-date": "Tue, 09 May 2023 19:15:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2f1eb17e-4fee-f5cb-25c2-a56da84931ed",
+        "x-ms-request-id": "da6c5c01-401e-0062-2aaa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1181396887",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
@@ -1,0 +1,170 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9cce5188-f04a-697e-53e9-95b8b0a6806e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-19bc2a5cc1ce3f17a594af0df35d2da1-a03fafb06fbdcd68-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ca16e6f8-cf5c-99f6-7e5c-47f9974653d0",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "ETag": "\u00220x8DB50C1B104A50C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ca16e6f8-cf5c-99f6-7e5c-47f9974653d0",
+        "x-ms-request-id": "da6c6229-401e-0062-11aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9cce5188-f04a-697e-53e9-95b8b0a6806e/test-blob-d04543ad-18df-149c-8c9b-58e86bf46728",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-32f0073332e1a319de539a0b502045a7-994d70bdd4466ff6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "39892fca-455b-4735-f2e1-ee4ddbc10695",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "ETag": "\u00220x8DB50C1B10EB5AA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "39892fca-455b-4735-f2e1-ee4ddbc10695",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "da6c624d-401e-0062-33aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9cce5188-f04a-697e-53e9-95b8b0a6806e/test-blob-d04543ad-18df-149c-8c9b-58e86bf46728?comp=block\u0026blockid=AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3c1da9b4-2d6b-51cd-4eeb-acc9302a2e86",
+        "x-ms-content-crc64": "Jn\u002B9btj4DiE=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Zcaokh8jZhq0RfJ05\u002Bt2VnM/v8mPthJKVYigZCai8WOCOC0sVOM21X/8FRfdgbKT5fCGV4aJQa60XjyWggHzElOO8q69SgKQCepKkqH7bdPWDH41HJrd\u002BPd/ePamoFJ9CQLDTo4E1pvt9k6cP64MuPBpwHWDvfa5sfm2PtIM6WiXzImfNx5E0TbjRyVMQLlIcr8FPeDd\u002BksLCp2VTZfI4QzlBXIlbYDRJO4/n3XQbHA/bcsTBquIutE\u002Bky2Br4OeG2YZZztGIwU/NBnxnVvVOp4tVeDMtdpgXEuh59lTUHRqoIQPtwU0\u002BEnG1NKSlxx2aFiPU1qj0maLuAvwpTwr6\u002BOkh/3XxoOY\u002BFyWBuAHzsQuK36AxPwax80dg/76RFMNmujv7RAen6LV9lv9DMyFhOlGwXq\u002BqyfnisAwuUOEnrQIiWv4GOG0EIzcqs2hHLoBmP8Vs4LZT\u002B/AB2JQ7uVfUVen9INgjGsIkbHu4QBZRW0FLyFDb\u002BoxLzp8NxB\u002BZCKmfVl1\u002Big3oAuTDCLR623uZsL1Sr7EG\u002BFtdcVI41VaiiyPR2Sm5EtFzo4Vr2LIYETNjtBOiRpj4mF4CIRj7ry2OYL1QqMISIJ2r3wvrmt\u002BpBWAe1WECwASK2QCLtvH4t/SX3bg0h6gxEVO2NmdMzT2\u002BWNv4nNnMi2B4xY/BRqmr82cXU/0ntL34LYPNTMndPcwDDR4WABsayxIXu8HYb8rpykMAdblAVqRdwG8V/z6Wm4eDvnlLlbNL/IirEDi73/35I0KG3MhSwra5uD\u002BsBMvTgOA6VLFRnnSPtHjwlUZroiCxHNv8D77/MLuCkd2z3/e8l48YQYsMZ0UN9yhPoi1wDhYe\u002BugwF3FheyP1zsxXG9SBND33UyCVpLVWrliWb46OUoPHlOTPjEAd9wZnFph4ttsTzm4vePr1SRZymakYisuVZ7xIj0bvsaf9mVwabk4dHjd9QqEgXtmI0gvOnTLWxSw6ka8cL\u002BdUJBzGcZ9e2xqIFbtxm0hqtQjiv717IRS05tQv35zfAO4QKR5EWi06ajcxBkd3ZSnj0BymeXBqGMMIUUrLLvu96RSNYbIp5hrbqFWGShqNPYGqTA9AOMe95dAbPAjiLzt7cx0y6cN3\u002BenBipEa487ouxOJYOKsPbBMz7vhzuoSObkaCtc9mlO\u002BMlJlvm42owIBcoD1GI5Yj3VspdpHlis/75DXwJk36uDAC25QRr9CVmy5oFwpXSDqgXthkPR5NlxnJc7dHqJpCYef9M1fyEj2Kk\u002BtzjWO1lKwLT9dlhoshtTSKSCwZTeKEJbUiWgTSvkya6Zky2hmmE98bTFjC3Ots244Td8oBYVX472e\u002BkzqXKJGK2qzh7tsg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3c1da9b4-2d6b-51cd-4eeb-acc9302a2e86",
+        "x-ms-content-crc64": "Jn\u002B9btj4DiE=",
+        "x-ms-request-id": "da6c6272-401e-0062-55aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9cce5188-f04a-697e-53e9-95b8b0a6806e/test-blob-d04543ad-18df-149c-8c9b-58e86bf46728?comp=blocklist",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "107",
+        "Content-Type": "application/xml",
+        "If-Match": "\u00220x8DB50C1B10EB5AA\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3198864d-caa4-832a-b7c0-fcffa13d5da0",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\uFEFF\u003CBlockList\u003E\u003CLatest\u003EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\u003C/Latest\u003E\u003C/BlockList\u003E",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "ETag": "\u00220x8DB50C1B11C6F5D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3198864d-caa4-832a-b7c0-fcffa13d5da0",
+        "x-ms-content-crc64": "17m5j6ScWgM=",
+        "x-ms-request-id": "da6c6293-401e-0062-75aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-9cce5188-f04a-697e-53e9-95b8b0a6806e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3ad555ea63739d9a6ed1999959305678-7a7137573eb75c34-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aa7ce280-fc91-71e2-7b3e-44519fc3daea",
+        "x-ms-date": "Tue, 09 May 2023 19:15:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aa7ce280-fc91-71e2-7b3e-44519fc3daea",
+        "x-ms-request-id": "da6c62d1-401e-0062-2eaa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "515908481",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d8ab3849-c102-2cc0-1efc-3f5abe79a640?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5b97361b1f4935f437168c26fe05e441-2d98e3aee8876927-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "1eb2605c-6a06-657c-82d6-518b8f409c35",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:51 GMT",
+        "ETag": "\u00220x8DB50C7F439C2CA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1eb2605c-6a06-657c-82d6-518b8f409c35",
+        "x-ms-request-id": "1fcbece8-701e-0034-09b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d8ab3849-c102-2cc0-1efc-3f5abe79a640/test-blob-7651d7d3-ce90-bef3-3df9-0a9802b1cc73",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c7a46640525c052513fb987f3afb4874-489432bec66ceda4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "cb2669f2-292b-10da-86f5-73badfba1ea0",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F451F51D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb2669f2-292b-10da-86f5-73badfba1ea0",
+        "x-ms-request-id": "1fcbed64-701e-0034-76b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d8ab3849-c102-2cc0-1efc-3f5abe79a640/test-blob-7651d7d3-ce90-bef3-3df9-0a9802b1cc73",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e1debbf7704832da6ca9bddacb96e82f-4948632d1744567f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "99a5130a-008a-f447-337d-b10b301b69c4",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F451F51D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "99a5130a-008a-f447-337d-b10b301b69c4",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1fcbed97-701e-0034-25b0-82a24a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d8ab3849-c102-2cc0-1efc-3f5abe79a640/test-blob-7651d7d3-ce90-bef3-3df9-0a9802b1cc73?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F451F51D\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ccb03a50-8414-5016-2467-d6736d97fee5",
+        "x-ms-content-crc64": "LXLwmAkJZuU=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CCc8/yRnt9MEZBoLdzzmDrPm/l3HhzkzAyY8hyOot3xbFXse1Ek09KneGqFPce5F8ELXqEI\u002BbYDuCPz\u002BKzCvW62dr2LAxzpqsgm06G2X45I49pbh0Q86Haf6MMtMNcl4L770scGLhCgIbfU4iYUTViVqxjSZzoqdY5K7xpdvHX1APLmvozLQrHFt2GQZAZMi59ql4m6U3mAzVk4u0L6RmE93\u002BE3LY7PzmRnDLPUmhGH/mN\u002B8yToOq11Ye0zkotuz20AUoQlGVoMnsklU0bJrDdLsLzje1M8UaUzvc\u002BhnD/c\u002BD1C1EeJYuEFclRbxudqr7G1593Kj1AZx/zi9V\u002BOav6NRFsFhtvvwk3f2gj\u002B4Iq9xRIZ77ReFmjtJQxGqm2FewdVzoKIYSTZxiGP7rVHHud2ISxJcH9KMzHyFGHLqRvgVl8FpRYIMWfpPCWWziezqgYo0IVBOAaID5tMmkjHEh0Jr5RaPXnNae/IYDBVt2UKQm5bntSWoxpUfZV6u5sbJi4EiR6PWWiMX2qVeNvSMlg2Rlfeb3dIdwx\u002BAcPgVq5UrToGUSpGfukFy0Np/So\u002Bgk89RHVHOLq2vBYSEVukqAS4QMuhz90x88du2KAz3nXiP390pw45DXSDU5EUMGmNXSM6sbxinLZuC1St1GAagt2gM9XYMAD2gzNXHnhMGb9d3Xt8\u002BSy1g57FCp\u002B5izkQaMyzdACXtSkeQC6NC4I6Ie2VU/bkmYmw6qw3FyllPPv2QrWvmKW\u002BxihOXrT\u002BJHQciuiuIDtCK89DAolQXJ4DuQc2lsjIjoVL2onOljrQtsI0GohAuxjAtBbmaJocamWKTqWxy42vU/xjYkmtd5GUckvHGEYVwwHqdeKx5iHvK2wgQEuVHu8wiMqP4VTTE0CFUfpOVU4jdI\u002Bny1Gu\u002BW3ecDrZiTNJ/1Ncko9/heGpG2KiLJAnoNYeAMu/8VeZhY9YrW0d9YoNO1Km7cLCp\u002B6p\u002Bq/vCMzZttNgu4hrjg37xw0AItR0jyXYlPFBfLMXX1jZEfqrqnjCgvqZuTn9pa1Aqya1voUaNWuKFnfblDYgTVwzjngXUBiQPZ/d2tHr3vNH/NGIYZzXwtiPHZQE5urAeWvdzhcxLVsKIYDlOF6VnjuEl5tgl\u002B\u002B/X8ujiDaEj1q1GWFqDhDYEtN6fjwf7op99X9cgE9TX\u002BV8Hm5LkaUkhZYmMB79L5AmqITH6hWzn21BIZK3KA8LYbl76e\u002BikH0uVfip9b5rfMXrNdfKj3XPzIMBBmwSbVmLHs5hgUGkhBgHmZAZBamy2aTMy/Y3PNZHrB1snYoRH\u002BSfItrsBf\u002BARq2/wvHlssbVUizLQaVnU934HdUgO\u002BqN9n2vfebSwtOlSIQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F45FD5C1\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "ccb03a50-8414-5016-2467-d6736d97fee5",
+        "x-ms-content-crc64": "LXLwmAkJZuU=",
+        "x-ms-request-id": "1fcbedd7-701e-0034-63b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d8ab3849-c102-2cc0-1efc-3f5abe79a640?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-04e97f36eb2df621707a119e8fa2c1cd-521262600c5c464a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f5bb6633-9d6a-a6af-5116-89420e93652d",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f5bb6633-9d6a-a6af-5116-89420e93652d",
+        "x-ms-request-id": "1fcbee02-701e-0034-0bb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1459920918",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83dba254-1027-105c-a33c-21527209f528?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fef691024bb3db03565fe0e92e6cfe96-edf149df12dd3bd7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "8f2d9ca7-d47c-6e4f-31b6-54cdaff1a371",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F4C329C4\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8f2d9ca7-d47c-6e4f-31b6-54cdaff1a371",
+        "x-ms-request-id": "1fcbf048-701e-0034-17b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83dba254-1027-105c-a33c-21527209f528/test-blob-ad98450f-d854-babf-2bef-b78ceabfc014",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-18733c0f4c8fe6d658f2c9e67485aaef-f8abf1a90c91dd86-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "5f6ab40a-290f-928b-8195-5ecac49acc1b",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F4CB58F7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5f6ab40a-290f-928b-8195-5ecac49acc1b",
+        "x-ms-request-id": "1fcbf084-701e-0034-4cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83dba254-1027-105c-a33c-21527209f528/test-blob-ad98450f-d854-babf-2bef-b78ceabfc014",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-86118c756ce3cd6cebbe7060edef15a8-116054c5649fd6e1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "36820bc5-6155-9b05-781d-b7732078821b",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F4CB58F7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "36820bc5-6155-9b05-781d-b7732078821b",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1fcbf0ae-701e-0034-72b0-82a24a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83dba254-1027-105c-a33c-21527209f528/test-blob-ad98450f-d854-babf-2bef-b78ceabfc014?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F4CB58F7\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b804ebc1-9618-2cc6-5c1d-ea3781426f8a",
+        "x-ms-content-crc64": "pFLxvSWihCQ=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Gbts2yPO2K8F7hHFi9SVxwUFq9XbZayRNcpw5U/QPIC9E26\u002BcFz42MR9io3DieJcIY3HqkXNlbMP2qVYXfJgNbKQCHdm1lepDNIRXdsfzqvoFMTCCJI67326r5W2oHvRHVTaMoFq9Uo1Hp1yvDjX7wz5cEgtnS0gVRj6rCbC8mxXQD\u002BHRJsqfR96jOn0yDNF4sCIvC8zo4Anut1ocEkjcywwG3v4UKpxz/IpsxBDK43ltMlmOTU8JJy/YIq\u002BwQzVVhm8w6y3TZIVF\u002B08Ce9v445Pg7t/vDr39PffOPAfsg3mU1z3h2fgLmc3USJI/xqsT3z8bj5QVprfxc\u002B12BSh9WTfVraTeFwmb1VUSGsYr/TcMuhzI0TPlf3CGMGYKlVSlVy9aKlkGdcg1f/p/A0uxhba2aUsLtEgEMG40F\u002BajUT/AbMOWkZLdxgRUk1E5Znvk1GqvVGvJmaKnVfnrEl3hke76vpaH2zPj2KNGtyE2ysoyDwO79DyT9tMhL3uY8vPmswFifuelXTl2y3vIguKBsEsv\u002BMMaJZ3yJoeDZuu4SyWvYAQflIviTPIKRSiAy3Pwn77waPowjE1jsBgf4fYNvkBWGSLeohu/TavRD\u002BB1MVtT0sdsh\u002BIrvtO2vCSzwms7/MaoKrIQ0j1jcRtOH7ys7n68jA8u4PaealpPJ\u002BX3C0sA1RLZzQapQsDJyVaGnV8XCY2l9zZcDRvQCcAXweoXrCXQDUqpkyF300kOJRdf1407N95YERQU5Mf3CYMGUUEW8l0w9pAUrbZsbiPtDegEsDIzHInLv1sRu2iCsoleMUHIN3K6LyE85opn6\u002BMwZ5bf8lmQ03T3CzMCH3snUjstDnyh5NZ1SkDRNjY/o9O34RPRosAvjR4NESx/t8/mFZRPOt1mjoKAamfY/90\u002Bt6cfij4nFe97PUFeVJPqNdJxKyChsKk2EVJREXhYFs1BDlmFIC3Rvv/lFD1cCDnuljSVp5S8nQb\u002BKXir1cR24uZ0HUZ6ZRWkn6wg/JyrmglYorsDwq94hHFShva1Jej7bjEXKCrztHEe8Mgom6CqUo9vUzNJcyB3O1jVJ95fL7nDZY5rVHIeZS5KJNHnUCjQqDQnRZK1cfsQ4CyR3kxSv8FOJTYSfz4dUS4FP05Oj\u002BtwBH/qN6nnTfOTWrRFTEah92UQWSryvmk1yjSkcHJswlABYdoMqIgXZtdCfyRJ18SnY0gpPjbAvUXWtC21Qt2BZlhkRCqslU6c\u002BTITcH9ErDJv/MzqA4QZQKSUNfRaoeQ5wRiMJZOZ\u002Bs35TATErQ0GUgf7RUXQlyLUCsNGGF\u002BaQlcOGa8m\u002BIaelgI/MPd/FNOXTaPsX1yeaWo1t9qQU\u002BJuXwntw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F4D78C2D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "b804ebc1-9618-2cc6-5c1d-ea3781426f8a",
+        "x-ms-content-crc64": "pFLxvSWihCQ=",
+        "x-ms-request-id": "1fcbf0d4-701e-0034-15b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-83dba254-1027-105c-a33c-21527209f528?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2e99f697e6053d0c8058b12a16e5b176-4c00a95b0bee9e64-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "34b1f5ea-ca74-e203-9744-27e1dc1f4ebd",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "34b1f5ea-ca74-e203-9744-27e1dc1f4ebd",
+        "x-ms-request-id": "1fcbf0ff-701e-0034-3bb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1650879147",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,512).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,512).json
@@ -1,0 +1,216 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d30eb678-3cce-3892-b093-1ca4bde7ec6a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9eae696e27990e13653337c7ea605726-d200910500b79949-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "693b4bd5-8b56-438e-8db6-cfa439ff9fe5",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F46E117B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "693b4bd5-8b56-438e-8db6-cfa439ff9fe5",
+        "x-ms-request-id": "1fcbee3e-701e-0034-40b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d30eb678-3cce-3892-b093-1ca4bde7ec6a/test-blob-6c87f78c-4724-8389-4173-a2d2a0e07c47",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7749b3d8de576a6112681db71df775d6-e83800b8c3677d97-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "0ffaff9d-20ff-c662-96d2-d6a0bb282cac",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F475A47D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0ffaff9d-20ff-c662-96d2-d6a0bb282cac",
+        "x-ms-request-id": "1fcbee82-701e-0034-79b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d30eb678-3cce-3892-b093-1ca4bde7ec6a/test-blob-6c87f78c-4724-8389-4173-a2d2a0e07c47",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3fd36ded737c368d218d3fde7278d5bd-d7c6321172011dae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a034ef99-6de6-3447-47ba-4fa2691ee645",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F475A47D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "a034ef99-6de6-3447-47ba-4fa2691ee645",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1fcbeeb4-701e-0034-2ab0-82a24a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d30eb678-3cce-3892-b093-1ca4bde7ec6a/test-blob-6c87f78c-4724-8389-4173-a2d2a0e07c47?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F475A47D\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cc063cd5-8cf3-d1c6-4600-a0081da9e31a",
+        "x-ms-content-crc64": "LZ4PzDwsXZE=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-511",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Q/AmLX\u002BTke/Yr1kRJbPg5C7bznKsghQiuTpLP7k5JXoeMpxnpTfAQrlLkKYxfR7a1up2XTAsOMDcBHNFSFI2n4rf8/IWeT73G4u4YfFt8DwccGjOw8dJ8fnciqHEe/pnFPEcUokrxFysf0KkdNfObhM3KNjpaNzClQL5Ou6dM5\u002BRUEwAUZ6z8KsLIkSFpHwhDRyNjFIifqsVWryGMYpuDkuiEyOLzh11gzcs3UaXPPCF1yzRD6ZNb9Kg6vfhLL4hnRP445FZlj//GAgb9aFlfR3MAVpdnP6lVaNR6uMlk1d4CkAyn1hfLEHt0vedMnoxO23ZFStkxAAUUo7uCKtc2YSxoutgMt3EbNQYcMkHCCMpH691TH0sE0Y/Hk3KcSOWkPhy64\u002BO0AiPFKhWTFQ2DUlrxOj75o0HhI6kIRSP\u002Bvuwgt/RlByTmk\u002Bm5jfU1sfyCBAEX6w7mqpra2YB6a70/xqtpcl0ZXks1yqZVP9VMq7GshkEi5tPdec0ZSm2krCgsuYdJzD9faKW14eCoUaqFTi4OjaV8HN\u002BXS/iP/9QdkV5\u002BaIZNwt9yDV2bbQTzdOhilDw/Vd5CsJynskBGz2jRmFCCKikkd0tOnIBH4O/a5BcQLWvX3juAO7fpplBfK340yZT0MUq/fhyw8PkeOo\u002BszM5pdqH8\u002BfoVAi6xOpE7L0=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F481B0A5\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "cc063cd5-8cf3-d1c6-4600-a0081da9e31a",
+        "x-ms-content-crc64": "LZ4PzDwsXZE=",
+        "x-ms-request-id": "1fcbeed7-701e-0034-47b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d30eb678-3cce-3892-b093-1ca4bde7ec6a/test-blob-6c87f78c-4724-8389-4173-a2d2a0e07c47?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F481B0A5\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2ccd3a4c-1a17-ec52-7cf6-b07152e61309",
+        "x-ms-content-crc64": "7LHXc2SJpU4=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=512-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "xQhMXGyayzFDvD2ctQmHA6HzZQfX0nDfP2p8vXA5Di3XBR9vnuJGmG5zl8q2SjJKgLYi997k5vOYbB0BHQ7ACa4PxbDpGGW/rM2ZYzqlKfQ4Mjy6FhZP8h8s1zLERXpgs40cpoWCYGdRY0oRSoK48kIoyevRBfOYwNKRvUEy\u002BmdSObCsiYNvttHVabLLPaicc\u002BTvm3uPjq2ahOay8KMmHmnjvhDSC2m/uRMZ/JxAzIIp9ElcQ17rw6oCEgWdvcUurkpJ6H6Xymh7MOJodZIRWbdjiPxZydsK9/tmz/ljIvxN601R9\u002BQEkirh4BJ8g00X8bhNOTTJ1ORvPvCDMfpvGA7mGopFv2HTX/bReOnJjnStTt5AFujHhBZo4rnzgWAwccgDlWjD0jJWeto991z7prB81eMbLgEmHpZz3dyo396VoAYgxfgM6Xus6ZsNiYy5bDwJd6t9FULG3XbRT/VVrpv8qFZV2\u002BC3cOtnb0VmGZQJunCgn2cyF4vDWeiBOpmGVzv/EOE2ZJFbUge/FqX9YMTiyJWEtA4zypDKkYH4NTVR4BcKZgiz01XfRU1gcgHmxvkkn3EEAaIsy0ZRa9IPYhzRbTWN8vm7LvU/pW7B01eO5MuI1JXDTd913prBYmeDz\u002BMwjgXMWNMAaHF8xFszavjvwoYGh42HDR9WGBRe\u002Bsw=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F487A333\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "2ccd3a4c-1a17-ec52-7cf6-b07152e61309",
+        "x-ms-content-crc64": "7LHXc2SJpU4=",
+        "x-ms-request-id": "1fcbeefa-701e-0034-69b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d30eb678-3cce-3892-b093-1ca4bde7ec6a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f8ed36270e25170641d3950e4d9c2e9a-7700ea3745a4053f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e2bc3cee-b7dc-e402-6719-99c256b65419",
+        "x-ms-date": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e2bc3cee-b7dc-e402-6719-99c256b65419",
+        "x-ms-request-id": "1fcbef2a-701e-0034-15b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2095687171",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,512)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,512)Async.json
@@ -1,0 +1,216 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36b71612-ea91-05a0-212d-aa754fb2d731?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6567b6f56f74e7b98a066f82af2e1122-5ef1b616915b76cc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2c759799-d4c1-f237-d9d2-86e9400fd2ae",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F4E5A0D2\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2c759799-d4c1-f237-d9d2-86e9400fd2ae",
+        "x-ms-request-id": "1fcbf150-701e-0034-06b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36b71612-ea91-05a0-212d-aa754fb2d731/test-blob-9cae9eb0-6d6e-a2d7-32e3-8122560baa09",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3222e6553747b83888f1510dfe8a059a-a0ae83ab60b18b1e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "5ee74aa7-635f-021d-2687-1daa4bd773c7",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F4EE451B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5ee74aa7-635f-021d-2687-1daa4bd773c7",
+        "x-ms-request-id": "1fcbf1ab-701e-0034-57b0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36b71612-ea91-05a0-212d-aa754fb2d731/test-blob-9cae9eb0-6d6e-a2d7-32e3-8122560baa09",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-78a05282f1d7b75fdb6f64a7d801766e-ec286ee2ecca0d7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0b7bd71d-4b24-15aa-f962-4e4efb665b66",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F4EE451B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "0b7bd71d-4b24-15aa-f962-4e4efb665b66",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1fcbf1ff-701e-0034-22b0-82a24a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36b71612-ea91-05a0-212d-aa754fb2d731/test-blob-9cae9eb0-6d6e-a2d7-32e3-8122560baa09?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F4EE451B\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "748cc6d1-685b-61a2-a8e9-d3142ff79c26",
+        "x-ms-content-crc64": "5zAdCV/9LCA=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-511",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "kQh5i/XbH3rtZL2og1icwFda3Lg8qnD6fm0ahxE/E2kWuLZg6EtavXf7P1wXj26ANsaR5TMZceeXfwyIwZdorVFTksqiPNgM/x5AQWsT4\u002B/\u002BmVFLri02/EfOyGk\u002B0vzgkpELw/yj3fnuhOUU2S98g5sciSdGHf8jHZWD03Nvzi0iYK/ZBx/yW7xXXSpHISMXUkXNIknUmnSS56VnIAqGf7a48XiAont7KS5r7sDV3Ptxa4EuoavkTcY6RyB6izux0d5zjzCrlq/JUfgaaKu0vQuq9rSJWN0K1KOyRltbAZ7zuRziYU3LxtXRZFCyyeQahooU0JWGKHkAabqM\u002BFBUbU9aJ6\u002BO0lu\u002B3i/ft/OMVwq/l7/QRzEIbJCj4fiSP82EfPYAWKE1jLMuVfFlp3GGcxGvzWGQgyYeUbse6/BjLJ9hWjv8jP9piQsLovFAo8QfHW3m4nJs8/jP4gbmF6DDyilSA001iecRRkNVhOE13q72/86CfUos9WdCLKn4gnJqSNfH7Z936ZOG1JsuF24XmgRY8BfSQE3fJQ7l81w9GcTR6jwJbvAOfxU6/Kiv/t35KpKloJJamAiJ6MiRkfU2SLvWXSwyDSwUSnACl0OlMCcw7MjKmHgxd1I0f4UofO0fBLTs2KCxxx1mkVUhVwDE5LigYaUtbK9CpObZ/o2m7M0=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F504AFFE\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "748cc6d1-685b-61a2-a8e9-d3142ff79c26",
+        "x-ms-content-crc64": "5zAdCV/9LCA=",
+        "x-ms-request-id": "1fcbf22a-701e-0034-4ab0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36b71612-ea91-05a0-212d-aa754fb2d731/test-blob-9cae9eb0-6d6e-a2d7-32e3-8122560baa09?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F504AFFE\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "357c14de-e7da-de0b-85dd-f1f2251ff90d",
+        "x-ms-content-crc64": "80blz6W8cCg=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=512-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "g\u002BKTj7hYhn4lq2QHIxAfUm\u002BbzYcbSPKYBKozutfJj7\u002BliJ51bDUrYBrigIEHqB\u002BUxoeO8tlksTvw\u002B4oOJMunXBykYppxquU5b2xtOchxkFuKnvNPOp3mQNZjhHGrHTtOOyNkY0aEIhyiVYJs93hzf2sug4bXVyF/vSLEDiV0jlExH/6kDCwVBXvXreUaekhe8AUFfJq0duMB5aYkwBT3LcYwOth6znM\u002BGX0LAKk8ZUPZZh4gbhG3fKgaoiaG8EVn338e6T9w4yGSx2IcqXU6xYBjS1r217\u002B0eL0vXyxMuCg4oyApHnsDaIL8jqevm9Mz4N2mI6XqcQjAaXCCQIT0RQ864wVUEKYEYOLY\u002BUkYBd3q/H9PppSDTjIYaLULgCj\u002BB0iXdLfN3s82ocPDEXe/qGOSl0MEpZ56tpXSPKfx\u002Bd\u002B62vEAgJAlHR6vGAXRwDy6WMBReOjk\u002BWKpHb0i\u002BqInRajkCTeGvyfSbXolVY2ZqfZYGOPnn4H21eGOVmPTAyJ8h9Nc7bYFM5mYfgpuvqPUEHPGyeK\u002BQKUm7TNV92jE/2lYqc26PLxAU\u002BRJTiB2iBY9uUbvDDk/vUctNv\u002BDrzsx1H\u002BhFRXVGtO3hnb\u002BdPKEsGUcGD4i1PMwGOuGjAa8vKOoGHmh1XIAZ59zOIXCQUhUqIWaZpf9Dv\u002BLcP0qT47M\u002Bso=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F50AA28A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "357c14de-e7da-de0b-85dd-f1f2251ff90d",
+        "x-ms-content-crc64": "80blz6W8cCg=",
+        "x-ms-request-id": "1fcbf250-701e-0034-6db0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36b71612-ea91-05a0-212d-aa754fb2d731?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6c44e33c625393f3f1f2824faf4dcb79-178886c866b7a8ef-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b3644d9-677a-c54c-ec8e-d0d02989ff84",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1b3644d9-677a-c54c-ec8e-d0d02989ff84",
+        "x-ms-request-id": "1fcbf2a0-701e-0034-3ab0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1703566174",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5d754203-836a-359d-aa1b-70a8b68839df?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-04778249ed99c9ba704e2b7bccddf87c-b956908e78ce528e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "dd6003c0-9cb7-47e8-2432-d9de7ef2e0ea",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "ETag": "\u00220x8DB50C1B16C5822\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dd6003c0-9cb7-47e8-2432-d9de7ef2e0ea",
+        "x-ms-request-id": "da6c646e-401e-0062-2baa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5d754203-836a-359d-aa1b-70a8b68839df/test-blob-b9dd08af-a438-0e1a-8b17-167094c9d1ce",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d9e2a1dc8a59962797c7a029a5d5ee81-de2e2b793b26b98a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "0f6346ef-248a-0da1-58ac-ad47ad6906f2",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "ETag": "\u00220x8DB50C1B192030F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0f6346ef-248a-0da1-58ac-ad47ad6906f2",
+        "x-ms-request-id": "da6c654b-401e-0062-70aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5d754203-836a-359d-aa1b-70a8b68839df/test-blob-b9dd08af-a438-0e1a-8b17-167094c9d1ce",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c01f9d37a5554417de0d5c1a90cf18aa-a9713cdb85e8f3c4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d800488-c165-a244-d05f-da07f2c5e9fb",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "ETag": "\u00220x8DB50C1B192030F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "4d800488-c165-a244-d05f-da07f2c5e9fb",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "da6c659b-401e-0062-3aaa-8253a5000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5d754203-836a-359d-aa1b-70a8b68839df/test-blob-b9dd08af-a438-0e1a-8b17-167094c9d1ce?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1B192030F\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a9bfde9a-b8e8-f98d-0b0b-3d4bf2b01c36",
+        "x-ms-content-crc64": "\u002B2X/mfVG/Ac=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3mmrlvNcLfQZeEA7aKvjkPZ\u002B6LIoWyfyWfCVgzRLfitOMBLob47\u002BY9VrxD9crd54TknnAAktwYNBuD0Dx6rAzfkU7DeZ\u002ByBogITdvZfolawSHDTrY34hIW6PprZR\u002Bpwqq/ZGR8Cm31Iof4CFTwTsWSKQ8ap11Wl68svJCVRqF4XoshKgoU7raz3iwuT\u002BnNFqo02TwAnxtNaMy1T13dX9vmj6nZ3xS7fUpIVskxKFe1b5XmUH1lZ79v08E9b59o1n5AN8A/40eFeWvhyEhCHDB0/9\u002B39v9ugRf6aftTjh2674BK8PCXhXxeUOcRc693HceQuG\u002B/oO\u002BO0baoRXlMMftONti4Bxs/3XpjaZYYXQ14g1wjwsWt\u002Bz6QzB9J/0ADAi7rw0zGvxa8UOrlXEdZZoSpL7ItGH8loDuqJzr79e46YFdnLJnAodRFd2HquK7nR2WakM\u002BN1em/xhMBHJfbsFsMuvv/4jnq6H3d16ENSuecwt/VUVUerIptt2Z2v5VMaccG7g2i91Urr7hBr/5Ions7dFm4Bl8F7g5xgjrTdCjokX3Z9mzp6cuKqaGs3PyMJQTrO0s7lFNoAP//MWUaWDuPWR6AfrweUYqOPVytWQEB5W016EjtvQ0aYfVs6qhmYFF2LXPuC6ZY3OmwvWcGyqf\u002B7VwH5H/ykawRZgy2sWbSJ80LJzudI\u002Bm27QtfPQ\u002BWE6dNff1cXovRg4vXzJWpkity7oWZ\u002B5NsUcliQQdkk2Sse1JVeTN5dclBOZO/xWdEDUrv7E56DCgD4Rwz6g10fPAXK0FDRCjoCWi8SLH/vJxiLkO8dLcWIn8qUZgnRYvLzMyjmJoWALkiB\u002BLlzbNmBCR/0cvJx/hJAPjSGPKAwMPc8Iv1XCQCXB2KinzEMGTLxE1jp2PP8gTEWpeRM\u002BfGoUcvGM03YKgAfYWuT017dNCUFlS1LRlQHP6HMQGMYRg1s\u002Bk1pReXhFOVUznuEbK3SOW3DS2TEXQtzvvesD\u002BmdAxteItkRc\u002B4/IHxH8nvYfs7z\u002Bgr1WP6kqJlB\u002BYryNQT/u8tgKk3UwMWDhCbofG6Tm0AkuBXiq6ocuXY/03pnSO93SDqwdFSBHzlBcdTXvCgurl5GzXjzGQwdQ3DXlO1LHDs7cTQ34yLro5zYnTXVRPlOESEcHH9ygC8qkzTnrYZL9lWZnEr3\u002Bs87WyncFn/aS/p3iYPMLv\u002B/xO0FCU/uB/YWkKbcP6iyVhpR4MFRlmmzTEs6bCACf8tZ3ddZ7u1/TVc3xYXU\u002BghRxTNpek46ajKDVb0Et5fSFBTfhmHVVGss1pduHdDn3lY\u002B5KrwmQF5H3Ok2pUsepW/Ya1w9XOqeGzEOKe6zExdn3tmxc7s4XsTZmg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "ETag": "\u00220x8DB50C1B1A7AABD\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "a9bfde9a-b8e8-f98d-0b0b-3d4bf2b01c36",
+        "x-ms-content-crc64": "\u002B2X/mfVG/Ac=",
+        "x-ms-request-id": "da6c65d4-401e-0062-71aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5d754203-836a-359d-aa1b-70a8b68839df?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b904d8f656c46af32a43ea4fb8a092a3-ffb0a53c74d9381a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "146d89c8-3f06-0312-af5e-a003441c30de",
+        "x-ms-date": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:03 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "146d89c8-3f06-0312-af5e-a003441c30de",
+        "x-ms-request-id": "da6c65ee-401e-0062-0baa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "754679848",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-686bed80-bfa7-915e-0391-c40b5d2a101d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-e920243cb33d92adc8c29e34ae173d49-a881e534e5837750-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a4ace172-a482-7c72-d271-52af8b145b4d",
+        "x-ms-date": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B25472D3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a4ace172-a482-7c72-d271-52af8b145b4d",
+        "x-ms-request-id": "da6c6a51-401e-0062-04aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-686bed80-bfa7-915e-0391-c40b5d2a101d/test-blob-796aab9b-0bb7-86b8-6f47-5d35e8d52763",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-57cdc9117360dac205e2411ebc8e924a-8c4450817a9a2af6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "77e5f267-003a-8250-cef6-d411ba3f040e",
+        "x-ms-date": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B25E83A0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "77e5f267-003a-8250-cef6-d411ba3f040e",
+        "x-ms-request-id": "da6c6a9c-401e-0062-4baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-686bed80-bfa7-915e-0391-c40b5d2a101d/test-blob-796aab9b-0bb7-86b8-6f47-5d35e8d52763",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2e6170510fc0d3889cf90bb7b4904e12-cc99899002cbe24a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f5cdd50f-b0ef-8128-aff3-d276da6d5e72",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B25E83A0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "f5cdd50f-b0ef-8128-aff3-d276da6d5e72",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "da6c6acf-401e-0062-7aaa-8253a5000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-686bed80-bfa7-915e-0391-c40b5d2a101d/test-blob-796aab9b-0bb7-86b8-6f47-5d35e8d52763?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1B25E83A0\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e50184a7-0e72-a81e-28d7-f7f3fa2c11bf",
+        "x-ms-content-crc64": "HcQzq7kbDeg=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "SZpLcFVkLzsu5fv/\u002BnAZwK7/mXx9a5oQrDd\u002BTvIP\u002B1hNd6Td93JvDbFwdpypc4JiV5IBi3vez97/OsQd5uBJH\u002BqisoLMPMg7kIvKDPT\u002BZzi1HPdgDW/dbqfF3r2uUSfRJ1eyBsD/lRvKxfvvE8LpAdOLaMnp6RF6xEPaBl0KjD5j\u002BeWdS2F3tYbblkh07Vrl3N3pI\u002Bhd5z5GN0F9JI\u002B\u002Bvzi8jBrdTLVyE7NDDlLIBtfp9SqAIWlWBhGnVhMf\u002BpD3HdcPuGE/CI8ndxA1GtnrfTFqky9lPZ7PZYYINfWiUhgiS/B7uU51qe2aWKlYIOs4u9nhtWdhkt84QFLbN9KZhSX3Es7ob8Tj9OlByuT0dkSa0HocwJ2xwbkRQnj7mXIbAdOEYA4cT0sV/sB9IMj7RMkNQWZXfcSIRlEV1yxL51p3JsgQcBU2fYAuB8LcM6HxFv6v7lgLw4QP/Bq8B3geyRZlBvr/6tOz1sPmKXUCqxOwI8EunPkCa2JEAXT7eXUIDz2rdy2m8isr\u002BxeUJZoODFAGDOS38C0dY5qXuulet1xO3hk4VzTlCTGVAqDhbUbINvQk9G2RUR4PjROTDzdCzEO6RkaA1rUcIQKzIe2NPPVTz4T0OsLvvY36KMogUvr5UzVcJicAR2A/B9Nq3i8wglAdPz\u002BzTpKAy4m5ha3r\u002B88Iuc63MBXOU4cjtTLvhN9dyaZ5AhK6RQSj3FqdRsKyUwsEYiRheVI6Tuy4j5lfkUepW7sHcvm9TnPJFFO7MAzFcGEn6yK6\u002B1BTPrMlArZrREsT8\u002BsGq\u002BESRhOxmGT\u002Bfx3f8h44OKUl719qszNFl0y9XdAIpz0hvsV/FKQOCWPsVb6VRQ\u002BXMwul7gSLnPeuza7H8zuU9djgvjNZuCMBF\u002Bb8fl51r1I8JinEY7k4liLN0Ef1RhUnV2DmtYfcPXropNYejh2ZOR1ci80S0JEeqCcQjOfcC9DQ1Cf\u002BjvrKYOiu27/iGgcFM5cpmbpHFYbOxwxfy7GTDJkGTbn2m6ojkSvlY/TSO40gC1hPsnIVib\u002BgL8fta5Q3G88m3M1ODpftBQePYrKR\u002B4t/P8BYQ1km8MP6VmziNiaXrkglrF/A0fzBYqxqhiYNDjQ7bizT3th2/\u002BwJU7grC8/h\u002BLRpbE8svm3El\u002BGsu2qc7Uc4p8j5w89vr6xyt35DlVfdiY1yo6HkDq\u002B/Dkb3yUOCbGZw82MG5zTk\u002Br2juQfugQGKzzHcKkqmU5gZObSIeOVo8EoY0qLz1qFYjanjQVSn0I1FbfoRpkIbyp/L7a2AXIHYOsm81q5flviPg5yhwhJDcWkmQwvqVkkI/AcCKOj02DEnCweK6/ne5dYCgSKlegeNh3xEWRh17Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B26B52FA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "e50184a7-0e72-a81e-28d7-f7f3fa2c11bf",
+        "x-ms-content-crc64": "HcQzq7kbDeg=",
+        "x-ms-request-id": "da6c6af2-401e-0062-1baa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-686bed80-bfa7-915e-0391-c40b5d2a101d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0a2f77cad364d3d673483761f944e270-5010b93bf553cec2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "56cfb158-786b-0aff-f70a-bdef99ad9f23",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "56cfb158-786b-0aff-f70a-bdef99ad9f23",
+        "x-ms-request-id": "da6c6b14-401e-0062-3aaa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1090047973",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d7fa65ac-f348-1af3-b3a1-34cf39d68cee?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-31bf5d6810bd4274fda04f1e8a95c1ad-86cc8de72593787f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "239fa126-6dea-1361-b6f6-7887808ded2e",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F49605F1\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "239fa126-6dea-1361-b6f6-7887808ded2e",
+        "x-ms-request-id": "1fcbef5b-701e-0034-42b0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d7fa65ac-f348-1af3-b3a1-34cf39d68cee/test-blob-3bfdfeed-0bed-f43f-876e-c9d43f83f60f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c3df0978446cb2c594e7ba39d831e2fa-6309fd669fa55932-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "5c68205e-c91e-8cd1-65ba-646c309f1c76",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F4A00994\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5c68205e-c91e-8cd1-65ba-646c309f1c76",
+        "x-ms-request-id": "1fcbef8f-701e-0034-6eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d7fa65ac-f348-1af3-b3a1-34cf39d68cee/test-blob-3bfdfeed-0bed-f43f-876e-c9d43f83f60f",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5103f8175b3bde1460f90bea29e04c5a-ee6787de2cb1f89a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1f753c62-991a-71f1-de09-c9937eea4446",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F4A00994\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "1f753c62-991a-71f1-de09-c9937eea4446",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:59:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1fcbefab-701e-0034-07b0-82a24a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d7fa65ac-f348-1af3-b3a1-34cf39d68cee/test-blob-3bfdfeed-0bed-f43f-876e-c9d43f83f60f?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F4A00994\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f40961cf-fd2a-195c-45ee-caa254828bbc",
+        "x-ms-content-crc64": "Ypz\u002BO1REQp0=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "SL1bIY4Gc/L6YKjokrZ/dJnrqZc3aQQxqiMb5UHjGqFxMvTe4ue5Hy2sKYrEeIEAdwPuleNW9t65KnZr642wFkUHd2DBoJGxMYlpij95bDKhGm4\u002B9IW9GzsVJLhxTTSf/BJEvQEhP9ZxPWNa7GyeP71EytAfcSHASVwkq3vZQONUyY4tNa8xgNuXzLchYy/PduX7LINjgIrwg3Ol/JNamPx/BSLdcQoOE0n1h6VqnuUtVDSW3RNg8UkEPbE7i4NHPTS7ol4M8gXa7Rk5bvjlhuSOeKdew7roHxTY2TRZ0ofGrUpxrvyHIGIvu/D5JoJQHrbMrRPb6Xl50oNKMxjRgRqSc8Guc9foBldFLwfK7viRiLp9jCVz6sTQ99t4PexKXTrWZ7LBoarf46a8lrlxr\u002BSKuKtdVPT0H4j93nz7cMhr\u002BtLN84dG0OYPnal\u002BtlQLXkj37YRA7AlF4UcpxMMu43PeUZvmpLtcROjFTrZLdmk08oAzA4JEKg7IhxJAHAwi4Lo2oGW4JLmMm6mcep1T\u002Bmve9dJD\u002B9/wmSaNHhypHCjco237FdUDe83GpmjZqK9wdI2mYiY63\u002BXaRQY\u002BKwWc43\u002BAv9cwV\u002BWW2nkEfFR3F/F3HKmPArkBosSHIc/OxVDIKcPpWOjYQBynEIetNWKRYy0Vxw5bDeDFfx0TqDYVxxUpO1OQjr4IntyM6PIyVGxh9r6iuf1BbBziI9nLxZfmkkhyg/oOANRuDCgyziTukyqwsbJ4cw4Y6M82rmrlPdlFplapwNByU/XpM6zUD5339JCvGxPlbh46WZsr11Jqic9P7CjORNJZPl68jkBhQ9gxP7nZNiLFXzg3b2Y0R3ujfqrdhSJ1KLC\u002BVd21KN/e2BbC\u002BZiZkVKtiYzwl9RsJfbjGRCVhL62vBYIG\u002BFEEDdYWZdPcU3iCu1XMPuVhJHbUTDm0g/PSFNXDD2CkHZxaHlVlz49HLOpAA8jPlPDITeELMmxXj4niRBD\u002BGUQYHl25ciCP\u002BxTnjR8PNEAqwkAlOoF/WOswAk6Lg4t\u002BSRNmZ\u002BVrFmLQOFKMY6UNCFsJ90GQ2N6CmMWyiS\u002BRxHeJaUQL6Mya/\u002BwdFMJuszVGIznzgYwJ7bA0o48fuI0zPnQawvpgwR9OrzdVs4QcU\u002BXQbGY13kKrv7uUFwV9ewde6haOE7A7JSHaZRKUtDor2E\u002BpT0wnPV/xb0M\u002BjOoaETQwNsltTgA1lUdEG3lwFsuBqD71k\u002Bu7N6z2nORs/Fh3wFPepH1wvooPs/oEoyHmgVi3vOSrZL1IdT8ctrFbyJjvDBslUbJOESm0piAxdlSKz9uLtX\u002BzjJuWli9\u002BE8fY86shVZbGwW\u002BmKWv69v6dFz6qkaaV0FNZQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "ETag": "\u00220x8DB50C7F4ABA0A0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "f40961cf-fd2a-195c-45ee-caa254828bbc",
+        "x-ms-content-crc64": "Ypz\u002BO1REQp0=",
+        "x-ms-request-id": "1fcbefc2-701e-0034-1cb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d7fa65ac-f348-1af3-b3a1-34cf39d68cee?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3f9cf6558a30fa8c7dd8a3f4de00f0b6-6afa2b3ac149739c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1dc454c4-50e1-e21c-f080-8c359a40eb87",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1dc454c4-50e1-e21c-f080-8c359a40eb87",
+        "x-ms-request-id": "1fcbf005-701e-0034-5ab0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1018572769",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c731bee1-ba63-48d4-ec33-d6242a125b0e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-93bba9d3340d076e178919a4b4f8a10d-0179abf5445588c7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ef74ac2d-cbe8-2637-2987-069b911fd313",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F51C601E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ef74ac2d-cbe8-2637-2987-069b911fd313",
+        "x-ms-request-id": "1fcbf2d7-701e-0034-6eb0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c731bee1-ba63-48d4-ec33-d6242a125b0e/test-blob-c2146b92-c66b-b574-18cd-1e008925223c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a040de62c987ecf241db2a0a66d0dedc-cc716e4aa877b152-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "85b089aa-3a7e-a376-4fc6-0307b5063241",
+        "x-ms-date": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F5248F60\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "85b089aa-3a7e-a376-4fc6-0307b5063241",
+        "x-ms-request-id": "1fcbf2fd-701e-0034-0eb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c731bee1-ba63-48d4-ec33-d6242a125b0e/test-blob-c2146b92-c66b-b574-18cd-1e008925223c",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ec2a0dc13c8cbdf10fa84acec4e71380-dac67d619ca3bbf9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ff566093-9d75-1fbe-a527-53696e372e1f",
+        "x-ms-date": "Tue, 09 May 2023 19:59:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F5248F60\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "ff566093-9d75-1fbe-a527-53696e372e1f",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:59:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1fcbf327-701e-0034-32b0-82a24a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c731bee1-ba63-48d4-ec33-d6242a125b0e/test-blob-c2146b92-c66b-b574-18cd-1e008925223c?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C7F5248F60\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5473c341-32b0-3ecc-3b26-441f3053b1f5",
+        "x-ms-content-crc64": "hnN9j02laTc=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:55 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "JbFZSZC4Cjw1iuB0hnSGDvxy932ebCUFOD2Pyp/uFccbIDoRhO3TdaI4ul7rw6C0APeeHihVdbmLUxBTKT\u002BcRnQYWGU6dYoPn4HbZrLHGnWd2smoUPefxquAhTHdf0tim3Pp0mo6eYttjn6meQ4HxDiatk519PZ9eZK6ufBYMh82eMs\u002B3kcLYmA\u002BO8F4\u002BEydecD4Qsn87aZ8a1nYgMCbFFxecABDyObwj1PuN7k1BIFFHUAvYO9WOYskwnLuMuKgoiZlGYdLWbDaCLN2DrXtR2bYkmJ/bLRsCDZ1HwZzAlxwTZWSz\u002Br5\u002BsOPVVc83yrVNnoLFp\u002BAITZy\u002BBFR1jqqZgVWBsEgWnd73pif7xZcLykLn\u002BiMZ\u002Bu88CteH9fZqCSJ5e5R5thptdwCkDcH4DIfFsnoRTZSHv4ZmRaVwTqgojZ0FgkoCklQouoMide0tQ/5PwkN8WLtNsfvN0zC0/OhYe4Aksoo9gyAl6NMRpQnZeQHnIIxk7DUh99CONL8js72aifpsyJE0Uj9jVq/oPAyyNJoujdxb849LAvr5b45hAnUVtttPrHBwso5NAVWFebuD3D/k9OWhfpYq4cWWeuKwwlR6koVxYogpvhsNzvJ5xcl/NVOOfA1PtDgFJIqqmjfr3D8BSqb2Urm3u3aKU2/j8Rv8V0VPIkZG6x5NLD39vuPjYjKzOLsiSKLaFoDWhSDIYTOurkLyXPn4\u002Bl\u002BIaWZ7ujxSpzE9MLhg2c6itQuFcCX9hIsKDxChMMV4\u002Bn4bWd98XlyEQ94vy3C7DdR0D\u002Beuc0o5yuSbcWsr8bYrhHY6RX/vJhauwSwHzblaTsE8LODdiocz4Y86oO0xmJJnxAc6QMhUROmRP3Jd8f0rQOJp74SVDjnvBmOw9EVpvWhZ4AmyIA4456f3DIsUle/Rz1/Kh\u002BjN0rYNCzqk45CkZ0HJxBHzuSDUcQgcncFumnBznuUlXzW/i81TpNUTk8QXUuUJCtGeHlY/Nlag8XS0nrCKMQSrfshMSnhEX9QLwN0EBQscZU\u002Be1YBO5mie3pqYnsZkSaL/bBPcvMBZWb5B83W5XOxpmHlhK1tEHFhfrWudq8EN57c6RJj3P6hPBXwBzPMzJUHubsaNAx5Hew\u002B7fM\u002BU\u002B\u002B29dAu\u002BfxgTcpiQ0iXfAg9lbIfpr3z6gKRY8wmJe4LY\u002BklOhJjndOZp2zxt/HE4aDjAVhBHqwywgvNnZUvOSjcV99fckL22vfehf9QAjIRzYIsQySVyUU883cGlQA\u002BaW5EFWARZW9d7CZgY5it4cDZu88SA/YERo6aIn7L8EX3nxyQDO3SAGgTzlb9NGasjxK3LdkwK2Z4P8/Sd0LwkvzhacN8HNTTBrtn/zWfBhEn7Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "ETag": "\u00220x8DB50C7F531D3D2\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "5473c341-32b0-3ecc-3b26-441f3053b1f5",
+        "x-ms-content-crc64": "hnN9j02laTc=",
+        "x-ms-request-id": "1fcbf356-701e-0034-5bb0-82a24a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c731bee1-ba63-48d4-ec33-d6242a125b0e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7b58a299c8aea86cf3cd21080e30c167-f670a0c8aab7b0dd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab274c7f-dac4-b96f-bc11-fc6b0957f477",
+        "x-ms-date": "Tue, 09 May 2023 19:59:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ab274c7f-dac4-b96f-bc11-fc6b0957f477",
+        "x-ms-request-id": "1fcbf378-701e-0034-7ab0-82a24a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1179170885",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,512).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,512).json
@@ -1,0 +1,216 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a6f42ea7-34ed-f76a-2517-f4b389e86cae?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-33db84bdb00cdd3fddbfd57a1c4e2f77-33de4480060506b7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "37d739b4-9549-5c55-9e99-69991ceac390",
+        "x-ms-date": "Wed, 10 May 2023 15:10:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:10:53 GMT",
+        "ETag": "\u00220x8DB5168BFE12B39\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "37d739b4-9549-5c55-9e99-69991ceac390",
+        "x-ms-request-id": "276fd515-401e-0072-6251-8396cd000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a6f42ea7-34ed-f76a-2517-f4b389e86cae/test-blob-b58a8cec-a7d4-8cd1-dec6-54e7d635f750",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-69df0e0a819ab53e60b47aeb78a6c915-9f5573cbb927107b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "045fd8f0-a8e4-d5c4-aa89-1f826b23f845",
+        "x-ms-date": "Wed, 10 May 2023 15:10:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:10:53 GMT",
+        "ETag": "\u00220x8DB5168BFF4C2B7\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "045fd8f0-a8e4-d5c4-aa89-1f826b23f845",
+        "x-ms-request-id": "276fd595-401e-0072-5651-8396cd000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a6f42ea7-34ed-f76a-2517-f4b389e86cae/test-blob-b58a8cec-a7d4-8cd1-dec6-54e7d635f750",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-33ffe7fbceaafcd115ae731364f68ec5-6c718d38450b3fed-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fef7f951-f3d5-2a6b-92e0-f02d2b40c4c1",
+        "x-ms-date": "Wed, 10 May 2023 15:10:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 10 May 2023 15:10:53 GMT",
+        "ETag": "\u00220x8DB5168BFF4C2B7\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "fef7f951-f3d5-2a6b-92e0-f02d2b40c4c1",
+        "x-ms-creation-time": "Wed, 10 May 2023 15:10:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "276fd5ba-401e-0072-7751-8396cd000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a6f42ea7-34ed-f76a-2517-f4b389e86cae/test-blob-b58a8cec-a7d4-8cd1-dec6-54e7d635f750?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB5168BFF4C2B7\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7231cf8f-fa2c-cd6f-8372-c6463b067589",
+        "x-ms-content-crc64": "APjYtKpUIPs=",
+        "x-ms-date": "Wed, 10 May 2023 15:10:54 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-511",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "borfZiVwk4Y5GpZYEQ2Zlf/t/1AQNGRQj6yX9bdbvSXRku7Tr7HhQ6VR/S///UqR/9OZLutzfzklj9d42Z7O3lxwhn8exuVODLuqvzc1UZJhBfXjwY86XhK0rSDaaGoGgh7Sj3bLcjnuSyEvyMAC8D1EFtOp6x3NNShsaRjEc6RRozwZY8IblpK89XZtCpVSsr3jlVGWXZcBBFlOXwkgKdd93iSD6Yx7KIBB7PamYCqSGrdb4d5SukalF19pzTaJm8ue8CxxzskwaG3QVXCgWqMuu0RRxUj5KiTe3dEtEVpJuFAqCHD\u002BIUvtKnlwgmXVBb27OhHxN9aDpcYIkvH4A1YShpwgdlIzL5r5ZJvOiKi\u002BCdgUctdIV4B6pmKp9o9Z9SYiXvvItI5qhwt3\u002BNM7tB0dSYgZ45F/yS8cpc/viTkLn290qymt9lRJqerM0V\u002BtP/FFi6wGQBGVo5XMrA\u002B/ev3RbFhjxwjzcFMzzzqms/fPbmbdqv2NBF5e3giU4UlFiS7s\u002BmUGSnjoUhtY0nHW7/Cd/D2o4dAARGf6BegAX48K7kULubiSyCTu9FjiNDLth\u002B8X9uQLnKde7Lb\u002BDESP5/OLTuQryzU4CzQZuu13HQ80DH756Wir/lGdrMwCk7vgXgxlV\u002BVNwru53uuw8uK65s\u002BmyQDGlv6K31CSjR9pNnc=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:10:54 GMT",
+        "ETag": "\u00220x8DB5168C0064C4A\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "7231cf8f-fa2c-cd6f-8372-c6463b067589",
+        "x-ms-content-crc64": "APjYtKpUIPs=",
+        "x-ms-request-id": "276fd600-401e-0072-2a51-8396cd000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a6f42ea7-34ed-f76a-2517-f4b389e86cae/test-blob-b58a8cec-a7d4-8cd1-dec6-54e7d635f750?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB5168C0064C4A\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5c9ea5a1-520f-5d95-5be4-1e7f56ee889d",
+        "x-ms-content-crc64": "P9G/eOnoX7w=",
+        "x-ms-date": "Wed, 10 May 2023 15:10:54 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=512-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "eDlb4BLFKedJwkAKfPoMb\u002BPG/VvKuxnIDtp3lbs1nE\u002Boczi4h9rUCXzitgNV8w3kQyOqWGvarL0fktE3TpQrFCbwYQjCU\u002BgI8fTe6AQWcxrMklGYi0Pjzcd7mfQInLrotqLcZJEEIvA7oWd3/MS4CB\u002B3a7tCk4jjDJRBR7rz/1U59jFhOg6Ix3BhXencbNECwpDVUTH/pSIZ\u002BVj9w9o2R6ERPgWSVs4QLqNK4TafBqDCPoUpHa4kOVAOSEC2iwSWKhVIyi3Mb2vCxCKNtMTsevK3OoRUDCnz7AS0hA6NWqOetLYhVztz9s4aZ1mLloWMIs5O/1CAQR7sVN4oF\u002BtcNGp/7/8NyyO2RES1OqXQZ1Z/J2FAP1pTHnKYNAJdSt7jvTLuDKeFf1eql7oLywd4G\u002B2Iqe\u002BKHPUPLNGMdZYgWfpm0n1y4lqu\u002BagKlaigR1NrIBkU1aDuWKA93uDW\u002BArAij3ApfiJBTmS2bBHgIdMb\u002BR9IVR8C4NZd3ncNQR62ACeSQtq36Ja4Rrggvzvp9gZ8G78WNe1RH66Zi1/rc81GACwqDZ74pBCIz86nImHatChwkWVfoAo6QWMsHh02zRKq2n7P/6hnQ7euTSYeqf0M/xd3euKn5qAh78x7jIXzkgL7/EgiyrR/yQ2t8RLkG5emHx8Fv1IvwvPerc/cK/bx\u002Bs=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:10:54 GMT",
+        "ETag": "\u00220x8DB5168C00EFD94\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "5c9ea5a1-520f-5d95-5be4-1e7f56ee889d",
+        "x-ms-content-crc64": "P9G/eOnoX7w=",
+        "x-ms-request-id": "276fd639-401e-0072-6051-8396cd000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a6f42ea7-34ed-f76a-2517-f4b389e86cae?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9a15ecee841a0874c97018033eb4ed5a-09b22593a73975e4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "96a4751f-1967-427a-78cd-70c93addded6",
+        "x-ms-date": "Wed, 10 May 2023 15:10:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:10:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "96a4751f-1967-427a-78cd-70c93addded6",
+        "x-ms-request-id": "276fd659-401e-0072-7c51-8396cd000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1894289631",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,512)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,512)Async.json
@@ -1,0 +1,216 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d2111980-8789-915b-4a21-70ded43d3aa6?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b78a284df0a1bc47263f9f4220725b6f-345ddd8c7a17b75f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "aacfb769-6759-1ac6-dcb9-711694ee6eb1",
+        "x-ms-date": "Wed, 10 May 2023 15:11:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:11:24 GMT",
+        "ETag": "\u00220x8DB5168D2947059\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:11:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aacfb769-6759-1ac6-dcb9-711694ee6eb1",
+        "x-ms-request-id": "20b81473-501e-009a-2551-830f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d2111980-8789-915b-4a21-70ded43d3aa6/test-blob-562659b1-935c-029a-0e9d-a84d80aaa4d9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3a6bcee833b9d939bf635150ba27019d-774c174c1c718d8a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "f0d191b8-3469-99f4-bff2-40abe7655d03",
+        "x-ms-date": "Wed, 10 May 2023 15:11:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:11:24 GMT",
+        "ETag": "\u00220x8DB5168D2A6F353\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:11:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f0d191b8-3469-99f4-bff2-40abe7655d03",
+        "x-ms-request-id": "20b814f4-501e-009a-1951-830f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d2111980-8789-915b-4a21-70ded43d3aa6/test-blob-562659b1-935c-029a-0e9d-a84d80aaa4d9",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e113c1714ccbd590a7e0733f0e967298-8f7e90bc613c9e28-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ee9421f5-b3d8-346f-2f77-783dbe05b77b",
+        "x-ms-date": "Wed, 10 May 2023 15:11:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 10 May 2023 15:11:24 GMT",
+        "ETag": "\u00220x8DB5168D2A6F353\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:11:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "ee9421f5-b3d8-346f-2f77-783dbe05b77b",
+        "x-ms-creation-time": "Wed, 10 May 2023 15:11:25 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "20b8151b-501e-009a-3d51-830f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d2111980-8789-915b-4a21-70ded43d3aa6/test-blob-562659b1-935c-029a-0e9d-a84d80aaa4d9?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB5168D2A6F353\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c6b6acb2-6fd1-c02a-2a62-fd24b96ff4a1",
+        "x-ms-content-crc64": "lTyUz/QVOJk=",
+        "x-ms-date": "Wed, 10 May 2023 15:11:26 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-511",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/O/efVXuwkCRy9tmxyFnt3FpdR1uj01c8Z3G085wsQi0Dj06tDKxevSOGY6MX1O7UbmlKnlRQ22hgou3KO9yIRrSsrjjLAM\u002Bt/sp33a/0JFKC4EUyoaPY8vQmDGm\u002BlIFHPhzua2b1yS1Z3N\u002BJ2P24rH5bRxtXVaTQk/sE5TRl72oI8N\u002BSxbkrjRdXmMTETto2bWArIw2mL6h4HZer8OQ5M\u002B11QOgeJebFb7oD/7yfzEThDneUeoxcosE3Gqghf9wzHqUXjs3yGAe5JbNTYi/r2BFSiuKsZLkhGJ4nJws\u002B5C/d0OEXiH13LvYwGxUYyQDRCwJWjvU5hror9nZvyvE8ukGDtZEO1E/T25vsfElkCE\u002BdFdvIqBV6pEonK5IHB2QFM2DTVROvgjbygvNZTQpwh\u002B4mkrUVM9JsSNFHJ\u002Bi9jJR35wjokPM77ZOlFeUiIVc/9mPkIHSu8D\u002BOZsxCKFpOdPYfIaYBSDc66qUhcB3tCme6R3GE2axfiPbJWinm\u002BYU5VqDvAz\u002Bw/m5sqTWPTYAhoRxkh\u002BEoiVsJ/1jvOC3NFDDgJ9l9PgdnyUkDWDC2kHs25/jNQjHj0M1FpQOmwcZAX1TEryXm5KMVPP6YJXFqky7duFB0/9I/PBcMN1jDgMeCgvib8eEVT8MV\u002BEUzC\u002Btb2xIUyUl2C5\u002BChXMOmu1KEU=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:11:24 GMT",
+        "ETag": "\u00220x8DB5168D2B8F208\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:11:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "c6b6acb2-6fd1-c02a-2a62-fd24b96ff4a1",
+        "x-ms-content-crc64": "lTyUz/QVOJk=",
+        "x-ms-request-id": "20b81565-501e-009a-0451-830f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d2111980-8789-915b-4a21-70ded43d3aa6/test-blob-562659b1-935c-029a-0e9d-a84d80aaa4d9?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "512",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB5168D2B8F208\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "118bd4e2-f14f-06a9-604a-fc7e7dc7cd75",
+        "x-ms-content-crc64": "cVJtkVzdy44=",
+        "x-ms-date": "Wed, 10 May 2023 15:11:26 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=512-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "79xViuI6hDcgojR7HjQwwa7AcBu73fgy3WRlsbgb1FcvmyTv2SKNMsMbBYOjsmDW5QqLqkQMiRHjIq1\u002B1dN/BM3cTIIPQOeLMj1Yn9h1jioDjsytjykTIhETDLZ1D13wnAC1x2bex6Qj/3gHtOk5bpSCekYG0XWkySlw/DQwFiPgZwPXv8fEJMcnio\u002BwDG0o2Z0i8pQW6cuLEf48bctv8ulVJk3mYq7MvlV/3kfm8728SCKWDiSOyn44S67JiLf8t5ilW\u002BUgQXbvVTQ\u002BlgqDpB1BfyWo2eTFxlvPrhYAAzWegyavQJfXnAasp7jvUDNztKaQhwmRU96z4JWKUZJg7lL\u002BnxPj1GSGaeMe/DEr1XYoW/pvb3ssDS9I\u002B2ACTUt0S7lm8bAfj99CCR4lcletiAoeYfWY8H7W0ZLkm9kEhByXqrB3xeTGCMwaLWVdBprYmnNV4\u002BtW21s6kB8dO/MGPoUBjcimNcImWFkofcMYeMv4DAFmr6AwQc5UPTXFqM3YFO7gXHnRMWSwLoqSLV6YIRdUJS/yoI/k0Ez5UviNYLCLT2jUOBxRJtqctoAWnhNwvBwdcYKe5nRf\u002B4ss2N9sIs7aBt31xOj7Av9UVukOzjI4iZXcb\u002B8t7Wn0dD2RJU37L5OyO5g2e/gzIm\u002BDSZCKUSxZ9E9JkLLerRh0AU\u002Brad0=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:11:24 GMT",
+        "ETag": "\u00220x8DB5168D2C01CE8\u0022",
+        "Last-Modified": "Wed, 10 May 2023 15:11:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "118bd4e2-f14f-06a9-604a-fc7e7dc7cd75",
+        "x-ms-content-crc64": "cVJtkVzdy44=",
+        "x-ms-request-id": "20b815aa-501e-009a-4551-830f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-d2111980-8789-915b-4a21-70ded43d3aa6?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-df8f5b0628747d28f319b62822b5507f-a36ee6a55e52663f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e54139ed-e3e4-dd51-500c-19c41c33fc6d",
+        "x-ms-date": "Wed, 10 May 2023 15:11:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 10 May 2023 15:11:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e54139ed-e3e4-dd51-500c-19c41c33fc6d",
+        "x-ms-request-id": "20b815ce-501e-009a-6751-830f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "105830481",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-22aab938-ecec-6201-03db-c8b90357ec7f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-cdc200dfc929fdd7a8d3074e4280e99b-b41e0a79e1cc3c19-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "daf60dc9-6882-5349-59ef-8a2d93d3fc1b",
+        "x-ms-date": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B1E45C7D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "daf60dc9-6882-5349-59ef-8a2d93d3fc1b",
+        "x-ms-request-id": "da6c670c-401e-0062-0baa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-22aab938-ecec-6201-03db-c8b90357ec7f/test-blob-2df9d22d-8f58-9aaf-2410-4541b9f0f718",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bc7f27d06f765ebc01147d62caf776ad-104d61a6ebcf324e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "81059d0a-091a-0381-4780-69f2bb92e27b",
+        "x-ms-date": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B1FE225E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "81059d0a-091a-0381-4780-69f2bb92e27b",
+        "x-ms-request-id": "da6c67ca-401e-0062-2eaa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-22aab938-ecec-6201-03db-c8b90357ec7f/test-blob-2df9d22d-8f58-9aaf-2410-4541b9f0f718",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-af4e47936b81f7c40bd71463a29a5987-db76571b6708bbe4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1c37cb05-76eb-88fd-6c44-e32e1d907eff",
+        "x-ms-date": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B1FE225E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "1c37cb05-76eb-88fd-6c44-e32e1d907eff",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:15:04 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "da6c6801-401e-0062-5eaa-8253a5000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-22aab938-ecec-6201-03db-c8b90357ec7f/test-blob-2df9d22d-8f58-9aaf-2410-4541b9f0f718?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1B1FE225E\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "efed78a1-c65a-e68f-7e1c-e0eabb7388be",
+        "x-ms-content-crc64": "hbhe5AVV\u002BLc=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nrc2ZmzEKBCyCqRxKUpmSSTa8PVhEfyQTQAsnJ3ZDap\u002BphhFg0\u002BABOTmJ3fD1ykOiUEIuOIGuoy6phlrl4tz2f3684IyIcXVWuwQeumFzHbXHhNb0VTId\u002ByLi902FWxYck56yeSn3Gd8Ml719j\u002BiNNmjlHl4FweoMnuWppbnn0R/twibCgKRMEGs35720oGs6FYDk4Hy4FtG0pdoEDXQlJMZdT43BynWEWQ4yzhosWD66r5A4wzDjdasVDhrKB8L3EoL3VxCdOAsLIEduhUj3iA3biZ2j7GHVehoi7Pxa\u002BhELO/tXdMDt3beFLaKptLBiXYYM7n4lEyZhIhz2ugtO8GY2I4mNYBMM7ewmHv6/K4WpgE92TcuS5eiVNlLkN2Nsdn18c5EmlP1ywACSPzQnofZXDPn72KJaoz2g\u002BGnAaPaI\u002BeiBQvf0gutRw03LAOb0bVRcTOppcF3a4dBTRdyTspdJyQULpl8\u002BYonOahUUj2JW7IrVY9vMH0mK5mDnoX0O/lD2gTehqIc1XeogWwYIhlKuPFkR/g67fan7gP/\u002BFsFMv6vEXg4qtUPDoAXxq8RDQiAOeWTkPQACOwNN5ifHdwbo09taRGhEQ4cVTh4IyZHleD6fr52cqIKrgmLKnM8cPGj/CNgpKT33yjXdzu7iOXFxqG4pJ4dpDGsY7sIFeaa3\u002BVH1CYD5/E8A5\u002BWn/pnTiUkxmTRhMtShVfys0Do78lBPJdWdLS\u002Bwt6we6D\u002BhgU2RRSW40\u002BCyVsZ9E7PEDOwUxTWVWNjEdlxZgOFIQgqVP5RvG4rUgt6v3I8PIBl7rGq/yiMKDGi0jM7JX1L/KhS76BPfVTFhAAJXJbwJtRZC3dS2iHgnivNr\u002Bk68C2NLsLK6U3gFnBd5Xong8ybsaxf4hkG\u002BSGGclF0gs5qi5TTey3TJTyHePQH9PWmuBpfMf492w4ThzWhRHf7a5Si8lrmVAeeyItv12kl/wQs37k2FFDPLa\u002BGv/T4MuHFjA1gZAGbwGQTwWlyzgSl7ogwdWS9xVZE0sWqYJQSppWqqUtbxJoDkB5VIlPmXV6r4dBsx718B8a2HJE88GDPABrTxyS5SSntLeRGaKIDXXVm/3/Dpt7YLqKEpagIx6C\u002BhiI4EpU68pinfprYNp4js74c1fHhC1k8\u002BpmCNKOB5WZDh\u002BKAykrfLA3nHChDAPgDYPLp6/Gv3HrI/Bj8t730Jpg0lK68ouh0Panj\u002Bu4w\u002BPqhftOxl/l0lKpnuM0y4nRP8vaQD2tJRr4JdK5Iy\u002BKLlwQdWznpQ46fwAADVOobQlo0kwf4oOmPVzcVpyJLK8nI3CHJFIc7Zq9o8U9qRvLT7jJUEzfak/YajQMB1JtrU5Q2OnjJUQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "ETag": "\u00220x8DB50C1B20C5121\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "efed78a1-c65a-e68f-7e1c-e0eabb7388be",
+        "x-ms-content-crc64": "hbhe5AVV\u002BLc=",
+        "x-ms-request-id": "da6c6831-401e-0062-09aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-22aab938-ecec-6201-03db-c8b90357ec7f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bb8b0ab2a4ae3bbfb9522576f07e1b6e-e5d2869213dd471e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a48daed4-8fa3-6ba5-f15a-bf72dd5fb087",
+        "x-ms-date": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:04 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a48daed4-8fa3-6ba5-f15a-bf72dd5fb087",
+        "x-ms-request-id": "da6c6870-401e-0062-44aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2047124070",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
@@ -1,0 +1,178 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f56adc77-8f17-f87e-7e05-ded8a5933e79?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5de6bc023adf6430008ce7fb34057ba6-d6f1909bc6707a27-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3dc9955c-30f7-4515-eb9c-f70dcbe83bfd",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:05 GMT",
+        "ETag": "\u00220x8DB50C1B29FA17C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3dc9955c-30f7-4515-eb9c-f70dcbe83bfd",
+        "x-ms-request-id": "da6c6c1b-401e-0062-36aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f56adc77-8f17-f87e-7e05-ded8a5933e79/test-blob-0862217c-da04-ea37-5cd2-01b308cb54f2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c5e8fd899d336cc726d47458c1cf3e4b-e1e3a10a820a086a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "ed2456e6-f869-6799-df81-310fa2592f98",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:05 GMT",
+        "ETag": "\u00220x8DB50C1B2A9643E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ed2456e6-f869-6799-df81-310fa2592f98",
+        "x-ms-request-id": "da6c6c44-401e-0062-56aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f56adc77-8f17-f87e-7e05-ded8a5933e79/test-blob-0862217c-da04-ea37-5cd2-01b308cb54f2",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c2d402f60060ed8527d80cb9fa5cb1a2-f6adbfc5ebe50d09-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b1cce476-67a7-9788-21dc-10f77736415c",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 09 May 2023 19:15:05 GMT",
+        "ETag": "\u00220x8DB50C1B2A9643E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "b1cce476-67a7-9788-21dc-10f77736415c",
+        "x-ms-creation-time": "Tue, 09 May 2023 19:15:05 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "da6c6cb0-401e-0062-3aaa-8253a5000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f56adc77-8f17-f87e-7e05-ded8a5933e79/test-blob-0862217c-da04-ea37-5cd2-01b308cb54f2?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-Match": "\u00220x8DB50C1B2A9643E\u0022",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd989e21-7d8c-8af1-ff59-74b5005f5ca4",
+        "x-ms-content-crc64": "FLiB3kOat\u002B4=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "DptVLnm9DvbgcOYTeqya5i7Sew/JAYJGA64qnInuLSXIF8LCQqiSnofTXIZJAss\u002BARHe\u002BWwsMw0ZDirKk3Fs8kLBSmLp16OGP9yH9qX7/QHj65p3DzS4nOO1qTN9yAsWZmlEiLhoVSpuWLmPpD1nHhEp56fW9OMOCK1/NC5vCHfRcI88t3VIe5ZwCbd7KfimTYsiU\u002BBjP3GFNX8K6CH8/k9BvjOtK2ac4GwRZusrkt\u002B12eaiTbWWbTAetoH1PZJ1dApoOWrE\u002BCIkhXJ0UdmGWqOgVQ86WbGaq1ECj3Tlp6PZnPHgw1h18eDDfsdCIRtXl1zdVOiCOhpZzo4YwWmtPt7Pm7XopZZKK2Qud9rqV4k1q/cYB1K6VmLWh/XKXC93FT/pcoZmb/HFkymDU8JAbnYF4xVxlTeMFURSER6hgM80t2GbAeQCzzwGU3MoNgKglhh\u002BxHkZBoAIXF1CE13TJBNaT5xgpG2RAxPZakLDY95BsnoFIrtVG7Hhk6SHwLveMy5gzudmP/Kq7cFlQJs\u002BRPl/AGHjzQFYBDPrfxHJCkJY\u002BjcTYpT323KIWjX58NoWo06qCL9a\u002B2YtCMmze8Dg4eJ\u002BDUZjK\u002BFliCXuW3LLXhRZ1NzCHgKD/v/R5lrKQ2Cyp3lSeuOTsndsRYCaa5/zYam1WqbjHcLg\u002Bw9HkkWHmkTFO7P5eOQwxSJkVdmB6ZJf3YSwFOm5zoq2cn7TTCAy5as71C/s\u002BujFhZSDf8fpXhJ86LTA1oVbC2wpQgZlXHkCMXAuRhRicuOc649VNk/CzRNsV2Rrcg8l4MnDwrjhXygagU5Xuhj9GnXRJOr1BtQdZnTy\u002BAUVlr5gCGVKn7AquoxnOrQBaxL7bz3vmk4lMNr0pVxD72YiBeqP9rKysnrFpmlejcsgHPth94nIJftwO9eLVvpU58slRDTKcXRgSLzCKfTkx6IO1Ilg4vjdWt/uH7vaJlyAcb\u002BeOEmXVaqHAa7MBvsHi3Q1fYFw8wTTR\u002BpU21K4hSJgQbg0Ro5Zdn7e2OBJEVPk5pNHpanaD326y/BeQnpYznyMa8RD00Xl2wYDkhokiTaWcPS\u002Bcd94hjI7enqd\u002BzMDhglkvaWPoBNOYcqi13xilkK6x9KGmV2cE\u002BWSB1nKSODS/wwQv8uRB8/gcA8V1q612OM44zNhfeysx6q//Zm6gxnpz9hwUdZ2KL8DpSlOhjw33S51kmSscYEgZPch0Qo2Juz2KwbWRIcNwbpzXtfDXkFtiCBqRPG0PV5WUO3eVVe1zH88WFs2YJinZ9CqOBOpXQa2s0jqy\u002BH7Qe6of/SaL2xjvpFYhgbmNyeHw90gCgRLrPPmJ6EOywGdQRZsjuGjDTdjRnqBUdb/0A==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:05 GMT",
+        "ETag": "\u00220x8DB50C1B2BAEDD9\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:06 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "bd989e21-7d8c-8af1-ff59-74b5005f5ca4",
+        "x-ms-content-crc64": "FLiB3kOat\u002B4=",
+        "x-ms-request-id": "da6c6cdd-401e-0062-66aa-8253a5000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f56adc77-8f17-f87e-7e05-ded8a5933e79?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7836dca9e120104b80c2d592f413d55f-a7b04bc6ba45a426-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d8d6a492-839e-f8cf-3347-027f50d3d6a0",
+        "x-ms-date": "Tue, 09 May 2023 19:15:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d8d6a492-839e-f8cf-3347-027f50d3d6a0",
+        "x-ms-request-id": "da6c6d0f-401e-0062-12aa-8253a5000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "558452445",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/Azure.Storage.DataMovement.Blobs.Tests.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/Azure.Storage.DataMovement.Blobs.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Remove="$(AzureStorageSharedTestSources)\ClientSideEncryptionTestExtensions.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\StorageTestBase.SasVersion.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\Sas\*.cs" />
+    <Compile Remove="$(AzureStorageSharedTestSources)\TransferValidationTestBase.cs" />
     <None Include="$(AzureStorageSharedTestSources)\*.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-f3305ab6-eaef-c380-fafc-0725ef37d70a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-acb410213a5c6f99d3a5149548a176ed-d949ddf792b3ff00-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "29fc29b6-18eb-5121-3529-f5819edc6877",
+        "x-ms-date": "Tue, 09 May 2023 19:59:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:56 GMT",
+        "ETag": "\u00220x8DB50C7F6CABBF7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "29fc29b6-18eb-5121-3529-f5819edc6877",
+        "x-ms-request-id": "c067fb17-701e-0016-7db0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-f3305ab6-eaef-c380-fafc-0725ef37d70a/test-file-9e6ba006-cdf0-ad05-88bb-41b4c8017166?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a5ab52777edcba507dd0909a28ad93e0-d4f5e9c8a00f0b15-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f73af9ab-1d35-d400-ab2d-88618d09c605",
+        "x-ms-date": "Tue, 09 May 2023 19:59:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:56 GMT",
+        "ETag": "\u00220x8DB50C7F6FE28E3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f73af9ab-1d35-d400-ab2d-88618d09c605",
+        "x-ms-request-id": "3d1029d4-a01f-0077-35b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-f3305ab6-eaef-c380-fafc-0725ef37d70a/test-file-9e6ba006-cdf0-ad05-88bb-41b4c8017166?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b7f1e87eab85901a44c3bd5dd716fe57-ee7ed3a41adecda3-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cf092e17-79c7-e630-f69e-fb2ce882b0fb",
+        "x-ms-date": "Tue, 09 May 2023 19:59:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:56 GMT",
+        "ETag": "\u00220x8DB50C7F70C4161\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cf092e17-79c7-e630-f69e-fb2ce882b0fb",
+        "x-ms-request-id": "3d1029d5-a01f-0077-36b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-f3305ab6-eaef-c380-fafc-0725ef37d70a/test-file-9e6ba006-cdf0-ad05-88bb-41b4c8017166?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5f49a4da-f7ff-e73d-def9-644eb92dac39",
+        "x-ms-content-crc64": "VVTPH9ZoPwo=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Gfl30hJBmzYV1xJCSwrnV9B2bsY7rR8VZne7bIrEugNDJ1ziK1p\u002BdY7GFBQG3gUrQp2wJ26iPGvaYWubhS6rUBwO/yStBCx1\u002BPg4dZgKD4dxkCrsE5OVoOrwCMnv4/BfGsP399/hfT1xOi91asfS0FHjKvQEvz2JeV45vPxihhQI2FvUEhiojxPse9hjHzYjHjh4C7n7WlqGbn6Bp8BADrQbbZFr/r05O5rhF0RkJVkoFp7E6ntbDH4ATqSaJuhSq2wkSLKktyB6PtAfGUIWIUgkWZEhfCQ4v2ATa68ZnxSxj2zXQNyng15\u002BSaurO/I76Sxbdc1XMC9I64hRkUtwYZ\u002B7bYrWP\u002BFrfdUyojJ4jYRt14KDvSlGWl48jlRUVfISDucL785oZKpK7/j4JY780F4E47nJ7KN2dBIsmbCNFyfjH5RKbJ61BXLYOM4wTjXQQL72T3E4SCFElXq7O8v5vNfQFQX6sWO/T95G8bPURSbdXFnxl8e1qtZyBtcj\u002Bcmn3nz3Xzkw1o5bNgCT8ldub1BU3d9xByUPG2ouh6uMm1UUnxI33eXsrYbLlmDHIrd/BJeGzxvpNddW50TOAU7iz5qrflNFNpFqZzBZpnHFSPmzr4MUBcw5K2k64fagHas36MfFG6NkOc4FHGfrkI5mkZ9LG1LKzsnOclPpClSbyUmEIb6p/yxVTnW1DuhlTZra1FBXVQJZbBn996lQei95alIdZ27QvJFy9czdFb/haSS4DjUEQ3RHK7WkrAeCBdNFPKOVR\u002BYsChe\u002B5F81e1daHI6Fl2v6dCbe1ju5KxCJ8PD5mNkcSyE9iwQdRV8UEa9dSo95/W1nS8d8tnGrc94HNPRvPON9PtFsRwtn3C7HysSLW\u002BGAEPOCkUwSn5SwkhgmFhFqpdXL4Ay\u002BDLViAG6YteytHxj8hiQB7KqWa548vLTzQcYdXCXuwHrVwgM9IJHdeeqoAnMAKZDsabgqNHVtgVAAbr6oeljGvl6dJ8Mhw8wZuPG0lLlB8hg1MfNtw4sFaEGzPbHSNf6R4UQUYwLMy6XrEHuDuOyWv3umckllWPrTl7\u002BCbYYbR4PyIrN1LI8WaWVNgrMPgq9UHX01K8K1LIhJQMtCSl0fz8n4kJU5IJPskAnjF9ZHxBQPLVAJ5hzBPfYqLOvE0x8ILbPpFvEaG/3qSZq50RSyAXy2Mx0NFumtNlOfDvOnJ73p2\u002BkjXq0j9RFSHp2BCGvheCtvDZ8C\u002BhfJPOCdegwJQiHdz/YrjqPOkz4LuvdLLC7ovpbIOBod5\u002BHSWSHNhXoESNx7ozh0tumHoHlh9j8gfhCxtbx1QQkGv\u002BcUWTWBAA7DBnEa0Ij1cwitQJigu/ChsdsQHM\u002B\u002Bjw==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5f49a4da-f7ff-e73d-def9-644eb92dac39",
+        "x-ms-content-crc64": "VVTPH9ZoPwo=",
+        "x-ms-request-id": "3d1029d6-a01f-0077-37b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-f3305ab6-eaef-c380-fafc-0725ef37d70a/test-file-9e6ba006-cdf0-ad05-88bb-41b4c8017166?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F70C4161\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "43510d2c-5139-b9fc-27fe-6ecae4d83c71",
+        "x-ms-date": "Tue, 09 May 2023 19:59:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "ETag": "\u00220x8DB50C7F74C1A54\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "43510d2c-5139-b9fc-27fe-6ecae4d83c71",
+        "x-ms-request-id": "3d1029d7-a01f-0077-38b0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-f3305ab6-eaef-c380-fafc-0725ef37d70a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5cc25e8ce36636514c03af85f85e94ac-0b8844d338f863ee-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab21f698-68db-2b00-a10e-d5d99855e92f",
+        "x-ms-date": "Tue, 09 May 2023 19:59:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ab21f698-68db-2b00-a10e-d5d99855e92f",
+        "x-ms-request-id": "c067fde3-701e-0016-0cb0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "400532453",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-6db850ed-34e1-f2ac-d0a8-a0fd187cb8e7?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-96b500245f868141b3e479aca9b452bc-51ac31226a808fb8-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "917db506-b1a7-a861-dd20-5722e80867d0",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "ETag": "\u00220x8DB50C7F8C16005\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "917db506-b1a7-a861-dd20-5722e80867d0",
+        "x-ms-request-id": "c06804ef-701e-0016-56b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-6db850ed-34e1-f2ac-d0a8-a0fd187cb8e7/test-file-ee73b1d3-c044-2ebf-7aad-ebd82394a87c?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f130548747b8fbd34305bd03342e3046-ffda116cba1d5a29-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "225b4d6c-4d64-c53f-b643-f1c5913f4794",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "ETag": "\u00220x8DB50C7F8D06AA3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "225b4d6c-4d64-c53f-b643-f1c5913f4794",
+        "x-ms-request-id": "3d102a6a-a01f-0077-4ab0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-6db850ed-34e1-f2ac-d0a8-a0fd187cb8e7/test-file-ee73b1d3-c044-2ebf-7aad-ebd82394a87c?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-055a605825be3875b5dad65e3a2997d5-849f2fb9d11163b3-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d66c210f-8638-9517-8fb0-1be87e7d3bb2",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "ETag": "\u00220x8DB50C7F8D79496\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d66c210f-8638-9517-8fb0-1be87e7d3bb2",
+        "x-ms-request-id": "3d102a6c-a01f-0077-4cb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-6db850ed-34e1-f2ac-d0a8-a0fd187cb8e7/test-file-ee73b1d3-c044-2ebf-7aad-ebd82394a87c?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6fb59d19-71d2-185b-c532-7cbc62ffe3f0",
+        "x-ms-content-crc64": "/oY6k\u002BzmyeI=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "y\u002B3/275G11X9dQdw\u002BzWSfCuf92P\u002BJj9oluiUIT8wWV0JaKtyVKFDwN4olDGp8aynjdv2SRED0aStlkTWsbUVzRuqZpKKICeKWzaE1pIOv6Q77ZRkORBMBZYHxb5cbA4oEsYV/4sZHWy0bO3af/sSntegm8QhsZMLXmD7g1tpLu8oW8TL\u002BcAZIdAnr80jcYab9CbmvNFKB2AzCqArHZkRSz7\u002BsiM3RqUXhnnz\u002BQLG6OzZYI40gnEd3VRjmO8f7gM2FmOPJL9jY66BzzVXVg1dbCK0Ub0L3cjM4NTP0622\u002BJh2veOeNsMsdvzfsrM8xYZGBivMapxGKjmbw0Trk5ABy9ed4ZkqvzZeiNvALCoVkBpNiM2B6Y38L5KqA3N\u002BQeJs3ufbnuTtHEb1buLAhv4OhTIpnQvDf\u002BJJoLEGgLvC30b5U01COvE2X2yGjHurO6mUm35AVaTXqV4Fkf4y55yKMo6bxzKwzEtB8z2ePPNnnmUIceQ9goqiIarvPajzBHjQ\u002B1nsD3N3488z/2JmOGxqnvOYKna3TbAD\u002BKWHwY6jTu7FzkGaeo/xkI4VCoIoPOk\u002BhJ\u002B0WtoCGa6p6RbN7yJBkLFzoWor0CRkp5nnoUIu27y8STzu7vMUw7SS8JF4I6Fr1HrQtJp/E7R7ULNAGndseg1aEaXmUqG9Xt61mN\u002BT7IP3fM3HXSciPTaIc51A06k9JnaDHRH8hYHYElW8yXrU6GQvSZ2ppB3lONRuXd8EfYs1eHFpD85x\u002B/ZL70rRZXO8tIo5EYoLk4JYneU9jSei1JXKhlEIatmVvU6mXrXTFNJhsqlUy2sAKuTvEXHoNG7PqRq0B98is0mxo1M8ZDXMhIkT3Np9TQkpyVxsGVhnrYnf17SaHwzyPv9foycYxMWvIozn1ViTUVsRij2CtZrwSfbKXI2AMmV8IJ3bHqrhEQWXvPbMf9cwTIZZiZTPcIhlb1kxTWg4L/Ana7W6uDOxMHg46/mkJMkemQ8HJ6nRra8Udq5Qr8ScXo0FpRQidpRSp1gbloWPwEqQErNYMQdHVb0FpkKEYYC0m4xrn3\u002B1/CN7tIBQtRYqhLVjwJwQRC2FvU9XHc9RzkXXZvv4JCHL2haP3HyH95\u002Bm2iGMIKHko1Zf5eEvXd5TKeY6eE8bMmCTmOWFgGew/savsEOtxa2k88OkmT5AnH04O7KWTX5Qi6fB\u002BYi7XiLurucaf62bpmQ5lYSLd5kiU/xoTUS1GbFIXyWb7Msk6JWgtepWJRzQnZVOXbf5xBMOnqaMUxDdOZQ20iCH/7mYFKzv68Gvyy3fmLCvZrz5TpoRjU0lmJSEwntVIFL8SJ3ctUgKCdlRXtJ4rLtgLtPYPISFdnFrcnwYaw==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6fb59d19-71d2-185b-c532-7cbc62ffe3f0",
+        "x-ms-content-crc64": "/oY6k\u002BzmyeI=",
+        "x-ms-request-id": "3d102a6e-a01f-0077-4eb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-6db850ed-34e1-f2ac-d0a8-a0fd187cb8e7/test-file-ee73b1d3-c044-2ebf-7aad-ebd82394a87c?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F8D79496\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e1cf18f9-ccc8-e5df-c154-612c14a08b67",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "ETag": "\u00220x8DB50C7F8E6D231\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e1cf18f9-ccc8-e5df-c154-612c14a08b67",
+        "x-ms-request-id": "3d102a71-a01f-0077-51b0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-6db850ed-34e1-f2ac-d0a8-a0fd187cb8e7?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3fb4004ce619e453fcdc5ba03eeb3a4d-d9026668a3b8a8df-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4ac287ee-022f-9f27-6969-30f2a1c76924",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4ac287ee-022f-9f27-6969-30f2a1c76924",
+        "x-ms-request-id": "c06805c6-701e-0016-15b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "223364957",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5c3a337c6e8ef05cf946e516a7e7485d-04fd5b72f4385473-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "47612b5d-cdbd-c086-4e60-5f23362e673c",
+        "x-ms-date": "Tue, 09 May 2023 19:59:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "ETag": "\u00220x8DB50C7F762C6EC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "47612b5d-cdbd-c086-4e60-5f23362e673c",
+        "x-ms-request-id": "c067fe3e-701e-0016-5db0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ac2934fbcbfe706b3411a527a5dffeff-00e97a9250527567-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a204ebb0-cffb-e1d4-1703-57bde8aa19cd",
+        "x-ms-date": "Tue, 09 May 2023 19:59:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "ETag": "\u00220x8DB50C7F7706653\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a204ebb0-cffb-e1d4-1703-57bde8aa19cd",
+        "x-ms-request-id": "3d1029f3-a01f-0077-54b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bed5aee3644ed08b86071fc513f5d8da-c57e0555144ddccf-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0465e921-6e6e-6bc0-1843-9a5c7245d082",
+        "x-ms-date": "Tue, 09 May 2023 19:59:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "ETag": "\u00220x8DB50C7F782BCE5\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0465e921-6e6e-6bc0-1843-9a5c7245d082",
+        "x-ms-request-id": "3d102a04-a01f-0077-65b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ff9c5571-1544-ad5f-091f-393acb142fcf",
+        "x-ms-content-crc64": "i1Kl8ukkHp8=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EuUrNL5dk3\u002BtLkgPy/3XiP7LuHKdKMjoqzZndRDTjGZOrP6lotEC/5fhmY\u002BFd/VRidYka3b0nuodQomH9h1v2aHiwB7\u002BMeUsyLjavI44YzNBFuw5riHvWQ4Uh2BIewl6csDtorbWUlfw\u002BKK9GeJb5N5VRt8xNSqA8mcQ6amF402vYEnOS8B9asOUSbZ\u002BMj8ruKOC8zQpST2VbbBPxmitaxRVDrmYjZke2NwcnOx0AcAn5DEGA/AYhhYMON0QLaNa592hKCSGkyo=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ff9c5571-1544-ad5f-091f-393acb142fcf",
+        "x-ms-content-crc64": "i1Kl8ukkHp8=",
+        "x-ms-request-id": "3d102a10-a01f-0077-71b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?action=append\u0026position=200",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1ceb2481-d1a9-033d-d2a5-9e2e90d07d65",
+        "x-ms-content-crc64": "gEuzGj3fTpM=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CmMaWAytUSBs8CjiN6doJD2HooxUuw2qOMG0DtPYnKFRBvyf1b95absYcSAFwSI/dH3rnOMH1U5WbyBK\u002BEJNk1SGkDGqyU5\u002BDjjQPErtpXafdZpW7f\u002B9STCuSGWeLnF4y97LfjDxlasubY2qNpkEaMqpq4Oo9qVUyUcA/IDo39/HWHFrISZFrd/vJ4ByEhOWquCb9ILu0NQ4d7Xp8JgqRY2t494omEakZP2juc8l4rYzalKgTepd2IicM6pxXL1HxOLyxC41bhI=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ceb2481-d1a9-033d-d2a5-9e2e90d07d65",
+        "x-ms-content-crc64": "gEuzGj3fTpM=",
+        "x-ms-request-id": "3d102a14-a01f-0077-75b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?action=append\u0026position=400",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a7b9fb0d-1229-d626-b6dd-1ba94b86c60e",
+        "x-ms-content-crc64": "lE3Rl8HPMTM=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "mfeQhEsWBRKV/raGRor4olALVotknDIHQFz07TIdh/77QAZVWtiNcZcgFHKmNgA66VBzI9/irf3EiEPuIhjgd3a3iwaEokh4feTzQ4jAYQpbugPiqmMfGJIIkdGUnk5/QJz87qv6tkYI\u002B6b672l1BCc5k2gU/s0SmHJzexF2496VdAPrxHJeYAO82q69JCkpk4ypWgvma0LO6VY5hzo1kRfHZHtliUC02zJkVyQeVXNJSeiEzInTrwjBHNocJdnJh0iX9sCuwwk=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a7b9fb0d-1229-d626-b6dd-1ba94b86c60e",
+        "x-ms-content-crc64": "lE3Rl8HPMTM=",
+        "x-ms-request-id": "3d102a16-a01f-0077-77b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?action=append\u0026position=600",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9520d2d9-d617-203c-9704-ae1cb97d3b1a",
+        "x-ms-content-crc64": "neXsoCOtSIw=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "S/V/2IITHq\u002BU4vA9UrDEjvO1cqRsZZe1WZvQ24des5qG3jjXCfss9aNtRjo1m3bXhAgCCzsenOZeyX/nQkInNS9VtnR37IT4iHwB/x9cgL0k\u002BVZ/XKdfZ0FSeUB8RbNgRREL4OQCX5eECoO/HZ3GAUjBwkjrqNiH9k8yJHNDfEPIoLoOUaDYIpm/\u002BlIkn0qkjHj3uoJqdJw4g\u002BqVzzsjQI1A9nzjuK\u002Bo6KCuLK6GY1YFjZj7TMHAXiwd1c62QlJem7rE5KjNwdM=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9520d2d9-d617-203c-9704-ae1cb97d3b1a",
+        "x-ms-content-crc64": "neXsoCOtSIw=",
+        "x-ms-request-id": "3d102a17-a01f-0077-78b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?action=append\u0026position=800",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "79d09d63-3165-c8f6-e9b7-8c5efd26f380",
+        "x-ms-content-crc64": "TzNUNflHoZ4=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "yE/S4rtH7rEfk5BCoij0zH\u002BYUMXj4PKlTVCR88J/rTfMxTL8792i5C8kryKyELtzxvdkEHz78OhdLJRrtvruoOVYdd3199yh9WyWvjHP8z2UHS3KGp270NRKnsNINy00NQ48WZrefc4bwhsQZTG3jjhX15nNI4VInaQJqlgZWb0\u002BYokikpqitp9er1eBq2ujkxCK8WCUZhGJ87v21dJ1AWld0QOolPuetSD5bnQtx/I5ZRdIjmhdqvt3mZ/erOHM6a7uJNln\u002Bv4=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "79d09d63-3165-c8f6-e9b7-8c5efd26f380",
+        "x-ms-content-crc64": "TzNUNflHoZ4=",
+        "x-ms-request-id": "3d102a18-a01f-0077-79b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?action=append\u0026position=1000",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1bb90ddf-c2ad-4db4-1bc2-7bc41c0a6391",
+        "x-ms-content-crc64": "D0YH/n/Vqeg=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Few7P5r3nVssybxvuy1yAf8nBzH7W78J",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1bb90ddf-c2ad-4db4-1bc2-7bc41c0a6391",
+        "x-ms-content-crc64": "D0YH/n/Vqeg=",
+        "x-ms-request-id": "3d102a1a-a01f-0077-7bb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85/test-file-a232186b-1e2c-040f-d93d-7315ef7211bb?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F782BCE5\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f07fb62d-d76d-65d3-ad98-82c8983d145e",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:57 GMT",
+        "ETag": "\u00220x8DB50C7F7C3F0A3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f07fb62d-d76d-65d3-ad98-82c8983d145e",
+        "x-ms-request-id": "3d102a1c-a01f-0077-7db0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-ddf1a4ef-b4c5-620e-5604-8c159efe6f85?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ad87cca2db1bb7b4e1ef0ccdf5704cb4-5e77d0bac0044131-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "65960826-738b-4123-5638-8642034fb65d",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "65960826-738b-4123-5638-8642034fb65d",
+        "x-ms-request-id": "c068003a-701e-0016-1fb0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1583347714",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-fc7eba6bfbcfeadd3be8ab3e60fe8793-942c9a217fb4d6c1-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2fb450a7-cc61-6797-b6eb-e570f9cbb2cc",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "ETag": "\u00220x8DB50C7F8F70E24\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2fb450a7-cc61-6797-b6eb-e570f9cbb2cc",
+        "x-ms-request-id": "c06805f6-701e-0016-43b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-111ee5c72499cee10c198f06515d7063-2b947f261505a63c-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "61ba1b21-a015-81b9-a3fe-a4209fbc025e",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "ETag": "\u00220x8DB50C7F904E35C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "61ba1b21-a015-81b9-a3fe-a4209fbc025e",
+        "x-ms-request-id": "3d102a75-a01f-0077-55b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5f57926dd38c10afcf67923cba61ecbc-1c2dfeb985aa0b60-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "92c5ce57-2f77-5aea-a468-88ab4024fc3e",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "ETag": "\u00220x8DB50C7F90BB4C0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "92c5ce57-2f77-5aea-a468-88ab4024fc3e",
+        "x-ms-request-id": "3d102a76-a01f-0077-56b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d0c9eec3-70f6-53e7-3b27-0ec909f8b51b",
+        "x-ms-content-crc64": "ojK/Qz1VlLI=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "uh0SeMLxwkaxoR7UK/zc3lgTSaE5Is4SHV9uBRvmO47MEI5LvXq5tY5ufcCuwju6DwcY5oIQk5hPAFtjg7wqy2aPCBttkCDdWZMSyqQOY1sjtPYUzlQMu332\u002B70fVTLSRLJZHrkgTH7mOozu/cjzQZz/P87GFvwRgkyed5VjvgRhQIbxtEShA2d3LZTIHr60A7ogHxZjCy22SJxtgtXpgnyIjLxCAY1XXjxnTuloSGOO6XTaQp7t/jRYO2uoNIGSjqoYQJIBcQE=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d0c9eec3-70f6-53e7-3b27-0ec909f8b51b",
+        "x-ms-content-crc64": "ojK/Qz1VlLI=",
+        "x-ms-request-id": "3d102a77-a01f-0077-57b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?action=append\u0026position=200",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "52e7bc21-2c5b-ef47-f1bb-2452e913847e",
+        "x-ms-content-crc64": "5zE1ftCH\u002Bp0=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "LMnA2vy9RE7/ON6YYQ4/3ZqOh\u002BrGIa4qu9TAPk8I0Yx4cq553RMCdxPta29V6DGAajqlBHmHOwsalh8n/Qb\u002B92dRIO5gxv\u002BGixDW2LU/1NKjQNMUYswS8DeiXkf02noN73QIA8hCH6Q7H3hpsGJV28FMg7wy6ZWaPy\u002B2vWe4krCVyOlBN9EJYCAv2UNUqUDVTYOFp1a92gXebcSZi2I9gozH1Oh4FKTwQyOcAw9SRpbv4XDjMupa2O3kYsoNcNS98Va2jNVXXDg=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52e7bc21-2c5b-ef47-f1bb-2452e913847e",
+        "x-ms-content-crc64": "5zE1ftCH\u002Bp0=",
+        "x-ms-request-id": "3d102a7a-a01f-0077-5ab0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?action=append\u0026position=400",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4da8d3f6-6211-dcc0-efff-6f0cb6e975dd",
+        "x-ms-content-crc64": "EMq6VWWI27c=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "35VkMyHX9YwmLqqq8llPom38\u002BpSx2uLTTt4RuJy6wJeENwSdhia2Fu7Vo97GKsuYBxMe2V3IhwWykeVCxTzwa20SJbtUshxHReOl2zYDDSMSeLGIm\u002Bc5vK//6vRAdFGy5ThxswUQRFT315R6IqvProTBL0yKaM\u002BF2WgLVccnBtCS8/b9klkeAjRckMRTvpoEMDxwfkQEJ3xp7NmcBe6N0NDD6C600RwqoywXLdgKMRrOBiWLtoiLjcx5lKaAgv1Fz7/0kNZrUF4=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4da8d3f6-6211-dcc0-efff-6f0cb6e975dd",
+        "x-ms-content-crc64": "EMq6VWWI27c=",
+        "x-ms-request-id": "3d102a88-a01f-0077-67b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?action=append\u0026position=600",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "155bc377-376b-ac6d-4429-017b76f831c8",
+        "x-ms-content-crc64": "KVEXqVwmxUo=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "H0bbF\u002Bz5pF66v83\u002ByQEaSDdaYjo9dqogL9JeGBahQ2O2xmtwrHOg0tU268C0/nzNpaxYewgVIamcu\u002Bgam4tIGXtqSAKWqpzDupBlB4rpazBWkXNpSMhaoKXC1PGLhjdJ7dJFSrZ5N/oQlcF4sBofsk\u002B4xAkY3tCzD6hd09arODNYGxm3oyF63Fl4WbMG4u\u002BLoyGh0sItMQ8BkjoOHGMkZVyNH5UAZw8tPuewn4QdrCy40TC0CWVxK\u002BkKthHna8D2U/RWeMNaijw=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "155bc377-376b-ac6d-4429-017b76f831c8",
+        "x-ms-content-crc64": "KVEXqVwmxUo=",
+        "x-ms-request-id": "3d102a8c-a01f-0077-6bb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?action=append\u0026position=800",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f394b265-608d-7a71-2ef6-c4ab3e45c5c0",
+        "x-ms-content-crc64": "T7Ruyra2ieo=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EnSU2n2SiuPmDVVKM29b9hzzq/ax/kbSJrpLkMczaV5H9KKV0JauV3/SKtkWdsLjmF9cz6\u002BTihMuwrTDRvkcs6T3Az/NxiaFRVN339Nsu6/3Z/hn1pmus2mOZg7h6xGGtXc1H3ODFtE514pcHKtAwQYFy94BtdwLSE/VPmAXo1pB8CpbNpw8dFEmLf8OUpa9TqQH3B8zhP\u002BbKtYjrdhxITMvGiuB5ItpyFeN2ofd/Pa5F/C7D8Y7DmsqwAzGGMZ5tQvL3zdqPGk=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f394b265-608d-7a71-2ef6-c4ab3e45c5c0",
+        "x-ms-content-crc64": "T7Ruyra2ieo=",
+        "x-ms-request-id": "3d102a8d-a01f-0077-6cb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?action=append\u0026position=1000",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c3159999-3e63-933a-8f93-8a9a75e078ce",
+        "x-ms-content-crc64": "nZtSFS6gRl0=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "GZ4TyKWqd70t32qV6LYRbPQLwFcjfqOw",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c3159999-3e63-933a-8f93-8a9a75e078ce",
+        "x-ms-content-crc64": "nZtSFS6gRl0=",
+        "x-ms-request-id": "3d102a8f-a01f-0077-6eb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f/test-file-71a186db-72b3-c168-b203-dfe6ad3191ff?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F90BB4C0\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a5124d0b-022f-8f5c-9e6a-bbe55590c656",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "ETag": "\u00220x8DB50C7F960ED48\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a5124d0b-022f-8f5c-9e6a-bbe55590c656",
+        "x-ms-request-id": "3d102a90-a01f-0077-6fb0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-78d50847-0853-4545-ae4b-8ef0f2ed522f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b542253b3ad3dbc4083249ab22d6eb56-48f5ab3a38721877-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "288fb8bc-d3ce-a49f-78b3-4a6488082ff6",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "288fb8bc-d3ce-a49f-78b3-4a6488082ff6",
+        "x-ms-request-id": "c068080f-701e-0016-07b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1025346648",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
@@ -1,0 +1,260 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-19f32be96cb6946e1540698e829ad190-0e3a338fed001400-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "626f5595-6f79-e834-2268-f0cbed77ebec",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "ETag": "\u00220x8DB50C1B5868922\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "626f5595-6f79-e834-2268-f0cbed77ebec",
+        "x-ms-request-id": "56dadd7e-801e-005f-22aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546/test-file-6a96d6da-ffeb-b542-fbfd-b7bb0591b70a?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b1a5b37ff42858d995ee30babf51ab04-2fac928ea67ba60b-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "456bea6d-cd51-b8f8-a213-af63a9adb1c5",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "ETag": "\u00220x8DB50C1B599253E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "456bea6d-cd51-b8f8-a213-af63a9adb1c5",
+        "x-ms-request-id": "a8e5cda0-301f-0075-26aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546/test-file-6a96d6da-ffeb-b542-fbfd-b7bb0591b70a?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c25362f5ab7d68b839439295ddcf5c06-5c55f70c944bff9b-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b4d9b0f-7226-4eb9-75c9-f3e42796e730",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "ETag": "\u00220x8DB50C1B5A95BD9\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1b4d9b0f-7226-4eb9-75c9-f3e42796e730",
+        "x-ms-request-id": "a8e5cdc1-301f-0075-47aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546/test-file-6a96d6da-ffeb-b542-fbfd-b7bb0591b70a?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0e54df96-955f-629f-b536-d627f087dc44",
+        "x-ms-content-crc64": "HrVnTG0WGbk=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "LIdDlaHs2yM0ibYJ3UIjeiPAeW/A480chgVgC\u002BfhjWFOCBCZcySsqHlLLe\u002B5KgrgRXWnLP58K0m5Jg\u002Bbi888U/tVutUxiQf/E9H1dbbdY1v6gMVxOmBj0t3H30wVEBypDtrzY3A1rrtuqBgshraT28OzoAsKyxmb8uj3aqq66QO0TGbb6v/rxdEJA5FINkwmMwOJYW8Qn0PBWHGHPUMRs74VeDpQt/HDyNs5AMeHUruc0DamMYiTo6wiGpGNY4eN\u002BE/TM74R1nwRxZmU1p97Oga262wNaoI2gtSNLZ1gNmVTrAd4sx/9ivq6lGvv/swNpuCK13gbgI7NnbHpg6jesY8zQCqXA4bnuGByUtUWRoMHgIe91V7sOCt5qxVtEwZR2\u002BPcu76idaJZox4YqC24tlYu4gMhIdswRwf\u002BHlhweaRZIXfyOovEZAvkYzI/1JD\u002BwfS/PzEDL7kHq3O2o1dJ6Cl6voe1xnvKaX34PL2p8XN3AF1ksTpzVfG96o8YDsGz",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0e54df96-955f-629f-b536-d627f087dc44",
+        "x-ms-content-crc64": "HrVnTG0WGbk=",
+        "x-ms-request-id": "a8e5cdd0-301f-0075-56aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546/test-file-6a96d6da-ffeb-b542-fbfd-b7bb0591b70a?action=append\u0026position=384",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "484dca62-d842-dfd1-4892-156fcb0598f7",
+        "x-ms-content-crc64": "A3kPHO3NdNw=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "mnsJxRUISPp59NWzC/L7XrkAP6P65TfuBmiW\u002BNzrslu8RKJCoCtdb7di6rxkwEr\u002BwYvVF84eubVEGr\u002BtcVAejUF698ZQub6Oo8/rl/p6ikYelzZQFpuMnovs/YZsr/1nRF176siDrgjNR3P/MiG6yo94jtoazXem7Vk7Y7s4IfPSg1Od/6B9muktg84njWtpMjP28yAjTXbm1PxvR0pMlCWALa/NHcvv\u002B/Tw7Empf2Du0TGIQi7SrjbctyqjDlKf4e6op2C8nBRoBvgsMmAsPVWbgXYYxFL3rX548GagS\u002ByhUQtaANcAMTUcHzs2pXzVsHrVB43chh2csPniQ6uux7sLi\u002BBV0Tx9m09A/KQXwQcBokDsy0NfxMvuvlDeHu6JbVd/KxqbgN49WGw9m4p4hO/x4KFrwvx3q8YVZxPsnn1ht45Ml5btZSJirnPXIShAdTlh7T1NHqtaCH9UhRjKUbnv3OT8LO1YBHp\u002BCBSJoImd1fLZirE/FJji8Y4WmeAJ",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "484dca62-d842-dfd1-4892-156fcb0598f7",
+        "x-ms-content-crc64": "A3kPHO3NdNw=",
+        "x-ms-request-id": "a8e5cdd9-301f-0075-5faa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546/test-file-6a96d6da-ffeb-b542-fbfd-b7bb0591b70a?action=append\u0026position=768",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "26c49428-9439-4602-8a71-20f39db9a16a",
+        "x-ms-content-crc64": "iYTEgvawm4Q=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "l1y550VDRElMCOnDzhaW0Wj2trAm8ccHsMhMGTpeQWqadXG40LhEWZCpjYLIe0WCTCAmIOMv46aVsTd89yoO7cZ\u002BKVmk3gGwslwffWNEPzSCys0aNyGHa5HKIh6Ax2Jmmp\u002B7SVLs3W0fdm2GD2VCUHIC\u002BSxd9Lal9r3H2rviL\u002Br5ueLEifbilu1f\u002B8GzAFsriNKsfs41CKbpFlKUJQOyPEaDjFWDfcd7IGM//vn08fZim1HpNrEcw7E823OjTXHqrb56MHQGqAoLMF1q9gqt9CRcMomxyQWVZ8ikRqJT2NLyVFE6esGBXPJG3QZTsc2mj\u002BdORhvnOOO45MmrYWFotw==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "26c49428-9439-4602-8a71-20f39db9a16a",
+        "x-ms-content-crc64": "iYTEgvawm4Q=",
+        "x-ms-request-id": "a8e5cde2-301f-0075-68aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546/test-file-6a96d6da-ffeb-b542-fbfd-b7bb0591b70a?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B5A95BD9\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3747cd38-7240-f7bd-22e7-5a71deaf46fc",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "ETag": "\u00220x8DB50C1B5D0E179\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3747cd38-7240-f7bd-22e7-5a71deaf46fc",
+        "x-ms-request-id": "a8e5cdf4-301f-0075-7aaa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-8f03e1fa-d244-437f-31dd-0e0ec4304546?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-095a00fe5829b7273c0abdf413e7d464-20dc7e7e2b5f2088-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d0bab98a-6a72-b929-e83a-c259ceec8578",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d0bab98a-6a72-b929-e83a-c259ceec8578",
+        "x-ms-request-id": "56dadeae-801e-005f-2caa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1314893269",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
@@ -1,0 +1,260 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-007b22bae04663183ebcba94db824f1c-259c6e65af9427ef-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "8417e03f-ae08-8fba-9ae7-c846b8ac3099",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B6E7E0D0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8417e03f-ae08-8fba-9ae7-c846b8ac3099",
+        "x-ms-request-id": "56dae1bf-801e-005f-56aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6/test-file-fd3bc4bb-67db-e6b3-7753-9b36806b08a9?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3bb53185920d5963b213a27d7c42171a-6baede74163ff288-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "72d20300-fda9-16ae-f1d1-baaeb76f44fb",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B6F32A57\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "72d20300-fda9-16ae-f1d1-baaeb76f44fb",
+        "x-ms-request-id": "a8e5cf91-301f-0075-17aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6/test-file-fd3bc4bb-67db-e6b3-7753-9b36806b08a9?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7dbf70470f8c3b6bab912667fe59ceb0-39557253f61213b1-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7d357056-9699-49ff-0e8b-d323803adbb9",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B6FB6883\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7d357056-9699-49ff-0e8b-d323803adbb9",
+        "x-ms-request-id": "a8e5cfa1-301f-0075-27aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6/test-file-fd3bc4bb-67db-e6b3-7753-9b36806b08a9?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4758742f-c739-c061-bdd2-1ce1ced601a0",
+        "x-ms-content-crc64": "U1HOeycArjo=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "at6sSye15Br7OFjPydpZuIukQ/8bVr7v6HdaQNMRxELIuCtix1L3ifv9ic9W68a/jhC6E2gwfhMfvWOvW6NG6XMVBxCv9/A4rbkDHs3umf2xmrLDVrHZlzoXQgnvRy5Ytp9cQOO1EJYfgWWvLF9GMCRl/cDxg5LCO2/Wl7TnSWaKq2ctklgZ/IobpNRLKmvb0RLliUluZjMMmQR033jiNzj/JIH3GJ7LTAE21d6\u002BdhEE\u002BsaiAr8cHEQ0IPhTpRwROWycTAbp47hzGT1HOJFUTiPzb\u002BSyQDV54gc8w/ileKbkJJxxIioKGhcOLuiB1OSz4NLVXzU4X/k3Imn\u002BrCDAzqGWYxP04iz46VXMoxFM9w0iieIlzxhxrMWjOv/AC233Tl9H63HRvv2l3HbgbLvn6itc2yM9mv6JJbdNUKgtON3n1FWxBQycUcrkgPOhkUAJvE/TZC9JubRhvsW6g21VeKSZ\u002BJdmNeQfv4pZWBkL55R2RJRYWdOtnRuhUEdG4c1c",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4758742f-c739-c061-bdd2-1ce1ced601a0",
+        "x-ms-content-crc64": "U1HOeycArjo=",
+        "x-ms-request-id": "a8e5cfb1-301f-0075-37aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6/test-file-fd3bc4bb-67db-e6b3-7753-9b36806b08a9?action=append\u0026position=384",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0bf453ba-94e1-d57f-c529-c844b4db8f33",
+        "x-ms-content-crc64": "3yNLN3AgeQs=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "jwhOB5ipooZrtKSl8GGaVdYxQz/Z/R7R7Ft8xeWd2N29/ckRvd/7zaEO7aUuB625BvpxFZ6Og5LpfBs9Ld2hzdvG6POYiJj2NXWeyw94ouSuwr7qLMM/L3k2J0DEvqDDbB/KZx\u002B5IX5het8o77iCcdo3j2oetqEXh7l5YWBYMnbU2l7wrjvE9KBAibHjFj/BtLZmjC82pbZ9suBmQMAdCUhpUxVZkcOecprK3i3wNHB6t6yq8qVGnjWnc/taXrPgI4BpesIpZyLyxxqVa8aJjH5v7IkTchaiIrXgsh7HQxTn6rqsh7qtUE\u002BJtyqLsTJuHuZ963EqzLBpxlcNSbUEKoMFrYEM3AXEwZs5ibrsFnCCcpM3SliivB0KQ8BinweZhYynhgOwYkLhuSnV8EL2fa/ni9cizOAqYvFkAphEYSGUnwQtRJBs0Q9RVpEuzcvbE8YQexQwd7msfCMSTGCpnFcHQVE\u002ByDgfernH0HVO\u002B5UmiO7SM\u002BUNZChLgMdtWoWv",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0bf453ba-94e1-d57f-c529-c844b4db8f33",
+        "x-ms-content-crc64": "3yNLN3AgeQs=",
+        "x-ms-request-id": "a8e5cfbd-301f-0075-43aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6/test-file-fd3bc4bb-67db-e6b3-7753-9b36806b08a9?action=append\u0026position=768",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7b27c1b2-f5e1-38bf-9a88-595c53ebcfd6",
+        "x-ms-content-crc64": "g7zGjB7lxXw=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "qLo5J4x6nUuN8QFbaaZDXoGN7MRx1mhx\u002Btwo80dwsR80Fyi7FNQJq\u002BujREHksfuBByJG327APtFRyCyvUqoDHUDhJlF\u002BiEmshEDYzpImjUjhpuslKdKxc9lWaUynWVlAoCcBA4qpA3/Zmlot528/Kjrjzqu\u002B3fNtL7N4Jx78BCvnmC5rJYq\u002BOKJsTI93hItpFj8RxIutgsIzk9PXMNxg3JUvRU9B1AWwJZYIUpFj9qsnDhDf6kCfORZrN5G25gfGC3D6SD47KEI5YZ71pC8x0J0osCHLgfFVkAw51Z10\u002Bj6OQkYhaa1s6\u002BbOpYmhqpTmOmfzjjbl\u002B4l\u002BpLgyAlKlxQ==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7b27c1b2-f5e1-38bf-9a88-595c53ebcfd6",
+        "x-ms-content-crc64": "g7zGjB7lxXw=",
+        "x-ms-request-id": "a8e5cfc9-301f-0075-4faa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6/test-file-fd3bc4bb-67db-e6b3-7753-9b36806b08a9?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B6FB6883\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3910968-14b4-5a52-37fd-74cc599cbf59",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B71F2932\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3910968-14b4-5a52-37fd-74cc599cbf59",
+        "x-ms-request-id": "a8e5cfd6-301f-0075-5caa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-47b552b6-1cc8-9971-2b29-c382df33dbc6?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-432f5e7e0e4cf79a683396eca63e7fea-66aca7407a744b49-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "49f4ac06-dc59-3222-ed9e-d2ca9c3aadbe",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "49f4ac06-dc59-3222-ed9e-d2ca9c3aadbe",
+        "x-ms-request-id": "56dae279-801e-005f-72aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "244242804",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-bb9cef82-9a72-e05b-ae29-ed311748c17c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-80abfc1aef728d3a2456cd35ea4b4c89-8b524845f14b3d08-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5bc68153-8873-4cb5-9d14-23362b5d818e",
+        "x-ms-date": "Tue, 09 May 2023 19:15:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:09 GMT",
+        "ETag": "\u00220x8DB50C1B5164BB5\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5bc68153-8873-4cb5-9d14-23362b5d818e",
+        "x-ms-request-id": "56dadbcc-801e-005f-56aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-bb9cef82-9a72-e05b-ae29-ed311748c17c/test-file-9638aa1a-eccf-5bf1-a021-78777667bef6?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5f96968cce15416f809c8f8b3a022195-877ac31210fcf712-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "52ab0f83-a9b8-3085-4176-129c506f0761",
+        "x-ms-date": "Tue, 09 May 2023 19:15:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:09 GMT",
+        "ETag": "\u00220x8DB50C1B54F08A8\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52ab0f83-a9b8-3085-4176-129c506f0761",
+        "x-ms-request-id": "a8e5cd42-301f-0075-4eaa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-bb9cef82-9a72-e05b-ae29-ed311748c17c/test-file-9638aa1a-eccf-5bf1-a021-78777667bef6?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-957f278504ee2bdb51e3bb6f5b8433f0-ace2607c65e30a7a-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "67f49106-6bbb-473d-6e49-154366f92a4c",
+        "x-ms-date": "Tue, 09 May 2023 19:15:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:09 GMT",
+        "ETag": "\u00220x8DB50C1B557B923\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "67f49106-6bbb-473d-6e49-154366f92a4c",
+        "x-ms-request-id": "a8e5cd52-301f-0075-5caa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-bb9cef82-9a72-e05b-ae29-ed311748c17c/test-file-9638aa1a-eccf-5bf1-a021-78777667bef6?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "be95ba33-a07b-fca6-7c2e-841dc6603b1c",
+        "x-ms-content-crc64": "ieVn7GLATN4=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "GA7w0kEgplU5a8063q7B9\u002BO/3paBZgnbR\u002BWHZQp/BZC1LZUQxnLsMtpxIge7em3vUytSa3/rDLIFFItbmUFKuWY9hbEYsDBw0qu7EEQBIMx3lxHeLZkRyiDjC7HnkJmZJmigffS816L74ZnTMPxtA/S\u002B5AIva4zNLLqQNaR\u002BiUISIenbYKLYusBv40sAPZojdQi9KayXarrb01E6K6H\u002BfFhXwQ8SkqJR5ilBwIhBzO4gbb\u002BcwV\u002BVe7YuAI1RnY8ecGfzqXyKEONla0OCVaoymgZiGb7hYbr4wUZY5JEVAEiaIk8gTiNylVzcN1UcEyUL/GWG7oTRPQ\u002Bt\u002Buc1MSxRUGv75zJbEUzi8INiBSpk3K0hTecsjhHDyeU/c1M7PGQviufpISvyr\u002BoZo/0BbjflSB06FORFJcFaNx5NHJ74prQfM3pCe7uBLp39EuoTwlqtWSs2ASd/6WUlj\u002BkNpZNMIfxJ4Tu9osxhuOZGSBLWRnTDn8JywqWMn0kUHevRdIkKsPHuyeEf8LZe1ElBOKFSTkl1SQXQ2V9XvUHyqIXhkERcPJch6HyTpK8LFO1cS2enws6iXCqDOdeSlgyfLEcxfEQE5PwJMWbM4qVWxMRx\u002B3LaSua2PzMZ2ALAjlFw83dn2pepV2ZrnpBn1XqFLXUSIJuZxeJhej0Q6gv5SaIUW\u002B4t7\u002BotyKMLb6xWT2m5lKuNrW221i6VBl9ZmWxacVTtUnqLVz6K5Fj3jVY2CivUVlZgbJs0XoW/mOiL0y43sf1XaPzvLTxsAsgUvkjYXvszhUIW\u002BgW4uPT0zL9V/xEpwNxY3qIv5SgZ82nTH5885zntV07sILf4n68H\u002BmF9FwO36v5sgIBYA58Z/Aab5ZhUuOSFZ6fCPZ8lXz7yJ\u002BrHnNtlGzWg0Ge5lVSu0iSwXLoWs0J897Bc9a1fRyBBZdy1UmAqNspjs\u002Bd9zNJSE2p6dAOE3HSoSqUrCCWHQYlHdy93\u002BYDDhibwsv9a/yrdCeFD5NMcvIloDAi6/i2k3HJeNlSi2xrqt\u002B3clCl0Tkt6Tf5ERFy2KrumD\u002B13CIf5S9aN\u002B8jVOy7GWC3lQChg8729QLAuX5gWqAyZ/Mstcq5m40hS5lKCpRLQfesu0OmSRRwvusjWyus\u002Bd1O7PD5jmeZ/f13fDQxrOpueXuKs59cjB7av/rjljxhcFG/\u002BxmnUbOMFrlGMszgPw38tOGwJko98mDSHtJstmu9EgvmcbHMxyfH\u002BpjiFllN\u002Bnzo4t1arU4Hggi40TLhI1xRhRzA\u002BclcL\u002B256CutW9gLhCBRh9eKYmC93vOpF/Xw5ts4jJE8jPy3jLLzoMUiWiYwrU0Sj5\u002BIyyK4Bx7Vsxf3xQFQcMtKzvcjnfQ==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "be95ba33-a07b-fca6-7c2e-841dc6603b1c",
+        "x-ms-content-crc64": "ieVn7GLATN4=",
+        "x-ms-request-id": "a8e5cd63-301f-0075-6caa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-bb9cef82-9a72-e05b-ae29-ed311748c17c/test-file-9638aa1a-eccf-5bf1-a021-78777667bef6?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B557B923\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ac10b9ec-6b63-c1d1-11a7-e1a2a461e00b",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:09 GMT",
+        "ETag": "\u00220x8DB50C1B56ED476\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ac10b9ec-6b63-c1d1-11a7-e1a2a461e00b",
+        "x-ms-request-id": "a8e5cd71-301f-0075-79aa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-bb9cef82-9a72-e05b-ae29-ed311748c17c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-81bdbf026487ad8134c0cde2ffda5ccc-73815d8eeccaf990-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0d3135b7-8f50-27b8-bc43-089a03e43ab1",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0d3135b7-8f50-27b8-bc43-089a03e43ab1",
+        "x-ms-request-id": "56dadd5a-801e-005f-03aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "843570256",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-35b93185-195e-88a4-0080-4c41a9e9ef8c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-de501263490f53e1363ca6f6f828ad2b-c734f0b69c276430-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "aaf0efd2-df14-0b3e-4ce9-3217f5e25d1b",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B69E387F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aaf0efd2-df14-0b3e-4ce9-3217f5e25d1b",
+        "x-ms-request-id": "56dae0f2-801e-005f-1baa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-35b93185-195e-88a4-0080-4c41a9e9ef8c/test-file-fe04e177-1221-b4fa-afe0-fabe7b4a447d?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3266f1835a92068619a8982932f8a908-8c4aed643855980a-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bdec7f40-c7cd-f0b9-b1c1-98168e2b55de",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "ETag": "\u00220x8DB50C1B6AB969B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bdec7f40-c7cd-f0b9-b1c1-98168e2b55de",
+        "x-ms-request-id": "a8e5cf26-301f-0075-2caa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-35b93185-195e-88a4-0080-4c41a9e9ef8c/test-file-fe04e177-1221-b4fa-afe0-fabe7b4a447d?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a01897af0107d8a6136f12fb39931d6a-029c23273283a360-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fb7d8c11-875d-e3b0-37f0-a6f648cb40ba",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B6B7C379\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fb7d8c11-875d-e3b0-37f0-a6f648cb40ba",
+        "x-ms-request-id": "a8e5cf32-301f-0075-38aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-35b93185-195e-88a4-0080-4c41a9e9ef8c/test-file-fe04e177-1221-b4fa-afe0-fabe7b4a447d?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0105e104-59ae-9580-18d2-11ac68874e35",
+        "x-ms-content-crc64": "BA/UWK5p/io=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "H3k/1OFaRMg3mhHe2udZm5deb7r4RXedoduPnovhKUIiI521JRMMd6oocnnNYDBlkJaAl3KjI9oBojMGy6Y9VXHPu7ZJo3aDUfcPz9L\u002Bz0CqKQ70YZHPfgDDtILfBawE6xwH/qR5HOwg/EV7k1MHAtPzW6GXSPPgADy2he70o0tLCuS29tCbMA0h1GVLVOusvLKv7KkKbKIoJ/5ow5b9K1j6L4lvUAwCVyuTdXSOlKxRCsk8RLehQJ5Bjs7SM213JKgMUSRhPWumrJR\u002Bd/YumZNSFrnMwOehWO7qLsI9MCS\u002BHFHMgkKH78xelpgiI8mnEvQ7gByzqmPBavg1dw\u002BoaHxvwFqlYhdQyifsbipOfjUlQxvOAa8ICnLtCxdKUni9ti4bsmJuArDc67X1xzw5cuvDEDPz2WbNZ7bot1cABniuLrf8M8zTtkFq8hb5EkI1tJgrh0FEydzHTkushUpZ3OU9RpiEPT8f8FnyiedQ01RzsgO\u002B1H82aWTaNOSAJjH2EBUxvMupsXZZDJboUkD1d3v2ONNHmwhlB90zqQhan8kn/HjSHheJyQGMZMjoTRck5b1piu5ernUMy7Xudghu/mzNwFXHI1hkbW7RujZAfbnFD8RL8RXbyU0DxVJimlP4HmZbGo3CXcFkBRx/jPQ/zE37KGdDIw1X8vcIxF4GAtIb2JzQ5WMsA7IC5uv4Wz1ZxPgEZnHstftYAyiVuZhjXgNJY7NYbufqzyW1QTwhX5a5rwBlAZthLyOgd\u002BE6lkkZn4jor/eKAFUQGZZMN3O\u002BNqSR3AqY/Vxn6DSPt/cGsDnbm6K0OLCeL66rVegFFfew4UE9qLk/gaErgcbC\u002BkleCmlccJvRCv308qxc7ah0YdI839W2yAd/nBoAiLfp2zRkTUp\u002BqKRc3tdDSLUN45P5tx/zhRtzqEFi3dOA0YFGChd396Bd9bkt4AD\u002BcoBRcrmGBtGY9VUZ8aUIHMvR2wxV/T2elevznMJmxaUadDXBEGoa\u002BcuwrhXBXgX6VNjtXAT0qHVCst3Nk2oOMS\u002Bw/nxvRwxhtuJBpU8o3Tbl\u002BEfpeWmhJsu/f16NTGZhoXzmEF\u002BJiw3MjKUiswMmGdSm55oiJbjGDtiwsMet1Gp73wPSQszXXG05HezDfnPImWWJ5mTMPnzEHwGG2NtFHrg7ptP/U9cHz4ss6AfLA5Bl6BZiJO0FrqGHDiLKUISS9P40h9efyEWNgRbZn1V0\u002BBxxIe/E4/rKNfgxeEW1PH8GmvQJlnu4xSDR1KLWLA5MEhUFWS6VzhEEaVHfbk//2EWX0gVga2GhuVvP8w5Y9Anp5WUvr\u002BNQccvjBC0p2FfQ0ftdP1kJ66e0ZJ/SxtoCrHVI9ojq0A==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0105e104-59ae-9580-18d2-11ac68874e35",
+        "x-ms-content-crc64": "BA/UWK5p/io=",
+        "x-ms-request-id": "a8e5cf50-301f-0075-56aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-35b93185-195e-88a4-0080-4c41a9e9ef8c/test-file-fe04e177-1221-b4fa-afe0-fabe7b4a447d?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B6B7C379\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "66f1f440-3ec5-520c-7449-17707425c97b",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B6D2246F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "66f1f440-3ec5-520c-7449-17707425c97b",
+        "x-ms-request-id": "a8e5cf5c-301f-0075-62aa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-35b93185-195e-88a4-0080-4c41a9e9ef8c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-35f845fb11d5fd390c6dc69e31e5838b-21d89092f2416919-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "736b729f-e895-b76f-5022-d7d675051696",
+        "x-ms-date": "Tue, 09 May 2023 19:15:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "736b729f-e895-b76f-5022-d7d675051696",
+        "x-ms-request-id": "56dae19d-801e-005f-3baa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "683135791",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-e118aa6c-62b1-cfdd-07d3-002240b098d8?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1f787826d78e48cf4e13af9a962c5b7e-5824a874fbd6aeb9-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "59c17ced-eed2-da7c-90c6-1c0a9b0b0118",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "ETag": "\u00220x8DB50C7F7D24133\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "59c17ced-eed2-da7c-90c6-1c0a9b0b0118",
+        "x-ms-request-id": "c068007e-701e-0016-5db0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-e118aa6c-62b1-cfdd-07d3-002240b098d8/test-file-da49ee88-6223-57c9-f752-2c9193a994fd?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4bc9eab4049439a99032d120f6f6d9db-ec745ae1f124057a-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7e364cb4-aa77-c69d-7ff4-b0d9f2615c4a",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "ETag": "\u00220x8DB50C7F7DDC351\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7e364cb4-aa77-c69d-7ff4-b0d9f2615c4a",
+        "x-ms-request-id": "3d102a1f-a01f-0077-80b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-e118aa6c-62b1-cfdd-07d3-002240b098d8/test-file-da49ee88-6223-57c9-f752-2c9193a994fd?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-babeaf1c044da534551eb28fd3965c85-48b44ee1cf48e177-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "46dcff75-1672-5985-ce96-47626dc8b685",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "ETag": "\u00220x8DB50C7F7EA01AB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "46dcff75-1672-5985-ce96-47626dc8b685",
+        "x-ms-request-id": "3d102a21-a01f-0077-02b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-e118aa6c-62b1-cfdd-07d3-002240b098d8/test-file-da49ee88-6223-57c9-f752-2c9193a994fd?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f263f966-1584-4ed7-2240-186d4ffefc84",
+        "x-ms-content-crc64": "4mPvGYcQPh4=",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "fOHqyj2Ryo4/\u002B18JFotKQiT3NMPvPwaFPMcyEMJhgXamM9Sj2uXMW7EzGdaPc8MEfNnlpNY\u002BKT3bZY11X7rM3nnpY\u002BO3pmc/KtgRuyUv9skELZToe92fZwmXx3VYVvz3ZztdpQ/fTdVxpnn\u002BLG0XrG7DcTEm5GKcSvvZH9/y59PbGlTq0lG6JOC/dtVjoDqcfxsGlOXL0ILYwFsTBi31f76lIhIYLdkdCExQZ22NOanBPaDE61LtEEnSERH1ph6yyfcWvX4ohFJB6YyZemkVS4eyUsmNMZNstxLJRhzIJ2Eunp12dnsqmblNggLGVJXfvMWKQ1RVJZdkqgVrXj02ecEqatzLntQLh7kPP66QpmN96YlWPeQN2XgGEsx2vjp7FwlBm\u002Bq4Ex7wfruaReXo0wSi7nW03zvcHJFjxYwIlch/lCilTwp4xNVrZb4pcpSTHT7I1NDFxzfNZH9ZVE6S6OnyG7C8Q4T5KSmfSHl9s6n9z6dNP8H4uczw1\u002BqLH3CH2X3UNlfj19q6zqqmJn69ULHVW4SnRKgo\u002BWHky2uZbgm5GG/8qHxSGfjMknEWUpNOM4c4tsPr35TUrDz1/wtvIGCh7A0Owac1gkKL2rE3EafOlZjkYbhFzTjbJ/w/XRrsXXIQdWWFP3LfAzOBYAXinZqVJmlzi7\u002BnWx/VM5mr9iQnnnw/JpxBSFYmBF2Ew20y\u002BYpiqjaxedKzaRlGrwzYNA0PWsGJo3b9U94TTIZhI5ixozkOSUvtdiWpjL2C\u002B5hKTc9QdWmsqVYUZFZYnSxLUUaBlAzSyuvBIuOc3xa4eldFyf\u002B3EK0uBfnj\u002BeT1lNj4XTp3AWaLd4Lkj1OFEMo/XOn\u002BEtQtlECYUo8T7tAGzI0Lo4HbQXnxulF804FaqfQvpJ379oIDy8n6367WeIiy3cPFeWxIYxpvDViDsMG\u002BPama5EozC9UKCNi44WHLGkLIyva\u002BlC\u002BI5kCCi\u002BgqgBoHO6EFO5M\u002Bf9HtunGUkIK5pPIWuubLAKh5Ev4JsIDt4Ie9saXAxt\u002BuiUsk0Nm\u002B9FW\u002Byef2E8U0PDr4iymVNM5RANrp1t/c\u002BN4TZzCbpjDPux6oS\u002BaZ983CiXRrxzq1GFV809D/1B124tAI4qyUmZUKKdAK7enotwkMJ0xqcTCkXU7bHtJfz\u002BYAMWkVkBQgLvDfYJ5pqytrlBvH8q3RDHCgZIRduHrCqlrqCbuA0if07PhcixCSO7IjcIq2mNw5LyX4dSuQw3Z1HLVEfqFv6sL00ga0dIFfDSnROUfwCxJ9sdmWiFz7ZCiC5m5bTrwQs4bHwsXVhLujmGgCvoouhRCjxs3H2WJl\u002BG7eMY4SBL5twYXBKElMqCwe8vD0\u002BaWeVGFetw==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f263f966-1584-4ed7-2240-186d4ffefc84",
+        "x-ms-content-crc64": "4mPvGYcQPh4=",
+        "x-ms-request-id": "3d102a24-a01f-0077-04b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-e118aa6c-62b1-cfdd-07d3-002240b098d8/test-file-da49ee88-6223-57c9-f752-2c9193a994fd?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F7EA01AB\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "73fb93c0-c464-ff00-4f4c-fd66dcbbceed",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "ETag": "\u00220x8DB50C7F7FE2B7A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "73fb93c0-c464-ff00-4f4c-fd66dcbbceed",
+        "x-ms-request-id": "3d102a25-a01f-0077-05b0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-e118aa6c-62b1-cfdd-07d3-002240b098d8?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-74f7da4748ddb83834a124f686220e78-493aad504a502f1f-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bbac369d-8902-2520-6d9c-7ae36faaa21a",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bbac369d-8902-2520-6d9c-7ae36faaa21a",
+        "x-ms-request-id": "c0680163-701e-0016-33b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1174078172",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-2eaf3d5c-b4bc-baa8-3b48-dbc89f4fff5f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a2ec3bd69e387f8b4a1e7f48c2aba838-019772eb89e44d1d-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "936b4aea-b36a-8361-7f66-9fa3e657a12d",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "ETag": "\u00220x8DB50C7F96E4F73\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "936b4aea-b36a-8361-7f66-9fa3e657a12d",
+        "x-ms-request-id": "c068083a-701e-0016-2cb0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-2eaf3d5c-b4bc-baa8-3b48-dbc89f4fff5f/test-file-786f46d0-2c96-d094-7309-59ab97035773?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9da6de25feabf05d5c489c4b13ba0769-93fd0e6bd47cadce-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7af1d911-ec01-7abd-7bcf-fdab8b023e89",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "ETag": "\u00220x8DB50C7F97F8D98\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7af1d911-ec01-7abd-7bcf-fdab8b023e89",
+        "x-ms-request-id": "3d102a91-a01f-0077-70b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-2eaf3d5c-b4bc-baa8-3b48-dbc89f4fff5f/test-file-786f46d0-2c96-d094-7309-59ab97035773?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7b4bec87b30bb199489b12f93a0b61cc-fc1e18ca5a00e37b-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd9920b9-dc11-3771-e16d-a1f2681b9371",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:00 GMT",
+        "ETag": "\u00220x8DB50C7F98AC137\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bd9920b9-dc11-3771-e16d-a1f2681b9371",
+        "x-ms-request-id": "3d102a93-a01f-0077-72b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-2eaf3d5c-b4bc-baa8-3b48-dbc89f4fff5f/test-file-786f46d0-2c96-d094-7309-59ab97035773?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6bf11c1f-8168-4c78-daf0-22104e7c0164",
+        "x-ms-content-crc64": "uU3Z86jm8U8=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nSmjXdpfP\u002BRUs2ansKEYVh8J3VXja/Rm6UehKdhGFXBz12l4QMz3iguGPrdNutPeTUmE3HpMSTE0PXOSvhUMDZ31M9g3oBVSElJJXC09GS90wtyOwTn2Jo04QwNZZcz1ejAZV4b6pqwzMskoAu0E9iNEHvs5fUxj/w1L/10R\u002BKyGU\u002BL8JMKoeRwvW49vzSOgM0zgFUfQvPzktld5r6dPITkdoa8KCNJgm6TfCSK98zHpqssQMeNltZfmF25rL8p14DlVUix0lSt6f3mi8LLZJ8IlkATbPvBWt\u002BwXJPFk9WzZaijoaKEFdBWglbFpwsXkDO\u002BrRZ7FmaFJ/po/XHE6FYkNyIaJ8b8hHxvvOqg\u002B7PUmMxgBuK/NFNCHn2kGxhejZn8nXPk/WhowiiaD1l/4ChGlGClZOV3ZP7S1AlFWGlkDS9MoF5D759j90C2JSj1xjpVXYK3uSi0iTR1EiVjJ2m/Mf4qLz/OBqjFQW2gvUPV2Q3S8/rqsFQCmBslztl2AM/W9vMqy5b6i1bZ7nu7F8/0nzkbjDNy1IGqK5ckpDvPTzydycZMqw121GigDMHYR4RPLS\u002BgXnCYZCJxgKAD1eMfCqM7HUoFp/QroLvKzsu/zeAS2XcMLuzIAWGn3yZtdwKFhQIioSo6RYk3eL240ZVWsbLD8PxoDt\u002BybxvkXcjNvi25RUnFnSi11JPt2LYzEzPITS13rYICGXYmbDYSVefAZb6P/4hPkRCGChhoejYpg1vkGBCbWgyrtyvXozD2p4KoLXL3oxOrfLwc7aNpmZ8/\u002BOzaLjnXJQ\u002Bt5Ehgd\u002B3fj2KZvEzHMdxIOJtQfmxtQh2Im6pEHHlE0QhjSbrLSwTSPV5Az9lSdMsMjfGehqajPKYu19xHm3LpUO9AY\u002BQhfPGSgkEOLHJANiLfN46Lpk5hwAkUnHMoiqHvV37uDhTi7xD8CARlkRA36qG9ZGfgYaqc4p/bDOCCafefItT3VigJ/ER9i5pF/DL03LHRayY6DvXQTS91B\u002BIseaIQxnI/QJB5s2QjYtYMVuJs5iwusP7RZRffJwj4lPhmTQ34NTnAuZwhW7u\u002BGqgjw/ZJCCG2AcijQ2FaYB2LfR5vuRHEFCGoqCyMDVVHE0pru2MSr4jasE9FWPXUZlWCldqZTl2aX6vUoF/1JfBzXCwW8qi6eM2VlQjCgr8r0EXXCXd\u002BqcDo0V\u002B7Og8o4Ypa0fjJwXeoyB0JB7lQ19zsrMwaHhh89LZrLiFNAz7CaLOCa6zCXhLSKkFacaILl/1\u002Byo0/Dsdt3dlGYpdWX8jiSp8F0mgsLk69S/PbJocQX5YjzjSxh13sEInTe/9/f850dCsHAcWRUpg\u002BfcbTlrtWMgL9Mo2QMMA==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6bf11c1f-8168-4c78-daf0-22104e7c0164",
+        "x-ms-content-crc64": "uU3Z86jm8U8=",
+        "x-ms-request-id": "3d102a94-a01f-0077-73b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-2eaf3d5c-b4bc-baa8-3b48-dbc89f4fff5f/test-file-786f46d0-2c96-d094-7309-59ab97035773?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F98AC137\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4cd23bcd-2829-df09-5008-f87928aad3ee",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "ETag": "\u00220x8DB50C7F9A184A7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4cd23bcd-2829-df09-5008-f87928aad3ee",
+        "x-ms-request-id": "3d102a97-a01f-0077-76b0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-2eaf3d5c-b4bc-baa8-3b48-dbc89f4fff5f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b33443da8fa8851837dfccbf3b4e49cd-9ea0fe8b7e67e13a-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "124206a1-b5a9-933b-88b6-c2b6e4fd46ba",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "124206a1-b5a9-933b-88b6-c2b6e4fd46ba",
+        "x-ms-request-id": "c0680952-701e-0016-26b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "159803190",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b378fad10b32ccb04b1f2c9037653387-bfd7e0a5d5261942-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a85857a2-806c-fcd3-37fd-1395f29da033",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:58 GMT",
+        "ETag": "\u00220x8DB50C7F80D45B2\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a85857a2-806c-fcd3-37fd-1395f29da033",
+        "x-ms-request-id": "c0680184-701e-0016-52b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-074593889ec30df0bfa3dbd226de9ad2-c48c3c438a7a3823-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "876fc412-1ef1-0d0f-6b51-1a6dfda84361",
+        "x-ms-date": "Tue, 09 May 2023 19:59:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "ETag": "\u00220x8DB50C7F866ADDB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "876fc412-1ef1-0d0f-6b51-1a6dfda84361",
+        "x-ms-request-id": "3d102a2d-a01f-0077-0db0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-893606108062f0d997061a65b334c81f-525c8126e4015bb6-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "374b2118-e561-ccfe-2b1b-4af1bb4983b6",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "ETag": "\u00220x8DB50C7F86E8968\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "374b2118-e561-ccfe-2b1b-4af1bb4983b6",
+        "x-ms-request-id": "3d102a4e-a01f-0077-2eb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dc55b218-0b5c-8e00-aa3b-dc83bfbfab82",
+        "x-ms-content-crc64": "x43eY0\u002BNGFg=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "MrgIczArm7ZbW6J1ApJ78Qx61UVcKWIJFThWuL39VL7R2kieA5fGdruiTBDeXvmlgSGJeMda1glW/l741eP4XgfjpChK3e51tF\u002BJut1SK7c\u002BsTabdNz3dgQ/RwQ4zaDYqe4J\u002BrrRWqMzFMNn0BsrBNOnuSSsXOkq7C0jCpXpPOa\u002BsRDuSDH8bVaTaGAYj6bpE0MxkRN8K00E3g6MrVANStfcqB4KPbuiqkzNGfSJEVyGOvdRuKrTQobD6WoicL8GhR2IPOaH3tU=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dc55b218-0b5c-8e00-aa3b-dc83bfbfab82",
+        "x-ms-content-crc64": "x43eY0\u002BNGFg=",
+        "x-ms-request-id": "3d102a50-a01f-0077-30b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?action=append\u0026position=200",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "09d87ec6-a7f4-0759-7f7f-a14138994954",
+        "x-ms-content-crc64": "jQDhGW2pQi0=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "iI7nx68RWXvMsQZzWLuSLAlmmEZTUH86jMeT1gHVdv9bIckpwwySdGpunXFpTK7Ji1syf\u002B\u002BYgjcPrTrofoJ59jsGFzbyaGn90yPc5bMO0EAZykqlovYPw5\u002BRGhbRqvbn9KY1YzV31iLyNavMu5yEAN36zrQ31FRF91OXYU5TKyks9PAM2W0KofMos21KQwcCDBk419tCryBS8Gvh4HXUngqCn8areCdw7y3ADyDn\u002BrNLlFU1GlNN6kTQuegBKcF9VBRix6RBVpM=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "09d87ec6-a7f4-0759-7f7f-a14138994954",
+        "x-ms-content-crc64": "jQDhGW2pQi0=",
+        "x-ms-request-id": "3d102a52-a01f-0077-32b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?action=append\u0026position=400",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "41bcaa46-a1e6-978e-37fb-b8124aaaca6b",
+        "x-ms-content-crc64": "UJOKTrIMSbw=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "8cjoroGg/2v2uJVLIJ6EtzW0gdu/P27Fa0K7DIQyDwo9wUNRap5opNFN8kiTdV21kKuS77971LJZIkM\u002B5PLnw6mKDl5bMkyXTN0JcUwmMvXlBnzYoB9LweyQ90dbKr/eZi\u002BfCGf/Wl1f\u002B6PhcWNmM/BNWd52DiOJP0xxyjsEPCEdKwodhimO5asfeaV8aVCJKsRXDdDhZ1cLFskajZAhWr6BxEZYSK3GvnMyV5V\u002BDNX86J93rC5RPMOzEW9gc1gb/R7m\u002B6UJMeI=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "41bcaa46-a1e6-978e-37fb-b8124aaaca6b",
+        "x-ms-content-crc64": "UJOKTrIMSbw=",
+        "x-ms-request-id": "3d102a56-a01f-0077-36b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?action=append\u0026position=600",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8efbc71c-08dc-bb6d-aa56-0ffb6428e01c",
+        "x-ms-content-crc64": "nV/kxrh\u002Bwl8=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "FpBOXa4Qwo0K9B6k8KqukDCHg6U3PWZLGhZad5cRL/O3vWAc3/OOsvCDZWtVtCpScFXKHoaLq9kqA0KXtUv1\u002BcUr7TNKkbA8\u002BdC0s9j79WbrCAZCRhFsKxGH8tyx9v2ljmymKsf3CN6ljSS11/gALw7cq61Es7K0vsEhwp/UiwLTDiRsVMqf9P8onbnstlMZhsPO1UtPYdq58mwF1UU\u002B0AIi4snTlNpDPLauGxb5yAdtBzzcBra3g61JsmFemR\u002B66sy2ydSKRvE=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8efbc71c-08dc-bb6d-aa56-0ffb6428e01c",
+        "x-ms-content-crc64": "nV/kxrh\u002Bwl8=",
+        "x-ms-request-id": "3d102a5c-a01f-0077-3cb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?action=append\u0026position=800",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "83f5e0db-3caf-f18f-6241-478ba03e431b",
+        "x-ms-content-crc64": "zjAS\u002BuNnt3Y=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "6IqYlKFFxMAqZJfNCGHKTGtfHInieOSjl/MxSUL\u002BM\u002BPBSvR7HiLiZ4TxN/kCUbGIAmpedW69D2\u002Bm9fytE3t\u002BLDGzDL5sTy5IfLQE8EHroEVCqEfYn751BDuE1SglNFMJcwvHTkXzG7M8Fvi5uB8uulS3a2ozpYxzPgiD6HkFIkdg\u002Bnw1I1IATo2Um4nFu0sbVhrUbsno1c1\u002BVA89cDM5N/OxWL2i\u002BJcCthzdnwoCrYO8Z5FfMLR\u002BeCWuts9Cw95ZW2SWFGKNeV0=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "83f5e0db-3caf-f18f-6241-478ba03e431b",
+        "x-ms-content-crc64": "zjAS\u002BuNnt3Y=",
+        "x-ms-request-id": "3d102a5f-a01f-0077-3fb0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?action=append\u0026position=1000",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8420188e-5d32-4b6d-dc2e-b669286bf631",
+        "x-ms-content-crc64": "9RhjPZ7ZYhU=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "g9K3rQs1w3ymjIAIodkGPzLgmPNBx7/z",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8420188e-5d32-4b6d-dc2e-b669286bf631",
+        "x-ms-content-crc64": "9RhjPZ7ZYhU=",
+        "x-ms-request-id": "3d102a61-a01f-0077-41b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce/test-file-a544843d-996c-2e20-ee34-dc5efcd06cef?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F86E8968\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "88fc89e5-bf1e-6fe8-b9ce-86f251c48264",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "ETag": "\u00220x8DB50C7F8B0F653\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "88fc89e5-bf1e-6fe8-b9ce-86f251c48264",
+        "x-ms-request-id": "3d102a65-a01f-0077-45b0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-fea2ee87-10e7-d30d-fd16-71789db5d2ce?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a09cb05c3ebfcb77de4c6b81aba45e97-4f7b992607435bdb-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9f838847-6e6e-1012-f9fc-7e03dce382ef",
+        "x-ms-date": "Tue, 09 May 2023 20:00:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:59:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9f838847-6e6e-1012-f9fc-7e03dce382ef",
+        "x-ms-request-id": "c06804bd-701e-0016-27b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "686072945",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
@@ -1,0 +1,356 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-96e752d28cbabc5799e4322790293e6d-56c14f13df1c2c66-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c07ec690-0a3e-2c30-3ca1-f7ab67f68955",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "ETag": "\u00220x8DB50C7F9B0F402\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c07ec690-0a3e-2c30-3ca1-f7ab67f68955",
+        "x-ms-request-id": "c0680987-701e-0016-51b0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f5cc0434e723a75b7f26b52aa13408f0-4b25a1baec819adb-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f22eddcf-3679-2db9-487c-348426c1493f",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "ETag": "\u00220x8DB50C7F9C36369\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:02 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f22eddcf-3679-2db9-487c-348426c1493f",
+        "x-ms-request-id": "3d102aa9-a01f-0077-08b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-518444a19c3dcb0c570179566c1a1a12-b329388072d9992c-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "24869b75-d9b6-528c-b970-6bb0adf71c23",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "ETag": "\u00220x8DB50C7F9CACC47\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:02 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "24869b75-d9b6-528c-b970-6bb0adf71c23",
+        "x-ms-request-id": "3d102aaa-a01f-0077-09b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8b0e20e2-243a-dc89-c7c1-04be74509b31",
+        "x-ms-content-crc64": "SjTw3FEPFtE=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "xq8LodD5RtuXs8nOYAdhz9qa0DQRXDr/Vq0\u002BAvJ\u002BJ8bLVJBhOjf5l3\u002BiKIpAYsw1PyjQzSVVRGl1DEojukTpGYwDAgx2AJWioDm0bjOvvvPhCcLKrVqgdg8n6y3s1dw7uA/\u002BPV/Avj\u002BTLSzsodU1xU5WQrGBH2wyY4z8TxRotctceLYksIGUIEqDN38ts9Q58SXelpMquZmjzNnTw28qKnhhjygfERXMwiFn/ejsBK\u002B3w13uiR83Mr4cgOSnwF3aWQwHzCSsGeA=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8b0e20e2-243a-dc89-c7c1-04be74509b31",
+        "x-ms-content-crc64": "SjTw3FEPFtE=",
+        "x-ms-request-id": "3d102aab-a01f-0077-0ab0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?action=append\u0026position=200",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8ccedcaf-90e8-34e8-57de-6dc75f0a7b8a",
+        "x-ms-content-crc64": "02fLB71UnMc=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EBHTccO8sbbIKhsAEjuhWCldaQKQMSUBxIyk3OU3igupfN53TMVuAmvJG3ylXcgeaq6ixkIXT9/s0a02GNTRkJ8PV5VcKQxj72eXxxWoXGfDhnE2lMTJki3/i3oYN\u002BqW\u002BIrclQUzwUCiP9fbf4jKQ3VGcpJjmvzbRsRoXZ6RS7d8AM6KzMZhkMQxlFXs7RKkNEcE0sRYM16OAU9By2OhEfMgXn\u002B5P3ev5eLNMQan7liywylXjXnyJMxw/Mt2IMVhj4JhzI\u002BT6/U=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8ccedcaf-90e8-34e8-57de-6dc75f0a7b8a",
+        "x-ms-content-crc64": "02fLB71UnMc=",
+        "x-ms-request-id": "3d102aae-a01f-0077-0db0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?action=append\u0026position=400",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "970eee6c-0e82-c748-2d89-3521f7c3b2c8",
+        "x-ms-content-crc64": "YYTgBlqZ1Zs=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0FTs4ooBWOcS9o4HOkqDei45sklDrDnFHGuig0UhyR/YM4c4jA\u002BayxcUuH\u002BRvSdF/\u002BeeVeGhsSMbJ8UfX9Wi8C1vLwbDS\u002B4en\u002BYxL/O5M15EXYNeg3Q9NoJjHGRJe2tCcsdSIo4hgbT4f7X6b4IvYvRn2gFRQ224MfiDYC6J1CR677wrZhHQItvPZQO/Q8cAM7pv4qBq8C5amvCWnSGFbqqQf4DFBPvjlrgmgd5p\u002BO4xgyxzGfKEEP6N0cwgOoS6SfZYL8NGOi8=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "970eee6c-0e82-c748-2d89-3521f7c3b2c8",
+        "x-ms-content-crc64": "YYTgBlqZ1Zs=",
+        "x-ms-request-id": "3d102ab2-a01f-0077-11b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?action=append\u0026position=600",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "715b2d12-e3fb-3b08-50e5-ba5bfe6c86d2",
+        "x-ms-content-crc64": "N8ZyTDBh77I=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "voxL50RvUPGhAmQa9BJUuAtugTgyLsJcM2s45xDJKupJ/bSNpp3MjzzfKx7VasU3oaAkVMUC/I/K7rPYNmng19d60fddxxJuovH7UwOjh8mlAEVwpdUlRwEkwrfp9FjT/lRHW5jO2dqOtrLTBqiMJ2fqMjUkcDIBVIr2OAVahK2ZJ1SvXCww1ydr4e8jUUBYmJtQ/sEir44hRQYO2KDVMzEEOt5U3cs7uVsOuI5D3gNJnaBpCoXrdnjGjRYlIv6Glq69HhZhA7o=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "715b2d12-e3fb-3b08-50e5-ba5bfe6c86d2",
+        "x-ms-content-crc64": "N8ZyTDBh77I=",
+        "x-ms-request-id": "3d102ab6-a01f-0077-12b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?action=append\u0026position=800",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "200",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c90e942f-4168-38cc-b64b-27f5b3d57de1",
+        "x-ms-content-crc64": "dhWer7HRPVk=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0BVFZhT2/95nA8Q6AGspqxjEZo1QtBWXXIgi4IW/7Oea5pn0QIVigseuriJdxIYqhBIFUvt1ahv/rQqL0x5ZpxbcoBnRNGqTYuPGogXzOZgC\u002BFxzuZnsJHx\u002B9ZJ71q6oVQcLgSNsWU\u002BncvAYr8cVDHRxidvC5e198HydUz/XGIw1HU3\u002B57h0lp4Ny0ep1HW0aOgeCU3T5m8ZjpCnzgYQz1pk4pF6FiW7/PM8tRqm0xwH6epWuA4\u002BYTfe5VgozceY/PvtRfHjOVI=",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c90e942f-4168-38cc-b64b-27f5b3d57de1",
+        "x-ms-content-crc64": "dhWer7HRPVk=",
+        "x-ms-request-id": "3d102ab8-a01f-0077-14b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?action=append\u0026position=1000",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "24",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "692bd1f6-bc5e-086a-2450-65e32d6f4ae7",
+        "x-ms-content-crc64": "hx5ls1LrmDI=",
+        "x-ms-date": "Tue, 09 May 2023 20:00:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "w2MMWZYxVHK7dKDkHLkXSyWAWpwwzJMv",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "692bd1f6-bc5e-086a-2450-65e32d6f4ae7",
+        "x-ms-content-crc64": "hx5ls1LrmDI=",
+        "x-ms-request-id": "3d102aba-a01f-0077-16b0-82aa26000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79/test-file-1eb8a42b-8db8-232b-b097-925502e5cb05?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C7F9CACC47\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e2ff3327-14a9-0e83-ba99-c16bd78c9059",
+        "x-ms-date": "Tue, 09 May 2023 20:00:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "ETag": "\u00220x8DB50C7FA0D1136\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:02 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e2ff3327-14a9-0e83-ba99-c16bd78c9059",
+        "x-ms-request-id": "3d102abb-a01f-0077-17b0-82aa26000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-8643c0c5-0a24-725e-15b3-6460fb8f1d79?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c176e034206cfed5da96bf2381be0d5e-4e176ec059c8b01f-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f9bc86b2-686f-003d-e358-382048c11b97",
+        "x-ms-date": "Tue, 09 May 2023 20:00:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f9bc86b2-686f-003d-e358-382048c11b97",
+        "x-ms-request-id": "c0680b8e-701e-0016-0eb0-828965000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2011404058",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
@@ -1,0 +1,260 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ba0bdabd5c0b9d99b9f97e86d194854b-e3d4d79bbb1e2064-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "8fcbe3c2-b9d3-f33e-1863-adf54310b9fd",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "ETag": "\u00220x8DB50C1B6321926\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8fcbe3c2-b9d3-f33e-1863-adf54310b9fd",
+        "x-ms-request-id": "56dadfb1-801e-005f-80aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858/test-file-b1cb28f8-0237-313d-8a61-9651c81fd1da?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3c38aab6fcae458e11cd3790482f9e97-69e646b4837de79c-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fd250939-e7d7-2e7b-819f-903241bdf769",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "ETag": "\u00220x8DB50C1B6413390\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fd250939-e7d7-2e7b-819f-903241bdf769",
+        "x-ms-request-id": "a8e5ce91-301f-0075-17aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858/test-file-b1cb28f8-0237-313d-8a61-9651c81fd1da?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-662d33416011310a0a62415755a7346e-d38bc644c171cdd0-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bf17d690-d3fa-ed02-0a1d-3d2edc43cf57",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "ETag": "\u00220x8DB50C1B64A1AD5\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bf17d690-d3fa-ed02-0a1d-3d2edc43cf57",
+        "x-ms-request-id": "a8e5cea6-301f-0075-2caa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858/test-file-b1cb28f8-0237-313d-8a61-9651c81fd1da?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6aa2ca58-38a5-e36f-bbd7-0a77334eae6e",
+        "x-ms-content-crc64": "z640AJyw4pA=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "dR86y57H\u002B5wYEgibNk3RDjpDIxMMGYXPdZon3PDXbDolP35XwOEG\u002B\u002BcvdsCxo7zLkZ66AO2m8VyZa1UDoB\u002BrQaXNdvfOek5ZPCcr3KLEHtLdW0pSHGxMf00hvVWLA1vIhDUb4y3F/BdQYcPGehS61UyDJUTVWCQ5gfaprb35zTnMY1htqTulGF8zAbuohgQ5Z\u002BcICN0X8ysQ4WI2G09ZVpSJ\u002Bhe7TCwR3Q3koVZokPvycEXV8MRctXAtXMfZb/wQ2aonH4zsfRq79yrPMlHUqFBmQ6sJhGbPLUWmju9lOG4R1MisQXFvBfMqGfmZjIIfWLR2citRBlREV/FGRu4qVr\u002B8vl2IKGbf9z243mptNqDChzU77sVCv85zZ\u002Bp/KL8E/8M53c0lljBOl3rtmSfq1yFRhL6472f5ef\u002BPFcB7X89\u002Bs9\u002BmM1jSnPEF7VdLVSamiZDJLqMBSxBbQGTOloBv0jeqb\u002BVIQ6PIfufNswIQriTY6IwwsjEsfWjPS/P0AwZw",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6aa2ca58-38a5-e36f-bbd7-0a77334eae6e",
+        "x-ms-content-crc64": "z640AJyw4pA=",
+        "x-ms-request-id": "a8e5ceb7-301f-0075-3daa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858/test-file-b1cb28f8-0237-313d-8a61-9651c81fd1da?action=append\u0026position=384",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "12d6e188-65a1-61b1-8f7d-7127b2b3943e",
+        "x-ms-content-crc64": "AQBqxE4uP/g=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "lRogoOVAXkXsAK\u002B7M5cNS5E/9q30PyAFfvF9ePiw1HrgXR7n8A0\u002Bl4pGQ7GBcEnQwQBhtA1Ze1X5GiL0w\u002BVNOyw12tZ4JVuDAV4jrvtvhA2orLf4TyBth\u002BHJ7dXrStSk\u002BAiFTJVyV5uk3bKvNs1aipYUSxYuVewLx1P1rziFmLeJfrXz6Td3NVUbU3FtvlETbmM\u002B1/6\u002BdqMbeYRCfadjH0X7JbcYZqFfnBbBEgJ7ngkC4UDVRsC4ywgS2HCyNbetuDMrcpia\u002BwjB3zrn/WSgn9t7QJxnjtiEQlquBY4wrGdfFFnPTytwZ\u002BU4E2aG0c6kcTiUN/QbRilapi8\u002B6/V6kTPSiOkK0U\u002BvCti2Lnty/nGLCpRVnHVyRM0vdKj7MnzwvoEzs0jlmaDp5CwcZBeu6Ki\u002BsuFhJPW9X0Qb2lyms9hcxnD5PkoopnDza7dIVt\u002B2gYwAPX\u002BajpmMdVMEyb5DQjBTv56ntKlelQtwbbk9dQllZVnQpnZZwTfWbMn2JNyx",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "12d6e188-65a1-61b1-8f7d-7127b2b3943e",
+        "x-ms-content-crc64": "AQBqxE4uP/g=",
+        "x-ms-request-id": "a8e5cecf-301f-0075-55aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858/test-file-b1cb28f8-0237-313d-8a61-9651c81fd1da?action=append\u0026position=768",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "52eed536-9c77-85cd-93a9-0c46aa9f21f8",
+        "x-ms-content-crc64": "60QIXNw4wdE=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "rymG9JZADszioqdzKiDgTgBKn2Rlc5y6\u002Bv5n0UffZ3Euvr2Qt4ByJFaM7QTO5ZYW9h7Jq4R4TDyMy/qY2T2EAzo2RWxiUJeA2HoN2YWY7BVnUNopFrvstnGBA\u002ByG2UsZB\u002BrJmKAqtKaGSNMKanO39N/kMYliW\u002Bx/SY764Uyr\u002Bv8v9NGbz1N1PJw0os3o4kv\u002ByQ8MoajBt6z9Sk8RMNJZ207T2nahGySLbvTtLbgflmZC\u002Bxc9nlhWbTwlnYUEYwzJ28Z\u002BFAfVXK7qgDOz1Inz3rPpzzS6Gz32fW05fH6fhwroI1LxoIFebZ5pUx0lo5izMb/RGpTXDr\u002BJiJeam98vSg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52eed536-9c77-85cd-93a9-0c46aa9f21f8",
+        "x-ms-content-crc64": "60QIXNw4wdE=",
+        "x-ms-request-id": "a8e5cedb-301f-0075-61aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858/test-file-b1cb28f8-0237-313d-8a61-9651c81fd1da?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B64A1AD5\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dcf19b23-42c5-4ec6-0fac-7321ec509263",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "ETag": "\u00220x8DB50C1B6791604\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dcf19b23-42c5-4ec6-0fac-7321ec509263",
+        "x-ms-request-id": "a8e5ceea-301f-0075-70aa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-53c2e53a-727b-4841-09e8-e7e5f6d7a858?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-224ef88dcf2787a4b2eacd8d4911a16e-33cb3c170072a0eb-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0e238b4d-45ae-7832-2d27-9b072647a3fa",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0e238b4d-45ae-7832-2d27-9b072647a3fa",
+        "x-ms-request-id": "56dae09e-801e-005f-52aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1671405826",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
@@ -1,0 +1,260 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4e4120cceadb40a41622225e8b99a751-d056a3b5316b6049-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "6bde8d41-9703-65a7-4b6a-3d13f5ccac2a",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "ETag": "\u00220x8DB50C1B7AC7361\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6bde8d41-9703-65a7-4b6a-3d13f5ccac2a",
+        "x-ms-request-id": "56dae435-801e-005f-05aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae/test-file-e6be2d49-7577-4667-832c-72b1caca3d61?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-112c02ec70b7ed45b2b85a7a13ba5b62-207e48928815befc-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7aba49cf-e14f-b1fa-bcc0-c4fd87a1db19",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "ETag": "\u00220x8DB50C1B7BC1E56\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7aba49cf-e14f-b1fa-bcc0-c4fd87a1db19",
+        "x-ms-request-id": "a8e5d095-301f-0075-1aaa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae/test-file-e6be2d49-7577-4667-832c-72b1caca3d61?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c78cc7cce0a77b265a5aa4cfbcc987c0-e40475ff20a1ece5-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "81e14658-c20f-ab11-e169-63eb7af1308d",
+        "x-ms-date": "Tue, 09 May 2023 19:15:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "ETag": "\u00220x8DB50C1B7CB7273\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "81e14658-c20f-ab11-e169-63eb7af1308d",
+        "x-ms-request-id": "a8e5d0ab-301f-0075-30aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae/test-file-e6be2d49-7577-4667-832c-72b1caca3d61?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "41a46e2f-5abf-840a-7fc2-04d7576f8f4d",
+        "x-ms-content-crc64": "bx2nqzul6l4=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Rh1RhY8TrS1NQ1Rc6xUMDMdgiQU7OqqVRNgBaqs7jbqetKgnpRVPLt\u002BwHcBDSno2XjFLlUKn7wxzvEC3EkOCEbWZvTdt5GaxEVslihzqUvleygt57/h398Sbs\u002BjUlxybLgsKqY1CyXrLmYPngWTviGpHWUc4CCK8IcZy0TB93Hk/ilwQ36hsGwCQrlV0kHVgrCt\u002BjT7UYiXpTYfG0PhJTb0Kp/cH36jB2j1Gp1rMSJFQESQF/k46aic3JpIgpUsIR2CYauh\u002BWc2CvbMAjbrKHQX2dr7TQ05uzzzPz7gWoDXyPmD6M92o0rhXg0GbOd1sbQmMKi\u002BNNAMRKpqrrokUaxx9Dk9a0OknTaQGfMAM0pVfYmKuinYGZQlc6AlD/SMuQhclHiuNEpwgZNyKhrhDBVgES0snZuCmd6lF/ujf5FCA1zmo57Nq0lDFjSaZe95RGOOxPrHXBtw3fqaCSBS0QX\u002BMCq9/mh2kmnn7Yti6DfvL9OUFLqWfqNFdcWgN6Ik8",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "41a46e2f-5abf-840a-7fc2-04d7576f8f4d",
+        "x-ms-content-crc64": "bx2nqzul6l4=",
+        "x-ms-request-id": "a8e5d0c4-301f-0075-49aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae/test-file-e6be2d49-7577-4667-832c-72b1caca3d61?action=append\u0026position=384",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0cbcb91d-ef4c-06cd-eb89-a4fbe913bd7f",
+        "x-ms-content-crc64": "dkLU/lFV\u002BMk=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EEymDHEu0n3FDKQ33KQDfHGqtlQurxLa7GHeIim0l7HwvlGMFACKnCFnPyEBaMssWfT3YjE1DWE5zB8PULBUEHXyRx5Td2hwIBoyx2/x2ISVscg0vTSAurDvUkfhektxEi6rDiGt2eKMhkIXA0byR/ObeZ/nH1NBcoxtYyQhj6XOwLRARspj6NfmqDbyaLdq/QpURQGrivPbapuUP3a\u002Ba/ecSEORsQEoN5DHAXcdTgrVA2UZzUmkIzXBZdsvzqlhJz0/VSBz2EwJKw5w5Ih7vRuQvzwQpJ6t\u002BCUN0Esl\u002BGnnZtk63fjpYSoZEKE7Mz6sRafAng9sUIOekl36ZgcA4zKkiH2vQeAjpl0S95T8ccXmYIujZVpaehVWm0ub7/oiGC1vlqrB/QTHnPexWlnvoiCXFAZ8XX3YSg1oWKWUh7dj799mjdoaJWKH3MhiqCC8Z/krA9r0prqvlkycWKReMxRATmt5iBRFfe\u002Bj9YG0dqLtrPGsaYTcbkkkt/aOfcy\u002B",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0cbcb91d-ef4c-06cd-eb89-a4fbe913bd7f",
+        "x-ms-content-crc64": "dkLU/lFV\u002BMk=",
+        "x-ms-request-id": "a8e5d0d0-301f-0075-55aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae/test-file-e6be2d49-7577-4667-832c-72b1caca3d61?action=append\u0026position=768",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "256",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9db9e141-82b2-e600-5bd4-847bc89b8047",
+        "x-ms-content-crc64": "e0PiVZqPkZw=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "KKi0Ilq0Qt7k5YXrUbA5\u002ByCqr6yyscmQY98iVdEdtwAi5czYAFRHOGoSyIP\u002B8B2Y6rvW5M4fC3feI756kuwNxi6FyWzkYfrMYnZCn\u002BhGkXLCiWoVR9IxAtlU\u002BdyVzaZ9BAFVeSewtInACoJY3WuOmJJMtwiC\u002BH9bU8aSj2geNpTPxZvm8BhKEdXhVDxQ2SVtxmBKSBad\u002BgyC\u002BiVhHiUhotPtiBfQp6h5AqUzoaRCC3mhJMgH1O5\u002BMsqOZPby6fOwv7FpYlENnR640EZwaVlnQO\u002Brv/lcGc7lb1VNQUOyhhiyg\u002BHy2agok4eqTwSnDchxJiMGRyn5U6XjhPL7wFvaBQ==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9db9e141-82b2-e600-5bd4-847bc89b8047",
+        "x-ms-content-crc64": "e0PiVZqPkZw=",
+        "x-ms-request-id": "a8e5d0e6-301f-0075-6baa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae/test-file-e6be2d49-7577-4667-832c-72b1caca3d61?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B7CB7273\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "08baed8c-2059-9fcc-ee8c-a60f562af93a",
+        "x-ms-date": "Tue, 09 May 2023 19:15:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:14 GMT",
+        "ETag": "\u00220x8DB50C1B7FBAEA6\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "08baed8c-2059-9fcc-ee8c-a60f562af93a",
+        "x-ms-request-id": "a8e5d0f5-301f-0075-7aaa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-dbc69b16-caa8-5003-0362-40cb9219a5ae?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-aca47a15a0ec605a5d184b82481f0ddb-23c0a21a06cafd32-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "daee4595-78e1-eeed-459d-abc7d92febe9",
+        "x-ms-date": "Tue, 09 May 2023 19:15:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "daee4595-78e1-eeed-459d-abc7d92febe9",
+        "x-ms-request-id": "56dae569-801e-005f-15aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1739390660",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-9eb2b950-b61a-16b0-8720-75cefc5f57d4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d7f17a4d21c1ee94708432dd25e52b58-a96bf92e77495857-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3158c17f-4ca9-462c-13bc-c8eebfa71556",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "ETag": "\u00220x8DB50C1B5E870D0\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3158c17f-4ca9-462c-13bc-c8eebfa71556",
+        "x-ms-request-id": "56daded8-801e-005f-51aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-9eb2b950-b61a-16b0-8720-75cefc5f57d4/test-file-db7eff5f-2a9d-3910-a9b3-e271ab873ddc?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-297b962751cd0d14bdc448ba2e4b98d8-c08c8e44127bd0eb-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ac4db694-f507-39b7-db63-92c614d07c85",
+        "x-ms-date": "Tue, 09 May 2023 19:15:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "ETag": "\u00220x8DB50C1B5F54AF1\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ac4db694-f507-39b7-db63-92c614d07c85",
+        "x-ms-request-id": "a8e5ce30-301f-0075-36aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-9eb2b950-b61a-16b0-8720-75cefc5f57d4/test-file-db7eff5f-2a9d-3910-a9b3-e271ab873ddc?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4f518881282ef34c876a7c8dc4df3830-e182940991244468-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f5dd6468-913a-cad4-375c-54e769751e9c",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "ETag": "\u00220x8DB50C1B5FCCAA2\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f5dd6468-913a-cad4-375c-54e769751e9c",
+        "x-ms-request-id": "a8e5ce3d-301f-0075-43aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-9eb2b950-b61a-16b0-8720-75cefc5f57d4/test-file-db7eff5f-2a9d-3910-a9b3-e271ab873ddc?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af5d28f3-86f2-904b-eeaa-645709dffa4d",
+        "x-ms-content-crc64": "Z0l5Q3/tfMA=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "1\u002B\u002B6eVzNOs\u002BlBnc\u002BqOIvN8CRTzoHJipD5WZqPLcl63/Ht/f3lOWIsoeJi6LU7p0xjZEtLljaT7DEd5P1Yv4XgBr4dvHqN6PbCZyzfZuIbvfJOa8m\u002BL0n7GhHMxxSkk\u002BIcQqH3HerRlXtUiW7J9EUPAibLClO8Yhd0ImJowSGiHZMKgyQAJKAHfJaOaWXa8WXMvcUtmYlOoCCKgvtIqNRZ8mvbvzEgzt2Gw439LfixWXE8nAMctEPJ/CMDdaGkvtPCdLc6PzI0q\u002B7nZtY7kXIoGSmKC8yRPT3n0cMN3Vl74kS5\u002BvlBt1o/B/BUdU2tzirxG1x4GnLHcTd5Em1u5s5Vq0RRQZZ4pqGPSsQcPMfwecPYXII8w8fR8omCCGTs0GEh/onJHIxUeLS6qI9u6zRvSNhpVooMWKe8v47Mtl48orqi\u002Bn495x13Q\u002BPNQhs4YseVUr\u002BMg3nW1aYiTJ09h4JWvcYUy/C2cWG68hKmPxZMRByHN2OesB8Ay\u002BTX25pAefxhtsQU45bXHuEd0ZFncNZPlciAdlBet83nE8AL3lXHOrgWBEgSd6BF8BiCgJ5NmZsOSEXRwAOsAz72bY/WywBLVtcZESxOfV5oOoY32/dvWXpk/ZYQNTp0qgEJW8nQruUYNynHdIiuwAsnqcV9tGdHhtRVcg2qe2GcpKbrBSFUV4ug36SNqCTx9f2LKIt09zXZwZU1uzzXbfvIKo/hw/rpkxI53JSCuh6vY7wQHxLWJ62w0QNMHpxOyXHohX2Uz/ICoVV5OxphV0e2RhdAh06pMgLicPK3nXR16tMimfShGlOJzb39XSyTD3m7ldhFDkIjf5N68p8/isPgw1BHfr2TFWvDtrnQq5TWT2F4/Aeb8NyRP1ohZif0ikK53JmcC5D8KEBsgVeIEpP\u002BZKM9ho68BNKztn8jca9Dzyw3Vs87egOQvNOHby\u002BEyOzGYwGEtwPz/deHKJVRmLbRKPJrUPvEgyqfrMn7NNXjLq2SXQ6tvxfoQ1j3tBGufuQc9kZ9GbfwwaAXJQo5\u002BMjB5Dnnv3uoY2maQs2izM7ZMS4lnj5PZdU1oVtulpoN7kpQNc/Xxr\u002BodJMc4taqTjSRPjPcFBqKsn5ksh3gecyPTJRDUtc\u002BwSqufWmrcoL\u002BSxNmnVimcZovhUNRsxRhx/rGTVYCJztdkjzJLZbxHz/7ZibKudxz6Nr6E41TrQ4WDLVu5OUsvCQYCMsb3QPDfqZDlkztl04eUmR7SBNtyiUusyEhgjpazqoC8nDRWAvXNtUnD9bBaLVnEFJAsXQQqj7mLSoi4bxsKIei6uTdDTpYpBE\u002BRvoOLUpr\u002BnGn2l018ghyKyrhtFUY\u002BydPHn3QigNYJ80jEmNEg==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "af5d28f3-86f2-904b-eeaa-645709dffa4d",
+        "x-ms-content-crc64": "Z0l5Q3/tfMA=",
+        "x-ms-request-id": "a8e5ce46-301f-0075-4caa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-9eb2b950-b61a-16b0-8720-75cefc5f57d4/test-file-db7eff5f-2a9d-3910-a9b3-e271ab873ddc?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B5FCCAA2\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "40f34a94-6e17-beaa-e88b-17204a732c0e",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "ETag": "\u00220x8DB50C1B616BA53\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "40f34a94-6e17-beaa-e88b-17204a732c0e",
+        "x-ms-request-id": "a8e5ce4e-301f-0075-54aa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-9eb2b950-b61a-16b0-8720-75cefc5f57d4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e7349ea1651678f0942569ad12e3580a-d455916b9301dba1-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bfc20867-baec-be36-27d7-5429517e6e25",
+        "x-ms-date": "Tue, 09 May 2023 19:15:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bfc20867-baec-be36-27d7-5429517e6e25",
+        "x-ms-request-id": "56dadf79-801e-005f-4faa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1731901114",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-a6f57460-3e68-7c1a-89f6-490c28b0154b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b783c5830f0042bea972b16233b3f7fe-e0f0bcadacbf1530-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "27f21408-7160-549a-f12f-48b896cd1587",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "ETag": "\u00220x8DB50C1B72E2E42\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "27f21408-7160-549a-f12f-48b896cd1587",
+        "x-ms-request-id": "56dae290-801e-005f-06aa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-a6f57460-3e68-7c1a-89f6-490c28b0154b/test-file-b0d8d345-72d3-d69b-71c1-60ee67c40629?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5dd4bdd251295373e89f045b65a46f9a-2767ab0d3327ff14-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "676af16d-4266-7241-8d8f-926386389ca9",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B73B8A5F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "676af16d-4266-7241-8d8f-926386389ca9",
+        "x-ms-request-id": "a8e5cff3-301f-0075-79aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-a6f57460-3e68-7c1a-89f6-490c28b0154b/test-file-b0d8d345-72d3-d69b-71c1-60ee67c40629?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d8e60d69c5e0c1db5ad4dcdcf0427927-7880e976d9507022-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76802402-9f5a-06c3-0914-db2251859f30",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:12 GMT",
+        "ETag": "\u00220x8DB50C1B7434F2C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76802402-9f5a-06c3-0914-db2251859f30",
+        "x-ms-request-id": "a8e5cffa-301f-0075-80aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-a6f57460-3e68-7c1a-89f6-490c28b0154b/test-file-b0d8d345-72d3-d69b-71c1-60ee67c40629?action=append\u0026position=0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6261f1a4-25b8-d94f-d4ff-f7348eeb0e64",
+        "x-ms-content-crc64": "bVNN5Zfxcak=",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "sFVL27siZTP0H1tEhHtoiORuAxO97euBZaGJgOXGP30OM\u002B6/tjcg5q\u002B/MkAVVdB2x8DUJ8oBycNpynUZmORNLuDdNlCNqNGsTR1k/rqqaw/QE7kl8RezDGorVevBBk3KcQRgOB9/6B7uKNqtnMoIvl5lSIQrJzzIKinmYVLm6kbPmoy1SjPwUSqaN8k9Bm\u002BfIpaNXL7In0rHlw71mYfLCD2T3QI9UnQrdfdakPBziyO6Rz68WI6IBvtC7bMk\u002Brijzi\u002BMqihsYc8iYebGbg9aVAvqO1JID6\u002BuCtcH\u002B2TAB3o/tsHA5\u002BH7TeVumfanwpjr6JmoOb9mW76A3Z9RZWZqYVpshrdNmWwq7u5s2Xa4B0c\u002BGxPLGM272VsCQApBqud\u002BBDebOzvgnk4sfUrR\u002BYFIx9ZYEklSn0mNsK1cS1li6EQG7dU\u002BHMsMXn3FnpqC6uDauXg06ZidLGTuDoqOhFL0yZUGygusCqsKTLTMjQGuC8XNgZHgLv\u002BsaMFxTw5Afdkq0NQFex/ULq/NKZ3j0Z5jQALEwALBE5uVWmJKOrqcyc7aor0sqY\u002Bl\u002BFPhEwViyJcjDQ8LfL3Xabw5byG9ivP1MGDOCS7gNpdzH8iu3wCWM5HKJi2qkU0RAzkA8jlu6G5g7OOkk79oQtZ4mFz1KIm8ozuP8mPGS54TvQX14ENdBDZZTvMc8Z/SYuRWMvnwHNqvQ0/93/UKmqBEkda5cmGTGpMlm9qVoLGcvJB/bxilIqEqRp30YCVBTrNS2GDJGPCCwxdlyoAAGaOdYSJliiqIn240jizEnrpu5EwmQ8dR0qOg/awAP1ghKSz6Vv4C3MSJyjnylYrDviRd9uU02tbbTI9/xI19h18VE2UAyUi7bAeInXmOXzwZ3D\u002BIo0ly7U9WHwpvgxc2C0Pa3IIlw/TboYreqz1dTO1SZehN9eMVoiYVqqo9TOnwUZE1tIK69BlLrAG/lEES\u002BNIdHR0v6BZfxDpbDxlJnlWg7VqrJ5hql3DOAkjiVg7lA7HYIC/LwGh71u9IX\u002BUAAg6rHqbnZtE5soWsYObOfW4rdgxocH0m1S3xMFCpIjiLzgA5Njdn/Zzfnm2pHmCCrVmBHOjZmJGQhUl59TWBkJBNIZLllEY2xHhviNEQfbbNboP3JwVPsjZvqbHu7QdmXg7cXP3NnRgTSldvaQ\u002B/gAiSrIeyiWiL/W5bduqUR9dxCCrDMyC5/9Fq492t4EgmrympXECAtNSlUV\u002BOciYufgOA/mHl/Ezn2K21SKaL3R0lNMfB6\u002BqX8FNVHeLBKoyrPGXZLeHmQbLcwYSSy2wuGXNCaD1fbJIY6A4OkN5qJa0gCgtAsq87PvMU5SlmBCTnJgRuf8JPS9DSwA==",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6261f1a4-25b8-d94f-d4ff-f7348eeb0e64",
+        "x-ms-content-crc64": "bVNN5Zfxcak=",
+        "x-ms-request-id": "a8e5d002-301f-0075-08aa-82149e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.dfs.core.windows.net/test-filesystem-a6f57460-3e68-7c1a-89f6-490c28b0154b/test-file-b0d8d345-72d3-d69b-71c1-60ee67c40629?action=flush\u0026position=1024",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-Match": "\u00220x8DB50C1B7434F2C\u0022",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "607e4318-3d23-1878-0154-7ecbc6be75f6",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "ETag": "\u00220x8DB50C1B756951B\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "607e4318-3d23-1878-0154-7ecbc6be75f6",
+        "x-ms-request-id": "a8e5d00a-301f-0075-10aa-82149e000000",
+        "x-ms-request-server-encrypted": "false",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanhnscanada.blob.core.windows.net/test-filesystem-a6f57460-3e68-7c1a-89f6-490c28b0154b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-486afe7af915d76a004cdb20702631af-d9dcf8720405e577-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4a1b35f4-ae6d-d540-9ea1-2372190a7d73",
+        "x-ms-date": "Tue, 09 May 2023 19:15:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4a1b35f4-ae6d-d540-9ea1-2372190a7d73",
+        "x-ms-request-id": "56dae358-801e-005f-3daa-82cb8e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "491414551",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanhnscanada\nU2FuaXRpemVk\nhttps://seanhnscanada.blob.core.windows.net\nhttps://seanhnscanada.file.core.windows.net\nhttps://seanhnscanada.queue.core.windows.net\nhttps://seanhnscanada.table.core.windows.net\n\n\n\n\nhttps://seanhnscanada-secondary.blob.core.windows.net\nhttps://seanhnscanada-secondary.file.core.windows.net\nhttps://seanhnscanada-secondary.queue.core.windows.net\nhttps://seanhnscanada-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanhnscanada.blob.core.windows.net/;QueueEndpoint=https://seanhnscanada.queue.core.windows.net/;FileEndpoint=https://seanhnscanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanhnscanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanhnscanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanhnscanada-secondary.file.core.windows.net/;AccountName=seanhnscanada;AccountKey=Sanitized\n\nXClient\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-7bd1f6d6-461a-d6b1-2d70-2ae10bbea9aa?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-827b4383c48d12f62c8f09f228f333d6-00a8cb8a0adf1f3c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "54b4aed8-d0bb-7cc0-bbdf-d35c8b09160c",
+        "x-ms-date": "Tue, 09 May 2023 20:00:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:04 GMT",
+        "ETag": "\u00220x8DB50C7FBB56FEA\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "54b4aed8-d0bb-7cc0-bbdf-d35c8b09160c",
+        "x-ms-request-id": "15dda9ff-a01a-00a1-7eb0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-7bd1f6d6-461a-d6b1-2d70-2ae10bbea9aa/test-file-7351fd63-daa3-f6bc-8e6f-2b725ccee1ca",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-063a263ef8c46dd79d76cb0fa9a73bf8-8162bc632f13aa9a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "40150428-7207-4fcb-188e-f5c06429ffda",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:04 GMT",
+        "ETag": "\u00220x8DB50C7FBCC36CE\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "40150428-7207-4fcb-188e-f5c06429ffda",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:05.6235726Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:05.6235726Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:05.6235726Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa06-a01a-00a1-03b0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-7bd1f6d6-461a-d6b1-2d70-2ae10bbea9aa?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d8c13119dc468e8fd0e6459b0d817f4e-a2c6e4b1d418fa51-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "574ae509-a1b8-11c2-b503-385e5608f10d",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:04 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "574ae509-a1b8-11c2-b503-385e5608f10d",
+        "x-ms-request-id": "15ddaa09-a01a-00a1-06b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1257739018",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,1024)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-770af0f1-3b91-ce8e-20da-33cbc917b631?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b20c62b22e0991e335a649f655ed88a8-9459a518801c78cd-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f838eef0-b683-6403-28b1-6530bb10bb4d",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC442CEB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f838eef0-b683-6403-28b1-6530bb10bb4d",
+        "x-ms-request-id": "15ddaa2a-a01a-00a1-18b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-770af0f1-3b91-ce8e-20da-33cbc917b631/test-file-13092699-3700-79ee-61fe-5b98684bd1fd",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-383b9b973fa3256d4dff215fa41192c6-b6f4331f5af0f8e4-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fb86b85d-41e0-2d6c-0a21-049802118fc5",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC4BB42C\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fb86b85d-41e0-2d6c-0a21-049802118fc5",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:06.4590892Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:06.4590892Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:06.4590892Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa2c-a01a-00a1-19b0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-770af0f1-3b91-ce8e-20da-33cbc917b631?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4a64c1c3af40c06003cf130576c4f4f3-31a8ff4db269cc9b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b03a4f6e-d6c5-e71d-af3c-837c27119699",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b03a4f6e-d6c5-e71d-af3c-837c27119699",
+        "x-ms-request-id": "15ddaa2f-a01a-00a1-1cb0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1736926620",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-dadaa7be-f2a9-d9c8-7d48-480ed2e6c69e?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7153c8cb49cdd8c26f28c3b4f9bacce4-925017b1f4c1746f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c9946cf8-8e24-8e24-27c6-c48dd4291197",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:04 GMT",
+        "ETag": "\u00220x8DB50C7FBE97060\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c9946cf8-8e24-8e24-27c6-c48dd4291197",
+        "x-ms-request-id": "15ddaa18-a01a-00a1-09b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-dadaa7be-f2a9-d9c8-7d48-480ed2e6c69e/test-file-05d2c7e5-77e9-db80-4bc7-6ea883e7da8d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-afe0a6496c3dd818dc9c3dc02f9be3c0-49a072e1ccacd8d0-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ada6b42d-5879-fbe4-2a78-2a28806da24d",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:04 GMT",
+        "ETag": "\u00220x8DB50C7FBF03433\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ada6b42d-5879-fbe4-2a78-2a28806da24d",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:05.8594355Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:05.8594355Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:05.8594355Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa1a-a01a-00a1-0ab0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-dadaa7be-f2a9-d9c8-7d48-480ed2e6c69e?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dc96d45525f22f104ef6024f37de861a-f2b824c325ae35a7-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cf7b8df1-2d40-0914-4beb-67b4dcee88f1",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cf7b8df1-2d40-0914-4beb-67b4dcee88f1",
+        "x-ms-request-id": "15ddaa1b-a01a-00a1-0bb0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1022256470",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(1024,200)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-74304339-c474-baa6-faf9-9792d7f5ab82?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c53984901ce41041225088a154c8c398-f7f9ada2a00c11dc-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fa20dcc9-e88a-52a1-caa4-618c99e63a10",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC5DCB7F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fa20dcc9-e88a-52a1-caa4-618c99e63a10",
+        "x-ms-request-id": "15ddaa30-a01a-00a1-1db0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-74304339-c474-baa6-faf9-9792d7f5ab82/test-file-ab756fee-1c09-71d2-c60e-806ef88e6ba7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c93b42ac838ffc522be389eaa47ae973-5c3344779ae7cd4c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bed3809e-99d3-fe34-04d8-a6b20f35efaa",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC64689D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bed3809e-99d3-fe34-04d8-a6b20f35efaa",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:06.6209949Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:06.6209949Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:06.6209949Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa33-a01a-00a1-1fb0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-74304339-c474-baa6-faf9-9792d7f5ab82?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-35421c5539ac654d9767591bcb403aa0-686e276aafa888fc-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "77d0d01d-adbb-fbd3-c119-fe52064c15e7",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "77d0d01d-adbb-fbd3-c119-fe52064c15e7",
+        "x-ms-request-id": "15ddaa38-a01a-00a1-22b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "361295425",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-57a4eabc-621f-7294-e02b-3058943a2f69?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-276d42b358fc8ef1d2e9cdc91996b667-fc66e515c3ee9736-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "56abe659-71f7-89eb-fdcf-41fa034d4925",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:17 GMT",
+        "ETag": "\u00220x8DB50C1BA4E207F\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "56abe659-71f7-89eb-fdcf-41fa034d4925",
+        "x-ms-request-id": "f8cf7985-601a-0038-13aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-57a4eabc-621f-7294-e02b-3058943a2f69/test-file-ac569a24-87b6-d5a9-fe6b-78277262a2ce",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-57529e3dfdc22b2fa28a55a655d1e0f8-9f4b0e5417b1828b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b2f30a34-060f-fa07-c815-c2250e5648d6",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BA56A6F7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b2f30a34-060f-fa07-c815-c2250e5648d6",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:18.8208375Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:18.8208375Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:18.8208375Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf798a-601a-0038-17aa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-57a4eabc-621f-7294-e02b-3058943a2f69?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ff06f9de798e72acdd5ef7aae2fa2fb4-cc816cd379c0a79e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "67f2126a-ef6e-10be-2b8b-af7c95f9436c",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "67f2126a-ef6e-10be-2b8b-af7c95f9436c",
+        "x-ms-request-id": "f8cf798e-601a-0038-1baa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "769598962",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(False)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-46dbf9cb-4729-74b1-eac9-a3ee5f78bb58?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-598a8ba9629b67385079d0cd4e15d0ea-d90c27ee50aa14be-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "62555cb6-4e30-3767-75fc-0965217391ff",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BACBF09A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "62555cb6-4e30-3767-75fc-0965217391ff",
+        "x-ms-request-id": "f8cf79b9-601a-0038-43aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-46dbf9cb-4729-74b1-eac9-a3ee5f78bb58/test-file-d76dfcaa-dfef-f2c2-87a3-8912f48e591b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0073f0e6f30c462331c744d2cf66bc1d-16196603574a2ebc-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e12de3fb-eb3f-0899-c405-7f382b331f18",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BAD4EBF4\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e12de3fb-eb3f-0899-c405-7f382b331f18",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:19.6483572Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:19.6483572Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:19.6483572Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf79bb-601a-0038-44aa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-46dbf9cb-4729-74b1-eac9-a3ee5f78bb58?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8a0ddf0ebaa39d0bb846fc88c5e9c35a-8a76bd2b36f645fd-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1017400c-7860-76dc-1a95-36cb567e4020",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1017400c-7860-76dc-1a95-36cb567e4020",
+        "x-ms-request-id": "f8cf79bf-601a-0038-46aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "193475269",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-0dee87ea-bae3-ca63-406c-cdf78382b7ce?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-705eb15d92b4df469f93a775d3ecb0f0-d0dcd5d8e7bcdfb6-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "18236717-e939-9b9b-571f-00aa0ac4a62e",
+        "x-ms-date": "Tue, 09 May 2023 19:15:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:17 GMT",
+        "ETag": "\u00220x8DB50C1BA1A46E1\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "18236717-e939-9b9b-571f-00aa0ac4a62e",
+        "x-ms-request-id": "f8cf7973-601a-0038-04aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-0dee87ea-bae3-ca63-406c-cdf78382b7ce/test-file-9e361250-de9a-073e-8498-409419abf349",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-00700bbc262c7373674e36cf72ee37d8-32c1e432e7d6655d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5b876190-689f-bad3-9894-4edf93788db0",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:17 GMT",
+        "ETag": "\u00220x8DB50C1BA32F7A3\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5b876190-689f-bad3-9894-4edf93788db0",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:18.5869731Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:18.5869731Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:18.5869731Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf7976-601a-0038-05aa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-0dee87ea-bae3-ca63-406c-cdf78382b7ce?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f265ad84a7c35f0de0737875817369be-4c61e7cf56951ce9-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b704cd49-9724-e5a9-be94-29986fd90210",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b704cd49-9724-e5a9-be94-29986fd90210",
+        "x-ms-request-id": "f8cf797c-601a-0038-0aaa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "651996711",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteFailsOnCallerProvidedCrcMismatch(True)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-d77923d6-2ad8-c3be-7230-3b3b3115f1d5?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-baa3ea8c532cc23098e6098999296fc8-15e9172ac0f060ac-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "238e29b1-a045-14e5-3880-e9ff86997b5a",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BAA8413E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "238e29b1-a045-14e5-3880-e9ff86997b5a",
+        "x-ms-request-id": "f8cf79b2-601a-0038-3daa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-d77923d6-2ad8-c3be-7230-3b3b3115f1d5/test-file-b34e32e2-f3e1-6a0b-0863-c081591948c4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9d017b296afc34d60ec79e324db7455f-170aea4db07d6907-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "718375ea-4048-1656-602b-7d3663aa1012",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BAB9EDE7\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "718375ea-4048-1656-602b-7d3663aa1012",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:19.4714599Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:19.4714599Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:19.4714599Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf79b7-601a-0038-41aa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-d77923d6-2ad8-c3be-7230-3b3b3115f1d5?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4fe526e4a8a3c5a8c9dbb9e4a9513b2b-8b6d8f4567834ea0-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e497f04b-d696-977b-b2a7-a28e27d7149d",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e497f04b-d696-977b-b2a7-a28e27d7149d",
+        "x-ms-request-id": "f8cf79b8-601a-0038-42aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "287957298",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-01a1c2f9-3102-ca44-e4b6-425d2412b7e5?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1c48005fa9637cc1456719a6bf814393-3ff2b470050c5274-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "db68a13b-be53-7967-274b-037c1cd000ae",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC133937\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "db68a13b-be53-7967-274b-037c1cd000ae",
+        "x-ms-request-id": "15ddaa1e-a01a-00a1-0eb0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-01a1c2f9-3102-ca44-e4b6-425d2412b7e5/test-file-f2c62e88-9218-3f20-c7ab-3e6262189a0a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bd03c034942b49858f7a669503a7e9d7-53ed999d6e49d278-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "92968f24-f2fa-abd5-0cc7-2da8883f22ad",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC19AF0E\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "92968f24-f2fa-abd5-0cc7-2da8883f22ad",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:06.1312782Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:06.1312782Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:06.1312782Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa20-a01a-00a1-0fb0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-01a1c2f9-3102-ca44-e4b6-425d2412b7e5?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1fdc5c9faf84f209db0d07612b6aed45-4f84e407350abaa1-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d23ea1e2-0882-f70f-9c60-7d3dc5b86ca3",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d23ea1e2-0882-f70f-9c60-7d3dc5b86ca3",
+        "x-ms-request-id": "15ddaa21-a01a-00a1-10b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1011071330",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,1024)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-c20f756b-aa39-e2cd-6bce-bb62508c73f2?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d49f8deb648f1c1dda6eb9afe9e1fd45-a0504103dedd00ac-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "58893036-b74a-b720-25e5-c263d64157b3",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC7658DE\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "58893036-b74a-b720-25e5-c263d64157b3",
+        "x-ms-request-id": "15ddaa3a-a01a-00a1-24b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-c20f756b-aa39-e2cd-6bce-bb62508c73f2/test-file-369524ec-0ee4-f23f-3175-4beceb618ead",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a2ded9b59baf8fd9a14f2464f991c58d-d7fcc84d19bb0432-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9c7120cc-6619-275c-33f7-fb852713a128",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC7CA7F8\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9c7120cc-6619-275c-33f7-fb852713a128",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:06.7799032Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:06.7799032Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:06.7799032Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa3c-a01a-00a1-25b0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-c20f756b-aa39-e2cd-6bce-bb62508c73f2?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a4c89556d91df04b95991fec374e1071-25cc1a77e9152de2-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cb20fcd2-f2f0-3d93-7137-1eb2d6d8953e",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb20fcd2-f2f0-3d93-7137-1eb2d6d8953e",
+        "x-ms-request-id": "15ddaa3e-a01a-00a1-27b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1209957596",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-a6873282-4a70-e8e1-722b-d817293cc8bb?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4aff1bc913624d6332ac656842eadfc7-edb8c0b5443401c8-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b7a463b5-e954-fbac-45b6-823f849d8828",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC2B035D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b7a463b5-e954-fbac-45b6-823f849d8828",
+        "x-ms-request-id": "15ddaa22-a01a-00a1-11b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-a6873282-4a70-e8e1-722b-d817293cc8bb/test-file-b673c828-0ba4-a522-d044-d60c69e56dc7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-093625de5dbd2fbc6196710d46206d2d-c5817365349e66a6-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b83480bd-51a4-2619-4e4c-beec1172429e",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "ETag": "\u00220x8DB50C7FC31C760\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b83480bd-51a4-2619-4e4c-beec1172429e",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:06.2891872Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:06.2891872Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:06.2891872Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa26-a01a-00a1-14b0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-a6873282-4a70-e8e1-722b-d817293cc8bb?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ea65eb4944c45645732e1a7cc09f9456-21450a94857398c0-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e84e3f03-b5b1-7d22-28b6-4b64ab211368",
+        "x-ms-date": "Tue, 09 May 2023 20:00:06 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:05 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e84e3f03-b5b1-7d22-28b6-4b64ab211368",
+        "x-ms-request-id": "15ddaa28-a01a-00a1-16b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "231569762",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(1024,200)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-a007dc53-ad46-534d-31d2-6f15344340e1?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a19a43cbbe56af92012c157067c5a10a-ca89bac042c98cb4-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bc2b62c9-6c35-7fb9-014c-6c0d327a784b",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:06 GMT",
+        "ETag": "\u00220x8DB50C7FC9108C9\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bc2b62c9-6c35-7fb9-014c-6c0d327a784b",
+        "x-ms-request-id": "15ddaa40-a01a-00a1-29b0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-a007dc53-ad46-534d-31d2-6f15344340e1/test-file-b74b2d4f-89e1-3963-8ac2-10922deb1322",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3e24abcc16c40960653a578fe8b886e3-a99d7800e8d0f8f7-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1a75e888-09b9-3290-0f73-8f42b96c3080",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:06 GMT",
+        "ETag": "\u00220x8DB50C7FC99A18A\u0022",
+        "Last-Modified": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1a75e888-09b9-3290-0f73-8f42b96c3080",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T20:00:06.9697930Z",
+        "x-ms-file-creation-time": "2023-05-09T20:00:06.9697930Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T20:00:06.9697930Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "15ddaa44-a01a-00a1-2bb0-824aff000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-a007dc53-ad46-534d-31d2-6f15344340e1?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-275bc0b4b0eab1c409991b7d74b17220-2ffabc0a3bbff2dc-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "45093d13-f875-5269-238b-fdc806ddf249",
+        "x-ms-date": "Tue, 09 May 2023 20:00:07 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 20:00:06 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "45093d13-f875-5269-238b-fdc806ddf249",
+        "x-ms-request-id": "15ddaa45-a01a-00a1-2cb0-824aff000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "554033761",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-f1d177fa-3d61-8483-ba62-c3f0fb6bd5e2?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-79f7c25c18641a442522bf36eb71da79-6995a5c8377ca4fd-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8896a3e7-dfa1-9879-5287-ff288e2594c8",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BA8EA272\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8896a3e7-dfa1-9879-5287-ff288e2594c8",
+        "x-ms-request-id": "f8cf799e-601a-0038-2aaa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-f1d177fa-3d61-8483-ba62-c3f0fb6bd5e2/test-file-e251d789-cfe0-404e-342e-d791ec001fcf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c2bfd2f88dd8f5457092a79299605dea-f24c410161de7834-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5088fbf3-d36c-6c4e-1176-a95218319871",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BA96DABC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5088fbf3-d36c-6c4e-1176-a95218319871",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:19.2415932Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:19.2415932Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:19.2415932Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf79a5-601a-0038-30aa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-f1d177fa-3d61-8483-ba62-c3f0fb6bd5e2?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d43b20d51c4220dce4d3b43fff5d3f84-001dc4c0230a292e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f09ede19-cf77-c763-d561-5f73ca62b644",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f09ede19-cf77-c763-d561-5f73ca62b644",
+        "x-ms-request-id": "f8cf79ac-601a-0038-37aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "162011947",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(False)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-dc23aa3f-d95e-9b63-f386-b7b73221ff6c?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a6ed053b978b9cf1b7bcf00e1a0a2f37-a82967ae6e166de8-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f44c251b-9990-27a0-709b-0d2bd8049463",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:19 GMT",
+        "ETag": "\u00220x8DB50C1BB0288EB\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f44c251b-9990-27a0-709b-0d2bd8049463",
+        "x-ms-request-id": "f8cf79c4-601a-0038-4aaa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-dc23aa3f-d95e-9b63-f386-b7b73221ff6c/test-file-d4057fc4-9261-4732-99e1-175dee3c1497",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5970f084593f3a4968d4428e6abcfcfa-eef4efc37f627099-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f0314895-4a32-c8ed-317d-de406beab047",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:19 GMT",
+        "ETag": "\u00220x8DB50C1BB0BAB45\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:20 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f0314895-4a32-c8ed-317d-de406beab047",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:20.0071493Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:20.0071493Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:20.0071493Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf79c6-601a-0038-4baa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-dc23aa3f-d95e-9b63-f386-b7b73221ff6c?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-251fcb2e9fc7bc5b14fc8d9ac3254ed3-ce844de2de5296d5-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a6c7cca0-230b-bd64-f4e5-6ec258b1644e",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a6c7cca0-230b-bd64-f4e5-6ec258b1644e",
+        "x-ms-request-id": "f8cf79c7-601a-0038-4caa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1020566973",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True).json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-90d00689-593e-c5f7-17f5-db43e8987ee3?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6988077109546b92375772beeae08f95-02bf5aff332d5789-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d987f247-a043-20cd-7293-86727a01e4b6",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BA7181CC\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d987f247-a043-20cd-7293-86727a01e4b6",
+        "x-ms-request-id": "f8cf7990-601a-0038-1daa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-90d00689-593e-c5f7-17f5-db43e8987ee3/test-file-de126468-ac4c-3f9c-ef0a-b9a753406758",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-214b46147a5bd20f1aaec8566b0de899-4eec7483a70099f6-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "275b450b-d69c-3801-9b45-61b4c0cb1f11",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BA7C78D9\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "275b450b-d69c-3801-9b45-61b4c0cb1f11",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:19.0686937Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:19.0686937Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:19.0686937Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf7994-601a-0038-20aa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-90d00689-593e-c5f7-17f5-db43e8987ee3?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0cb6524592fc6c41d747def8fbbad6b3-bb158c5eaad5d570-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0e9c4cfb-40e5-25bb-5b58-d526beb38d13",
+        "x-ms-date": "Tue, 09 May 2023 19:15:19 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0e9c4cfb-40e5-25bb-5b58-d526beb38d13",
+        "x-ms-request-id": "f8cf7998-601a-0038-24aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "501950653",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareFileClientTransferValidationTests/OpenWriteSucceedsWithCallerProvidedCrc(True)Async.json
@@ -1,0 +1,113 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-6e11dc6e-a2c2-688e-0228-de8833d145c4?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-41ad1e30baf0e61e383d16b5baaac62c-c48bd5b9ec8a8d28-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e528251a-445d-963b-92e3-d4ca1c932cee",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:18 GMT",
+        "ETag": "\u00220x8DB50C1BAE42FF4\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e528251a-445d-963b-92e3-d4ca1c932cee",
+        "x-ms-request-id": "f8cf79c0-601a-0038-47aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-6e11dc6e-a2c2-688e-0228-de8833d145c4/test-file-a8d14366-a746-6b9f-5d3a-345c485437ac",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1e02922ca1876d550306a1d1e7356c52-1d1bbd8701e13406-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ed161dd2-837a-a1b1-3c70-26bae90e069f",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:19 GMT",
+        "ETag": "\u00220x8DB50C1BAF0D43D\u0022",
+        "Last-Modified": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ed161dd2-837a-a1b1-3c70-26bae90e069f",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2023-05-09T19:15:19.8312509Z",
+        "x-ms-file-creation-time": "2023-05-09T19:15:19.8312509Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2023-05-09T19:15:19.8312509Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "5144323600546320195*17277118026500876237",
+        "x-ms-request-id": "f8cf79c2-601a-0038-48aa-823542000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.file.core.windows.net/test-share-6e11dc6e-a2c2-688e-0228-de8833d145c4?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6d54b7caa70cb945fff9199f568aebe1-625ee98ea52f11ac-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.15.0-alpha.20230509.1 (.NET 7.0.5; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2a891a74-4a3d-6a32-88bf-e13b1b302984",
+        "x-ms-date": "Tue, 09 May 2023 19:15:20 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 09 May 2023 19:15:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2a891a74-4a3d-6a32-88bf-e13b1b302984",
+        "x-ms-request-id": "f8cf79c3-601a-0038-49aa-823542000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "252372514",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}


### PR DESCRIPTION
OpenWrite accepted a caller-provided checksum when it was a CRC but failed to do anything with it.

The stream now compares the long-running master crc calculation to the caller-provided crc on dispose and throws if there is a mismatch.