### PR TITLE
Fix Version of OpenTelemetry.Extensions.AzureMonitor in package list

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -120,7 +120,7 @@
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.4.0"   />
+    <PackageReference Update="OpenTelemetry" Version="1.4.0" />
     <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0" />
     <PackageReference Update="OpenTelemetry.Extensions.AzureMonitor" Version="1.0.0-beta.4" />
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
@@ -266,6 +266,7 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Update="OpenTelemetry" Version="1.4.0" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -116,14 +116,18 @@
     <!-- TODO: Make sure this package is arch-board approved -->
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
 
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Monitor.OpenTelemetry'))">
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.4.0"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry" Version="1.4.0"   />
+    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0" />
     <PackageReference Update="OpenTelemetry.Extensions.AzureMonitor" Version="1.0.0-beta.4" />
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
     <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
     <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.14" />
-    <PackageReference Update="OpenTelemetry.PersistentStorage.FileSystem" Version="1.0.0-beta.2" Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry.PersistentStorage.FileSystem" Version="1.0.0-beta.2" />
   </ItemGroup>
 
   <!--
@@ -262,12 +266,6 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Update="OpenTelemetry" Version="1.4.0" />
-    <PackageReference Update="OpenTelemetry.Exporter.InMemory" Version="1.4.0" />
-    <PackageReference Update="OpenTelemetry.Extensions.AzureMonitor" Version="1.0.0-beta.3" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -118,7 +118,7 @@
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
     <PackageReference Update="OpenTelemetry" Version="1.4.0"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
-    <PackageReference Update="OpenTelemetry.Extensions.AzureMonitor" VersionOverride="1.0.0-beta.4" />
+    <PackageReference Update="OpenTelemetry.Extensions.AzureMonitor" Version="1.0.0-beta.4" />
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
     <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />

--- a/eng/scripts/dependencies/AnalyzeDeps.ps1
+++ b/eng/scripts/dependencies/AnalyzeDeps.ps1
@@ -76,6 +76,10 @@ Function Save-PkgDep($PkgDeps, $TargetFramework, $DepName, $DepVersion) {
 }
 
 Function Save-Locked($Locked, $DepName, $DepVersion, $Condition) {
+  if (!$DepVersion) {
+    Write-Warning "$DepName in $LockfilePath does not contain a Version property so skipping it."
+    return
+  }
   if (-Not $Locked[$DepName]) {
     $Locked[$DepName] = @{ }
   }
@@ -164,7 +168,7 @@ foreach ($PkgFile in (Get-ChildItem "$PackagesPath/*.nupkg")) {
       }
     } else {
       $Pkgs[$LibraryName]["Deps"].Add(@{name = $DepName; version = ($DepVersions.Keys | Select-Object -first 1) }) | Out-Null
-    }
+    } 
   }
 }
 


### PR DESCRIPTION
Also update the AnalyzeDeps to not fail if the Version property doesn't exists but instead just skip it.

cc @jsquire 