### PR TITLE
change playsource input from object to enumerable

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -157,8 +157,8 @@ namespace Azure.Communication.CallAutomation
         public static Azure.Communication.CallAutomation.ChoiceResult ChoiceResult(string label = null, string recognizedPhrase = null) { throw null; }
         public static Azure.Communication.CallAutomation.CollectTonesResult CollectTonesResult(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.DtmfTone> tones = null) { throw null; }
         public static Azure.Communication.CallAutomation.ContinuousDtmfRecognitionStopped ContinuousDtmfRecognitionStopped(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, Azure.Communication.CallAutomation.ResultInformation resultInformation = null) { throw null; }
-        public static Azure.Communication.CallAutomation.ContinuousDtmfRecognitionToneFailed ContinuousDtmfRecognitionToneFailed(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, Azure.Communication.CallAutomation.ResultInformation resultInformation = null) { throw null; }
-        public static Azure.Communication.CallAutomation.ContinuousDtmfRecognitionToneReceived ContinuousDtmfRecognitionToneReceived(Azure.Communication.CallAutomation.ToneInfo toneInfo = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, Azure.Communication.CallAutomation.ResultInformation resultInformation = null) { throw null; }
+        public static Azure.Communication.CallAutomation.ContinuousDtmfRecognitionToneFailed ContinuousDtmfRecognitionToneFailed(string callConnectionId = null, string serverCallId = null, string correlationId = null, Azure.Communication.CallAutomation.ResultInformation resultInformation = null, string operationContext = null) { throw null; }
+        public static Azure.Communication.CallAutomation.ContinuousDtmfRecognitionToneReceived ContinuousDtmfRecognitionToneReceived(Azure.Communication.CallAutomation.ToneInfo toneInfo = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, Azure.Communication.CallAutomation.ResultInformation resultInformation = null, string operationContext = null) { throw null; }
         public static Azure.Communication.CallAutomation.CreateCallResult CreateCallResult(Azure.Communication.CallAutomation.CallConnection callConnection = null, Azure.Communication.CallAutomation.CallConnectionProperties callConnectionProperties = null) { throw null; }
         public static Azure.Communication.CallAutomation.DtmfResult DtmfResult(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.DtmfTone> tones = null) { throw null; }
         public static Azure.Communication.CallAutomation.MuteParticipantsResponse MuteParticipantsResponse(string operationContext = null) { throw null; }
@@ -291,12 +291,16 @@ namespace Azure.Communication.CallAutomation
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.CancelAllMediaOperationsResult>> CancelAllMediaOperationsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallAutomation.PlayResult> Play(Azure.Communication.CallAutomation.PlayOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallAutomation.PlayResult> Play(Azure.Communication.CallAutomation.PlaySource playSource, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> playTo, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Communication.CallAutomation.PlayResult> Play(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.PlaySource> playSources, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> playTo, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.PlayResult>> PlayAsync(Azure.Communication.CallAutomation.PlayOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.PlayResult>> PlayAsync(Azure.Communication.CallAutomation.PlaySource playSource, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> playTo, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.PlayResult>> PlayAsync(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.PlaySource> playSources, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> playTo, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallAutomation.PlayResult> PlayToAll(Azure.Communication.CallAutomation.PlaySource playSource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallAutomation.PlayResult> PlayToAll(Azure.Communication.CallAutomation.PlayToAllOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Communication.CallAutomation.PlayResult> PlayToAll(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.PlaySource> playSources, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.PlayResult>> PlayToAllAsync(Azure.Communication.CallAutomation.PlaySource playSource, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.PlayResult>> PlayToAllAsync(Azure.Communication.CallAutomation.PlayToAllOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.PlayResult>> PlayToAllAsync(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.PlaySource> playSources, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Communication.CallAutomation.SendDtmfResult> SendDtmf(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.DtmfTone> tones, Azure.Communication.CommunicationIdentifier targetParticipant, string operationContext = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Communication.CallAutomation.SendDtmfResult>> SendDtmfAsync(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.DtmfTone> tones, Azure.Communication.CommunicationIdentifier targetParticipant, string operationContext = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response StartContinuousDtmfRecognition(Azure.Communication.CommunicationIdentifier targetParticipant, string operationContext = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -775,9 +779,10 @@ namespace Azure.Communication.CallAutomation
     public partial class PlayOptions
     {
         public PlayOptions(Azure.Communication.CallAutomation.PlaySource playSource, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> playTo) { }
+        public PlayOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.PlaySource> playSources, System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> playTo) { }
         public bool Loop { get { throw null; } set { } }
         public string OperationContext { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.PlaySource PlaySource { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Communication.CallAutomation.PlaySource> PlaySources { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.Communication.CommunicationIdentifier> PlayTo { get { throw null; } }
     }
     public partial class PlayResult
@@ -789,14 +794,15 @@ namespace Azure.Communication.CallAutomation
     public abstract partial class PlaySource
     {
         protected PlaySource() { }
-        public string PlaySourceId { get { throw null; } set { } }
+        public string PlaySourceCacheId { get { throw null; } set { } }
     }
     public partial class PlayToAllOptions
     {
         public PlayToAllOptions(Azure.Communication.CallAutomation.PlaySource playSource) { }
+        public PlayToAllOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.PlaySource> playSources) { }
         public bool Loop { get { throw null; } set { } }
         public string OperationContext { get { throw null; } set { } }
-        public Azure.Communication.CallAutomation.PlaySource PlaySource { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Communication.CallAutomation.PlaySource> PlaySources { get { throw null; } }
     }
     public partial class RecognizeCanceled : Azure.Communication.CallAutomation.CallAutomationEventBase
     {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
@@ -104,6 +104,41 @@ namespace Azure.Communication.CallAutomation
         }
 
         /// <summary>
+        /// Play list of media sources to specified participant(s) async.
+        /// </summary>
+        /// <param name="playSources"></param>
+        /// <param name="cancellationToken"></param>
+        /// <param name="playTo"></param>
+        /// <returns>Returns <see cref="PlayResult"/>, which can be used to wait for Play's related events.</returns>
+        public virtual async Task<Response<PlayResult>> PlayAsync(IEnumerable<PlaySource> playSources, IEnumerable<CommunicationIdentifier> playTo, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(Play)}");
+            scope.Start();
+            try
+            {
+                var playOptions = new PlayOptions(playSources, playTo)
+                {
+                    Loop = false,
+                    OperationContext = null
+                };
+
+                PlayRequestInternal request = CreatePlayRequest(playOptions);
+
+                var response = await CallMediaRestClient.PlayAsync(CallConnectionId, request, cancellationToken).ConfigureAwait(false);
+
+                var result = new PlayResult();
+                result.SetEventProcessor(EventProcessor, CallConnectionId, request.OperationContext);
+
+                return Response.FromValue(result, response);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Plays audio to specified participant(s).
         /// </summary>
         /// <param name="cancellationToken">An optional CancellationToken to cancel the request.</param>
@@ -166,13 +201,48 @@ namespace Azure.Communication.CallAutomation
             }
         }
 
+        /// <summary>
+        /// Plays a file.
+        /// </summary>
+        /// <param name="playSources"></param>
+        /// <param name="cancellationToken"></param>
+        /// <param name="playTo"></param>
+        /// <returns>Returns <see cref="PlayResult"/>, which can be used to wait for Play's related events.</returns>
+        public virtual Response<PlayResult> Play(IEnumerable<PlaySource> playSources, IEnumerable<CommunicationIdentifier> playTo, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(Play)}");
+            scope.Start();
+            try
+            {
+                var playOptions = new PlayOptions(playSources, playTo)
+                {
+                    Loop = false,
+                    OperationContext = null
+                };
+
+                PlayRequestInternal request = CreatePlayRequest(playOptions);
+
+                var response = CallMediaRestClient.Play(CallConnectionId, request, cancellationToken);
+
+                var result = new PlayResult();
+                result.SetEventProcessor(EventProcessor, CallConnectionId, request.OperationContext);
+
+                return Response.FromValue(result, response);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
         private static PlayRequestInternal CreatePlayRequest(PlayOptions options)
         {
-            PlaySourceInternal sourceInternal = TranslatePlaySourceToInternal(options.PlaySource);
+            List<PlaySourceInternal> sources = options.PlaySources.Select(source => TranslatePlaySourceToInternal(source)).ToList();
 
-            if (sourceInternal != null)
+            if (sources != null)
             {
-                PlayRequestInternal request = new PlayRequestInternal(sourceInternal);
+                PlayRequestInternal request = new PlayRequestInternal(sources);
                 request.PlayTo = options.PlayTo.Select(t => CommunicationIdentifierSerializer.Serialize(t)).ToList();
 
                 if (options != null)
@@ -189,7 +259,7 @@ namespace Azure.Communication.CallAutomation
                 return request;
             }
 
-            throw new NotSupportedException(options.PlaySource.GetType().Name);
+            throw new NotSupportedException(options.PlaySources.GetType().Name);
         }
 
         /// <summary>
@@ -204,7 +274,7 @@ namespace Azure.Communication.CallAutomation
             scope.Start();
             try
             {
-                PlayOptions playOptions = new PlayOptions(options.PlaySource, Enumerable.Empty<CommunicationIdentifier>());
+                PlayOptions playOptions = new PlayOptions(options.PlaySources, Enumerable.Empty<CommunicationIdentifier>());
                 playOptions.OperationContext = options.OperationContext;
                 playOptions.Loop = options.Loop;
                 return await PlayAsync(playOptions, cancellationToken).ConfigureAwait(false);
@@ -238,6 +308,27 @@ namespace Azure.Communication.CallAutomation
         }
 
         /// <summary>
+        /// Play to all participants async.
+        /// </summary>
+        /// <param name="playSources"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Returns <see cref="PlayResult"/>, which can be used to wait for Play's related events.</returns>
+        public virtual async Task<Response<PlayResult>> PlayToAllAsync(IEnumerable<PlaySource> playSources, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(PlayToAll)}");
+            scope.Start();
+            try
+            {
+                return await PlayAsync(playSources, Enumerable.Empty<CommunicationIdentifier>(), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Play audio to all participants.
         /// </summary>
         /// <param name="options">An optional object containing play options and configurations.</param>
@@ -249,7 +340,7 @@ namespace Azure.Communication.CallAutomation
             scope.Start();
             try
             {
-                PlayOptions playOptions = new PlayOptions(options.PlaySource, Enumerable.Empty<CommunicationIdentifier>());
+                PlayOptions playOptions = new PlayOptions(options.PlaySources, Enumerable.Empty<CommunicationIdentifier>());
                 playOptions.OperationContext = options.OperationContext;
                 playOptions.Loop = options.Loop;
                 return Play(playOptions, cancellationToken);
@@ -274,6 +365,27 @@ namespace Azure.Communication.CallAutomation
             try
             {
                 return Play(playSource, Enumerable.Empty<CommunicationIdentifier>(), cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Play to all participants.
+        /// </summary>
+        /// <param name="playSources"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Returns <see cref="PlayResult"/>, which can be used to wait for Play's related events.</returns>
+        public virtual Response<PlayResult> PlayToAll(IEnumerable<PlaySource> playSources, CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(CallMedia)}.{nameof(PlayToAll)}");
+            scope.Start();
+            try
+            {
+                return Play(playSources, Enumerable.Empty<CommunicationIdentifier>(), cancellationToken);
             }
             catch (Exception ex)
             {
@@ -507,7 +619,7 @@ namespace Azure.Communication.CallAutomation
             {
                 sourceInternal = new PlaySourceInternal(PlaySourceTypeInternal.File);
                 sourceInternal.FileSource = new FileSourceInternal(fileSource.FileUri.AbsoluteUri);
-                sourceInternal.PlaySourceId = fileSource.PlaySourceId;
+                sourceInternal.PlaySourceCacheId = fileSource.PlaySourceCacheId;
                 return sourceInternal;
             }
             else if (playSource != null && playSource is TextSource textSource)
@@ -517,14 +629,14 @@ namespace Azure.Communication.CallAutomation
                 sourceInternal.TextSource.SourceLocale = textSource.SourceLocale ?? null;
                 sourceInternal.TextSource.VoiceGender = textSource.VoiceGender ?? GenderType.Male;
                 sourceInternal.TextSource.VoiceName = textSource.VoiceName ?? null;
-                sourceInternal.PlaySourceId = textSource.PlaySourceId;
+                sourceInternal.PlaySourceCacheId = textSource.PlaySourceCacheId;
                 return sourceInternal;
             }
             else if (playSource != null && playSource is SsmlSource ssmlSource)
             {
                 sourceInternal = new PlaySourceInternal(PlaySourceTypeInternal.Ssml);
                 sourceInternal.SsmlSource = new SsmlSourceInternal(ssmlSource.SsmlText);
-                sourceInternal.PlaySourceId = ssmlSource.PlaySourceId;
+                sourceInternal.PlaySourceCacheId = ssmlSource.PlaySourceCacheId;
                 return sourceInternal;
             }
             else

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/CallAutomationModelFactory.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/CallAutomationModelFactory.cs
@@ -106,7 +106,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of RecordingStateChanged. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="recordingId"> The call recording id. </param>
         /// <param name="state"></param>
         /// <param name="startDateTime"> The time of the recording started. </param>
@@ -119,9 +119,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of PlayCompleted. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <returns> A new <see cref="CallAutomation.PlayCompleted"/> instance for mocking. </returns>
         public static PlayCompleted PlayCompleted(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
         {
@@ -131,9 +131,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of PlayFailed. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <returns> A new <see cref="CallAutomation.PlayFailed"/> instance for mocking. </returns>
         public static PlayFailed PlayFailed(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
         {
@@ -143,7 +143,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of PlayCanceled. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
         /// <returns> A new <see cref="CallAutomation.PlayCanceled"/> instance for mocking. </returns>
         public static PlayCanceled PlayCanceled(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null)
@@ -194,9 +194,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of RecognizeFailed. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <returns> A new <see cref="CallAutomation.RecognizeFailed"/> instance for mocking. </returns>
         public static RecognizeFailed RecognizeFailed(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
         {
@@ -206,7 +206,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of RecognizeCanceled. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
         /// <returns> A new <see cref="CallAutomation.RecognizeCanceled"/> instance for mocking. </returns>
         public static RecognizeCanceled RecognizeCanceled(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null)
@@ -217,13 +217,13 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of ContinuousDtmfRecognitionToneFailed. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
         /// <returns> A new <see cref="CallAutomation.ContinuousDtmfRecognitionToneFailed"/> instance for mocking. </returns>
-        public static ContinuousDtmfRecognitionToneFailed ContinuousDtmfRecognitionToneFailed(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
+        public static ContinuousDtmfRecognitionToneFailed ContinuousDtmfRecognitionToneFailed(string callConnectionId = null, string serverCallId = null, string correlationId = null, ResultInformation resultInformation = null, string operationContext = null)
         {
-            return new ContinuousDtmfRecognitionToneFailed(callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
+            return new ContinuousDtmfRecognitionToneFailed(callConnectionId, serverCallId, correlationId, resultInformation, operationContext);
         }
 
         /// <summary> Initializes a new instance of ContinuousDtmfRecognitionToneReceived. </summary>
@@ -231,12 +231,12 @@ namespace Azure.Communication.CallAutomation
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId or skype chain ID. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
         /// <returns> A new <see cref="CallAutomation.ContinuousDtmfRecognitionToneReceived"/> instance for mocking. </returns>
-        public static ContinuousDtmfRecognitionToneReceived ContinuousDtmfRecognitionToneReceived(ToneInfo toneInfo = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
+        public static ContinuousDtmfRecognitionToneReceived ContinuousDtmfRecognitionToneReceived(ToneInfo toneInfo = null, string callConnectionId = null, string serverCallId = null, string correlationId = null, ResultInformation resultInformation = null, string operationContext = null)
         {
-            return new ContinuousDtmfRecognitionToneReceived(toneInfo, callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
+            return new ContinuousDtmfRecognitionToneReceived(toneInfo, callConnectionId, serverCallId, correlationId, resultInformation, operationContext);
         }
 
         /// <summary> Initializes a new instance of ToneInfo. </summary>
@@ -251,9 +251,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of ContinuousDtmfRecognitionStopped. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <returns> A new <see cref="CallAutomation.ContinuousDtmfRecognitionStopped"/> instance for mocking. </returns>
         public static ContinuousDtmfRecognitionStopped ContinuousDtmfRecognitionStopped(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
         {
@@ -263,9 +263,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of SendDtmfCompleted. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <returns> A new <see cref="CallAutomation.SendDtmfCompleted"/> instance for mocking. </returns>
         public static SendDtmfCompleted SendDtmfCompleted(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
         {
@@ -275,9 +275,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of SendDtmfFailed. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <returns> A new <see cref="CallAutomation.SendDtmfFailed"/> instance for mocking. </returns>
         public static SendDtmfFailed SendDtmfFailed(string callConnectionId = null, string serverCallId = null, string correlationId = null, string operationContext = null, ResultInformation resultInformation = null)
         {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionStopped.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionStopped.cs
@@ -18,9 +18,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of ContinuousDtmfRecognitionStopped. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         internal ContinuousDtmfRecognitionStopped(string callConnectionId, string serverCallId, string correlationId, string operationContext, ResultInformation resultInformation)
         {
             CallConnectionId = callConnectionId;

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneFailed.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneFailed.Serialization.cs
@@ -21,8 +21,8 @@ namespace Azure.Communication.CallAutomation
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
             Optional<string> correlationId = default;
-            Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
+            Optional<string> operationContext = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("callConnectionId"u8))
@@ -40,11 +40,6 @@ namespace Azure.Communication.CallAutomation
                     correlationId = property.Value.GetString();
                     continue;
                 }
-                if (property.NameEquals("operationContext"u8))
-                {
-                    operationContext = property.Value.GetString();
-                    continue;
-                }
                 if (property.NameEquals("resultInformation"u8))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
@@ -54,8 +49,13 @@ namespace Azure.Communication.CallAutomation
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
                     continue;
                 }
+                if (property.NameEquals("operationContext"u8))
+                {
+                    operationContext = property.Value.GetString();
+                    continue;
+                }
             }
-            return new ContinuousDtmfRecognitionToneFailed(callConnectionId.Value, serverCallId.Value, correlationId.Value, operationContext.Value, resultInformation.Value);
+            return new ContinuousDtmfRecognitionToneFailed(callConnectionId.Value, serverCallId.Value, correlationId.Value, resultInformation.Value, operationContext.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneFailed.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneFailed.cs
@@ -18,16 +18,16 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of ContinuousDtmfRecognitionToneFailed. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
-        internal ContinuousDtmfRecognitionToneFailed(string callConnectionId, string serverCallId, string correlationId, string operationContext, ResultInformation resultInformation)
+        internal ContinuousDtmfRecognitionToneFailed(string callConnectionId, string serverCallId, string correlationId, ResultInformation resultInformation, string operationContext)
         {
             CallConnectionId = callConnectionId;
             ServerCallId = serverCallId;
             CorrelationId = correlationId;
-            OperationContext = operationContext;
             ResultInformation = resultInformation;
+            OperationContext = operationContext;
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneReceived.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneReceived.Serialization.cs
@@ -22,8 +22,8 @@ namespace Azure.Communication.CallAutomation
             Optional<string> callConnectionId = default;
             Optional<string> serverCallId = default;
             Optional<string> correlationId = default;
-            Optional<string> operationContext = default;
             Optional<ResultInformation> resultInformation = default;
+            Optional<string> operationContext = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("toneInfo"u8))
@@ -50,11 +50,6 @@ namespace Azure.Communication.CallAutomation
                     correlationId = property.Value.GetString();
                     continue;
                 }
-                if (property.NameEquals("operationContext"u8))
-                {
-                    operationContext = property.Value.GetString();
-                    continue;
-                }
                 if (property.NameEquals("resultInformation"u8))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
@@ -64,8 +59,13 @@ namespace Azure.Communication.CallAutomation
                     resultInformation = ResultInformation.DeserializeResultInformation(property.Value);
                     continue;
                 }
+                if (property.NameEquals("operationContext"u8))
+                {
+                    operationContext = property.Value.GetString();
+                    continue;
+                }
             }
-            return new ContinuousDtmfRecognitionToneReceived(toneInfo.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, operationContext.Value, resultInformation.Value);
+            return new ContinuousDtmfRecognitionToneReceived(toneInfo.Value, callConnectionId.Value, serverCallId.Value, correlationId.Value, resultInformation.Value, operationContext.Value);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneReceived.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/ContinuousDtmfRecognitionToneReceived.cs
@@ -20,16 +20,16 @@ namespace Azure.Communication.CallAutomation
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
         /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId or skype chain ID. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
-        internal ContinuousDtmfRecognitionToneReceived(ToneInfo toneInfo, string callConnectionId, string serverCallId, string correlationId, string operationContext, ResultInformation resultInformation)
+        internal ContinuousDtmfRecognitionToneReceived(ToneInfo toneInfo, string callConnectionId, string serverCallId, string correlationId, ResultInformation resultInformation, string operationContext)
         {
             ToneInfo = toneInfo;
             CallConnectionId = callConnectionId;
             ServerCallId = serverCallId;
             CorrelationId = correlationId;
-            OperationContext = operationContext;
             ResultInformation = resultInformation;
+            OperationContext = operationContext;
         }
 
         /// <summary> Information about Tone. </summary>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayCanceled.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayCanceled.cs
@@ -18,7 +18,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of PlayCanceled. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
         internal PlayCanceled(string callConnectionId, string serverCallId, string correlationId, string operationContext)
         {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.Serialization.cs
@@ -15,8 +15,13 @@ namespace Azure.Communication.CallAutomation
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("playSourceInfo"u8);
-            writer.WriteObjectValue(PlaySourceInfo);
+            writer.WritePropertyName("playSource"u8);
+            writer.WriteStartArray();
+            foreach (var item in PlaySource)
+            {
+                writer.WriteObjectValue(item);
+            }
+            writer.WriteEndArray();
             if (Optional.IsCollectionDefined(PlayTo))
             {
                 writer.WritePropertyName("playTo"u8);

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.Serialization.cs
@@ -15,9 +15,9 @@ namespace Azure.Communication.CallAutomation
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("playSource"u8);
+            writer.WritePropertyName("playSources"u8);
             writer.WriteStartArray();
-            foreach (var item in PlaySource)
+            foreach (var item in PlaySources)
             {
                 writer.WriteObjectValue(item);
             }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Azure.Communication;
 using Azure.Core;
 
@@ -16,18 +17,18 @@ namespace Azure.Communication.CallAutomation
     internal partial class PlayRequestInternal
     {
         /// <summary> Initializes a new instance of PlayRequestInternal. </summary>
-        /// <param name="playSourceInfo"> The source of the audio to be played. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="playSourceInfo"/> is null. </exception>
-        public PlayRequestInternal(PlaySourceInternal playSourceInfo)
+        /// <param name="playSource"> The source of the audio to be played. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="playSource"/> is null. </exception>
+        public PlayRequestInternal(IEnumerable<PlaySourceInternal> playSource)
         {
-            Argument.AssertNotNull(playSourceInfo, nameof(playSourceInfo));
+            Argument.AssertNotNull(playSource, nameof(playSource));
 
-            PlaySourceInfo = playSourceInfo;
+            PlaySource = playSource.ToList();
             PlayTo = new ChangeTrackingList<CommunicationIdentifierModel>();
         }
 
         /// <summary> The source of the audio to be played. </summary>
-        public PlaySourceInternal PlaySourceInfo { get; }
+        public IList<PlaySourceInternal> PlaySource { get; }
         /// <summary> Defines options for playing the audio. </summary>
         public PlayOptionsInternal PlayOptions { get; set; }
         /// <summary> The value to identify context of the operation. </summary>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayRequestInternal.cs
@@ -17,18 +17,18 @@ namespace Azure.Communication.CallAutomation
     internal partial class PlayRequestInternal
     {
         /// <summary> Initializes a new instance of PlayRequestInternal. </summary>
-        /// <param name="playSource"> The source of the audio to be played. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="playSource"/> is null. </exception>
-        public PlayRequestInternal(IEnumerable<PlaySourceInternal> playSource)
+        /// <param name="playSources"> The source of the audio to be played. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="playSources"/> is null. </exception>
+        public PlayRequestInternal(IEnumerable<PlaySourceInternal> playSources)
         {
-            Argument.AssertNotNull(playSource, nameof(playSource));
+            Argument.AssertNotNull(playSources, nameof(playSources));
 
-            PlaySource = playSource.ToList();
+            PlaySources = playSources.ToList();
             PlayTo = new ChangeTrackingList<CommunicationIdentifierModel>();
         }
 
         /// <summary> The source of the audio to be played. </summary>
-        public IList<PlaySourceInternal> PlaySource { get; }
+        public IList<PlaySourceInternal> PlaySources { get; }
         /// <summary> Defines options for playing the audio. </summary>
         public PlayOptionsInternal PlayOptions { get; set; }
         /// <summary> The value to identify context of the operation. </summary>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlaySourceInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlaySourceInternal.Serialization.cs
@@ -17,10 +17,10 @@ namespace Azure.Communication.CallAutomation
             writer.WriteStartObject();
             writer.WritePropertyName("sourceType"u8);
             writer.WriteStringValue(SourceType.ToString());
-            if (Optional.IsDefined(PlaySourceId))
+            if (Optional.IsDefined(PlaySourceCacheId))
             {
-                writer.WritePropertyName("playSourceId"u8);
-                writer.WriteStringValue(PlaySourceId);
+                writer.WritePropertyName("playSourceCacheId"u8);
+                writer.WriteStringValue(PlaySourceCacheId);
             }
             if (Optional.IsDefined(FileSource))
             {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlaySourceInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlaySourceInternal.cs
@@ -20,7 +20,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Defines the type of the play source. </summary>
         public PlaySourceTypeInternal SourceType { get; }
         /// <summary> Defines the identifier to be used for caching related media. </summary>
-        public string PlaySourceId { get; set; }
+        public string PlaySourceCacheId { get; set; }
         /// <summary> Defines the file source info to be used for play. </summary>
         public FileSourceInternal FileSource { get; set; }
         /// <summary> Defines the text source info to be used for play. </summary>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/RecognizeCanceled.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/RecognizeCanceled.cs
@@ -18,7 +18,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of RecognizeCanceled. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
         internal RecognizeCanceled(string callConnectionId, string serverCallId, string correlationId, string operationContext)
         {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/RecognizeCompletedInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/RecognizeCompletedInternal.cs
@@ -18,9 +18,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of RecognizeCompletedInternal. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         /// <param name="recognitionType">
         /// Determines the sub-type of the recognize operation.
         /// In case of cancel operation the this field is not set and is returned empty

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/RecordingStateChanged.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/RecordingStateChanged.cs
@@ -20,7 +20,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of RecordingStateChanged. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="recordingId"> The call recording id. </param>
         /// <param name="state"></param>
         /// <param name="startDateTime"> The time of the recording started. </param>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/SendDtmfCompleted.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/SendDtmfCompleted.cs
@@ -18,9 +18,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of SendDtmfCompleted. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         internal SendDtmfCompleted(string callConnectionId, string serverCallId, string correlationId, string operationContext, ResultInformation resultInformation)
         {
             CallConnectionId = callConnectionId;

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/SendDtmfFailed.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/SendDtmfFailed.cs
@@ -18,9 +18,9 @@ namespace Azure.Communication.CallAutomation
         /// <summary> Initializes a new instance of SendDtmfFailed. </summary>
         /// <param name="callConnectionId"> Call connection ID. </param>
         /// <param name="serverCallId"> Server call ID. </param>
-        /// <param name="correlationId"> Correlation ID for event to call correlation. Also called ChainId for skype chain ID. </param>
+        /// <param name="correlationId"> Correlation ID for event to call correlation. </param>
         /// <param name="operationContext"> Used by customers when calling mid-call actions to correlate the request to the response event. </param>
-        /// <param name="resultInformation"> Contains the resulting SIP code/sub-code and message from NGC services. </param>
+        /// <param name="resultInformation"> Contains the resulting SIP code, sub-code and message. </param>
         internal SendDtmfFailed(string callConnectionId, string serverCallId, string correlationId, string operationContext, ResultInformation resultInformation)
         {
             CallConnectionId = callConnectionId;

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// A PlaySource object representing the source to play.
         /// </summary>
-        public PlaySource PlaySource { get; }
+        public IReadOnlyList<PlaySource> PlaySources { get; }
 
         /// <summary>
         /// A list of target identifiers to play the file to.
@@ -36,7 +36,17 @@ namespace Azure.Communication.CallAutomation
         /// </summary>
         public PlayOptions(PlaySource playSource, IEnumerable<CommunicationIdentifier> playTo)
         {
-            PlaySource = playSource;
+            List<PlaySource> playSources = new List<PlaySource>(){ playSource };
+            PlaySources = playSources;
+            PlayTo = playTo.ToList();
+        }
+
+        /// <summary>
+        /// Creates a new PlayOptions object.
+        /// </summary>
+        public PlayOptions(IEnumerable<PlaySource> playSources, IEnumerable<CommunicationIdentifier> playTo)
+        {
+            PlaySources = playSources.ToList();
             PlayTo = playTo.ToList();
         }
     }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlaySource.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlaySource.cs
@@ -11,6 +11,6 @@ namespace Azure.Communication.CallAutomation
     public abstract class PlaySource
     {
         /// <summary> Defines the identifier to be used for caching related media. </summary>
-        public string PlaySourceId { get; set; }
+        public string PlaySourceCacheId { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayToAllOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayToAllOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Azure.Communication.CallAutomation
 {
@@ -13,7 +14,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// A PlaySource object representing the source to play.
         /// </summary>
-        public PlaySource PlaySource { get; }
+        public IReadOnlyList<PlaySource> PlaySources { get; }
 
         /// <summary>
         /// The option to play the provided audio source in loop when set to true.
@@ -30,7 +31,16 @@ namespace Azure.Communication.CallAutomation
         /// </summary>
         public PlayToAllOptions(PlaySource playSource)
         {
-            PlaySource = playSource;
+            List<PlaySource> playSources = new List<PlaySource>() { playSource };
+            PlaySources = playSources;
+        }
+
+        /// <summary>
+        /// Creates a new PlayToAllOptions object with list of play sources.
+        /// </summary>
+        public PlayToAllOptions(IEnumerable<PlaySource> playSources)
+        {
+            PlaySources = playSources.ToList();
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
@@ -10,7 +10,7 @@ tag: package-2023-01-15-preview
 model-namespace: false
 
 require:
-     - https://github.com/williamzhao87/azure-rest-api-specs/blob/015f5765336229426015d45d9cb985ecf8e8d950/specification/communication/data-plane/CallAutomation/readme.md
+     - https://github.com/williamzhao87/azure-rest-api-specs/blob/84cdf62245ed9feb1e2df4d26bb6cc16de706f18/specification/communication/data-plane/CallAutomation/readme.md
 
 title: Azure Communication Services
 

--- a/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
@@ -10,7 +10,7 @@ tag: package-2023-01-15-preview
 model-namespace: false
 
 require:
-     - https://github.com/williamzhao87/azure-rest-api-specs/blob/3e5d55eb8a13ce316e4b5e478fa3f75f2d2650fa/specification/communication/data-plane/CallAutomation/readme.md
+     - https://github.com/williamzhao87/azure-rest-api-specs/blob/015f5765336229426015d45d9cb985ecf8e8d950/specification/communication/data-plane/CallAutomation/readme.md
 
 title: Azure Communication Services
 

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
@@ -19,7 +19,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         private static readonly FileSource _fileSource = new FileSource(new System.Uri("file://path/to/file"));
         private static readonly TextSource _textSource = new TextSource("PlayTTS test text.", "en-US-ElizabethNeural");
         private static readonly SsmlSource _ssmlSource = new SsmlSource("<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"en-US-JennyNeural\">Recognize Choice Completed, played through SSML source.</voice></speak>");
-
+        private static readonly List<PlaySource> _playSources = new List<PlaySource>()
+        {
+            _fileSource,
+            _textSource,
+            _ssmlSource
+        };
         private static readonly PlayOptions _fileOptions = new PlayOptions(_fileSource, _target)
         {
             Loop = false,
@@ -38,6 +43,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             OperationContext = "context"
         };
 
+        private static readonly PlayOptions _playSourcesOptions = new PlayOptions(_playSources, _target)
+        {
+            Loop = false,
+            OperationContext = "context"
+        };
+
         private static readonly PlayToAllOptions _filePlayToAllOptions = new PlayToAllOptions(_fileSource)
         {
             Loop = false,
@@ -51,6 +62,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         };
 
         private static readonly PlayToAllOptions _ssmlPlayToAllOptions = new PlayToAllOptions(_ssmlSource)
+        {
+            Loop = false,
+            OperationContext = "context"
+        };
+
+        private static readonly PlayToAllOptions _playSourcesPlayToAllOptions = new PlayToAllOptions(_playSources)
         {
             Loop = false,
             OperationContext = "context"
@@ -137,7 +154,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         [SetUp]
         public void Setup()
         {
-            _fileSource.PlaySourceId = "playSourceId";
+            _fileSource.PlaySourceCacheId = "playSourceCacheId";
         }
 
         private CallMedia GetCallMedia(int responseCode)
@@ -414,6 +431,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 {
                    callMedia => callMedia.PlayToAllAsync(_ssmlPlayToAllOptions)
                 },
+                new Func<CallMedia, Task<Response<PlayResult>>>?[]
+                {
+                   callMedia => callMedia.PlayAsync(_playSourcesOptions)
+                },
+                new Func<CallMedia, Task<Response<PlayResult>>>?[]
+                {
+                   callMedia => callMedia.PlayToAllAsync(_playSourcesPlayToAllOptions)
+                },
             };
         }
 
@@ -482,6 +507,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 new Func<CallMedia, Response<PlayResult>>?[]
                 {
                    callMedia => callMedia.PlayToAll(_ssmlPlayToAllOptions)
+                },
+                new Func<CallMedia, Response<PlayResult>>?[]
+                {
+                   callMedia => callMedia.Play(_playSourcesOptions)
+                },
+                new Func<CallMedia, Response<PlayResult>>?[]
+                {
+                   callMedia => callMedia.PlayToAll(_playSourcesPlayToAllOptions)
                 },
             };
         }


### PR DESCRIPTION
# Contributing to the Azure SDK

Callautomation media accepts enumerable<playsource> instead only one playsource.
