### PR TITLE
[Search] Fix "Deploy test resources" failure in weekly pipeline

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/VectorSearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/VectorSearchTests.cs
@@ -94,6 +94,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         [Test]
+        [PlaybackOnly("The availability of Semantic Search is limited to specific regions, as indicated in the list provided here: https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=search. Due to this limitation, the deployment of resources for weekly test pipeline for setting the \"semanticSearch\": \"free\" fails in the UsGov and China cloud regions.")]
         public async Task SemanticHybridSearch()
         {
             await using SearchResources resources = await SearchResources.CreateWithHotelsIndexAsync(this);

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -57,7 +57,7 @@
         },
         "searchSku": {
             "type": "string",
-            "defaultValue": "standard",
+            "defaultValue": "basic",
             "allowedValues": [
                 "free",
                 "basic",
@@ -95,7 +95,6 @@
                 "name": "[parameters('searchSku')]"
             },
             "properties": {
-                "semanticSearch": "free",
                 "replicaCount": 1,
                 "partitionCount": 1,
                 "hostingMode": "Default",


### PR DESCRIPTION
The availability of Semantic Search is limited to specific regions, as indicated in the list provided here: https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=search. 

Weekly test resource deployment started failing for UsGov and China cloud(see [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2789732&view=logs&j=8202aa58-244c-5614-d0df-1d06f4ac1fb7&t=035c745c-4917-5121-74ed-750510b17368&l=92)) because semantic search feature is not available for those regions. 

Running the semantic search test in playback mode until the feature becomes available in all the regions.