### PR TITLE
[Storage][DataMovement] Attempt to fix flakey StopOnAllFailures test

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -316,6 +316,7 @@ namespace Azure.Storage.DataMovement
             // Cancel the entire job if one job part fails and StopOnFailure is set
             if (_errorHandling == ErrorHandlingOptions.StopOnAllFailures &&
                 jobPartStatus == StorageTransferStatus.CompletedWithFailedTransfers &&
+                jobStatus != StorageTransferStatus.CancellationInProgress &&
                 jobStatus != StorageTransferStatus.CompletedWithFailedTransfers &&
                 jobStatus != StorageTransferStatus.CompletedWithSkippedTransfers &&
                 jobStatus != StorageTransferStatus.Completed)


### PR DESCRIPTION
The recently introduced `DirectoryUpload_ErrorHandling(StopOnAllFalures` test occasionally fails in the Live test pipeline because it has some extra status changes for the job. I was not able to reproduce locally so I assumed it was switching back and forth between `CancellationInProgress`/`CompletedWithFailedTransfers` twice. This change hopefully will prevent that but I'm not sure since I wasn't able to reproduce the failure locally.