### PR TITLE
Add `db.name` to custom properties

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -17,6 +17,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
         public RemoteDependencyData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor) : base(version)
         {
+            Properties = new ChangeTrackingDictionary<string, string>();
+            Measurements = new ChangeTrackingDictionary<string, double>();
+
             string? httpUrl = null;
             string dependencyName;
 
@@ -90,9 +93,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 Type = "InProc";
             }
-
-            Properties = new ChangeTrackingDictionary<string, string>();
-            Measurements = new ChangeTrackingDictionary<string, double>();
 
             TraceHelper.AddActivityLinksToProperties(activity, ref activityTagsProcessor.UnMappedTags);
             TraceHelper.AddPropertiesToTelemetry(Properties, ref activityTagsProcessor.UnMappedTags);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -52,6 +52,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     Data = depDataAndType[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
                     Target = activityTagsProcessor.MappedTags.GetDbDependencyTarget().Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
                     Type = s_sqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
+
+                    // special case for db.name
+                    Properties.Add(SemanticConventions.AttributeDbName, AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbName)?.ToString().Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
                     break;
                 case OperationType.Rpc:
                     var depInfo = AzMonList.GetTagValues(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeRpcService, SemanticConventions.AttributeRpcSystem, SemanticConventions.AttributeRpcStatus);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -53,16 +53,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 case OperationType.Db:
                     var depDataAndType = AzMonList.GetTagValues(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbStatement, SemanticConventions.AttributeDbSystem);
                     Data = depDataAndType[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
-                    activityTagsProcessor.MappedTags.GetDbDependencyTargetAndName(out var dbTarget, out var dbName);
-                    Target = dbTarget.Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
-                    Type = s_sqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
+                    var dbNameAndTarget = activityTagsProcessor.MappedTags.GetDbDependencyTargetAndName();
+                    Target = dbNameAndTarget.DbTarget.Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
 
                     // special case for db.name
-                    var sanitizedDbName = dbName.Truncate(SchemaConstants.KVP_MaxValueLength);
-                    if (dbName != null)
+                    var sanitizedDbName = dbNameAndTarget.DbName.Truncate(SchemaConstants.KVP_MaxValueLength);
+                    if (sanitizedDbName != null)
                     {
-                        Properties.Add(SemanticConventions.AttributeDbName, dbName);
+                        Properties.Add(SemanticConventions.AttributeDbName, sanitizedDbName);
                     }
+                    Type = s_sqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
                     break;
                 case OperationType.Rpc:
                     var depInfo = AzMonList.GetTagValues(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeRpcService, SemanticConventions.AttributeRpcSystem, SemanticConventions.AttributeRpcStatus);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -53,11 +53,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 case OperationType.Db:
                     var depDataAndType = AzMonList.GetTagValues(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbStatement, SemanticConventions.AttributeDbSystem);
                     Data = depDataAndType[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
-                    Target = activityTagsProcessor.MappedTags.GetDbDependencyTarget().Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
+                    activityTagsProcessor.MappedTags.GetDbDependencyTargetAndName(out var dbTarget, out var dbName);
+                    Target = dbTarget.Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
                     Type = s_sqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
 
                     // special case for db.name
-                    var dbName = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbName)?.ToString().Truncate(SchemaConstants.KVP_MaxValueLength);
+                    var sanitizedDbName = dbName.Truncate(SchemaConstants.KVP_MaxValueLength);
                     if (dbName != null)
                     {
                         Properties.Add(SemanticConventions.AttributeDbName, dbName);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -54,7 +54,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                     Type = s_sqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
 
                     // special case for db.name
-                    Properties.Add(SemanticConventions.AttributeDbName, AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbName)?.ToString().Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
+                    var dbName = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeDbName)?.ToString().Truncate(SchemaConstants.KVP_MaxValueLength);
+                    if (dbName != null)
+                    {
+                        Properties.Add(SemanticConventions.AttributeDbName, dbName);
+                    }
                     break;
                 case OperationType.Rpc:
                     var depInfo = AzMonList.GetTagValues(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeRpcService, SemanticConventions.AttributeRpcSystem, SemanticConventions.AttributeRpcStatus);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -287,9 +287,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         }
 
         ///<summary>
-        /// Gets Database dependency target from activity tag objects.
+        /// Gets Database dependency target and name from activity tag objects.
         ///</summary>
-        internal static string? GetDbDependencyTarget(this AzMonList tagObjects)
+        internal static void GetDbDependencyTargetAndName(this AzMonList tagObjects, out string? dbTarget, out string? dbName)
         {
             string? target = null;
             string defaultPort = GetDefaultDbPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString());
@@ -303,7 +303,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 target = tagObjects.GetTargetUsingNetPeerAttributes(defaultPort);
             }
 
-            string? dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
+            dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
             bool isTargetEmpty = string.IsNullOrWhiteSpace(target);
             bool isDbNameEmpty = string.IsNullOrWhiteSpace(dbName);
             if (!isTargetEmpty && !isDbNameEmpty)
@@ -319,7 +319,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 target = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString();
             }
 
-            return target;
+            dbTarget = target;
         }
 
         ///<summary>
@@ -332,7 +332,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 case OperationType.Http:
                     return tagObjects.GetHttpDependencyTarget();
                 case OperationType.Db:
-                    return tagObjects.GetDbDependencyTarget();
+                    tagObjects.GetDbDependencyTargetAndName(out var target, out _);
+                    return target;
                 default:
                     return null;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -289,7 +289,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ///<summary>
         /// Gets Database dependency target and name from activity tag objects.
         ///</summary>
-        internal static void GetDbDependencyTargetAndName(this AzMonList tagObjects, out string? dbTarget, out string? dbName)
+        internal static (string? DbName, string? DbTarget) GetDbDependencyTargetAndName(this AzMonList tagObjects)
         {
             string? target = null;
             string defaultPort = GetDefaultDbPort(AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString());
@@ -303,7 +303,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 target = tagObjects.GetTargetUsingNetPeerAttributes(defaultPort);
             }
 
-            dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
+            var dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
             bool isTargetEmpty = string.IsNullOrWhiteSpace(target);
             bool isDbNameEmpty = string.IsNullOrWhiteSpace(dbName);
             if (!isTargetEmpty && !isDbNameEmpty)
@@ -319,7 +319,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 target = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString();
             }
 
-            dbTarget = target;
+            return (DbName: dbName, DbTarget: target);
         }
 
         ///<summary>
@@ -332,8 +332,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 case OperationType.Http:
                     return tagObjects.GetHttpDependencyTarget();
                 case OperationType.Db:
-                    tagObjects.GetDbDependencyTargetAndName(out var target, out _);
-                    return target;
+                    return tagObjects.GetDbDependencyTargetAndName().DbTarget;
                 default:
                     return null;
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
@@ -574,7 +574,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 hostName = $"{netPeerIp}:{netPeerPort}";
             }
             string expectedTarget = $"{hostName} | DbName";
-            string? target = mappedTags.GetDbDependencyTarget();
+            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
             Assert.Equal(expectedTarget, target);
         }
 
@@ -583,7 +583,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var mappedTags = AzMonList.Initialize();
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
-            string? target = mappedTags.GetDbDependencyTarget();
+            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
             Assert.Equal("DbName", target);
         }
 
@@ -592,7 +592,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var mappedTags = AzMonList.Initialize();
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "DbSystem"));
-            string? target = mappedTags.GetDbDependencyTarget();
+            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
             Assert.Equal("DbSystem", target);
         }
 
@@ -600,7 +600,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         public void DbDependencyTargetIsSetToNullByDefault()
         {
             var mappedTags = AzMonList.Initialize();
-            string? target = mappedTags.GetDbDependencyTarget();
+            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
             Assert.Null(target);
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzMonListExtensionsTests.cs
@@ -574,8 +574,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 hostName = $"{netPeerIp}:{netPeerPort}";
             }
             string expectedTarget = $"{hostName} | DbName";
-            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
-            Assert.Equal(expectedTarget, target);
+            Assert.Equal(expectedTarget, mappedTags.GetDbDependencyTargetAndName().DbTarget);
         }
 
         [Fact]
@@ -583,8 +582,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var mappedTags = AzMonList.Initialize();
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbName, "DbName"));
-            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
-            Assert.Equal("DbName", target);
+            Assert.Equal("DbName", mappedTags.GetDbDependencyTargetAndName().DbTarget);
         }
 
         [Fact]
@@ -592,16 +590,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             var mappedTags = AzMonList.Initialize();
             AzMonList.Add(ref mappedTags, new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "DbSystem"));
-            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
-            Assert.Equal("DbSystem", target);
+            Assert.Equal("DbSystem", mappedTags.GetDbDependencyTargetAndName().DbTarget);
         }
 
         [Fact]
         public void DbDependencyTargetIsSetToNullByDefault()
         {
             var mappedTags = AzMonList.Initialize();
-            mappedTags.GetDbDependencyTargetAndName(out var target, out _);
-            Assert.Null(target);
+            Assert.Null(mappedTags.GetDbDependencyTargetAndName().DbTarget);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -134,6 +135,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             activity.Stop();
 
             activity.SetStatus(Status.Ok);
+            activity.SetTag(SemanticConventions.AttributeDbName, "mysqlserver");
             activity.SetTag(SemanticConventions.AttributeDbSystem, "mssql");
             activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via peer.service. all possible combinations are covered in AzMonListExtensionsTests.
             activity.SetTag(SemanticConventions.AttributeDbStatement, "Select * from table");
@@ -145,10 +147,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal(ActivityName, remoteDependencyData.Name);
             Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
             Assert.Equal("Select * from table", remoteDependencyData.Data);
+            Assert.Equal("localhost | mysqlserver", remoteDependencyData.Target);
             Assert.Null(remoteDependencyData.ResultCode);
             Assert.Equal(activity.Duration.ToString("c", CultureInfo.InvariantCulture), remoteDependencyData.Duration);
             Assert.Equal(activity.GetStatus() != Status.Error, remoteDependencyData.Success);
-            Assert.True(remoteDependencyData.Properties.Count == 0);
+            Assert.True(remoteDependencyData.Properties.Count == 1);
+            Assert.True(remoteDependencyData.Properties.Contains(new KeyValuePair<string, string>(SemanticConventions.AttributeDbName, "msqlserver" )));
             Assert.True(remoteDependencyData.Measurements.Count == 0);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -152,7 +152,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal(activity.Duration.ToString("c", CultureInfo.InvariantCulture), remoteDependencyData.Duration);
             Assert.Equal(activity.GetStatus() != Status.Error, remoteDependencyData.Success);
             Assert.True(remoteDependencyData.Properties.Count == 1);
-            Assert.True(remoteDependencyData.Properties.Contains(new KeyValuePair<string, string>(SemanticConventions.AttributeDbName, "msqlserver" )));
+            Assert.True(remoteDependencyData.Properties.Contains(new KeyValuePair<string, string>(SemanticConventions.AttributeDbName, "mysqlserver" )));
             Assert.True(remoteDependencyData.Measurements.Count == 0);
         }
 


### PR DESCRIPTION
This is to allow querying based on `db.name` property. It will continue to be part of `Target` field on RemoteDependency