### PR TITLE
[Validation] Fixing broken links

### DIFF
--- a/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
+++ b/doc/DataPlaneCodeGeneration/AzureSDKCodeGeneration_DataPlane_Quickstart.md
@@ -18,7 +18,7 @@ We will generate an SDK under the SDK project folder of `azure-sdk-for-net`.
 
 You can update `tsp-location.yaml` under sdk project folder to set the typespec project.
 
-You can refer to the [tsp-location.yaml](https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/Typespec-Project-Scripts.md#tsp-locationyaml) which describes the supported properties in the file.
+You can refer to the [tsp-location.yaml](https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/TypeSpec-Project-Scripts.md#tsp-locationyaml) which describes the supported properties in the file.
 
 ### Generate Code
 
@@ -39,14 +39,14 @@ Code review happens on 2 places.
 
 One is the usual GitHub pull request, for developers.
 
-Another is the [apiview](https://apiview.dev/), for architects. GitHub pull request (PR) should automatically trigger the apiview. If this does not happen, please help to file an issue in [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) to report the failure. 
+Another is the [apiview](https://apiview.dev/), for architects. GitHub pull request (PR) should automatically trigger the apiview. If this does not happen, please help to file an issue in [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) to report the failure.
 And you can upload one manually:
 
  - Build the SDK, Run `dotnet pack` to create SDK package.
  - Login apiview with GitHub account.
  - Click "Create + review" at bottom-right corner.
  - "Browse" and upload .nupkg (e.g. /home/azure-sdk-for-net/artifacts/package/Debug/Azure.AI.AnomalyDetector/Azure.AI.AnomalyDetector.3.0.0-alpha.20230331.1.nupkg), and comment the result apiview link in the PR.
-  
+
 **Comment @Azure/dpg-devs for awareness in PR to loop in SDK developers for review.**
 
 ## Package Release

--- a/doc/DataPlaneCodeGeneration/AzureSDKGeneration_Prerequistites.md
+++ b/doc/DataPlaneCodeGeneration/AzureSDKGeneration_Prerequistites.md
@@ -12,7 +12,7 @@
 
 ## Set up TypeSpec project
 
-Make sure you have typespec project in API specification repo, e.g. [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs) repo or you can follow [TypeSpec Getting Started](https://github.com/microsoft/typespec/#using-node--npm) to initialize your typespec project, and refer to [TypeSpec Structure Guidelines](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/cadl-structure-guidelines.md) to configure your typespec project.
+Make sure you have typespec project in API specification repo, e.g. [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs) repo or you can follow [TypeSpec Getting Started](https://github.com/microsoft/typespec/#using-node--npm) to initialize your typespec project, and refer to [TypeSpec Structure Guidelines](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/typespec-structure-guidelines.md) to configure your typespec project.
 
 ## Set up SDK Project Folder
 

--- a/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/README.md
+++ b/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/README.md
@@ -1,6 +1,6 @@
-# Deprecated. Azure Video Analyzer Edge client library for .NET
+# **_(Retired)_**. Azure Video Analyzer Edge client library for .NET
 
-Deprecated. We’re retiring the Azure Video Analyzer preview service, you're advised to transition your applications off of Video Analyzer by 01 December 2022. This SDK is not longer maintained.
+The Azure Video Analyzer preview service has been retired as of December, 2022.  This SDK is no longer supported or maintained.
 
 Azure Video Analyzer is an [Azure Applied AI Service][applied-ai-service] that provides a platform for you to build intelligent video applications that can span both edge and cloud infrastructures. The platform offers the capability to capture, record, and analyze live video along with publishing the results, video and video analytics, to Azure services at the edge or in the cloud. It is designed to be an extensible platform, enabling you to connect different video inferencing edge modules such as Cognitive services modules, or custom inferencing modules that have been trained with your own data using either open-source machine learning or [Azure Machine Learning][machine-learning].
 
@@ -9,7 +9,7 @@ Use the client library for Video Analyzer Edge to:
 -   Simplify interactions with the [Microsoft Azure IoT SDKs](https://github.com/azure/azure-iot-sdks)
 -   Programmatically construct pipeline topologies and live pipelines
 
-[Product documentation][doc_product] | [Direct methods][doc_direct_methods] | [Pipelines][doc_pipelines] | [Source code][source] | [Samples][samples]
+[Product documentation][doc_product] | [Source code][source] | [Samples][samples]
 
 ## Getting started
 
@@ -59,7 +59,7 @@ Please visit the [Examples](#examples) for starter code.
 
 ### Pipeline topology vs live pipeline
 
-A _pipeline topology_ is a blueprint or template for instantiating live pipelines. It defines the parameters of the pipeline using placeholders as values for them. A _live pipeline_ references a pipeline topology and specifies the parameters. This way you are able to have multiple live pipelines referencing the same topology but with different values for parameters. For more information please visit [pipeline topologies and live pipelines][doc_pipelines].
+A _pipeline topology_ is a blueprint or template for instantiating live pipelines. It defines the parameters of the pipeline using placeholders as values for them. A _live pipeline_ references a pipeline topology and specifies the parameters. This way you are able to have multiple live pipelines referencing the same topology but with different values for parameters.
 
 ### CloudToDeviceMethod
 
@@ -222,8 +222,6 @@ additional questions or comments.
 [package]: https://aka.ms/ava/sdk/client/net
 [source]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/src
 [samples]: https://go.microsoft.com/fwlink/?linkid=2162276
-[doc_direct_methods]: https://docs.microsoft.com/azure/azure-video-analyzer/video-analyzer-docs/direct-methods
-[doc_pipelines]: https://docs.microsoft.com/azure/azure-video-analyzer/video-analyzer-docs/pipeline
 [doc_product]: https://docs.microsoft.com/azure/azure-video-analyzer/video-analyzer-docs/
 [iot-device-sdk]: https://www.nuget.org/packages/Microsoft.Azure.Devices.Client/
 [iot-hub-sdk]: https://www.nuget.org/packages/Microsoft.Azure.Devices/

--- a/sdk/videoanalyzer/Microsoft.Azure.Management.VideoAnalyzer/CHANGELOG.md
+++ b/sdk/videoanalyzer/Microsoft.Azure.Management.VideoAnalyzer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Changes in 1.0.0-beta.3
 
-We're retiring the Azure Video Analyzer preview service, you're advised to transition your applications off of Video Analyzer by 01 December 2022. This SDK is no longer maintained and won’t work after the service is retired. To learn how to transition off, please refer to [Transition from Azure Video Analyzer](https://docs.microsoft.com/azure/azure-video-analyzer/video-analyzer-docs/transition-from-video-analyzer).
+We're retiring the Azure Video Analyzer preview service, you're advised to transition your applications off of Video Analyzer by 01 December 2022. This SDK is no longer maintained or supported.
 
 ## Changes in 1.0.0-beta.2
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove broken links that were flagged by the validation pipeline.  I've also reworded the heading for the now retired Video Analyzer library to clarify its status.

# References and Related

- [Failed validation run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2793535&view=logs&j=d41e9505-d81b-5b3c-5b50-be71bc9b0ccb&t=2521f384-3a28-5bc9-41e5-2f3e6ef99ecd) _(Microsoft internal)_