### PR TITLE
[ServiceBus] [Azure Functions] Fix early executions cancelling on listener stop

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                                 receiveActions,
                                 _client.Value);
 
-                            await TriggerWithMessagesInternal(messagesArray, input, receiver, receiveActions, messageActions, cancellationToken).ConfigureAwait(false);
+                            await TriggerWithMessagesInternal(messagesArray, input, receiver, receiveActions, messageActions, CancellationToken.None).ConfigureAwait(false);
                         }
 
                         if (_supportMinBatchSize && _cachedMessagesManager.HasCachedMessages)


### PR DESCRIPTION
During closing ServiceBus message processor new messages can still be delivered to the processing handler but we already canceled the token which is used in execution pipeline before closing the processor. It causes multiple deliveries and TaskCanceledExceptions due:
[azure-functions-host/GrpcWorkerChannel.cs at 428215c25052dfde38e66fd064b9981dffbda562 · Azure/azure-functions-host (github.com)](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FAzure%2Fazure-functions-host%2Fblob%2F428215c25052dfde38e66fd064b9981dffbda562%2Fsrc%2FWebJobs.Script.Grpc%2FChannel%2FGrpcWorkerChannel.cs%23L743&data=05%7C01%7Calrod%40microsoft.com%7C3d4fc2b6638548b4e10308db61770f64%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638210936220807813%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=w2YsjMFotgsVzusoI8qtFZRsYglEgR4OMk85kwSsP28%3D&reserved=0)

CRI: 381018457