### PR TITLE
Add back RequestContent.Create() overload for DynamicData

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -538,6 +538,7 @@ namespace Azure.Core
     public abstract partial class RequestContent : System.IDisposable
     {
         protected RequestContent() { }
+        public static Azure.Core.RequestContent Create(Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
@@ -547,6 +548,7 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
         public abstract void Dispose();
+        public static implicit operator Azure.Core.RequestContent (Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
         public abstract bool TryComputeLength(out long length);

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -538,6 +538,7 @@ namespace Azure.Core
     public abstract partial class RequestContent : System.IDisposable
     {
         protected RequestContent() { }
+        public static Azure.Core.RequestContent Create(Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
@@ -547,6 +548,7 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
         public abstract void Dispose();
+        public static implicit operator Azure.Core.RequestContent (Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
         public abstract bool TryComputeLength(out long length);

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -538,6 +538,7 @@ namespace Azure.Core
     public abstract partial class RequestContent : System.IDisposable
     {
         protected RequestContent() { }
+        public static Azure.Core.RequestContent Create(Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
@@ -547,6 +548,7 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
         public abstract void Dispose();
+        public static implicit operator Azure.Core.RequestContent (Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
         public abstract bool TryComputeLength(out long length);

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -538,6 +538,7 @@ namespace Azure.Core
     public abstract partial class RequestContent : System.IDisposable
     {
         protected RequestContent() { }
+        public static Azure.Core.RequestContent Create(Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
@@ -547,6 +548,7 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
         public abstract void Dispose();
+        public static implicit operator Azure.Core.RequestContent (Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
         public abstract bool TryComputeLength(out long length);

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -538,6 +538,7 @@ namespace Azure.Core
     public abstract partial class RequestContent : System.IDisposable
     {
         protected RequestContent() { }
+        public static Azure.Core.RequestContent Create(Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
         public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
@@ -547,6 +548,7 @@ namespace Azure.Core
         public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
         public static Azure.Core.RequestContent Create(string content) { throw null; }
         public abstract void Dispose();
+        public static implicit operator Azure.Core.RequestContent (Azure.Core.Dynamic.DynamicData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
         public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
         public abstract bool TryComputeLength(out long length);

--- a/sdk/core/Azure.Core/samples/DynamicContent.md
+++ b/sdk/core/Azure.Core/samples/DynamicContent.md
@@ -41,7 +41,7 @@ JSON members can be set on the dynamic object.
 Response response = client.GetWidget();
 dynamic widget = response.Content.ToDynamicFromJson(DynamicCaseMapping.PascalToCamel);
 widget.Name = "New Name";
-client.SetWidget(RequestContent.Create((object)widget));
+client.SetWidget(RequestContent.Create(widget));
 ```
 
 ### Get or set array values
@@ -170,7 +170,7 @@ To make this common case easier to implement, Dynamic JSON is mutable.  This all
 Response response = client.GetWidget();
 dynamic widget = response.Content.ToDynamicFromJson(DynamicCaseMapping.PascalToCamel);
 widget.Name = "New Name";
-client.SetWidget(RequestContent.Create((object)widget));
+client.SetWidget(RequestContent.Create(widget));
 ```
 
 Note: The implementation of Azure.Core's dynamic JSON is optimized for round-trip scenarios.  Given the performance goals of its design, using it to author large JSON payloads from scratch is not recommended.

--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Buffers;
+using Azure.Core.Dynamic;
 using Azure.Core.Serialization;
 
 namespace Azure.Core
@@ -72,6 +73,13 @@ namespace Azure.Core
         public static RequestContent Create(BinaryData content) => new MemoryContent(content.ToMemory());
 
         /// <summary>
+        /// Creates an instance of <see cref="RequestContent"/> that wraps a <see cref="DynamicData"/>.
+        /// </summary>
+        /// <param name="content">The <see cref="DynamicData"/> to use.</param>
+        /// <returns>An instance of <see cref="RequestContent"/> that wraps a <see cref="DynamicData"/>.</returns>
+        public static RequestContent Create(DynamicData content) => new DynamicDataContent(content);
+
+        /// <summary>
         /// Creates an instance of <see cref="RequestContent"/> that wraps a serialized version of an object.
         /// </summary>
         /// <param name="serializable">The <see cref="object"/> to serialize.</param>
@@ -90,6 +98,12 @@ namespace Azure.Core
         /// </summary>
         /// <param name="content">The <see cref="BinaryData"/> to use.</param>
         public static implicit operator RequestContent(BinaryData content) => Create(content);
+
+        /// <summary>
+        /// Creates a RequestContent that wraps a <see cref="DynamicData"/>.
+        /// </summary>
+        /// <param name="content">The <see cref="DynamicData"/> to use.</param>
+        public static implicit operator RequestContent(DynamicData content) => Create(content);
 
         /// <summary>
         /// Writes contents of this object to an instance of <see cref="Stream"/>.
@@ -267,6 +281,35 @@ namespace Azure.Core
             public override async Task WriteToAsync(Stream stream, CancellationToken cancellation)
             {
                 await stream.WriteAsync(_bytes, cancellation).ConfigureAwait(false);
+            }
+        }
+
+        private sealed class DynamicDataContent : RequestContent
+        {
+            private readonly DynamicData _data;
+
+            public DynamicDataContent(DynamicData data) => _data = data;
+
+            public override void Dispose()
+            {
+                _data.Dispose();
+            }
+
+            public override void WriteTo(Stream stream, CancellationToken cancellation)
+            {
+                _data.WriteTo(stream);
+            }
+
+            public override bool TryComputeLength(out long length)
+            {
+                length = default;
+                return false;
+            }
+
+            public override Task WriteToAsync(Stream stream, CancellationToken cancellation)
+            {
+                _data.WriteTo(stream);
+                return Task.CompletedTask;
             }
         }
     }

--- a/sdk/core/Azure.Core/tests/samples/DynamicJsonSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/DynamicJsonSamples.cs
@@ -60,7 +60,7 @@ namespace Azure.Core.Samples
             Response response = client.GetWidget();
             dynamic widget = response.Content.ToDynamicFromJson(DynamicCaseMapping.PascalToCamel);
             widget.Name = "New Name";
-            client.SetWidget(RequestContent.Create((object)widget));
+            client.SetWidget(RequestContent.Create(widget));
             #endregion
 
             Assert.IsTrue(widget.Name == "New Name");
@@ -225,7 +225,7 @@ namespace Azure.Core.Samples
             Response response = client.GetWidget();
             dynamic widget = response.Content.ToDynamicFromJson(DynamicCaseMapping.PascalToCamel);
             widget.Name = "New Name";
-            client.SetWidget(RequestContent.Create((object)widget));
+            client.SetWidget(RequestContent.Create(widget));
             #endregion
         }
 


### PR DESCRIPTION
This was previously discussed in https://github.com/Azure/azure-sdk-for-net/pull/35852