### PR TITLE
Create .npmrc if emitter-package.json uses alpha package

### DIFF
--- a/eng/common/scripts/TypeSpec-Project-Generate.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Generate.ps1
@@ -45,6 +45,14 @@ function NpmInstallForProject([string]$workingDirectory) {
 
         Write-Host("Copying package.json from $replacementPackageJson")
         Copy-Item -Path $replacementPackageJson -Destination "package.json" -Force
+
+        $useAlphaNpmFeed = (Get-Content $replacementPackageJson -Raw).Contains("-alpha.")
+
+        if($useAlphaNpmFeed) {
+            Write-Host "Package.json contains -alpha. in the version, Creating .npmrc using azure-sdk-for-js-test-autorest feed."
+            "registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js-test-autorest/npm/registry/ `n`nalways-auth=true" | Out-File '.npmrc'
+        }
+
         npm install --no-lock-file
         if ($LASTEXITCODE) { exit $LASTEXITCODE }
     }


### PR DESCRIPTION
Currently, the Autorest Regen Preview pipeline publishes alpha versions of the c# emitter package to an alternate package feed.  This is breaking the validation builds because the alpha version specified doesn't exist in the default public repository.

To fix this, if we detect an alpha package version number in emitter-package.json, we create an npmrc file prior to running the code generation check.