### PR TITLE
DataMovement Pause All

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 12.0.0-beta.3 (Unreleased)
 
 ### Features Added
+- `TransferManager` new API `PauseAllRunningTransfersAsync`.
 
 ### Breaking Changes
+- [BREAKING CHANGE] Altered API signatures on `TransferManager` and `DataTransfer` for pausing.
 
 ### Bugs Fixed
 - Fix to prevent empty strings or null to be passed as paths for `LocalFileStorageResource` and `LocalDirectoryStorageResourceContainer`.

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -8,7 +8,7 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
-        public System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.FlagsAttribute]
     public enum ErrorHandlingOptions

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -8,7 +8,7 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
-        public System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.FlagsAttribute]
     public enum ErrorHandlingOptions

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
@@ -8,7 +8,7 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
-        public System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task PauseIfRunningAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     [System.FlagsAttribute]
     public enum ErrorHandlingOptions

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransfer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransfer.cs
@@ -91,9 +91,11 @@ namespace Azure.Storage.DataMovement
         ///
         /// Will return true if the pause has taken place.
         /// </returns>
-        public async Task PauseIfRunningAsync(CancellationToken cancellationToken = default)
+        public virtual async Task PauseIfRunningAsync(CancellationToken cancellationToken = default)
         {
             await _state.PauseIfRunningAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        internal virtual bool CanPause() => _state.CanPause();
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransferState.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransferState.cs
@@ -173,12 +173,12 @@ namespace Azure.Storage.DataMovement
             }
         }
 
+        internal bool CanPause()
+            => _status == StorageTransferStatus.InProgress;
+
         public async Task PauseIfRunningAsync(CancellationToken cancellationToken)
         {
-            if (StorageTransferStatus.Paused == _status ||
-                StorageTransferStatus.Completed == _status ||
-                StorageTransferStatus.CompletedWithSkippedTransfers == _status ||
-                StorageTransferStatus.CompletedWithFailedTransfers == _status)
+            if (!CanPause())
             {
                 return;
             }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -262,9 +263,12 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        internal virtual Task<bool> TryPauseAllTransfersAsync()
+        internal virtual async Task PauseAllRunningTransfersAsync(CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            await Task.WhenAll(_dataTransfers.Values
+                .Where(transfer => transfer.CanPause())
+                .Select(transfer => transfer.PauseIfRunningAsync(cancellationToken)))
+                .ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
New public API `TransferManger.PauseAllRunningTransfersAsync()`.

Internal API `CanPause` filters down to transfers that actually need pausing to avoid long-lived TransferManagers using more and more memory over time.

Includes forgotten changelog entry for previous PR changing API of single pause.