### PR TITLE
[Event Hubs Web Jobs Extensions] Cancellation Token Adjustment

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                             // Try to acquire the semaphore. This protects the cached events.
                             if (!_cachedEventsGuard.Wait(0, linkedCts.Token))
                             {
+                                // This will throw if the cancellation token is canceled.
                                 await _cachedEventsGuard.WaitAsync(linkedCts.Token).ConfigureAwait(false);
                             }
                             acquiredSemaphore = true;
@@ -201,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                     else
                     {
                         UpdateCheckpointContext(events, context);
-                        await TriggerExecute(events, context, _cts.Token).ConfigureAwait(false);
+                        await TriggerExecute(events, context, linkedCts.Token).ConfigureAwait(false);
                         _firstFunctionExecute = false;
                         eventToCheckpoint = events.LastOrDefault();
                     }


### PR DESCRIPTION
Fixing a bug where sometimes the cancellation token in the function doesn't get signaled when it should.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
