### PR TITLE
Fixed bug where a null reference exception would throw on resuming on directory transfers

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs Fixed
 - Fix to prevent empty strings or null to be passed as paths for `LocalFileStorageResource` and `LocalDirectoryStorageResourceContainer`.
 - Fixed `ErrorHandlingOptions.ContinueOnFailure` not be respected.
+- Fixed bug where resuming a transfer where the source and destination is a `StorageResourceContainer` would throw a null reference exception. 
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlanExtensions.cs
@@ -20,8 +20,6 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            baseJob.VerifyJobPartPlanHeader(header);
-
             // Apply credentials to the saved transfer job path
             StorageTransferStatus jobPartStatus = header.AtomicJobStatus;
             StreamToUriJobPart jobPart = await StreamToUriJobPart.CreateJobPartAsync(
@@ -32,6 +30,8 @@ namespace Azure.Storage.DataMovement
                 destinationResource: destinationResource,
                 partPlanFileExists: true,
                 isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+
+            jobPart.VerifyJobPartPlanHeader(header);
 
             // TODO: When enabling resume chunked upload Add each transfer to the CommitChunkHandler
             return jobPart;
@@ -46,8 +46,6 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            baseJob.VerifyJobPartPlanHeader(header);
-
             // Apply credentials to the saved transfer job path
             StorageTransferStatus jobPartStatus = header.AtomicJobStatus;
             ServiceToServiceJobPart jobPart = await ServiceToServiceJobPart.CreateJobPartAsync(
@@ -58,6 +56,8 @@ namespace Azure.Storage.DataMovement
                 destinationResource: destinationResource,
                 partPlanFileExists: true,
                 isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+
+            jobPart.VerifyJobPartPlanHeader(header);
 
             // TODO: When enabling resume chunked upload Add each transfer to the CommitChunkHandler
             return jobPart;
@@ -72,8 +72,6 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            baseJob.VerifyJobPartPlanHeader(header);
-
             // Apply credentials to the saved transfer job path
             StorageTransferStatus jobPartStatus = header.AtomicJobStatus;
             UriToStreamJobPart jobPart = await UriToStreamJobPart.CreateJobPartAsync(
@@ -84,6 +82,8 @@ namespace Azure.Storage.DataMovement
                 destinationResource: destinationResource,
                 partPlanFileExists: true,
                 isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+
+            jobPart.VerifyJobPartPlanHeader(header);
 
             // TODO: When enabling resume chunked upload Add each transfer to the CommitChunkHandler
             return jobPart;
@@ -97,8 +97,6 @@ namespace Azure.Storage.DataMovement
         {
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
-            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
@@ -115,6 +113,8 @@ namespace Azure.Storage.DataMovement
                 partPlanFileExists: true,
                 isFinalPart: header.IsFinalPart).ConfigureAwait(false);
 
+            jobPart.VerifyJobPartPlanHeader(header);
+
             // TODO: When enabling resume chunked upload Add each transfer to the CommitChunkHandler
             return jobPart;
         }
@@ -127,8 +127,6 @@ namespace Azure.Storage.DataMovement
         {
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
-            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
@@ -143,6 +141,8 @@ namespace Azure.Storage.DataMovement
                 partPlanFileExists: true,
                 isFinalPart: header.IsFinalPart).ConfigureAwait(false);
 
+            jobPart.VerifyJobPartPlanHeader(header);
+
             // TODO: When enabling resume chunked upload Add each transfer to the CommitChunkHandler
             return jobPart;
         }
@@ -155,8 +155,6 @@ namespace Azure.Storage.DataMovement
         {
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
-
-            baseJob.VerifyJobPartPlanHeader(header);
 
             // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
@@ -172,6 +170,8 @@ namespace Azure.Storage.DataMovement
                 destinationResource: destinationResource.GetChildStorageResource(childDestinationName),
                 partPlanFileExists: true,
                 isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+
+            jobPart.VerifyJobPartPlanHeader(header);
 
             // TODO: When enabling resume chunked upload Add each transfer to the CommitChunkHandler
             return jobPart;
@@ -286,22 +286,22 @@ namespace Azure.Storage.DataMovement
         /// Verifies the contents of the Job Part Plan Header with the
         /// information passed to resume the transfer.
         /// </summary>
-        /// <param name="job">The job containing the resume information.</param>
+        /// <param name="jobPart">The job partcontaining the resume information.</param>
         /// <param name="header">The header which holds the state of the job when it was stopped/paused.</param>
-        internal static void VerifyJobPartPlanHeader(this TransferJobInternal job, JobPartPlanHeader header)
+        internal static void VerifyJobPartPlanHeader(this JobPartInternal jobPart, JobPartPlanHeader header)
         {
             // Check source path
             string passedSourcePath;
-            if (job._sourceResource.CanProduceUri == ProduceUriType.ProducesUri)
+            if (jobPart._sourceResource.CanProduceUri == ProduceUriType.ProducesUri)
             {
                 // Remove any query or SAS that could be attach to the Uri
-                UriBuilder uriBuilder = new UriBuilder(job._sourceResource.Uri.AbsoluteUri);
+                UriBuilder uriBuilder = new UriBuilder(jobPart._sourceResource.Uri.AbsoluteUri);
                 uriBuilder.Query = "";
                 passedSourcePath = uriBuilder.Uri.AbsoluteUri;
             }
             else
             {
-                passedSourcePath = job._sourceResource.Path;
+                passedSourcePath = jobPart._sourceResource.Path;
             }
             // We only check if it starts with the path because if we're passed a container
             // then we only need to check if the prefix matches
@@ -312,16 +312,16 @@ namespace Azure.Storage.DataMovement
 
             // Check destinationPath
             string passedDestinationPath;
-            if (job._destinationResource.CanProduceUri == ProduceUriType.ProducesUri)
+            if (jobPart._destinationResource.CanProduceUri == ProduceUriType.ProducesUri)
             {
                 // Remove any query or SAS that could be attach to the Uri
-                UriBuilder uriBuilder = new UriBuilder(job._destinationResource.Uri.AbsoluteUri);
+                UriBuilder uriBuilder = new UriBuilder(jobPart._destinationResource.Uri.AbsoluteUri);
                 uriBuilder.Query = "";
                 passedDestinationPath = uriBuilder.Uri.AbsoluteUri;
             }
             else
             {
-                passedDestinationPath = job._destinationResource.Path;
+                passedDestinationPath = jobPart._destinationResource.Path;
             }
             // We only check if it starts with the path because if we're passed a container
             // then we only need to check if the prefix matches
@@ -331,10 +331,10 @@ namespace Azure.Storage.DataMovement
             }
 
             // Check CreateMode / Overwrite
-            if ((header.ForceWrite && job._createMode != StorageResourceCreateMode.Overwrite) ||
-                (!header.ForceWrite && job._createMode == StorageResourceCreateMode.Overwrite))
+            if ((header.ForceWrite && jobPart._createMode != StorageResourceCreateMode.Overwrite) ||
+                (!header.ForceWrite && jobPart._createMode == StorageResourceCreateMode.Overwrite))
             {
-                throw Errors.MismatchResumeCreateMode(header.ForceWrite, job._createMode);
+                throw Errors.MismatchResumeCreateMode(header.ForceWrite, jobPart._createMode);
             }
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -225,7 +225,7 @@ namespace Azure.Storage.DataMovement.Tests
             return await manager.StartTransferAsync(sourceResource, destinationResource, transferOptions);
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -274,7 +274,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(File.Exists(fileName.FullPath));
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -339,7 +339,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.CatchAsync(async () => await transferManager.PauseTransferIfRunningAsync("bad transfer Id"));
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -393,7 +393,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(File.Exists(fileName.FullPath));
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -608,7 +608,7 @@ namespace Azure.Storage.DataMovement.Tests
             return await manager.StartTransferAsync(sourceResource, destinationResource, transferOptions);
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -654,7 +654,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -700,7 +700,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -752,7 +752,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -225,7 +225,7 @@ namespace Azure.Storage.DataMovement.Tests
             return await manager.StartTransferAsync(sourceResource, destinationResource, transferOptions);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -274,7 +274,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(File.Exists(fileName.FullPath));
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -339,7 +339,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.CatchAsync(async () => await transferManager.PauseTransferIfRunningAsync("bad transfer Id"));
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -393,7 +393,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(File.Exists(fileName.FullPath));
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -608,7 +608,7 @@ namespace Azure.Storage.DataMovement.Tests
             return await manager.StartTransferAsync(sourceResource, destinationResource, transferOptions);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -654,7 +654,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -700,7 +700,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]
@@ -752,7 +752,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferType.Upload)]
         [TestCase(TransferType.Download)]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TestEventsRaised.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TestEventsRaised.cs
@@ -232,7 +232,6 @@ namespace Azure.Storage.DataMovement.Tests
         {
             AssertUnexpectedFailureCheck();
             Assert.IsEmpty(SkippedEvents);
-            Assert.IsEmpty(SingleCompletedEvents);
             /* TODO: Reenable check:  https://github.com/Azure/azure-sdk-for-net/issues/35976
             Assert.AreEqual(3, StatusEvents.Count);
             Assert.AreEqual(StorageTransferStatus.InProgress, StatusEvents.First().StorageTransferStatus);


### PR DESCRIPTION
Fixed bug where a null reference exception would throw on resuming on `StorageResourceContainer` transfers

