### PR TITLE
[OpenAI] Fix Embedding Options Description

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/EmbeddingsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/EmbeddingsOptions.cs
@@ -16,8 +16,7 @@ namespace Azure.AI.OpenAI
         /// <summary> Initializes a new instance of EmbeddingsOptions. </summary>
         /// <param name="input">
         /// Input text to get embeddings for, encoded as a string.
-        /// To get embeddings for multiple inputs in a single request, pass an array of strings.
-        /// Each input must not exceed 2048 tokens in length.
+        /// The number of input tokens varies depending on the model you are using.
         /// 
         /// Unless you are embedding code, we suggest replacing newlines (\n) in your input with a single space,
         /// as we have observed inferior results when newlines are present.
@@ -36,8 +35,7 @@ namespace Azure.AI.OpenAI
         /// <param name="nonAzureModel"> ID of the model to use. </param>
         /// <param name="input">
         /// Input text to get embeddings for, encoded as a string.
-        /// To get embeddings for multiple inputs in a single request, pass an array of strings.
-        /// Each input must not exceed 2048 tokens in length.
+        /// The number of input tokens varies depending on the model you are using.
         /// 
         /// Unless you are embedding code, we suggest replacing newlines (\n) in your input with a single space,
         /// as we have observed inferior results when newlines are present.
@@ -56,8 +54,7 @@ namespace Azure.AI.OpenAI
         public string InputType { get; set; }
         /// <summary>
         /// Input text to get embeddings for, encoded as a string.
-        /// To get embeddings for multiple inputs in a single request, pass an array of strings.
-        /// Each input must not exceed 2048 tokens in length.
+        /// The number of input tokens varies depending on the model you are using.
         /// 
         /// Unless you are embedding code, we suggest replacing newlines (\n) in your input with a single space,
         /// as we have observed inferior results when newlines are present.


### PR DESCRIPTION
The reference docs for the [`EmbeddingsOptions`](https://learn.microsoft.com/en-us/dotnet/api/azure.ai.openai.embeddingsoptions?view=azure-dotnet-preview) class suggest it is possible to send in multiple inputs but the underlying REST API doesn't support this as mentioned [here](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#embeddings).

This PR updates the description accordingly.

resolves #36441