### PR TITLE
Provide indexer lookup as the way to distinguish between null and absent

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicData/DynamicData.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -94,7 +95,7 @@ namespace Azure.Core.Dynamic
                         return new DynamicData(element);
                     }
 
-                    throw new InvalidOperationException($"Could not find JSON member with name '{propertyName}'.");
+                    throw new KeyNotFoundException($"Could not find JSON member with name '{propertyName}'.");
 
                 case int arrayIndex:
                     return new DynamicData(_element.GetIndexElement(arrayIndex));

--- a/sdk/core/Azure.Core.Experimental/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicData/DynamicData.cs
@@ -93,7 +93,9 @@ namespace Azure.Core.Dynamic
                     {
                         return new DynamicData(element);
                     }
-                    return null;
+
+                    throw new InvalidOperationException($"Could not find JSON member with name '{propertyName}'.");
+
                 case int arrayIndex:
                     return new DynamicData(_element.GetIndexElement(arrayIndex));
             }

--- a/sdk/core/Azure.Core.Experimental/tests/DynamicData/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/DynamicData/DynamicJsonTests.cs
@@ -641,7 +641,7 @@ namespace Azure.Core.Tests
             Assert.AreEqual(1, (int)dynamicJson.Foo);
             Assert.AreEqual(3, (int)dynamicJson.bar);
             Assert.AreEqual(3, (int)dynamicJson.Bar);
-            Assert.Throws<InvalidOperationException>(() => _ = dynamicJson["Bar"]);
+            Assert.Throws<KeyNotFoundException>(() => _ = dynamicJson["Bar"]);
 
             // This updates the PascalCase property and not the camelCase one.
             dynamicJson.Foo = 4;
@@ -1058,7 +1058,8 @@ namespace Azure.Core.Tests
 
             // Indexer lookup mimics JsonNode behavior and so throws if a property is absent.
             Assert.IsTrue(json["foo"] == null);
-            Assert.Throws<InvalidOperationException>(() => _ = json["bar"]);
+            Assert.Throws<KeyNotFoundException>(() => _ = json["bar"]);
+            Assert.Throws<KeyNotFoundException>(() => { if (json["bar"] == null) { ; } });
         }
 
         #region Helpers

--- a/sdk/core/Azure.Core.Experimental/tests/DynamicData/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/DynamicData/DynamicJsonTests.cs
@@ -641,7 +641,7 @@ namespace Azure.Core.Tests
             Assert.AreEqual(1, (int)dynamicJson.Foo);
             Assert.AreEqual(3, (int)dynamicJson.bar);
             Assert.AreEqual(3, (int)dynamicJson.Bar);
-            Assert.AreEqual(null, dynamicJson["Bar"]);
+            Assert.Throws<InvalidOperationException>(() => _ = dynamicJson["Bar"]);
 
             // This updates the PascalCase property and not the camelCase one.
             dynamicJson.Foo = 4;
@@ -1046,6 +1046,27 @@ namespace Azure.Core.Tests
             Assert.Throws<InvalidCastException>(() => { DateTimeOffset d = (DateTimeOffset)json.Foo; });
         }
 
+        [Test]
+        public void CanDifferentiateBetweenNullAndAbsent()
+        {
+            dynamic json = BinaryData.FromString("""{ "foo": null }""").ToDynamicFromJson();
+
+            // GetMember binding mirrors Azure SDK models, so we allow a null check for an optional
+            // property through the C#-style dynamic interface.
+            Assert.IsTrue(json.foo == null);
+            Assert.IsTrue(json.bar == null);
+
+            // Indexer lookup mimics JsonNode behavior and so throws if a property is absent.
+            Assert.IsTrue(json["foo"] == null);
+            Assert.Throws<InvalidOperationException>(() => _ = json["bar"]);
+        }
+
+        #region Helpers
+        internal static dynamic GetDynamicJson(string json)
+        {
+            return new BinaryData(json).ToDynamicFromJson();
+        }
+
         public static IEnumerable<object[]> NumberValues()
         {
             // Valid ranges:
@@ -1061,12 +1082,6 @@ namespace Azure.Core.Tests
             yield return new object[] { "42.1", 42.1f, 43.1f, 44.1f, false /* don't test range */ };
             yield return new object[] { "42.1", 42.1d, 43.1d, 44.1d, false /* don't test range */ };
             yield return new object[] { "42.1", 42.1m, 43.1m, 44.1m, false /* don't test range */ };
-        }
-
-        #region Helpers
-        internal static dynamic GetDynamicJson(string json)
-        {
-            return new BinaryData(json).ToDynamicFromJson();
         }
 
         internal class CustomType


### PR DESCRIPTION
In the arch board, it was suggested that we let indexer access be the way to differentiate between a JSON property having a value of `null` vs. not being present in the JSON buffer.  This is nice, because it is consistent with the story that indexer access lets you bypass conveniences or limitations in the dynamic layer that we add to make it look and behave more like an Azure SDK model.

This PR implements this, and I will document it in samples when the type moves back to the Core library.

Addresses https://github.com/Azure/azure-sdk-for-net/issues/35944