### PR TITLE
[Storage][DataMovement] Add a small delay before asserting job status events

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -263,7 +263,7 @@ namespace Azure.Storage.DataMovement.Tests
             await transferManager.PauseTransferIfRunningAsync(transfer.Id, cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
 
             // Check if Job Plan File exists in checkpointer path.
@@ -312,7 +312,7 @@ namespace Azure.Storage.DataMovement.Tests
             await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
 
             // Check if Job Plan File exists in checkpointer path.
@@ -377,7 +377,7 @@ namespace Azure.Storage.DataMovement.Tests
             await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
 
             CancellationTokenSource cancellationTokenSource2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -440,7 +440,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert - Confirm we've paused
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
 
             // Act - Resume Job
             TransferOptions resumeOptions = new TransferOptions()
@@ -458,7 +458,7 @@ namespace Azure.Storage.DataMovement.Tests
             await resumeTransfer.AwaitCompletion(waitTransferCompletion.Token);
 
             // Assert
-            testEventRaised2.AssertContainerCompletedCheck(1);
+            await testEventRaised2.AssertContainerCompletedCheck(1);
             Assert.AreEqual(StorageTransferStatus.Completed, resumeTransfer.TransferStatus);
             Assert.IsTrue(resumeTransfer.HasCompleted);
 
@@ -650,7 +650,7 @@ namespace Azure.Storage.DataMovement.Tests
             await transferManager.PauseTransferIfRunningAsync(transfer.Id, cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
@@ -696,7 +696,7 @@ namespace Azure.Storage.DataMovement.Tests
             await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
@@ -742,13 +742,13 @@ namespace Azure.Storage.DataMovement.Tests
             await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
 
             CancellationTokenSource cancellationTokenSource2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await transferManager.PauseTransferIfRunningAsync(transfer, cancellationTokenSource2.Token);
 
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
         }
 
@@ -802,7 +802,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert - Confirm we've paused
             Assert.AreEqual(StorageTransferStatus.Paused, transfer.TransferStatus);
-            testEventsRaised.AssertPausedCheck();
+            await testEventsRaised.AssertPausedCheck();
 
             // Act - Resume Job
             TransferOptions resumeOptions = new TransferOptions()
@@ -821,7 +821,7 @@ namespace Azure.Storage.DataMovement.Tests
             await resumeTransfer.AwaitCompletion(waitTransferCompletion.Token);
 
             // Assert
-            testEventsRaised2.AssertContainerCompletedCheck(100);
+            await testEventsRaised2.AssertContainerCompletedCheck(100);
             Assert.AreEqual(StorageTransferStatus.Completed, resumeTransfer.TransferStatus);
             Assert.IsTrue(resumeTransfer.HasCompleted);
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferAsyncCopyDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferAsyncCopyDirectoryTests.cs
@@ -78,7 +78,7 @@ namespace Azure.Storage.DataMovement.Tests
             CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(waitTimeInSec));
             await transfer.AwaitCompletion(tokenSource.Token);
 
-            testEventRaised.AssertContainerCompletedCheck(sourceFiles.Count);
+            await testEventRaised.AssertContainerCompletedCheck(sourceFiles.Count);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
 
@@ -576,7 +576,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
-            testEventRaised.AssertContainerCompletedCheck(4);
+            await testEventRaised.AssertContainerCompletedCheck(4);
         }
 
         [Test]
@@ -608,7 +608,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
             Assert.IsTrue(testEventRaised.FailedEvents.First().Exception.Message.Contains("BlobAlreadyExists"));
-            testEventRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventRaised.AssertContainerCompletedWithFailedCheck(1);
         }
 
         [Test]
@@ -640,7 +640,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);
-            testEventRaised.AssertContainerCompletedWithSkippedCheck(1);
+            await testEventRaised.AssertContainerCompletedWithSkippedCheck(1);
         }
 
         [Test]
@@ -663,7 +663,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
-            testEventRaised.AssertContainerCompletedCheck(4);
+            await testEventRaised.AssertContainerCompletedCheck(4);
         }
 
         [Test]
@@ -695,7 +695,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
             Assert.IsTrue(testEventRaised.FailedEvents.First().Exception.Message.Contains("BlobAlreadyExists"));
-            testEventRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventRaised.AssertContainerCompletedWithFailedCheck(1);
         }
 
         [Test]
@@ -727,7 +727,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);
-            testEventRaised.AssertContainerCompletedWithSkippedCheck(1);
+            await testEventRaised.AssertContainerCompletedWithSkippedCheck(1);
         }
         #endregion
     }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferAsyncCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferAsyncCopyTests.cs
@@ -1461,20 +1461,17 @@ namespace Azure.Storage.DataMovement.Tests
             await transfer.AwaitCompletion(cancellationTokenSource.Token);
 
             // Assert
-            testEventRaised.AssertUnexpectedFailureCheck();
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);
             Assert.IsTrue(skippedSeen);
             Assert.IsTrue(await destinationClient.ExistsAsync());
-            Assert.AreEqual(1, testEventRaised.SkippedEvents.Count);
+
+            testEventRaised.AssertSingleSkippedCheck();
             Assert.AreEqual(sourceResource.Path, testEventRaised.SkippedEvents.First().SourceResource.Path);
             Assert.AreEqual(destinationResource.Uri, testEventRaised.SkippedEvents.First().DestinationResource.Uri);
             Assert.AreEqual(transfer.Id, testEventRaised.SkippedEvents.First().TransferId);
-            Assert.IsEmpty(testEventRaised.SingleCompletedEvents);
-            Assert.AreEqual(2, testEventRaised.StatusEvents.Count);
-            Assert.AreEqual(StorageTransferStatus.InProgress, testEventRaised.StatusEvents.First().StorageTransferStatus);
-            Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, testEventRaised.StatusEvents.ElementAt(1).StorageTransferStatus);
+
             // Verify Upload - That we skipped over and didn't reupload something new.
             using (FileStream fileStream = File.OpenRead(originalSourceFile))
             {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferDownloadDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferDownloadDirectoryTests.cs
@@ -73,7 +73,7 @@ namespace Azure.Storage.DataMovement.Tests
             CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(waitTimeInSec));
             await transfer.AwaitCompletion(tokenSource.Token);
 
-            testEventsRaised.AssertContainerCompletedCheck(sourceFiles.Count);
+            await testEventsRaised.AssertContainerCompletedCheck(sourceFiles.Count);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
 
@@ -516,7 +516,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedCheck(4);
+            await testEventsRaised.AssertContainerCompletedCheck(4);
         }
 
         [Test]
@@ -553,7 +553,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
             Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains("Cannot overwrite file."));
-            testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
         }
 
         [Test]
@@ -590,7 +590,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
         }
 
         [Test]
@@ -620,7 +620,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedCheck(4);
+            await testEventsRaised.AssertContainerCompletedCheck(4);
         }
 
         [Test]
@@ -657,7 +657,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
             Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains("Cannot overwrite file."));
-            testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
         }
 
         [Test]
@@ -694,7 +694,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
         }
         #endregion
     }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferSyncCopyDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferSyncCopyDirectoryTests.cs
@@ -78,7 +78,7 @@ namespace Azure.Storage.DataMovement.Tests
             CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(waitTimeInSec));
             await transfer.AwaitCompletion(tokenSource.Token);
 
-            testEventFailed.AssertContainerCompletedCheck(sourceFiles.Count);
+            await testEventFailed.AssertContainerCompletedCheck(sourceFiles.Count);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
 
@@ -572,7 +572,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
             Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains("BlobAlreadyExists"));
         }
 
@@ -605,7 +605,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
         }
 
         [Test]
@@ -660,7 +660,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
             Assert.IsTrue(testEventsRaised.FailedEvents.First().Exception.Message.Contains("BlobAlreadyExists"));
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadDirectoryTests.cs
@@ -70,7 +70,7 @@ namespace Azure.Storage.DataMovement.Tests
             CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(waitTimeInSec));
             await transfer.AwaitCompletion(tokenSource.Token);
 
-            testEventsRaised.AssertContainerCompletedCheck(files.Count);
+            await testEventsRaised.AssertContainerCompletedCheck(files.Count);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
 
@@ -539,7 +539,7 @@ namespace Azure.Storage.DataMovement.Tests
             {
                 Assert.AreEqual(blob.Properties.BlobType, blobType);
             }
-            testEventsRaised.AssertContainerCompletedCheck(2);
+            await testEventsRaised.AssertContainerCompletedCheck(2);
         }
         #endregion DirectoryUploadTests
 
@@ -637,7 +637,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             if (errorHandling == ErrorHandlingOptions.ContinueOnFailure)
             {
-                testEventsRaised.AssertContainerCompletedWithFailedCheckContinue(1);
+                await testEventsRaised.AssertContainerCompletedWithFailedCheckContinue(1);
 
                 // Verify all files exist, meaning files without conflict were transferred.
                 Assert.IsTrue(files
@@ -647,7 +647,7 @@ namespace Azure.Storage.DataMovement.Tests
             }
             else if (errorHandling == ErrorHandlingOptions.StopOnAllFailures)
             {
-                testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
+                await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
 
                 // Cannot do any file verification as transfer may proceed while job being cancelled
             }
@@ -736,7 +736,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
-            testEventsRaised.AssertContainerCompletedCheck(4);
+            await testEventsRaised.AssertContainerCompletedCheck(4);
         }
 
         [Test]
@@ -766,7 +766,7 @@ namespace Azure.Storage.DataMovement.Tests
             await transfer.AwaitCompletion(cancellationTokenSource.Token).ConfigureAwait(false);
 
             // Assert
-            testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
@@ -801,7 +801,7 @@ namespace Azure.Storage.DataMovement.Tests
             await transfer.AwaitCompletion(cancellationTokenSource.Token).ConfigureAwait(false);
 
             // Assert
-            testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);
@@ -830,7 +830,7 @@ namespace Azure.Storage.DataMovement.Tests
             transfer.EnsureCompleted(cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertContainerCompletedCheck(4);
+            await testEventsRaised.AssertContainerCompletedCheck(4);
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.Completed, transfer.TransferStatus);
@@ -863,7 +863,7 @@ namespace Azure.Storage.DataMovement.Tests
             transfer.EnsureCompleted(cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithFailedCheck(1);
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithFailedTransfers, transfer.TransferStatus);
@@ -898,7 +898,7 @@ namespace Azure.Storage.DataMovement.Tests
             transfer.EnsureCompleted(cancellationTokenSource.Token);
 
             // Assert
-            testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
+            await testEventsRaised.AssertContainerCompletedWithSkippedCheck(1);
             Assert.NotNull(transfer);
             Assert.IsTrue(transfer.HasCompleted);
             Assert.AreEqual(StorageTransferStatus.CompletedWithSkippedTransfers, transfer.TransferStatus);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TestEventsRaised.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TestEventsRaised.cs
@@ -178,12 +178,14 @@ namespace Azure.Storage.DataMovement.Tests
         /// <param name="blobCount">
         /// Expected amount of single transfers within the container transfer.
         /// </param>
-        public void AssertContainerCompletedCheck(int transferCount)
+        public async Task AssertContainerCompletedCheck(int transferCount)
         {
             AssertUnexpectedFailureCheck();
             Assert.IsEmpty(SkippedEvents);
             // TODO: Reenable check:  https://github.com/Azure/azure-sdk-for-net/issues/35976
             // Assert.AreEqual(transferCount, SingleCompletedEvents.Count);
+
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
             CollectionAssert.AreEqual(
                 new StorageTransferStatus[] {
                     StorageTransferStatus.InProgress,
@@ -199,10 +201,12 @@ namespace Azure.Storage.DataMovement.Tests
         /// <param name="expectedFailureCount">
         /// Expected amount of failure single transfers to occur within the container transfers.
         /// </param>
-        public void AssertContainerCompletedWithFailedCheck(int expectedFailureCount)
+        public async Task AssertContainerCompletedWithFailedCheck(int expectedFailureCount)
         {
             Assert.AreEqual(expectedFailureCount, FailedEvents.Count);
             Assert.IsEmpty(SkippedEvents);
+
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
             CollectionAssert.AreEqual(
                 new StorageTransferStatus[] {
                     StorageTransferStatus.InProgress,
@@ -219,10 +223,12 @@ namespace Azure.Storage.DataMovement.Tests
         /// <param name="expectedFailureCount">
         /// Expected amount of failure single transfers to occur within the container transfers.
         /// </param>
-        public void AssertContainerCompletedWithFailedCheckContinue(int expectedFailureCount)
+        public async Task AssertContainerCompletedWithFailedCheckContinue(int expectedFailureCount)
         {
             Assert.AreEqual(expectedFailureCount, FailedEvents.Count);
             Assert.IsEmpty(SkippedEvents);
+
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
             CollectionAssert.AreEqual(
                 new StorageTransferStatus[] {
                     StorageTransferStatus.InProgress,
@@ -237,10 +243,12 @@ namespace Azure.Storage.DataMovement.Tests
         /// <param name="expectedSkipCount">
         /// Expected amount of skipped single transfers to occur within the container transfers.
         /// </param>
-        public void AssertContainerCompletedWithSkippedCheck(int expectedSkipCount)
+        public async Task AssertContainerCompletedWithSkippedCheck(int expectedSkipCount)
         {
             AssertUnexpectedFailureCheck();
             Assert.AreEqual(expectedSkipCount, SkippedEvents.Count);
+
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
             CollectionAssert.AreEqual(
                 new StorageTransferStatus[] {
                     StorageTransferStatus.InProgress,
@@ -248,10 +256,12 @@ namespace Azure.Storage.DataMovement.Tests
                 StatusEvents.Select(e => e.StorageTransferStatus));
         }
 
-        public void AssertPausedCheck()
+        public async Task AssertPausedCheck()
         {
             AssertUnexpectedFailureCheck();
             Assert.IsEmpty(SkippedEvents);
+
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
             CollectionAssert.AreEqual(
                 new StorageTransferStatus[] {
                     StorageTransferStatus.InProgress,
@@ -283,7 +293,7 @@ namespace Azure.Storage.DataMovement.Tests
             }
             else
             {
-                // If blobNames is popluated make sure these number of blobs match
+                // If blobNames is populated make sure these number of blobs match
                 Assert.AreEqual(transferCount, listOptions.Count);
                 // Add TestEventRaised to each option
                 foreach (TransferOptions currentOptions in listOptions)
@@ -293,6 +303,15 @@ namespace Azure.Storage.DataMovement.Tests
                 }
             }
             return eventRaisedList;
+        }
+
+        /// <summary>
+        /// The final job status event can come in after the transfer is finished.
+        /// This is expected so wait for a brief time to allow that event to come in.
+        /// </summary>
+        private Task WaitForStatusEventsAsync()
+        {
+            return Task.Delay(100);
         }
     }
 }


### PR DESCRIPTION
Tests that assert on expected job status events can be flakey in the Live test pipeline. This is likely because a transfer can complete before the final job status event is raised. This is by design and expected so this change adds a small delay before asserting on job status events.