### PR TITLE
Explicitly set SSL1.2 and SSL1.3 protocol for networking

### DIFF
--- a/eng/pipelines/templates/steps/archetype-sdk-docs.yml
+++ b/eng/pipelines/templates/steps/archetype-sdk-docs.yml
@@ -1,7 +1,7 @@
 steps:
   - pwsh: |
       Write-Host ("Before SecurityProtocl = " + [Net.ServicePointManager]::SecurityProtocol.ToString())
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls13
       Write-Host ("After SecurityProtocl = " + [Net.ServicePointManager]::SecurityProtocol.ToString())
       # Download and Extract or restore Packages required for Doc Generation
       Write-Host "Download and Extract mdoc to Build.BinariesDirectory/mdoc"

--- a/eng/pipelines/templates/steps/archetype-sdk-docs.yml
+++ b/eng/pipelines/templates/steps/archetype-sdk-docs.yml
@@ -1,5 +1,8 @@
 steps:
   - pwsh: |
+      Write-Host ("Before SecurityProtocl = " + [Net.ServicePointManager]::SecurityProtocol.ToString())
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+      Write-Host ("After SecurityProtocl = " + [Net.ServicePointManager]::SecurityProtocol.ToString())
       # Download and Extract or restore Packages required for Doc Generation
       Write-Host "Download and Extract mdoc to Build.BinariesDirectory/mdoc"
       try {


### PR DESCRIPTION
Testing whether or not explicitly setting the SSL version helps workaround the issue:
```
System.Security.Authentication.AuthenticationException: Authentication failed, see inner exception.
                  ---> System.ComponentModel.Win32Exception (0x80090304): The Local Security Authority cannot be contacted
```
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2783642&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=e2744c02-d5ab-5ec4-b597-2a76a072b500

Trying to figure out how to fix the issue outlined in https://github.com/actions/runner-images/issues/7007
