### PR TITLE
Specify requirement for setup in conversion option constructor

### DIFF
--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.1 (2022-08-09)
+## 1.2.2 (2023-05-12)
 - Minor documentation fixes.
 
 ## 1.2.0-beta.1 (2021-11-16)

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Azure.MixedReality.RemoteRendering.csproj
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Azure.MixedReality.RemoteRendering.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure Mixed Reality ARR Client</AssemblyTitle>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.1.0</ApiCompatVersion>
+    <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <PackageTags>Azure MixedReality</PackageTags>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Generated/Models/AssetConversionInputOptions.cs
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Generated/Models/AssetConversionInputOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.MixedReality.RemoteRendering
     /// <summary> Conversion input settings describe the origin of conversion input. </summary>
     public partial class AssetConversionInputOptions
     {
-        /// <summary> Initializes a new instance of AssetConversionInputOptions. </summary>
+        /// <summary> Initializes a new instance of AssetConversionInputOptions. Only works if a storage account is linked to your ARR account. See: <see href="https://learn.microsoft.com/en-us/azure/remote-rendering/how-tos/create-an-account#link-storage-accounts">Link storage accounts</see> </summary>
         /// <param name="storageContainerUri"> The URI of the Azure blob storage container containing the input model. </param>
         /// <param name="relativeInputAssetPath"> The relative path starting at blobPrefix (or at the container root if blobPrefix is not provided) to the input model. Must point to a file with a supported file format ending. See https://docs.microsoft.com/azure/remote-rendering/how-tos/conversion/model-conversion for details. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="storageContainerUri"/> or <paramref name="relativeInputAssetPath"/> is null. </exception>
@@ -26,12 +26,12 @@ namespace Azure.MixedReality.RemoteRendering
             RelativeInputAssetPath = relativeInputAssetPath;
         }
 
-        /// <summary> Initializes a new instance of AssetConversionInputOptions. </summary>
+        /// <summary> Initializes a new instance of AssetConversionInputOptions. Works with or without a linked storage account. </summary>
         /// <param name="storageContainerUri"> The URI of the Azure blob storage container containing the input model. </param>
         /// <param name="storageContainerReadListSas"> An Azure blob storage container shared access signature giving read and list access to the storage container. Optional. If not provided, the Azure Remote Rendering account needs to be linked with the storage account containing the blob container. See https://docs.microsoft.com/azure/remote-rendering/how-tos/create-an-account#link-storage-accounts for details. For security purposes this field will never be filled out in responses bodies. </param>
         /// <param name="blobPrefix"> Only Blobs starting with this prefix will be downloaded to perform the conversion. Optional. If not provided, all Blobs from the container will be downloaded. </param>
         /// <param name="relativeInputAssetPath"> The relative path starting at blobPrefix (or at the container root if blobPrefix is not provided) to the input model. Must point to a file with a supported file format ending. See https://docs.microsoft.com/azure/remote-rendering/how-tos/conversion/model-conversion for details. </param>
-        internal AssetConversionInputOptions(Uri storageContainerUri, string storageContainerReadListSas, string blobPrefix, string relativeInputAssetPath)
+        public AssetConversionInputOptions(Uri storageContainerUri, string storageContainerReadListSas, string blobPrefix, string relativeInputAssetPath)
         {
             StorageContainerUri = storageContainerUri;
             StorageContainerReadListSas = storageContainerReadListSas;

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Generated/Models/AssetConversionOutputOptions.cs
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Generated/Models/AssetConversionOutputOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.MixedReality.RemoteRendering
     /// <summary> Conversion output settings describe the destination of conversion output. </summary>
     public partial class AssetConversionOutputOptions
     {
-        /// <summary> Initializes a new instance of AssetConversionOutputOptions. </summary>
+        /// <summary> Initializes a new instance of AssetConversionOutputOptions. Only works if a storage account is linked to your ARR account. See: <see href="https://learn.microsoft.com/en-us/azure/remote-rendering/how-tos/create-an-account#link-storage-accounts">Link storage accounts</see> </summary>
         /// <param name="storageContainerUri"> The URI of the Azure blob storage container where the result of the conversion should be written to. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="storageContainerUri"/> is null. </exception>
         public AssetConversionOutputOptions(Uri storageContainerUri)
@@ -23,12 +23,12 @@ namespace Azure.MixedReality.RemoteRendering
             StorageContainerUri = storageContainerUri;
         }
 
-        /// <summary> Initializes a new instance of AssetConversionOutputOptions. </summary>
+        /// <summary> Initializes a new instance of AssetConversionOutputOptions. Works with or without a linked storage account. </summary>
         /// <param name="storageContainerUri"> The URI of the Azure blob storage container where the result of the conversion should be written to. </param>
         /// <param name="storageContainerWriteSas"> An Azure blob storage container shared access signature giving write access to the storage container. Optional. If not provided, the Azure Remote Rendering account needs to be linked with the storage account containing the blob container. See https://docs.microsoft.com/azure/remote-rendering/how-tos/create-an-account#link-storage-accounts for details. For security purposes this field will never be filled out in responses bodies. </param>
         /// <param name="blobPrefix"> A prefix which gets prepended in front of all files produced by the conversion process. Will be treated as a virtual folder. Optional. If not provided, output files will be stored at the container root. </param>
         /// <param name="outputAssetFilename"> The file name of the output asset. Must end in &apos;.arrAsset&apos;. Optional. If not provided, file name will the same name as the input asset, with &apos;.arrAsset&apos; extension. </param>
-        internal AssetConversionOutputOptions(Uri storageContainerUri, string storageContainerWriteSas, string blobPrefix, string outputAssetFilename)
+        public AssetConversionOutputOptions(Uri storageContainerUri, string storageContainerWriteSas, string blobPrefix, string outputAssetFilename)
         {
             StorageContainerUri = storageContainerUri;
             StorageContainerWriteSas = storageContainerWriteSas;


### PR DESCRIPTION
We had an issue with a customer here https://github.com/Azure/azure-sdk-for-net/issues/36019, which basically boiled down to the fact, that they were trying to initiate SAS conversion, but that did fail, because the only public constructor in the Options implicitly requires some setup in Azure (Linking a storage account to an ARR account).

With this change the other constructor, that contains more parameters and allows SAS conversions directly through the constructor, is made public and some comments are added to clarify what is needed to convert properly.