### PR TITLE
Communication Resource | API Version Update 

### DIFF
--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -45,7 +45,7 @@
   "resources": [
       {
           "type": "Microsoft.Communication/CommunicationServices",
-          "apiVersion": "2021-10-01-preview",
+          "apiVersion": "2023-03-31",
           "name": "[variables('uniqueSubDomainName')]",
           "location": "global",
           "properties": {
@@ -78,7 +78,7 @@
       },
       "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
           "type": "string",
-          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
+          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
       },
       "RESOURCE_GROUP_NAME": {
           "type": "string",

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -45,7 +45,7 @@
   "resources": [
       {
           "type": "Microsoft.Communication/CommunicationServices",
-          "apiVersion": "2023-03-31",
+          "apiVersion": "2021-10-01-preview",
           "name": "[variables('uniqueSubDomainName')]",
           "location": "global",
           "properties": {
@@ -78,7 +78,7 @@
       },
       "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
           "type": "string",
-          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
+          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
       },
       "RESOURCE_GROUP_NAME": {
           "type": "string",

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -78,7 +78,7 @@
       },
       "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
           "type": "string",
-          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
+          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
       },
       "RESOURCE_GROUP_NAME": {
           "type": "string",

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -78,7 +78,7 @@
       },
       "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
           "type": "string",
-          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
+          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
       },
       "RESOURCE_GROUP_NAME": {
           "type": "string",

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -45,7 +45,7 @@
   "resources": [
       {
           "type": "Microsoft.Communication/CommunicationServices",
-          "apiVersion": "2020-08-20-preview",
+          "apiVersion": "2023-03-31",
           "name": "[variables('uniqueSubDomainName')]",
           "location": "global",
           "properties": {
@@ -78,7 +78,7 @@
       },
       "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
           "type": "string",
-          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
+          "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
       },
       "RESOURCE_GROUP_NAME": {
           "type": "string",


### PR DESCRIPTION
Live test pipelines are failing due to the failure of deployment test resources in INT environment for all the modalities across all the platforms since the Communication Services API version : 2020-08-20-preview is obsolete, which was recently removed from support.
Updating API version to 2023-03-31.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
