### PR TITLE
Handle error content without error: {} wrapper

### DIFF
--- a/sdk/core/Azure.Core/src/RequestFailedException.cs
+++ b/sdk/core/Azure.Core/src/RequestFailedException.cs
@@ -258,6 +258,7 @@ namespace Azure
                 {
                     return false;
                 }
+                // Try the ErrorResponse format and fallback to the ResponseError format.
                 error = System.Text.Json.JsonSerializer.Deserialize<ErrorResponse>(content)?.Error;
                 error ??= System.Text.Json.JsonSerializer.Deserialize<ResponseError>(content);
             }

--- a/sdk/core/Azure.Core/src/RequestFailedException.cs
+++ b/sdk/core/Azure.Core/src/RequestFailedException.cs
@@ -247,8 +247,6 @@ namespace Azure
         {
             error = null;
             data = null;
-            //string? message = null;
-            //string? code = null;
 
             try
             {

--- a/sdk/core/Azure.Core/src/RequestFailedException.cs
+++ b/sdk/core/Azure.Core/src/RequestFailedException.cs
@@ -247,8 +247,8 @@ namespace Azure
         {
             error = null;
             data = null;
-            string? message = null;
-            string? code = null;
+            //string? message = null;
+            //string? code = null;
 
             try
             {
@@ -260,40 +260,8 @@ namespace Azure
                 {
                     return false;
                 }
-                var reader = new System.Text.Json.Utf8JsonReader(response.Content);
-                int objectDepth = 0;
-                while (reader.Read())
-                {
-                    if (code is not null && message is not null || objectDepth > 2)
-                    {
-                        break;
-                    }
-                    switch (reader.TokenType)
-                    {
-                        case System.Text.Json.JsonTokenType.EndObject:
-                            objectDepth++;
-                            break;
-                        case System.Text.Json.JsonTokenType.PropertyName:
-                            var propName = reader.GetString();
-                            if (!reader.Read())
-                            {
-                                break;
-                            }
-                            if (propName == "message")
-                            {
-                                message = reader.GetString();
-                            }
-                            else if (propName == "code")
-                            {
-                                code = reader.GetString();
-                            }
-                            break;
-                    }
-                }
-                if (objectDepth <= 2)
-                {
-                    error = new ResponseError(code, message);
-                }
+                error = System.Text.Json.JsonSerializer.Deserialize<ErrorResponse>(content)?.Error;
+                error ??= System.Text.Json.JsonSerializer.Deserialize<ResponseError>(content);
             }
             catch (Exception)
             {

--- a/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
+++ b/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
@@ -288,7 +288,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ParsesJsonErrors()
+        public void ParsesJsonErrors([Values(true, false)] bool hasErrorWrapper)
         {
             var formattedResponse =
                 "Custom message" + s_nl +
@@ -296,13 +296,16 @@ namespace Azure.Core.Tests
                 "ErrorCode: StatusCode" + s_nl +
                 s_nl +
                 "Content:" + s_nl +
-                "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" + s_nl +
+            (hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Content-Type: text/json" + s_nl;
 
             var response = new MockResponse(210, "Reason");
-            response.SetContent("{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}");
+            var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
+            response.SetContent(errorContent);
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;
 
@@ -312,7 +315,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ParsesJsonErrors_ResponseCtor()
+        public void ParsesJsonErrors_ResponseCtor([Values(true, false)] bool hasErrorWrapper)
         {
             var formattedResponse =
                 "Custom message" + s_nl +
@@ -320,13 +323,16 @@ namespace Azure.Core.Tests
                 "ErrorCode: StatusCode" + s_nl +
                 s_nl +
                 "Content:" + s_nl +
-                "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" + s_nl +
+            (hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Content-Type: text/json" + s_nl;
 
             var response = new MockResponse(210, "Reason");
-            response.SetContent("{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}");
+            var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
+            response.SetContent(errorContent);
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;
 
@@ -336,7 +342,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ParsesJsonErrors_ResponseCtor_Stream([Values(true, false)] bool canSeek)
+        public void ParsesJsonErrors_ResponseCtor_Stream([Values(true, false)] bool canSeek, [Values(true, false)] bool hasErrorWrapper)
         {
             var formattedResponse =
                 "Custom message" + s_nl +
@@ -344,13 +350,16 @@ namespace Azure.Core.Tests
                 "ErrorCode: StatusCode" + s_nl +
                 s_nl +
                 "Content:" + s_nl +
-                "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" + s_nl +
+            (hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Content-Type: text/json" + s_nl;
 
             var response = new MockResponse(210, "Reason");
-            response.ContentStream = GetStream(canSeek, "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}");
+            var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
+            response.ContentStream = GetStream(canSeek, errorContent);
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;
 
@@ -361,11 +370,11 @@ namespace Azure.Core.Tests
 
             Assert.IsInstanceOf<MemoryStream>(rawResponse.ContentStream);
             Assert.AreEqual(0, rawResponse.ContentStream.Position);
-            Assert.AreEqual("{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}", rawResponse.Content.ToString());
+            Assert.AreEqual(errorContent, rawResponse.Content.ToString());
         }
 
         [Test]
-        public async Task ParsesJsonErrors_ResponseCtor_StreamAsync([Values(true, false)] bool canSeek)
+        public async Task ParsesJsonErrors_ResponseCtor_StreamAsync([Values(true, false)] bool canSeek, [Values(true, false)] bool hasErrorWrapper)
         {
             await Task.Yield();
             var formattedResponse =
@@ -374,13 +383,16 @@ namespace Azure.Core.Tests
                 "ErrorCode: StatusCode" + s_nl +
                 s_nl +
                 "Content:" + s_nl +
-                "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" + s_nl +
+            (hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }") + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Content-Type: text/json" + s_nl;
 
             var response = new MockResponse(210, "Reason");
-            response.ContentStream = GetStream(canSeek, "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}");
+            var errorContent = hasErrorWrapper ? "{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}" :
+                "{ \"code\":\"StatusCode\", \"message\":\"Custom message\" }";
+            response.ContentStream = GetStream(canSeek, errorContent);
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;
 
@@ -391,7 +403,7 @@ namespace Azure.Core.Tests
             Response rawResponse = exception.GetRawResponse();
             Assert.IsInstanceOf<MemoryStream>(rawResponse.ContentStream);
             Assert.AreEqual(0, rawResponse.ContentStream.Position);
-            Assert.AreEqual("{ \"error\": { \"code\":\"StatusCode\", \"message\":\"Custom message\" }}", rawResponse.Content.ToString());
+            Assert.AreEqual(errorContent, rawResponse.Content.ToString());
         }
 
         [Test]
@@ -424,13 +436,35 @@ namespace Azure.Core.Tests
                 "Status: 210 (Reason)" + s_nl +
                 s_nl +
                 "Content:" + s_nl +
-                "{ \"code\":\"StatusCode\" }" + s_nl +
+                "{ \"customCode\":\"StatusCode\" }" + s_nl +
                 s_nl +
                 "Headers:" + s_nl +
                 "Content-Type: text/json" + s_nl;
 
             var response = new MockResponse(210, "Reason");
-            response.SetContent("{ \"code\":\"StatusCode\" }");
+            response.SetContent("{ \"customCode\":\"StatusCode\" }");
+            response.AddHeader(new HttpHeader("Content-Type", "text/json"));
+            response.Sanitizer = Sanitizer;
+
+            RequestFailedException exception = new RequestFailedException(response);
+            Assert.AreEqual(formattedResponse, exception.Message);
+        }
+
+        [Test]
+        public void IgnoresUnexpectedNestedJson()
+        {
+            var formattedResponse =
+                "Service request failed." + s_nl +
+                "Status: 210 (Reason)" + s_nl +
+                s_nl +
+                "Content:" + s_nl +
+                "{ \"error\": { \"error\": { \"code\":\"StatusCode\" }}}" + s_nl +
+                s_nl +
+                "Headers:" + s_nl +
+                "Content-Type: text/json" + s_nl;
+
+            var response = new MockResponse(210, "Reason");
+            response.SetContent("{ \"error\": { \"error\": { \"code\":\"StatusCode\" }}}");
             response.AddHeader(new HttpHeader("Content-Type", "text/json"));
             response.Sanitizer = Sanitizer;
 

--- a/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
+++ b/sdk/core/Azure.Core/tests/FailedResponseExceptionTests.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
-using Azure.Core.Shared;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -288,7 +287,8 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ParsesJsonErrors([Values(true, false)] bool hasErrorWrapper)
+        public void ParsesJsonErrors(
+            [Values(true, false)] bool hasErrorWrapper)
         {
             var formattedResponse =
                 "Custom message" + s_nl +
@@ -315,7 +315,8 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ParsesJsonErrors_ResponseCtor([Values(true, false)] bool hasErrorWrapper)
+        public void ParsesJsonErrors_ResponseCtor(
+            [Values(true, false)] bool hasErrorWrapper)
         {
             var formattedResponse =
                 "Custom message" + s_nl +
@@ -342,7 +343,9 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void ParsesJsonErrors_ResponseCtor_Stream([Values(true, false)] bool canSeek, [Values(true, false)] bool hasErrorWrapper)
+        public void ParsesJsonErrors_ResponseCtor_Stream(
+            [Values(true, false)] bool canSeek,
+            [Values(true, false)] bool hasErrorWrapper)
         {
             var formattedResponse =
                 "Custom message" + s_nl +
@@ -374,7 +377,9 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public async Task ParsesJsonErrors_ResponseCtor_StreamAsync([Values(true, false)] bool canSeek, [Values(true, false)] bool hasErrorWrapper)
+        public async Task ParsesJsonErrors_ResponseCtor_StreamAsync(
+            [Values(true, false)] bool canSeek,
+            [Values(true, false)] bool hasErrorWrapper)
         {
             await Task.Yield();
             var formattedResponse =


### PR DESCRIPTION
closes #36223