### PR TITLE
Return CLR null for JSON elements with JsonValueKind.Null

### DIFF
--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.Operators.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.Operators.cs
@@ -370,9 +370,6 @@ namespace Azure.Core.Dynamic
         /// This operator calls through to <see cref="DynamicData.Equals(object?)"/> when DynamicData is on the left-hand
         /// side of the operation.  <see cref="DynamicData.Equals(object?)"/> has value semantics when the DynamicData represents
         /// a JSON primitive, i.e. string, bool, number, or null, and reference semantics otherwise, i.e. for objects and arrays.
-        ///
-        /// Please note that if DynamicData is on the right-hand side of a <c>!=</c> operation, this operator will not be invoked.
-        /// Because of this the result of a <c>!=</c> comparison with <c>null</c> on the left and a DynamicData instance on the right will return <c>true</c>.
         /// </remarks>
         /// <param name="left">The <see cref="DynamicData"/> to compare.</param>
         /// <param name="right">The <see cref="object"/> to compare.</param>

--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
@@ -129,6 +129,11 @@ namespace Azure.Core.Dynamic
                 case string propertyName:
                     if (_element.TryGetProperty(propertyName, out MutableJsonElement element))
                     {
+                        if (element.ValueKind == JsonValueKind.Null)
+                        {
+                            return null;
+                        }
+
                         return new DynamicData(element, _options);
                     }
 

--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
@@ -93,6 +93,11 @@ namespace Azure.Core.Dynamic
 
             if (_element.TryGetProperty(name, out MutableJsonElement element))
             {
+                if (element.ValueKind == JsonValueKind.Null)
+                {
+                    return null;
+                }
+
                 return new DynamicData(element, _options);
             }
 
@@ -102,6 +107,11 @@ namespace Azure.Core.Dynamic
             {
                 if (_element.TryGetProperty(ConvertToCamelCase(name), out element))
                 {
+                    if (element.ValueKind == JsonValueKind.Null)
+                    {
+                        return null;
+                    }
+
                     return new DynamicData(element, _options);
                 }
             }
@@ -125,7 +135,14 @@ namespace Azure.Core.Dynamic
                     throw new KeyNotFoundException($"Could not find JSON member with name '{propertyName}'.");
 
                 case int arrayIndex:
-                    return new DynamicData(_element.GetIndexElement(arrayIndex), _options);
+                    MutableJsonElement arrayElement = _element.GetIndexElement(arrayIndex);
+
+                    if (arrayElement.ValueKind == JsonValueKind.Null)
+                    {
+                        return null;
+                    }
+
+                    return new DynamicData(arrayElement, _options);
             }
 
             throw new InvalidOperationException($"Tried to access indexer with an unsupported index type: {index}");

--- a/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonTests.cs
@@ -196,6 +196,8 @@ namespace Azure.Core.Tests
 
             Assert.IsNull((CustomType)jsonData.Foo);
             Assert.IsNull((int?)jsonData.Foo);
+            Assert.IsNull(jsonData.Foo);
+            Assert.IsNull(jsonData.foo);
         }
 
         [Test]
@@ -205,6 +207,7 @@ namespace Azure.Core.Tests
 
             Assert.IsNull((CustomType)jsonData[0]);
             Assert.IsNull((int?)jsonData[0]);
+            Assert.IsNull(jsonData[0]);
         }
 
         [Test]
@@ -216,6 +219,8 @@ namespace Azure.Core.Tests
 
             Assert.IsNull((CustomType)jsonData.Foo);
             Assert.IsNull((int?)jsonData.Foo);
+            Assert.IsNull(jsonData.Foo);
+            Assert.IsNull(jsonData.foo);
         }
 
         [Test]
@@ -227,6 +232,7 @@ namespace Azure.Core.Tests
 
             Assert.IsNull((CustomType)jsonData[0]);
             Assert.IsNull((int?)jsonData[0]);
+            Assert.IsNull(jsonData[0]);
         }
 
         [Test]
@@ -445,9 +451,11 @@ namespace Azure.Core.Tests
 
             // Property is present
             Assert.IsFalse(json.Foo == null);
+            Assert.AreNotEqual(null, json.Foo);
 
             // Property is absent
             Assert.IsTrue(json.Bar == null);
+            Assert.AreEqual(null, json.Bar);
         }
 
         [Test]
@@ -471,11 +479,15 @@ namespace Azure.Core.Tests
 
             // Properties are present
             Assert.IsFalse(json.Foo == null);
+            Assert.AreNotEqual(null, json.Foo);
             Assert.IsFalse(json.Bar.B == null);
+            Assert.AreNotEqual(null, json.Bar.B);
             Assert.IsFalse(json.Baz == null);
+            Assert.AreNotEqual(null, json.Baz);
 
             // Properties are absent
             Assert.IsTrue(json.Bar.A == null);
+            Assert.AreEqual(null, json.Bar.A);
         }
 
         [Test]
@@ -489,6 +501,7 @@ namespace Azure.Core.Tests
 
             // Property is absent
             Assert.IsTrue(json.OptionalValue == null);
+            Assert.AreEqual(null, json.OptionalValue);
 
             json.OptionalValue = 5;
 
@@ -837,10 +850,13 @@ namespace Azure.Core.Tests
             // GetMember binding mirrors Azure SDK models, so we allow a null check for an optional
             // property through the C#-style dynamic interface.
             Assert.IsTrue(json.foo == null);
+            Assert.AreEqual(null, json.foo);
             Assert.IsTrue(json.bar == null);
+            Assert.AreEqual(null, json.bar);
 
             // Indexer lookup mimics JsonNode behavior and so throws if a property is absent.
             Assert.IsTrue(json["foo"] == null);
+            Assert.AreEqual(null, json["foo"]);
             Assert.Throws<KeyNotFoundException>(() => _ = json["bar"]);
             Assert.Throws<KeyNotFoundException>(() => { if (json["bar"] == null) {; } });
         }

--- a/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonTests.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Text.Json;
 using Azure.Core.Dynamic;
 using Azure.Core.GeoJson;
+using Azure.Core.Serialization;
+using Microsoft.CSharp.RuntimeBinder;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -153,6 +155,30 @@ namespace Azure.Core.Tests
             Assert.AreEqual(4, (int)jsonData.Foo[0]);
             Assert.AreEqual(5, (int)jsonData.Foo[1]);
             Assert.AreEqual(6, (int)jsonData.Foo[2]);
+        }
+
+        [Test]
+        public void CannotGetOrSetValuesOnAbsentArrays()
+        {
+            dynamic value = BinaryData.FromString("""{"foo": [1, 2]}""").ToDynamicFromJson(DynamicCaseMapping.PascalToCamel);
+
+            Assert.Throws<InvalidOperationException>(() => { int i = value[0]; });
+            Assert.Throws<InvalidOperationException>(() => { value[0] = 1; });
+
+            Assert.Throws<InvalidOperationException>(() => { int i = value.Foo[0][0]; });
+            Assert.Throws<InvalidOperationException>(() => { value.Foo[0][0] = 2; });
+        }
+
+        [Test]
+        public void CannotGetOrSetValuesOnAbsentProperties()
+        {
+            dynamic value = BinaryData.FromString("""{"foo": 1}""").ToDynamicFromJson(DynamicCaseMapping.PascalToCamel);
+
+            Assert.Throws<InvalidOperationException>(() => { int i = value.Foo.Bar.Baz; });
+            Assert.Throws<InvalidOperationException>(() => { value.Foo.Bar.Baz = "hi"; });
+
+            Assert.Throws<RuntimeBinderException>(() => { int i = value.A.B.C; });
+            Assert.Throws<RuntimeBinderException>(() => { value.A.B.C = 1; });
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/public/JsonDataArrayTests.cs
+++ b/sdk/core/Azure.Core/tests/public/JsonDataArrayTests.cs
@@ -197,6 +197,7 @@ namespace Azure.Core.Tests.Public
             Assert.AreEqual(5, (int)data[0]);
             Assert.AreEqual("valid", (string)data[1]);
             Assert.IsTrue(data[2] == null);
+            Assert.AreEqual(null, data[2]);
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/public/JsonDataPublicTests.cs
+++ b/sdk/core/Azure.Core/tests/public/JsonDataPublicTests.cs
@@ -338,30 +338,20 @@ namespace Azure.Core.Tests.Public
         public void EqualsNull()
         {
             dynamic value = JsonDataTestHelpers.CreateFromJson("""{ "foo": null }""");
-            Assert.IsTrue(value.foo.Equals(null));
+            Assert.AreEqual(null, value.foo);
             Assert.IsTrue(value.foo == null);
 
             string nullString = null;
             Assert.IsTrue(value.foo == nullString);
             Assert.IsTrue(nullString == value.foo);
 
-            // Because the DLR resolves `==` for nullable value types to take the non-nullable
-            // value on the right-hand side, we'll still require a cast for nullable primitives.
             int? nullInt = null;
             Assert.IsTrue(value.foo == nullInt);
-            Assert.IsTrue(nullInt == (int?)value.foo);
+            Assert.IsTrue(nullInt == value.foo);
 
             bool? nullBool = null;
             Assert.IsTrue(value.foo == nullBool);
-            Assert.IsTrue(nullBool == (bool?)value.foo);
-
-            // We cannot overload the equality operator with two nullable values, so
-            // the following is the consequence.
-            Assert.IsFalse(null == value.foo);
-
-            // However, this does give us a backdoor to differentiate between an
-            // absent property and a property whose JSON value is null, if we wanted to
-            // use it that way, although it's not really very nice.
+            Assert.IsTrue(nullBool == value.foo);
         }
 
         [Test]


### PR DESCRIPTION
It was noted that we have inconsistent behavior between the `null` value we return for absent JSON values, and when a JSON element value has JsonValueKind.Null.  This PR makes the behavior consistent by returning CLR `null` in both cases.

This is a follow-up that changes the behavior implemented in https://github.com/Azure/azure-sdk-for-net/pull/35733
