### PR TITLE
Add live test stages to sdk-client

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -6,12 +6,13 @@ parameters:
   DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
   TargetDocRepoOwner: 'not-specified'
   TargetDocRepoName: 'not-specified'
+  Environment: nuget
 stages:
   - stage: Signing
     dependsOn: ${{parameters.DependsOn}}
     jobs:
       - deployment: SignPackage
-        environment: esrp
+        environment: ${{parameters.Environment}}
         pool:
           name: azsdk-pool-mms-win-2022-general
           vmImage: windows-2022
@@ -49,7 +50,7 @@ stages:
               - deployment: TagRepository
                 displayName: "Create release tag"
                 condition: ne(variables['Skip.TagRepository'], 'true')
-                environment: github
+                environment: ${{parameters.Environment}}
 
                 pool:
                   name: azsdk-pool-mms-win-2022-general
@@ -96,7 +97,7 @@ stages:
               - deployment: PublishPackage
                 displayName: Publish package to Nuget.org and DevOps Feed
                 condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-                environment: nuget
+                environment: ${{parameters.Environment}}
                 dependsOn: TagRepository
 
                 pool:
@@ -126,7 +127,7 @@ stages:
               - deployment: UploadSymbols
                 displayName: Upload Symbols to Symbols Server
                 condition: and(succeeded(), ne(variables['Skip.SymbolsUpload'], 'true'))
-                environment: nuget
+                environment: ${{parameters.Environment}}
                 dependsOn: PublishPackage
 
                 pool:
@@ -153,7 +154,7 @@ stages:
               - deployment: PublicDocsMS
                 displayName: Publish to Docs.MS
                 condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-                environment: githubio
+                environment: ${{parameters.Environment}}
                 dependsOn: PublishPackage
 
                 pool:
@@ -186,7 +187,7 @@ stages:
               - deployment: PublishDocs
                 displayName: Publish Docs to GitHub pages
                 condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
-                environment: githubio
+                environment: ${{parameters.Environment}}
                 dependsOn: PublishPackage
 
                 pool:
@@ -212,7 +213,7 @@ stages:
               - deployment: UpdatePackageVersion
                 displayName: "Update Package Version"
                 condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-                environment: github
+                environment: ${{parameters.Environment}}
                 dependsOn: PublishPackage
 
                 pool:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -58,6 +58,15 @@ parameters:
 - name: LimitForPullRequest
   type: boolean
   default: false
+- name: RunDefaultLiveTestStages
+  type: boolean
+  default: false
+- name: LiveTestStages
+  type: stageList
+  default: []
+- name: ReleaseDependsOnLiveTests
+  type: string
+  default: not-specified
 
 variables:
   - template: ../variables/globals.yml
@@ -90,16 +99,26 @@ stages:
           - ${{ parameters.MatrixReplace }}
         TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
 
+  - ${{ parameters.LiveTestStages }}
+
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
     - template: archetype-net-release.yml
       parameters:
         SDKType: ${{ parameters.SDKType }}
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
-        DependsOn: Build
+        DependsOn:
+          - Build
+          # Only depend on live test stages if the build depends on live tests and the build reason is manual.
+          # This prevents check-in builds and scheduled builds from having a requirement on live test stages.
+          - ${{ if eq(parameters.ReleaseDependsOnLiveTests, 'true') }}:
+            - ${{ each liveTestStage in parameters.LiveTestStages }}:
+              - ${{ liveTestStage.stage }}
         Artifacts: ${{ parameters.Artifacts }}
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:
           TestPipeline: true
         ArtifactName: packages
         TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
         TargetDocRepoName: ${{ parameters.TargetDocRepoName }}
+        ${{ if eq(parameters.ReleaseDependsOnLiveTests, 'false') }}:
+          Environment: 'nuget-break-glass-approvers'

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -58,9 +58,6 @@ parameters:
 - name: LimitForPullRequest
   type: boolean
   default: false
-- name: RunDefaultLiveTestStages
-  type: boolean
-  default: false
 - name: LiveTestStages
   type: stageList
   default: []

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -99,10 +99,10 @@ stages:
           - ${{ parameters.MatrixReplace }}
         TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
 
-  - ${{ parameters.LiveTestStages }}
-
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+    - ${{ parameters.LiveTestStages }}
+
     - template: archetype-net-release.yml
       parameters:
         SDKType: ${{ parameters.SDKType }}

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -102,15 +102,14 @@ parameters:
         pathToPublish: '$(Build.ArtifactStagingDirectory)/SessionRecords'
         artifactName: SessionRecords
 
-variables:
-  - template: ../variables/globals.yml
-
 stages:
 - ${{ each cloud in parameters.CloudConfig }}:
   - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'tests-weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
     - ${{ if not(contains(parameters.UnsupportedClouds, cloud.key)) }}:
       - stage: ${{ cloud.key }}
         dependsOn: []
+        variables:
+        - template: ../variables/globals.yml
         jobs:
         - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
           parameters:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -33,6 +33,12 @@ pr:
     - eng/common/
 #endif
 
+parameters:
+- name: AllowFailingLiveTests
+  displayName: Allow release with failing live tests
+  type: boolean
+  default: false
+
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
@@ -41,3 +47,8 @@ extends:
     Artifacts:
     - name: Azure.Template
       safeName: AzureTemplate
+    ReleaseDependsOnLiveTests: ${{ not(parameters.AllowFailingLiveTests) }}
+    LiveTestStages:
+      - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+        parameters:
+          ServiceDirectory: template


### PR DESCRIPTION
- Move storage test stages to shared yml
- Have ci.yml and test.yml use the same test stages
- Have sdk-client and sdk-test use the same live test stages
- Have signing and, transitively, release conditionally depend on the live test stages
- Have sdk-client pass the break glass approvers environment to release if a build run disables the "ReleaseDependsOnLiveTests" parameter
  - If ReleaseDependsOnLiveTests == true, the signing stage will depend on the live test stages and the normal approver list will apply
  - If ReleaseDependsOnLiveTests == false, the signing stage will only depend on the build stage and the break glass approver list will apply