### PR TITLE
[Validation] Management API spelling exemptions

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -46,7 +46,9 @@
     "sdk/objectanchors/*/api/*.cs",
     "sdk/purview/*/api/*.cs",
     "sdk/remoterendering/*/api/*.cs",
-    "sdk/videoanalyzer/*/api/*.cs"
+    "sdk/videoanalyzer/*/api/*.cs",
+    "sdk/newrelicobservability/*/api/*.cs",
+    "sdk/paloaltonetworks.ngfw/*/api/*.cs"
   ],
   // cspell is not case sensitive
   // Sort words alphabetically to make this list easier to use


### PR DESCRIPTION
# Summary

The focus of these changes is to exempt two management libraries, `PaloAltoNetworks.Ngfw` and `NewRelicObservability`, from the cspell checks for their public API due to domain-specific abbreviations.

# References and Related

- [Spelling validation failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2793535&view=logs&j=d41e9505-d81b-5b3c-5b50-be71bc9b0ccb&t=9ff5a92d-14ef-5b48-a596-30a735a1a817) _(Microsoft internal)_