### PR TITLE
TryPause -> PauseIfRunning

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -8,7 +8,7 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
-        public System.Threading.Tasks.Task<bool> TryPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.FlagsAttribute]
     public enum ErrorHandlingOptions
@@ -117,11 +117,11 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, Azure.Storage.DataMovement.StorageResource destinationResource, Azure.Storage.DataMovement.Models.TransferOptions transferOptions = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartTransferAsync(Azure.Storage.DataMovement.StorageResourceContainer sourceResource, Azure.Storage.DataMovement.StorageResourceContainer destinationResource, Azure.Storage.DataMovement.Models.TransferOptions transferOptions = null) { throw null; }
         System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync() { throw null; }
-        public virtual System.Threading.Tasks.Task<bool> TryPauseTransferAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<bool> TryPauseTransferAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class TransferManagerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -8,7 +8,7 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
-        public System.Threading.Tasks.Task<bool> TryPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.FlagsAttribute]
     public enum ErrorHandlingOptions
@@ -117,11 +117,11 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, Azure.Storage.DataMovement.StorageResource destinationResource, Azure.Storage.DataMovement.Models.TransferOptions transferOptions = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartTransferAsync(Azure.Storage.DataMovement.StorageResourceContainer sourceResource, Azure.Storage.DataMovement.StorageResourceContainer destinationResource, Azure.Storage.DataMovement.Models.TransferOptions transferOptions = null) { throw null; }
         System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync() { throw null; }
-        public virtual System.Threading.Tasks.Task<bool> TryPauseTransferAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<bool> TryPauseTransferAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class TransferManagerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
@@ -8,7 +8,7 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
-        public System.Threading.Tasks.Task<bool> TryPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.FlagsAttribute]
     public enum ErrorHandlingOptions
@@ -117,11 +117,11 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, Azure.Storage.DataMovement.StorageResource destinationResource, Azure.Storage.DataMovement.Models.TransferOptions transferOptions = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartTransferAsync(Azure.Storage.DataMovement.StorageResourceContainer sourceResource, Azure.Storage.DataMovement.StorageResourceContainer destinationResource, Azure.Storage.DataMovement.Models.TransferOptions transferOptions = null) { throw null; }
         System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync() { throw null; }
-        public virtual System.Threading.Tasks.Task<bool> TryPauseTransferAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<bool> TryPauseTransferAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class TransferManagerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransfer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransfer.cs
@@ -91,9 +91,9 @@ namespace Azure.Storage.DataMovement
         ///
         /// Will return true if the pause has taken place.
         /// </returns>
-        public Task<bool> TryPauseAsync(CancellationToken cancellationToken = default)
+        public async Task PauseIfRunningAsync(CancellationToken cancellationToken = default)
         {
-            return _state.TryPauseAsync(cancellationToken);
+            await _state.PauseIfRunningAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransferState.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransferState.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -172,14 +173,14 @@ namespace Azure.Storage.DataMovement
             }
         }
 
-        public async Task<bool> TryPauseAsync(CancellationToken cancellationToken)
+        public async Task PauseIfRunningAsync(CancellationToken cancellationToken)
         {
             if (StorageTransferStatus.Paused == _status ||
                 StorageTransferStatus.Completed == _status ||
                 StorageTransferStatus.CompletedWithSkippedTransfers == _status ||
                 StorageTransferStatus.CompletedWithFailedTransfers == _status)
             {
-                return false;
+                return;
             }
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
             // Call the inner cancellation token to stop the transfer job
@@ -188,9 +189,7 @@ namespace Azure.Storage.DataMovement
             {
                 // Wait until full pause has completed.
                 await CompletionSource.Task.AwaitWithCancellation(cancellationToken);
-                return true;
             }
-            return false;
         }
 
         internal bool TriggerCancellation()

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
@@ -232,8 +232,8 @@ namespace Azure.Storage.DataMovement
         /// Return true once the transfer has been successfully paused or false if the transfer
         /// was already completed.
         /// </returns>
-        public virtual Task<bool> TryPauseTransferAsync(DataTransfer transfer, CancellationToken cancellationToken = default)
-            => TryPauseTransferAsync(transfer.Id, cancellationToken);
+        public virtual Task PauseTransferIfRunningAsync(DataTransfer transfer, CancellationToken cancellationToken = default)
+            => PauseTransferIfRunningAsync(transfer.Id, cancellationToken);
 
         /// <summary>
         /// Attempts to pause the transfer of the respective id.
@@ -247,17 +247,14 @@ namespace Azure.Storage.DataMovement
         /// Return true once the transfer has been successfully paused or false if the transfer
         /// was already completed.
         /// </returns>
-        public virtual Task<bool> TryPauseTransferAsync(string transferId, CancellationToken cancellationToken = default)
+        public virtual async Task PauseTransferIfRunningAsync(string transferId, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(transferId, nameof(transferId));
-            if (_dataTransfers.TryGetValue(transferId, out DataTransfer transfer))
+            if (!_dataTransfers.TryGetValue(transferId, out DataTransfer transfer))
             {
-                return transfer.TryPauseAsync(cancellationToken: cancellationToken);
+                throw Errors.InvalidTransferId(nameof(PauseTransferIfRunningAsync), transferId);
             }
-            else
-            {
-                throw Errors.InvalidTransferId(nameof(TryPauseTransferAsync), transferId);
-            }
+            await transfer.PauseIfRunningAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageTransferStatus.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageTransferStatus.cs
@@ -31,7 +31,7 @@ namespace Azure.Storage.DataMovement
         InProgress = 2,
 
         /// <summary>
-        /// The Job has been paused. When transfer is paused (e.g. see <see cref="TransferManager.TryPauseTransferAsync(string, System.Threading.CancellationToken)"/>) during the transfer,
+        /// The Job has been paused. When transfer is paused (e.g. see <see cref="TransferManager.PauseTransferIfRunningAsync(string, System.Threading.CancellationToken)"/>) during the transfer,
         /// this will be the value.
         ///
         /// This status is a resumable state, only

--- a/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
@@ -95,7 +95,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             DataTransfer transfer = new DataTransfer(StorageTransferStatus.InProgress);
 
-            Task<bool> pauseTask = transfer.TryPauseAsync();
+            Task pauseTask = transfer.PauseIfRunningAsync();
 
             Assert.AreEqual(StorageTransferStatus.PauseInProgress, transfer.TransferStatus);
 
@@ -104,9 +104,9 @@ namespace Azure.Storage.DataMovement.Tests
                 Assert.Fail("Unable to set the transfer status internally to the DataTransfer.");
             }
 
-            bool pauseResult = await pauseTask;
+            await pauseTask;
 
-            Assert.IsTrue(pauseResult);
+            Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
             Assert.IsFalse(transfer.HasCompleted);
         }
 
@@ -119,9 +119,9 @@ namespace Azure.Storage.DataMovement.Tests
         {
             DataTransfer transfer = new DataTransfer(status);
 
-            bool pauseResult = await transfer.TryPauseAsync();
-
-            Assert.IsFalse(pauseResult);
+            Assert.AreEqual(status, transfer.TransferStatus);
+            await transfer.PauseIfRunningAsync();
+            Assert.AreEqual(status, transfer.TransferStatus);
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             try
             {
-                await transfer.TryPauseAsync(cancellationTokenSource.Token);
+                await transfer.PauseIfRunningAsync(cancellationTokenSource.Token);
             }
             catch (OperationCanceledException exception)
             {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -256,12 +256,11 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer.Id, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer.Id, cancellationTokenSource.Token);
 
             // Assert
             testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            Assert.IsTrue(pauseSuccess);
 
             // Check if Job Plan File exists in checkpointer path.
             JobPartPlanFileName fileName = new JobPartPlanFileName(
@@ -306,12 +305,11 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
             testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            Assert.IsTrue(pauseSuccess);
 
             // Check if Job Plan File exists in checkpointer path.
             JobPartPlanFileName fileName = new JobPartPlanFileName(
@@ -334,7 +332,7 @@ namespace Azure.Storage.DataMovement.Tests
             TransferManager transferManager = new TransferManager(options);
 
             // Act / Assert
-            Assert.CatchAsync(async () => await transferManager.TryPauseTransferAsync("bad transfer Id"));
+            Assert.CatchAsync(async () => await transferManager.PauseTransferIfRunningAsync("bad transfer Id"));
         }
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
@@ -372,17 +370,16 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
             testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            Assert.IsTrue(pauseSuccess);
 
             CancellationTokenSource cancellationTokenSource2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseFailure = await transferManager.TryPauseTransferAsync(transfer, cancellationTokenSource2.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource2.Token);
 
-            Assert.IsFalse(pauseFailure);
+            Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
 
             // Check if Job Plan File exists in checkpointer path.
             JobPartPlanFileName fileName = new JobPartPlanFileName(
@@ -435,12 +432,11 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act - Pause Job
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer.Id, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer.Id, cancellationTokenSource.Token);
 
             // Assert - Confirm we've paused
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
             testEventsRaised.AssertPausedCheck();
-            Assert.IsTrue(pauseSuccess);
 
             // Act - Resume Job
             TransferOptions resumeOptions = new TransferOptions()
@@ -639,12 +635,11 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer.Id, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer.Id, cancellationTokenSource.Token);
 
             // Assert
             testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            Assert.IsTrue(pauseSuccess);
         }
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
@@ -686,12 +681,11 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
             testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            Assert.IsTrue(pauseSuccess);
         }
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
@@ -733,18 +727,16 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
             testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            Assert.IsTrue(pauseSuccess);
 
             CancellationTokenSource cancellationTokenSource2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            bool pauseFailure = await transferManager.TryPauseTransferAsync(transfer, cancellationTokenSource2.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource2.Token);
 
             testEventsRaised.AssertPausedCheck();
-            Assert.IsFalse(pauseFailure);
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
@@ -794,12 +786,11 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act - Pause Job
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(100));
-            bool pauseSuccess = await transferManager.TryPauseTransferAsync(transfer.Id, cancellationTokenSource.Token);
+            await transferManager.PauseTransferIfRunningAsync(transfer.Id, cancellationTokenSource.Token);
 
             // Assert - Confirm we've paused
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
             testEventsRaised.AssertPausedCheck();
-            Assert.IsTrue(pauseSuccess);
 
             // Act - Resume Job
             TransferOptions resumeOptions = new TransferOptions()


### PR DESCRIPTION
Removes the try pattern from pause APIs, as it's not clear what a user is meant to do with the result.
Paves the way for a sensible `PauseAll` API.