### PR TITLE
[AzureMonitorExporter] remove _OTELRESOURCE_ from Logs and Metrics

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -42,10 +42,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey);
                 if (telemetryItems.Count > 0)
                 {
-                    if (LogResource?.MetricTelemetry != null)
-                    {
-                        telemetryItems.Add(LogResource.MetricTelemetry);
-                    }
                     exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
                 }
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -46,10 +46,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, MetricResource, _instrumentationKey);
                     if (telemetryItems.Count > 0)
                     {
-                        if (MetricResource?.MetricTelemetry != null)
-                        {
-                            telemetryItems.Add(MetricResource.MetricTelemetry);
-                        }
                         exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
                     }
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -259,7 +259,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             // ASSERT
             metricReader.Collect();
-            Assert.True(telemetryItems.Count == 2);
+            Assert.True(telemetryItems.Count == 1);
             var telemetryItem = telemetryItems.Last()!;
             this.telemetryOutput.Write(telemetryItem);
             TelemetryItemValidationHelper.AssertMetricTelemetry(
@@ -274,7 +274,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             { }
 
             metricReader.Collect();
-            Assert.True(telemetryItems.Count == 2);
+            Assert.True(telemetryItems.Count == 1);
             telemetryItem = telemetryItems.Last()!;
             this.telemetryOutput.Write(telemetryItem!);
             TelemetryItemValidationHelper.AssertMetricTelemetry(

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             meterProvider?.ForceFlush();
 
             // Standard Metrics + Resource Metrics.
-            Assert.Equal(2, metricTelemetryItems.Count);
+            Assert.Single(metricTelemetryItems);
 
             var metricTelemetry = metricTelemetryItems.Last()!;
             Assert.Equal("MetricData", metricTelemetry.Data.BaseType);
@@ -105,7 +105,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             meterProvider?.ForceFlush();
 
             // Standard Metrics + Resource Metrics.
-            Assert.Equal(2, metricTelemetryItems.Count);
+            Assert.Single(metricTelemetryItems);
 
             var metricTelemetry = metricTelemetryItems.Last()!;
             Assert.Equal("MetricData", metricTelemetry.Data.BaseType);


### PR DESCRIPTION
Follow up to #36063

Due to a spec change, we're removing _OTELRESOURCE_ from Logs and Metrics.

### Changes
- remove `_OTELRESOURCE_` from Logs and Metrics.