### PR TITLE
Update description for FindBlobsByTags method

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -3402,8 +3402,8 @@ namespace Azure.Storage.Blobs
         #region FilterBlobs
         /// <summary>
         /// The Filter Blobs operation enables callers to list blobs across all containers whose tags
-        /// match a given search expression. Filter blobs searches across all containers within a
-        /// storage account but can be scoped within the expression to a single container.
+        /// match a given search expression and only the tags appearing in the expression will be returned.
+        /// Filter blobs searches across all containers within a storage account but can be scoped within the expression to a single container.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/find-blobs-by-tags">
@@ -3434,8 +3434,8 @@ namespace Azure.Storage.Blobs
 
         /// <summary>
         /// The Filter Blobs operation enables callers to list blobs across all containers whose tags
-        /// match a given search expression. Filter blobs searches across all containers within a
-        /// storage account but can be scoped within the expression to a single container.
+        /// match a given search expression and only the tags appearing in the expression will be returned.
+        /// Filter blobs searches across all containers within a storage account but can be scoped within the expression to a single container.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/find-blobs-by-tags">

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -2029,8 +2029,8 @@ namespace Azure.Storage.Blobs
         #region FilterBlobs
         /// <summary>
         /// The Filter Blobs operation enables callers to list blobs across all containers whose tags
-        /// match a given search expression. Filter blobs searches across all containers within a
-        /// storage account but can be scoped within the expression to a single container.
+        /// match a given search expression and only the tags appearing in the expression will be returned.
+        /// Filter blobs searches across all containers within a storage account but can be scoped within the expression to a single container.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/find-blobs-by-tags">


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-net#36406

Updating [this](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.findblobsbytags?view=azure-dotnet) docs, to include the below:

> The Filter Blobs operation enables callers to list blobs across all containers whose tags match a given search expression, **and only the tags appearing in the expression will be returned**.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
