### PR TITLE
Switch to pulling doc tools from storage instead of github

### DIFF
--- a/eng/pipelines/templates/steps/archetype-sdk-docs.yml
+++ b/eng/pipelines/templates/steps/archetype-sdk-docs.yml
@@ -3,7 +3,9 @@ steps:
       # Download and Extract or restore Packages required for Doc Generation
       Write-Host "Download and Extract mdoc to Build.BinariesDirectory/mdoc"
       try {
-        Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://github.com/mono/api-doc-tools/releases/download/mdoc-5.7.4.9/mdoc-5.7.4.9.zip" `
+        # Currently having issues downloading from github on windows 2022 so moved to a blob account
+        # https://github.com/mono/api-doc-tools/releases/download/mdoc-5.7.4.9/mdoc-5.7.4.9.zip
+        Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://azuresdkdocs.blob.core.windows.net/tools/mdoc/5.7.4.9/mdoc-5.7.4.9.zip" `
           -OutFile "mdoc.zip" | Wait-Process; Expand-Archive -Path "mdoc.zip" -DestinationPath "./mdoc/"
       } catch {
         $_.Exception | Format-List | Out-Host
@@ -12,7 +14,9 @@ steps:
 
       Write-Host "Download and Extract docfx to Build.BinariesDirectory/docfx"
       try {
-        Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://github.com/dotnet/docfx/releases/download/$(DocFxVersion)/docfx.zip" `
+        # Currently having issues downloading from github on windows 2022 so moved to a blob account
+        # https://github.com/dotnet/docfx/releases/download/$(DocFxVersion)/docfx.zip
+        Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://azuresdkdocs.blob.core.windows.net/tools/docfx/$(DocFxVersion)/docfx.zip" `
         -OutFile "docfx.zip" | Wait-Process; Expand-Archive -Path "docfx.zip" -DestinationPath "./docfx/"
       } catch {
         $_.Exception | Format-List | Out-Host


### PR DESCRIPTION
Currently have trouble downloading tools from github directly (see https://github.com/actions/runner-images/issues/7007) so moved the files we need to a storage account instead. 