### PR TITLE
[AzureMonitorExporter] add authenticated user id to Requests and Dependencies

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Features Added
 
-* Add support for Authenticated User Id.
-  ([]())
+* Add support for Authenticated User Id. ([#36509](https://github.com/Azure/azure-sdk-for-net/pull/36509))
  
 ### Breaking Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+* Add support for Authenticated User Id.
+  ([]())
+ 
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -114,11 +114,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetAuthenticatedUserId(ref ActivityTagsProcessor activityTagsProcessor)
         {
-            if (activityTagsProcessor.HasEndUserId)
+            if (activityTagsProcessor.EndUserId != null)
             {
-                var endUserId = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeEnduserId)?.ToString();
-
-                Tags[ContextTagKeys.AiUserAuthUserId.ToString()] = endUserId;
+                Tags[ContextTagKeys.AiUserAuthUserId.ToString()] = activityTagsProcessor.EndUserId;
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -114,10 +114,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetAuthenticatedUserId(ref ActivityTagsProcessor activityTagsProcessor)
         {
-            var endUserId = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeEnduserId)?.ToString();
-
-            if (endUserId != null)
+            if (activityTagsProcessor.HasEndUserId)
             {
+                var endUserId = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeEnduserId)?.ToString();
+
                 Tags[ContextTagKeys.AiUserAuthUserId.ToString()] = endUserId;
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -31,6 +31,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 Tags["ai.user.userAgent"] = userAgent;
             }
 
+            SetAuthenticatedUserId(ref activityTagsProcessor);
+
             // we only have mapping for server spans
             // todo: non-server spans
             if (activity.Kind == ActivityKind.Server)
@@ -107,6 +109,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         internal static DateTimeOffset FormatUtcTimestamp(System.DateTime utcTimestamp)
         {
             return DateTime.SpecifyKind(utcTimestamp, DateTimeKind.Utc);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SetAuthenticatedUserId(ref ActivityTagsProcessor activityTagsProcessor)
+        {
+            var endUserId = AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeEnduserId)?.ToString();
+
+            if (endUserId != null)
+            {
+                Tags[ContextTagKeys.AiUserAuthUserId.ToString()] = endUserId;
+            }
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -69,7 +69,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public OperationType activityType { get; private set; }
 
         public bool HasAzureNamespace { get; private set; } = false;
-        public bool HasEndUserId { get; private set; } = false;
+        public string? EndUserId { get; private set; } = null;
 
         public ActivityTagsProcessor()
         {
@@ -110,7 +110,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 {
                     if (tag.Key == SemanticConventions.AttributeEnduserId)
                     {
-                        this.HasEndUserId = true;
+                        this.EndUserId = tag.Value.ToString();
+                        continue;
                     }
 
                     AzMonList.Add(ref MappedTags, tag);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -59,7 +59,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             [SemanticConventions.AttributeMessagingDestination] = OperationType.Messaging,
             [SemanticConventions.AttributeMessagingDestinationKind] = OperationType.Messaging,
             [SemanticConventions.AttributeMessagingTempDestination] = OperationType.Messaging,
-            [SemanticConventions.AttributeMessagingUrl] = OperationType.Messaging
+            [SemanticConventions.AttributeMessagingUrl] = OperationType.Messaging,
+
+            [SemanticConventions.AttributeEnduserId] = OperationType.Common,
         };
 
         public AzMonList MappedTags;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ActivityTagsProcessor.cs
@@ -39,6 +39,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             [SemanticConventions.AttributeComponent] = OperationType.Common,
             ["otel.status_code"] = OperationType.Common,
             ["sampleRate"] = OperationType.Common,
+            [SemanticConventions.AttributeEnduserId] = OperationType.Common,
 
             [SemanticConventions.AttributeRpcService] = OperationType.Rpc,
             [SemanticConventions.AttributeRpcSystem] = OperationType.Rpc,
@@ -60,8 +61,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             [SemanticConventions.AttributeMessagingDestinationKind] = OperationType.Messaging,
             [SemanticConventions.AttributeMessagingTempDestination] = OperationType.Messaging,
             [SemanticConventions.AttributeMessagingUrl] = OperationType.Messaging,
-
-            [SemanticConventions.AttributeEnduserId] = OperationType.Common,
         };
 
         public AzMonList MappedTags;
@@ -70,6 +69,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public OperationType activityType { get; private set; }
 
         public bool HasAzureNamespace { get; private set; } = false;
+        public bool HasEndUserId { get; private set; } = false;
 
         public ActivityTagsProcessor()
         {
@@ -108,6 +108,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 // and then continue to the next iteration.
                 if (_currentActivityType == OperationType.Common)
                 {
+                    if (tag.Key == SemanticConventions.AttributeEnduserId)
+                    {
+                        this.HasEndUserId = true;
+                    }
+
                     AzMonList.Add(ref MappedTags, tag);
                     continue;
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -93,6 +93,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string? expectedTraceId,
             string? expectedSpanId,
             IDictionary<string, string>? expectedProperties,
+            string expectedAuthUserId,
             bool expectedSuccess = true)
         {
             Assert.Equal("RemoteDependency", telemetryItem.Name); // telemetry type
@@ -100,8 +101,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            Assert.Equal(4, telemetryItem.Tags.Count);
+            Assert.Equal(5, telemetryItem.Tags.Count);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
+            Assert.Equal(expectedAuthUserId, telemetryItem.Tags["ai.user.authUserId"]);
             Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
             Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
@@ -131,6 +133,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             string? expectedTraceId,
             IDictionary<string, string> expectedProperties,
             string? expectedSpanId,
+            string expectedAuthUserId,
             bool expectedSuccess = true)
         {
             Assert.Equal("Request", telemetryItem.Name); // telemetry type
@@ -138,11 +141,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
             Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
 
-            var expectedTagsCount = 4;
+            var expectedTagsCount = 5;
 
             if (activityKind == ActivityKind.Server)
             {
-                expectedTagsCount = 6;
+                expectedTagsCount = 7;
 
                 Assert.Contains("ai.operation.name", telemetryItem.Tags.Keys);
                 Assert.Contains("ai.location.ip", telemetryItem.Tags.Keys);
@@ -150,6 +153,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
             Assert.Equal(expectedTagsCount, telemetryItem.Tags.Count);
             Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
+            Assert.Equal(expectedAuthUserId, telemetryItem.Tags["ai.user.authUserId"]);
             Assert.Contains("ai.cloud.role", telemetryItem.Tags.Keys);
             Assert.Contains("ai.cloud.roleInstance", telemetryItem.Tags.Keys);
             Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -55,6 +54,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
+                activity.SetTag("enduser.id", "TestUser"); //authenticated user
                 activity.SetTag("integer", 1);
                 activity.SetTag("message", "Hello World!");
                 activity.SetTag("intArray", new int[] { 1, 2, 3 });
@@ -74,6 +74,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedName: "SayHello",
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
+                expectedAuthUserId: "TestUser",
                 expectedProperties: new Dictionary<string, string> { { "integer", "1" }, { "message", "Hello World!" }, { "intArray", "1,2,3" } });
         }
 
@@ -101,6 +102,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
+                activity.SetTag("enduser.id", "TestUser"); //authenticated user
                 activity.SetTag("integer", 1);
                 activity.SetTag("message", "Hello World!");
                 activity.SetTag("intArray", new int[] { 1, 2, 3 });
@@ -121,6 +123,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedName: "SayHello",
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
+                expectedAuthUserId: "TestUser",
                 expectedProperties: new Dictionary<string, string> { { "integer", "1" }, { "message", "Hello World!" }, { "intArray", "1,2,3" } });
         }
 
@@ -147,6 +150,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 traceId = activity.TraceId.ToHexString();
                 spanId = activity.SpanId.ToHexString();
 
+                activity.SetTag("enduser.id", "TestUser"); //authenticated user
+
                 try
                 {
                     throw new Exception("Test exception");
@@ -171,6 +176,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedName: "ActivityWithException",
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
+                expectedAuthUserId: "TestUser",
                 expectedProperties: null,
                 expectedSuccess: false);
 
@@ -229,6 +235,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 spanId = activity.SpanId.ToHexString();
                 traceId = activity.TraceId.ToHexString();
 
+                activity.SetTag("enduser.id", "TestUser"); //authenticated user
+
                 var logger = loggerFactory.CreateLogger(logCategoryName);
 
                 logger.Log(
@@ -253,6 +261,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                 expectedName: activityName,
                 expectedTraceId: traceId,
                 expectedSpanId: spanId,
+                expectedAuthUserId: "TestUser",
                 expectedProperties: null);
 
             Assert.True(logTelemetryItems?.Any(), "Unit test failed to collect telemetry.");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -315,8 +315,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             using var activity = CreateTestActivity(tagObjects, activityKind);
             activityTagsProcessor.CategorizeTags(activity);
 
-            Assert.True(activityTagsProcessor.HasEndUserId);
-            Assert.Equal("TestUser", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeEnduserId)?.ToString());
+            Assert.Equal("TestUser", activityTagsProcessor.EndUserId);
         }
 
         private static Activity CreateTestActivity(IEnumerable<KeyValuePair<string, object?>>? additionalAttributes = null, ActivityKind activityKind = ActivityKind.Server)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -300,6 +300,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal(activity.Kind == ActivityKind.Server ? 2 : 1, activityTagsProcessor.UnMappedTags.Length);
         }
 
+        [Theory]
+        [InlineData(ActivityKind.Client)]
+        [InlineData(ActivityKind.Server)]
+        public void ActivityTagsProcessor_CategorizeTags_ExtractsAuthUserId(ActivityKind activityKind)
+        {
+            var activityTagsProcessor = new ActivityTagsProcessor();
+
+            IEnumerable<KeyValuePair<string, object?>> tagObjects = new Dictionary<string, object?>
+            {
+                [SemanticConventions.AttributeEnduserId] = "TestUser",
+            };
+
+            using var activity = CreateTestActivity(tagObjects, activityKind);
+            activityTagsProcessor.CategorizeTags(activity);
+
+            Assert.True(activityTagsProcessor.HasEndUserId);
+            Assert.Equal("TestUser", AzMonList.GetTagValue(ref activityTagsProcessor.MappedTags, SemanticConventions.AttributeEnduserId)?.ToString());
+        }
+
         private static Activity CreateTestActivity(IEnumerable<KeyValuePair<string, object?>>? additionalAttributes = null, ActivityKind activityKind = ActivityKind.Server)
         {
             var startTimestamp = DateTime.UtcNow;


### PR DESCRIPTION
Update exporter to correctly map authenticated user id as described in our [public doc](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=net#set-the-user-id-or-authenticated-user-id).

### Changes
- Add support for authenticated user id (OTEL `enduser.id` --> AI `ai.user.authUserId`)
- Update `ActivityTagsProcessor`'s MappedTags.
- Update tests