### PR TITLE
Fix EmailAttachment validation to avoid excessive memory allocation

### DIFF
--- a/sdk/communication/Azure.Communication.Email/src/Models/EmailAttachment.cs
+++ b/sdk/communication/Azure.Communication.Email/src/Models/EmailAttachment.cs
@@ -31,7 +31,7 @@ namespace Azure.Communication.Email
 
         internal void ValidateAttachmentContent()
         {
-            if (string.IsNullOrWhiteSpace(ContentInBase64))
+            if (Content.ToMemory().IsEmpty)
             {
                 throw new ArgumentException(ErrorMessages.InvalidAttachmentContent);
             }

--- a/sdk/communication/Azure.Communication.Email/src/Models/ErrorMessages.cs
+++ b/sdk/communication/Azure.Communication.Email/src/Models/ErrorMessages.cs
@@ -9,7 +9,7 @@ namespace Azure.Communication.Email
         internal const string EmptyHeaderValue = "Empty Value is not allowed in Email Header";
         internal const string EmptySubject = "Email subject can not be empty";
         internal const string EmptyToRecipients = "ToRecipients cannot be empty";
-        internal const string InvalidAttachmentContent = "Attachment ContentBytes must be a base64 string.";
+        internal const string InvalidAttachmentContent = "Attachment Content cannot be empty.";
         internal const string InvalidEmailAddress = " is not a valid email address";
         internal const string InvalidSenderEmail = "Sender must be a valid email address";
     }


### PR DESCRIPTION
Currently, validation of `EmailAttachment` leads to excessive memory allocation due to unnecessary conversion of Content to Base64 string.

Below there is a measurement of that extra allocation for 5MB attachment:

Before validation:
<img width="271" alt="before_validation" src="https://github.com/Azure/azure-sdk-for-net/assets/106100749/6a5756fd-0677-4d21-b576-cb7e5de2561b">

After validation:
<img width="235" alt="after_validation" src="https://github.com/Azure/azure-sdk-for-net/assets/106100749/6e6af596-c3cc-47b8-b877-f8aa93b71b82">

Extra memory allocated:
<img width="560" alt="extra_allocation" src="https://github.com/Azure/azure-sdk-for-net/assets/106100749/c67753c1-d856-43b9-a756-8f2127154711">

<img width="496" alt="extra_allocation_1" src="https://github.com/Azure/azure-sdk-for-net/assets/106100749/1416fbdf-8bfe-4578-a4e3-d15b23125d85">

This PR is intended to fix this issue by checking `Content` property for not being empty.