### PR TITLE
Added support for system-assigned identity to EventGrid output bindings

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/api/Microsoft.Azure.WebJobs.Extensions.EventGrid.netstandard2.0.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/api/Microsoft.Azure.WebJobs.Extensions.EventGrid.netstandard2.0.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
     public sealed partial class EventGridAttribute : System.Attribute
     {
         public EventGridAttribute() { }
+        public string Connection { get { throw null; } set { } }
         [Microsoft.Azure.WebJobs.Description.AppSettingAttribute]
         public string TopicEndpointUri { get { throw null; } set { } }
         [Microsoft.Azure.WebJobs.Description.AppSettingAttribute]

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridAsyncCollectorFactory.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridAsyncCollectorFactory.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure;
+using Azure.Messaging.EventGrid;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Config
+{
+    internal class EventGridAsyncCollectorFactory
+    {
+        private readonly IConfiguration _configuration;
+        private readonly AzureComponentFactory _componentFactory;
+
+        protected EventGridAsyncCollectorFactory()
+        { }
+
+        public EventGridAsyncCollectorFactory(IConfiguration configuration, AzureComponentFactory componentFactory)
+        {
+            _configuration = configuration;
+            _componentFactory = componentFactory;
+        }
+
+        internal void Validate(EventGridAttribute attribute)
+        {
+            if (!string.IsNullOrWhiteSpace(attribute.Connection))
+            {
+                if (attribute.TopicKeySetting != null)
+                    throw new InvalidOperationException($"Conflicting Event Grid topic credentials have been set in '{nameof(EventGridAttribute.Connection)}' and '{nameof(EventGridAttribute.TopicKeySetting)}'");
+
+                var connectionSection = _configuration.GetSection(attribute.Connection);
+                if (!connectionSection.Exists())
+                    throw new InvalidOperationException($"Event Grid topic connection string '{attribute.Connection}' does not exist. " +
+                                                    $"Make sure that it is a defined App Setting.");
+
+                if (!string.IsNullOrWhiteSpace(connectionSection.Value))
+                {
+                    if (!Uri.IsWellFormedUriString(connectionSection.Value, UriKind.Absolute))
+                    {
+                        throw new InvalidOperationException($"Event Grid topic connection string '{attribute.Connection}' must be a valid absolute Uri");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(attribute.TopicEndpointUri) && attribute.TopicEndpointUri != connectionSection.Value)
+                    {
+                        throw new InvalidOperationException($"Event Grid topic connection string '{attribute.Connection}' is set to a different Uri");
+                    }
+                }
+            }
+            else if (string.IsNullOrWhiteSpace(attribute.TopicEndpointUri))
+            {
+                throw new InvalidOperationException($"The '{nameof(EventGridAttribute.Connection)}' property or '{nameof(EventGridAttribute.TopicEndpointUri)}' property must be set");
+            }
+            else
+            {
+                // if app setting is missing, it will be caught by runtime
+                // this logic tries to validate the practicality of attribute properties
+                if (string.IsNullOrWhiteSpace(attribute.TopicKeySetting))
+                {
+                    throw new InvalidOperationException($"The '{nameof(EventGridAttribute.TopicKeySetting)}' property must be the name of an application setting containing the Topic Key");
+                }
+
+                if (!Uri.IsWellFormedUriString(attribute.TopicEndpointUri, UriKind.Absolute))
+                {
+                    throw new InvalidOperationException($"The '{nameof(EventGridAttribute.TopicEndpointUri)}' property must be a valid absolute Uri");
+                }
+            }
+        }
+
+        internal virtual IAsyncCollector<object> CreateCollector(EventGridAttribute attribute)
+            => new EventGridAsyncCollector(CreateClient(attribute));
+
+        private EventGridPublisherClient CreateClient(EventGridAttribute attribute)
+        {
+            if (string.IsNullOrWhiteSpace(attribute.Connection))
+            {
+                return new EventGridPublisherClient(new Uri(attribute.TopicEndpointUri), new AzureKeyCredential(attribute.TopicKeySetting));
+            }
+
+            var connectionSection = _configuration.GetSection(attribute.Connection);
+            if (!string.IsNullOrWhiteSpace(connectionSection.Value))
+            {
+                return new EventGridPublisherClient(new Uri(connectionSection.Value), _componentFactory.CreateTokenCredential(connectionSection));
+            }
+            else
+            {
+                return new EventGridPublisherClient(new Uri(attribute.TopicEndpointUri), _componentFactory.CreateTokenCredential(connectionSection));
+            }
+        }
+    }
+}

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridAsyncCollectorFactory.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridAsyncCollectorFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure;
+using Azure.Core;
 using Azure.Messaging.EventGrid;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
@@ -25,11 +26,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Config
 
         internal void Validate(EventGridAttribute attribute)
         {
+            if (attribute.TopicKeySetting != null)
+            {
+                if (!string.IsNullOrWhiteSpace(attribute.Connection))
+                {
+                    throw new InvalidOperationException($"Conflicting Event Grid topic credentials have been set in '{nameof(EventGridAttribute.Connection)}' and '{nameof(EventGridAttribute.TopicKeySetting)}'");
+                }
+
+                if (string.IsNullOrWhiteSpace(attribute.TopicKeySetting))
+                {
+                    throw new InvalidOperationException($"The '{nameof(EventGridAttribute.TopicKeySetting)}' property must be the name of an application setting containing the Topic Key");
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(attribute.Connection))
             {
-                if (attribute.TopicKeySetting != null)
-                    throw new InvalidOperationException($"Conflicting Event Grid topic credentials have been set in '{nameof(EventGridAttribute.Connection)}' and '{nameof(EventGridAttribute.TopicKeySetting)}'");
-
                 var connectionSection = _configuration.GetSection(attribute.Connection);
                 if (!connectionSection.Exists())
                     throw new InvalidOperationException($"Event Grid topic connection string '{attribute.Connection}' does not exist. " +
@@ -37,35 +48,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Config
 
                 if (!string.IsNullOrWhiteSpace(connectionSection.Value))
                 {
-                    if (!Uri.IsWellFormedUriString(connectionSection.Value, UriKind.Absolute))
+                    var topicEndpointUri = connectionSection.Value;
+                    if (!Uri.IsWellFormedUriString(topicEndpointUri, UriKind.Absolute))
                     {
                         throw new InvalidOperationException($"Event Grid topic connection string '{attribute.Connection}' must be a valid absolute Uri");
                     }
 
-                    if (!string.IsNullOrWhiteSpace(attribute.TopicEndpointUri) && attribute.TopicEndpointUri != connectionSection.Value)
+                    if (!string.IsNullOrWhiteSpace(attribute.TopicEndpointUri) && topicEndpointUri != attribute.TopicEndpointUri)
                     {
-                        throw new InvalidOperationException($"Event Grid topic connection string '{attribute.Connection}' is set to a different Uri");
+                        throw new InvalidOperationException($"Conflicting Event Grid topic connection strings have been set in '{nameof(EventGridAttribute.Connection)}' and '{nameof(EventGridAttribute.TopicEndpointUri)}'");
                     }
-                }
-            }
-            else if (string.IsNullOrWhiteSpace(attribute.TopicEndpointUri))
-            {
-                throw new InvalidOperationException($"The '{nameof(EventGridAttribute.Connection)}' property or '{nameof(EventGridAttribute.TopicEndpointUri)}' property must be set");
-            }
-            else
-            {
-                // if app setting is missing, it will be caught by runtime
-                // this logic tries to validate the practicality of attribute properties
-                if (string.IsNullOrWhiteSpace(attribute.TopicKeySetting))
-                {
-                    throw new InvalidOperationException($"The '{nameof(EventGridAttribute.TopicKeySetting)}' property must be the name of an application setting containing the Topic Key");
-                }
 
+                    return;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(attribute.TopicEndpointUri))
+            {
                 if (!Uri.IsWellFormedUriString(attribute.TopicEndpointUri, UriKind.Absolute))
                 {
                     throw new InvalidOperationException($"The '{nameof(EventGridAttribute.TopicEndpointUri)}' property must be a valid absolute Uri");
                 }
+
+                return;
             }
+
+            throw new InvalidOperationException($"The '{nameof(EventGridAttribute.Connection)}' property or '{nameof(EventGridAttribute.TopicEndpointUri)}' property must be set");
         }
 
         internal virtual IAsyncCollector<object> CreateCollector(EventGridAttribute attribute)
@@ -73,20 +81,58 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Config
 
         private EventGridPublisherClient CreateClient(EventGridAttribute attribute)
         {
+            var connectionInformation = ResolveConnectionInformation(attribute);
+            if (connectionInformation.AzureKeyCredential != null)
+            {
+                return new EventGridPublisherClient(connectionInformation.Endpoint, connectionInformation.AzureKeyCredential);
+            }
+            else
+            {
+                return new EventGridPublisherClient(connectionInformation.Endpoint, connectionInformation.TokenCredential);
+            }
+        }
+
+        internal EventGridConnectionInformation ResolveConnectionInformation(EventGridAttribute attribute)
+        {
+            if (!string.IsNullOrWhiteSpace(attribute.TopicKeySetting))
+            {
+                return new EventGridConnectionInformation(new Uri(attribute.TopicEndpointUri), new AzureKeyCredential(attribute.TopicKeySetting));
+            }
+
             if (string.IsNullOrWhiteSpace(attribute.Connection))
             {
-                return new EventGridPublisherClient(new Uri(attribute.TopicEndpointUri), new AzureKeyCredential(attribute.TopicKeySetting));
+                var emptyConfiguration = new ConfigurationBuilder().Build();
+                return new EventGridConnectionInformation(new Uri(attribute.TopicEndpointUri), _componentFactory.CreateTokenCredential(emptyConfiguration));
             }
 
             var connectionSection = _configuration.GetSection(attribute.Connection);
             if (!string.IsNullOrWhiteSpace(connectionSection.Value))
             {
-                return new EventGridPublisherClient(new Uri(connectionSection.Value), _componentFactory.CreateTokenCredential(connectionSection));
+                return new EventGridConnectionInformation(new Uri(connectionSection.Value), _componentFactory.CreateTokenCredential(connectionSection));
             }
             else
             {
-                return new EventGridPublisherClient(new Uri(attribute.TopicEndpointUri), _componentFactory.CreateTokenCredential(connectionSection));
+                return new EventGridConnectionInformation(new Uri(attribute.TopicEndpointUri), _componentFactory.CreateTokenCredential(connectionSection));
             }
+        }
+
+        internal record EventGridConnectionInformation
+        {
+            public EventGridConnectionInformation(Uri endpoint, AzureKeyCredential azureKeyCredential)
+            {
+                Endpoint = endpoint;
+                AzureKeyCredential = azureKeyCredential;
+            }
+
+            public EventGridConnectionInformation(Uri endpoint, TokenCredential tokenCredential)
+            {
+                Endpoint = endpoint;
+                TokenCredential = tokenCredential;
+            }
+
+            public Uri Endpoint { get; }
+            public AzureKeyCredential AzureKeyCredential { get; }
+            public TokenCredential TokenCredential { get; }
         }
     }
 }

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridWebJobsBuilderExtensions.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridWebJobsBuilderExtensions.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid.Config;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
@@ -22,7 +25,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 throw new ArgumentNullException(nameof(builder));
             }
 
+            builder.Services.AddAzureClientsCore();
             builder.Services.TryAddSingleton<HttpRequestProcessor>();
+            builder.Services.AddSingleton<EventGridAsyncCollectorFactory>();
             builder.AddExtension<EventGridExtensionConfigProvider>();
             return builder;
         }

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
   </ItemGroup>

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" />
+		<PackageReference Include="Microsoft.Azure.WebJobs" />
+		<PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
   </ItemGroup>
 

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/OutputBinding/EventGridAttribute.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/OutputBinding/EventGridAttribute.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         [AppSetting]
         public string TopicKeySetting { get; set; }
 
-        /// <summary>Gets or sets whether to use the DefaultAzureCredential class for authentication.</summary>
-        public bool UseDefaultAzureCredential { get; set; }
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Event Grid topic's connection string.
+        /// </summary>
+        public string Connection { get; set; }
     }
 }

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/OutputBinding/EventGridAttribute.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/OutputBinding/EventGridAttribute.cs
@@ -21,5 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         /// <summary>Gets or sets the Topic Key setting. You can find information on getting the Key for a topic here: https://docs.microsoft.com/en-us/azure/event-grid/custom-event-quickstart#send-an-event-to-your-topic </summary>
         [AppSetting]
         public string TopicKeySetting { get; set; }
+
+        /// <summary>Gets or sets whether to use the DefaultAzureCredential class for authentication.</summary>
+        public bool UseDefaultAzureCredential { get; set; }
     }
 }

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/EventGridListener.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/EventGridListener.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/EventGridTriggerAttributeBindingProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/EventGridTriggerAttributeBindingProvider.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Messaging;
 using Azure.Messaging.EventGrid;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid.Config;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/Config/EventGridAsyncCollectorFactoryTests.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/Config/EventGridAsyncCollectorFactoryTests.cs
@@ -13,23 +13,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Config
     internal class EventGridAsyncCollectorFactoryTests
     {
         [Test]
-        [TestCase(null, null, null, "The 'Connection' property or 'TopicEndpointUri' property must be set")]
-        [TestCase("", null, null, "The 'Connection' property or 'TopicEndpointUri' property must be set")]
-        [TestCase(null, null, "", "The 'Connection' property or 'TopicEndpointUri' property must be set")]
-        [TestCase(null, null, "EmptyUri", "The 'Connection' property or 'TopicEndpointUri' property must be set")]
+        [TestCase(null, null, null, "The 'Connection.topicEndpointUri' property or 'TopicEndpointUri' property must be set")]
+        [TestCase("", null, null, "The 'Connection.topicEndpointUri' property or 'TopicEndpointUri' property must be set")]
+        [TestCase(null, null, "", "The 'Connection.topicEndpointUri' property or 'TopicEndpointUri' property must be set")]
+        [TestCase(null, null, "EmptyUri", "The 'Connection.topicEndpointUri' property or 'TopicEndpointUri' property must be set")]
         [TestCase("bar.com", "baz", null, "The 'TopicEndpointUri' property must be a valid absolute Uri")]
-        [TestCase(null, "baz", "ValidUri", "Conflicting Event Grid topic credentials have been set in 'Connection' and 'TopicKeySetting'")]
-        [TestCase("https://foo.com", null, "MissingUri", "Event Grid topic connection string 'MissingUri' does not exist. Make sure that it is a defined App Setting.")]
-        [TestCase("https://foo.com", null, "InvalidUri", "Event Grid topic connection string 'InvalidUri' must be a valid absolute Uri")]
-        [TestCase("https://foo.com", null, "AnotherUri", "Conflicting Event Grid topic connection strings have been set in 'Connection' and 'TopicEndpointUri'")]
+        [TestCase(null, "baz", "ValidUri", "Conflicting topic credentials have been set in 'ValidUri' and 'TopicKeySetting'")]
+        [TestCase("https://foo.com", "baz", "ValidUri", "Conflicting topic credentials have been set in 'ValidUri' and 'TopicKeySetting'")]
+        [TestCase("https://foo.com", null, "MissingUri", "The topic endpoint uri in 'MissingUri' does not exist. Make sure that it is a defined App Setting.")]
+        [TestCase("https://foo.com", null, "InvalidUri", "The topic endpoint uri in 'InvalidUri' must be a valid absolute Uri")]
+        [TestCase("https://foo.com", null, "AnotherUri", "Conflicting topic endpoint uris have been set in 'AnotherUri' and 'TopicEndpointUri'")]
         public void ValidateOutputBindingAttributeTests(string topicEndpointUri, string topicKeySetting, string connection, string message)
         {
             var host = TestHelpers.NewHost<Empty>(configuration: new Dictionary<string, string>
             {
-                { "EmptyUri", "" },
-                { "InvalidUri", "bar.com" },
-                { "ValidUri", "https://foo.com" },
-                { "AnotherUri", "https://bar.com" },
+                { "EmptyUri:topicEndpointUri", "" },
+                { "InvalidUri:topicEndpointUri", "bar.com" },
+                { "ValidUri:topicEndpointUri", "https://foo.com" },
+                { "AnotherUri:topicEndpointUri", "https://bar.com" },
             });
 
             var factory = host.Services.GetRequiredService<EventGridAsyncCollectorFactory>();
@@ -67,8 +68,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Config
         {
             var host = TestHelpers.NewHost<Empty>(configuration: new Dictionary<string, string>
             {
-                { "EmptyUri", "" },
-                { "ValidUri", "https://foo.com" },
+                { "EmptyUri:topicEndpointUri", "" },
+                { "ValidUri:topicEndpointUri", "https://foo.com" },
             });
             var factory = host.Services.GetRequiredService<EventGridAsyncCollectorFactory>();
 

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/Config/EventGridAsyncCollectorFactoryTests.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/Config/EventGridAsyncCollectorFactoryTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Identity;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid.Config;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Config
+{
+    internal class EventGridAsyncCollectorFactoryTests
+    {
+        [Test]
+        [TestCase(null, null, null, "The 'Connection' property or 'TopicEndpointUri' property must be set")]
+        [TestCase("", null, null, "The 'Connection' property or 'TopicEndpointUri' property must be set")]
+        [TestCase(null, null, "", "The 'Connection' property or 'TopicEndpointUri' property must be set")]
+        [TestCase(null, null, "EmptyUri", "The 'Connection' property or 'TopicEndpointUri' property must be set")]
+        [TestCase("bar.com", "baz", null, "The 'TopicEndpointUri' property must be a valid absolute Uri")]
+        [TestCase(null, "baz", "ValidUri", "Conflicting Event Grid topic credentials have been set in 'Connection' and 'TopicKeySetting'")]
+        [TestCase("https://foo.com", null, "MissingUri", "Event Grid topic connection string 'MissingUri' does not exist. Make sure that it is a defined App Setting.")]
+        [TestCase("https://foo.com", null, "InvalidUri", "Event Grid topic connection string 'InvalidUri' must be a valid absolute Uri")]
+        [TestCase("https://foo.com", null, "AnotherUri", "Conflicting Event Grid topic connection strings have been set in 'Connection' and 'TopicEndpointUri'")]
+        public void ValidateOutputBindingAttributeTests(string topicEndpointUri, string topicKeySetting, string connection, string message)
+        {
+            var host = TestHelpers.NewHost<Empty>(configuration: new Dictionary<string, string>
+            {
+                { "EmptyUri", "" },
+                { "InvalidUri", "bar.com" },
+                { "ValidUri", "https://foo.com" },
+                { "AnotherUri", "https://bar.com" },
+            });
+
+            var factory = host.Services.GetRequiredService<EventGridAsyncCollectorFactory>();
+            var exception = Assert.Throws<InvalidOperationException>(() => factory.Validate(new EventGridAttribute
+            {
+                TopicEndpointUri = topicEndpointUri,
+                TopicKeySetting = topicKeySetting,
+                Connection = connection
+            }));
+
+            Assert.That(exception.Message, Is.EqualTo(message));
+        }
+
+        [Test]
+        public void TestTopicKeySetting()
+        {
+            var host = TestHelpers.NewHost<Empty>();
+            var factory = host.Services.GetRequiredService<EventGridAsyncCollectorFactory>();
+
+            var connectionInformation = factory.ResolveConnectionInformation(new EventGridAttribute
+            {
+                TopicEndpointUri = "https://foo.com",
+                TopicKeySetting = "Bar",
+                Connection = null
+            });
+
+            Assert.That(connectionInformation.AzureKeyCredential, Is.Not.Null);
+        }
+
+        [Test]
+        [TestCase("https://foo.com", null, null)]
+        [TestCase(null, null, "ValidUri")]
+        [TestCase("https://foo.com", null, "EmptyUri")]
+        public void TestSystemAssignedIdentity(string topicEndpointUri, string topicKeySetting, string connection)
+        {
+            var host = TestHelpers.NewHost<Empty>(configuration: new Dictionary<string, string>
+            {
+                { "EmptyUri", "" },
+                { "ValidUri", "https://foo.com" },
+            });
+            var factory = host.Services.GetRequiredService<EventGridAsyncCollectorFactory>();
+
+            var connectionInformation = factory.ResolveConnectionInformation(new EventGridAttribute
+            {
+                TopicEndpointUri = topicEndpointUri,
+                TopicKeySetting = topicKeySetting,
+                Connection = connection
+            });
+
+            Assert.That(connectionInformation.TokenCredential, Is.Not.Null.And.TypeOf<DefaultAzureCredential>());
+        }
+
+        public class Empty
+        {
+        }
+    }
+}

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestHelpers.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestHelpers.cs
@@ -10,12 +10,18 @@ using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid.Config;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
     internal static class TestHelpers
     {
         public static IHost NewHost<T>(EventGridExtensionConfigProvider ext = null, Dictionary<string, string> configuration = null)
+        {
+            return NewHost<T>(ext == null ? null : provider => ext, configuration);
+        }
+
+        public static IHost NewHost<T>(Func<IServiceProvider, EventGridExtensionConfigProvider> ext, Dictionary<string, string> configuration = null)
         {
             var builder = new HostBuilder()
            .ConfigureServices(services =>


### PR DESCRIPTION
This change allows users to declare EventGrid bindings that use DefaultAzureCredential for authentication, so they can authenticate with the EventGrid topic using a system-assigned identity and RBAC rules instead of managing the access keys:

```csharp
[FunctionName("Example")]
public async Task RunAsync(
    [TimerTrigger("0 * * * * *", RunOnStartup = true)] TimerInfo timerInfo,
    [EventGrid(TopicEndpointUri = "EventGridEndpoint", UseDefaultAzureCredential = true)] IAsyncCollector<CloudEvent> eventCollector
)
```

The original binding properties continue to function the same as before:

```csharp
[FunctionName("Example")]
public async Task RunAsync(
    [TimerTrigger("0 * * * * *", RunOnStartup = true)] TimerInfo timerInfo,
    [EventGrid(TopicEndpointUri = "EventGridEndpoint", TopicKeySetting = "EventGridKey")] IAsyncCollector<CloudEvent> eventCollector
)
```

---

Looking for feedback on:
- Do we need a dedicated 'UseDefaultAzureCredential' property, or should that be the default behaviour if the 'TopicKeySetting' is null? I added the property to ensure backwards-compatible behaviour.
- The 'TopicKeySetting' property is decorated with the `[AppSetting]` attribute, and I've disabled the null-check when 'UseDefaultAzureCredential' is set to true. Will the functions runtime ignore a null value, or will this cause a runtime exception?