### PR TITLE
Set type to Queue Message in case of Activity.Kind = Producer

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -72,6 +72,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 {
                     Type = $"InProc | {activityTagsProcessor.MappedTags.GetAzNameSpace()}";
                 }
+                else if (activity.Kind == ActivityKind.Producer)
+                {
+                    Type = $"Queue Message | {activityTagsProcessor.MappedTags.GetAzNameSpace()}";
+                }
                 else
                 {
                     // The Azure SDK sets az.namespace with its resource provider information.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -86,7 +86,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
 
             Assert.True(activityTagsProcessor.HasAzureNamespace);
-            Assert.Equal(activity.Kind == ActivityKind.Internal ? "InProc | DemoAzureResource" : "DemoAzureResource", remoteDependencyData.Type);
+            if (activity.Kind == ActivityKind.Internal)
+            {
+                Assert.Equal("InProc | DemoAzureResource", remoteDependencyData.Type);
+            }
+            else if (activity.Kind == ActivityKind.Producer)
+            {
+                Assert.Equal("Queue Message | DemoAzureResource", remoteDependencyData.Type);
+            }
+            else
+            {
+                Assert.Equal("DemoAzureResource", remoteDependencyData.Type);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Queue Message | is required for UI to detect the remote dependency as Queue Message.

Note: this change only covers azure sdks for now. The generalized case will be "Queue Message | `messaging.destination`" (to be handled in separate PR)