### PR TITLE
Fix lists not rendering in documentation

### DIFF
--- a/sdk/maps/Azure.Maps.Rendering/src/Models/Options/GetMapTileOptions.cs
+++ b/sdk/maps/Azure.Maps.Rendering/src/Models/Options/GetMapTileOptions.cs
@@ -34,7 +34,7 @@ namespace Azure.Maps.Rendering
         public MapTileIndex MapTileIndex { get; }
         /// <summary>
         /// The desired date and time of the requested tile. This parameter must be specified in the standard date-time format (e.g. 2019-11-14T16:03:00-08:00), as defined by <see href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</see>. This parameter is only supported when <see cref="MapTileSetId"/> option is set to one of the values below.
-        /// <list>
+        /// <list type="bullet">
         /// <item> <c>microsoft.weather.infrared.main</c>: We provide tiles up to 3 hours in the past. Tiles are available in 10-minute intervals. We round the timeStamp value to the nearest 10-minute time frame. </item>
         /// <item> <c>microsoft.weather.radar.main</c>: We provide tiles up to 1.5 hours in the past and up to 2 hours in the future. Tiles are available in 5-minute intervals. We round the timeStamp value to the nearest 5-minute time frame. </item>
         /// </list>

--- a/sdk/maps/Azure.Maps.Routing/src/Models/Options/RouteDirectionOptions.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Models/Options/RouteDirectionOptions.cs
@@ -75,7 +75,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Possible values:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> <c>true</c> - Do consider all available traffic information during routing </description></item>
         /// <item><description> <c>false</c> - Ignore current traffic data during routing. Note that although the current traffic data is ignored </description></item>
         /// </list>
@@ -109,7 +109,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Maximum speed of the vehicle in km/hour. The max speed in the vehicle profile is used to check whether a vehicle is allowed on motorways.
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> A value of 0 means that an appropriate value for the vehicle will be determined and applied during route planning. </description></item>
         /// <item><description> A non-zero value may be overridden during route planning. For example, the current traffic flow is 60 km/hour. If the vehicle  maximum speed is set to 50 km/hour, the routing engine will consider 60 km/hour as this is the current situation.  If the maximum speed of the vehicle is provided as 80 km/hour but the current traffic flow is 60 km/hour, then routing engine will again use 60 km/hour. </description></item>
         /// </list>
@@ -118,7 +118,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Weight of the vehicle in kilograms.
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> It is mandatory if any of the *Efficiency parameters are set. </description></item>
         /// <item><description> It must be strictly positive when used in the context of the Consumption Model. Weight restrictions are considered. </description></item>
         /// <item><description> If no detailed <c>Consumption Model</c> is specified and the value of <c>vehicleWeight</c> is non-zero, then weight restrictions are considered. </description></item>
@@ -140,7 +140,7 @@ namespace Azure.Maps.Routing
         /// <summary>
         /// Specifies the speed-dependent component of consumption.
         /// Provided as an unordered list of colon-delimited speed &amp; consumption-rate pairs. The list defines points on a consumption curve. Consumption rates for speeds not in the list are found as follows:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> by linear interpolation, if the given speed lies in between two speeds in the list </description></item>
         /// <item><description> by linear extrapolation otherwise, assuming a constant (ΔConsumption/ΔSpeed) determined by the nearest two points in the list </description></item>
         /// </list>
@@ -208,7 +208,7 @@ namespace Azure.Maps.Routing
         /// <summary>
         /// Specifies the speed-dependent component of consumption.
         /// Provided as an unordered list of speed/consumption-rate pairs. The list defines points on a consumption curve. Consumption rates for speeds not in the list are found as follows:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> by linear interpolation, if the given speed lies in between two speeds in the list </description></item>
         /// <item><description> by linear extrapolation otherwise, assuming a constant (ΔConsumption/ΔSpeed) determined by the nearest two points in the list </description></item>
         /// </list>
@@ -247,7 +247,7 @@ namespace Azure.Maps.Routing
         /// <summary>
         /// Used for reconstructing a route and for calculating zero or more alternative routes to this reference route.  The provided sequence of coordinates is used as input for route reconstruction. The alternative routes  are calculated between the origin and destination points specified in the base path parameter locations.  If both minDeviationDistance and minDeviationTime are set to zero, then these origin and destination points  are expected to be at (or very near) the beginning and end of the reference route, respectively. Intermediate  locations (waypoints) are not supported when using supportingPoints.
         /// Setting at least one of minDeviationDistance or minDeviationTime to a value greater than zero has the  following consequences:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> The origin point of the calculateRoute request must be on (or very near) the input reference route. If  this is not the case, an error is returned. However, the origin point does not need to be at the beginning of  the input reference route (it can be thought of as the current vehicle position on the reference route). </description></item>
         /// <item><description> The reference route, returned as the first route in the calculateRoute response, will start at the origin  point specified in the calculateRoute request. The initial part of the input reference route up until the  origin point will be excluded from the response. </description></item>
         /// <item><description> The values of minDeviationDistance and minDeviationTime determine how far alternative routes will be  guaranteed to follow the reference route from the origin point onwards. </description></item>

--- a/sdk/maps/Azure.Maps.Routing/src/Models/Options/RouteMatrixOptions.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Models/Options/RouteMatrixOptions.cs
@@ -63,7 +63,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Maximum speed of the vehicle in km/hour. The max speed in the vehicle profile is used to check whether a vehicle is allowed on motorways.
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> A value of 0 means that an appropriate value for the vehicle will be determined and applied during route planning. </description></item>
         /// <item><description> A non-zero value may be overridden during route planning. For example, the current traffic flow is 60 km/hour. If the vehicle  maximum speed is set to 50 km/hour, the routing engine will consider 60 km/hour as this is the current situation.  If the maximum speed of the vehicle is provided as 80 km/hour but the current traffic flow is 60 km/hour, then routing engine will again use 60 km/hour. </description></item>
         /// </list>
@@ -87,7 +87,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Possible values:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> <c>true</c> - Do consider all available traffic information during routing </description></item>
         /// <item><description> <c>false</c> - Ignore current traffic data during routing. Note that although the current traffic data is ignored </description></item>
         /// </list>

--- a/sdk/maps/Azure.Maps.Routing/src/Models/Options/RouteRangeOptions.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Models/Options/RouteRangeOptions.cs
@@ -64,7 +64,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Possible values:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> <c>true</c> - Do consider all available traffic information during routing </description></item>
         /// <item><description> <c>false</c> - Ignore current traffic data during routing. Note that although the current traffic data is ignored </description></item>
         /// </list>
@@ -98,7 +98,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Maximum speed of the vehicle in km/hour. The max speed in the vehicle profile is used to check whether a vehicle is allowed on motorways.
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> A value of 0 means that an appropriate value for the vehicle will be determined and applied during route planning. </description></item>
         /// <item><description> A non-zero value may be overridden during route planning. For example, the current traffic flow is 60 km/hour. If the vehicle  maximum speed is set to 50 km/hour, the routing engine will consider 60 km/hour as this is the current situation.  If the maximum speed of the vehicle is provided as 80 km/hour but the current traffic flow is 60 km/hour, then routing engine will again use 60 km/hour. </description></item>
         /// </list>
@@ -107,7 +107,7 @@ namespace Azure.Maps.Routing
 
         /// <summary>
         /// Weight of the vehicle in kilograms.
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> It is mandatory if any of the *Efficiency parameters are set. </description></item>
         /// <item><description> It must be strictly positive when used in the context of the Consumption Model. Weight restrictions are considered. </description></item>
         /// <item><description> If no detailed Consumption Model is specified and the value of <c>vehicleWeight</c> is non-zero, then weight restrictions are considered. </description></item>
@@ -129,7 +129,7 @@ namespace Azure.Maps.Routing
         /// <summary>
         /// Specifies the speed-dependent component of consumption.
         /// Provided as an unordered list of colon-delimited speed &amp; consumption-rate pairs. The list defines points on a consumption curve. Consumption rates for speeds not in the list are found as follows:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> by linear interpolation, if the given speed lies in between two speeds in the list. </description></item>
         /// <item><description> by linear extrapolation otherwise, assuming a constant (ΔConsumption/ΔSpeed) determined by the nearest two points in the list. </description></item>
         /// </list>
@@ -197,7 +197,7 @@ namespace Azure.Maps.Routing
         /// <summary>
         /// Specifies the speed-dependent component of consumption.
         /// Provided as an unordered list of speed/consumption-rate pairs. The list defines points on a consumption curve. Consumption rates for speeds not in the list are found as follows:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> by linear interpolation, if the given speed lies in between two speeds in the list </description></item>
         /// <item><description> by linear extrapolation otherwise, assuming a constant (ΔConsumption/ΔSpeed) determined by the nearest two points in the list </description></item>
         /// </list>

--- a/sdk/maps/Azure.Maps.Routing/src/Models/RouteDirectionParameters.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Models/RouteDirectionParameters.cs
@@ -28,7 +28,7 @@ namespace Azure.Maps.Routing
         private GeoCollection _SupportingPoints;
         /// <summary>
         /// A GeoJSON collection representing sequence of coordinates used as input for route reconstruction and for calculating zero or more alternative routes to this reference route.
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> The provided sequence of supporting points is used as input for route reconstruction. </description></item>
         /// <item><description> The alternative routes are calculated between the origin and destination points specified in the base path parameter locations. </description></item>
         /// <item><description> If both <c>MinDeviationDistance</c> and <c>MinDeviationTime</c> are set to zero, then these origin and destination points are expected to be at (or very near) the beginning and end of the reference route, respectively. </description></item>

--- a/sdk/maps/Azure.Maps.Routing/src/Models/RouteInstruction.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Models/RouteInstruction.cs
@@ -27,14 +27,14 @@ namespace Azure.Maps.Routing.Models
         /// <param name="junctionType"> The type of the junction where the maneuver takes place. For larger roundabouts, two separate instructions are generated for entering and leaving the roundabout. </param>
         /// <param name="turnAngleInDegrees">
         /// Indicates the direction of an instruction. If junctionType indicates a turn instruction:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> 180 = U-turn </description></item>
         /// <item><description> [-179, -1] = Left turn </description></item>
         /// <item><description> 0 = Straight on (a "0 degree" turn) </description></item>
         /// <item><description> [1, 179] = Right turn </description></item>
         /// </list>
         /// If junctionType indicates a bifurcation instruction:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> less than 0 - keep left </description></item>
         /// <item><description> larger than 0 - keep right </description></item>
         /// </list>

--- a/sdk/maps/Azure.Maps.Search/src/Models/Options/FuzzySearchOptions.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/Options/FuzzySearchOptions.cs
@@ -23,7 +23,7 @@ namespace Azure.Maps.Search
         /// <summary>
         /// Specifies the level of filtering performed on geographies. Narrows the search for specified geography entity types, e.g. return only municipality. The resulting response will contain the geography ID as well as the entity type matched. If you provide more than one entity as a comma separated list, endpoint will return the &apos;smallest entity available&apos;. Returned Geometry ID can be used to get the geometry of that geography via <see href="https://docs.microsoft.com/rest/api/maps/search/getsearchpolygon">Get Search Polygon</see> API. The following parameters are ignored when entityType is set:
         /// </summary>
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> heading </description></item>
         /// <item><description> number </description></item>
         /// <item><description> returnRoadUse </description></item>
@@ -35,7 +35,7 @@ namespace Azure.Maps.Search
         /// <summary>
         /// Minimum fuzziness level to be used. Default: 1, minimum: 1 and maximum: 4
         /// </summary>
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> Level 1 has no spell checking. </description></item>
         /// <item><description> Level 2 uses normal n-gram spell checking. For example, query &quot;restrant&quot; can be matched to &quot;restaurant.&quot; </description></item>
         /// <item><description> Level 3 uses sound-like spell checking, and shingle spell checking. Sound-like spell checking is for &quot;rstrnt&quot; to &quot;restaurant&quot; matching. Shingle spell checking is for &quot;mountainview&quot; to &quot;mountain view&quot; matching. </description></item>
@@ -47,7 +47,7 @@ namespace Azure.Maps.Search
         /// Maximum fuzziness level to be used. Default: 2, minimum: 1 and maximum: 4
         /// The search engine will start looking for a match on the level defined by minFuzzyLevel, and will stop searching at the level specified by maxFuzzyLevel.
         /// </summary>
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> Level 1 has no spell checking. </description></item>
         /// <item><description> Level 2 uses normal n-gram spell checking. For example, query &quot;restrant&quot; can be matched to &quot;restaurant.&quot; </description></item>
         /// <item><description> Level 3 uses sound-like spell checking, and shingle spell checking. Sound-like spell checking is for &quot;rstrnt&quot; to &quot;restaurant&quot; matching. Shingle spell checking is for &quot;mountainview&quot; to &quot;mountain view&quot; matching. </description></item>
@@ -59,7 +59,7 @@ namespace Azure.Maps.Search
         /// Indexes which should be utilized for the search.
         ///
         /// Available indexes are:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> <c>Addr</c> - Address ranges </description></item>
         /// <item><description> <c>Geo</c> - Geographies </description></item>
         /// <item><description> <c>PAD</c> - Point Addresses </description></item>
@@ -76,7 +76,7 @@ namespace Azure.Maps.Search
         /// Indexes for which extended postal codes should be included in the results.
         ///
         /// Available indexes are:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> <c>Addr</c> - Address ranges </description></item>
         /// <item><description> <c>Geo</c> - Geographies </description></item>
         /// <item><description> <c>PAD</c> - Point Addresses </description></item>

--- a/sdk/maps/Azure.Maps.Search/src/Models/Options/ReverseSearchOptions.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/Options/ReverseSearchOptions.cs
@@ -35,7 +35,7 @@ namespace Azure.Maps.Search
 
         /// <summary>
         /// Specifies the level of filtering performed on geographies. Narrows the search for specified geography entity types, e.g. return only municipality. The resulting response will contain the geography ID as well as the entity type matched. If you provide more than one entity as a comma separated list, endpoint will return the &apos;smallest entity available&apos;. Returned Geometry ID can be used to get the geometry of that geography via <see href="https://docs.microsoft.com/rest/api/maps/search/getsearchpolygon">Get Search Polygon</see> API. The following parameters are ignored when entityType is set:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> heading </description></item>
         /// <item><description> number </description></item>
         /// <item><description> returnRoadUse </description></item>

--- a/sdk/maps/Azure.Maps.Search/src/Models/Options/SearchAddressOptions.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/Options/SearchAddressOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.Maps.Search
         /// <summary>
         /// Indexes for which extended postal codes should be included in the results.
         /// Available indexes are:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> <c>Addr</c> - Address ranges </description></item>
         /// <item><description> <c>Geo</c> - Geographies </description></item>
         /// <item><description> <c>PAD</c> - Point Addresses </description></item>
@@ -35,7 +35,7 @@ namespace Azure.Maps.Search
         /// <summary>
         /// Specifies the level of filtering performed on geographies. Narrows the search for specified geography entity types, e.g. return only municipality. The resulting response will contain the geography ID as well as the entity type matched. If you provide more than one entity as a comma separated list, endpoint will return the &apos;smallest entity available&apos;. Returned Geometry ID can be used to get the geometry of that geography via <see href="https://docs.microsoft.com/rest/api/maps/search/getsearchpolygon">Get Search Polygon</see> API.
         /// The following parameters are ignored when entityType is set:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> heading </description></item>
         /// <item><description> number </description></item>
         /// <item><description> returnRoadUse </description></item>

--- a/sdk/maps/Azure.Maps.Search/src/Models/Options/SearchStructuredAddressOptions.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/Options/SearchStructuredAddressOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.Maps.Search.Models
         /// <summary>
         /// Specifies the level of filtering performed on geographies. Narrows the search for specified geography entity types, e.g. return only municipality. The resulting response will contain the geography ID as well as the entity type matched. If you provide more than one entity as a comma separated list, endpoint will return the &apos;smallest entity available&apos;. Returned Geometry ID can be used to get the geometry of that geography via <see href="https://docs.microsoft.com/rest/api/maps/search/getsearchpolygon">Get Search Polygon</see> API.
         /// The following parameters are ignored when entityType is set:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> heading </description></item>
         /// <item><description> number </description></item>
         /// <item><description> returnRoadUse </description></item>

--- a/sdk/maps/Azure.Maps.Search/src/Models/SearchAddressResultItem.cs
+++ b/sdk/maps/Azure.Maps.Search/src/Models/SearchAddressResultItem.cs
@@ -26,7 +26,7 @@ namespace Azure.Maps.Search.Models
 
         /// <summary>
         /// One of:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description> POI </description></item>
         /// <item><description> Street </description></item>
         /// <item><description> Geography </description></item>

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
@@ -208,7 +208,7 @@ namespace Azure.Storage.Blobs.Models
         /// For a list of allowed premium page blob tiers, see
         /// <see href="https://docs.microsoft.com/azure/virtual-machines/windows/premium-storage#features" />. For general
         /// purpose v2 and blob storage account types, the valid values are:
-        /// <list>
+        /// <list type="bullet">
         ///  <item><description>Hot</description></item>
         ///  <item><description>Cool</description></item>
         ///  <item><description>Archive</description></item>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobNameValidationAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobNameValidationAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
     /// <summary>
     /// DataAnnotation attribute to validate a Blob Path against Azure Storage rules.
     /// A BlobPath could be:
-    /// <list>
+    /// <list type="bullet">
     /// <item>A Container / Blob Name</item>
     /// <item>An absolute URI specifying a Blob</item>
     /// <item>Just a Container Name</item>


### PR DESCRIPTION
As called out in [this issue](https://github.com/Azure/azure-sdk-for-net/issues/36172), some lists in the reference documentation aren't being rendered due to a missing `type` attribute which is required on the `list` nodes.

This PR adds it in multiple files that had it missing. @jsquire FYI

resolves #36172