### PR TITLE
[Event Hubs] Restore stress project references

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/Directory.Build.props
@@ -1,0 +1,14 @@
+﻿<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Force project references to Azure clients.  This is necessary because the stress project
+    uses a project reference to the Event Hubs core library and the processor library.  The
+    processor library takes a package reference on the Event Hubs core library, leading versioning
+    to get confused in some scenarios.
+  -->
+  <PropertyGroup Condition="'$(UseProjectReferenceToAzureClients)' == ''">
+    <UseProjectReferenceToAzureClients>true</UseProjectReferenceToAzureClients>
+  </PropertyGroup>
+
+  <!-- Import the common SDK build properties. -->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../.., Directory.Build.props))\Directory.Build.props" />
+</Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" / -->
+    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary

The focus of these changes is to restore the direct reference to the Event Hubs core project from the stress project.  To avoid versioning conflicts, a directory props file has been added that forces all stress project dependencies to use project references.  This will ensure that the references to the Event Hubs core package from stress and the processor are consistent.

# References and Resources

- [[Event Hubs] Temporarily resolve version conflict (#36135)](https://github.com/Azure/azure-sdk-for-net/pull/36135/files)