### PR TITLE
[Text Analytics] Refactor tests `AnalyzeOperationExtractiveSummarizeActionNotSupported` and `AnalyzeOperationAbstractiveSummarizeActionNotSupported`

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceClients/LanguageServiceClient.cs
@@ -1863,6 +1863,10 @@ namespace Azure.AI.TextAnalytics.ServiceClients
             {
                 Validation.SupportsOperation(nameof(ExtractiveSummarizeAction), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, ServiceVersion);
             }
+            if (actions.AbstractiveSummarizeActions != null && actions.AbstractiveSummarizeActions.Count > 0)
+            {
+                Validation.SupportsOperation(nameof(AbstractiveSummarizeAction), TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview, ServiceVersion);
+            }
 
             return analyzeTasks;
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractiveSummarizeTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AbstractiveSummarizeTests.cs
@@ -232,7 +232,6 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [RetryOnInternalServerError]
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationAbstractiveSummarize()
         {
             TextAnalyticsClient client = GetClient();
@@ -251,25 +250,6 @@ namespace Azure.AI.TextAnalytics.Tests
 
             AbstractiveSummarizeResultCollection abstractiveSummarizeDocumentsResults = abstractiveSummarizeActionsResults.FirstOrDefault().DocumentsResults;
             ValidateSummaryBatchResult(abstractiveSummarizeDocumentsResults);
-        }
-
-        [RecordedTest]
-        [RetryOnInternalServerError]
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
-        public void AnalyzeOperationAbstractiveSummarizeActionNotSupported()
-        {
-            TestDiagnostics = false;
-            TextAnalyticsClient client = GetClient();
-            TextAnalyticsActions batchActions = new()
-            {
-                AbstractiveSummarizeActions = new[]
-                {
-                    new AbstractiveSummarizeAction(),
-                },
-            };
-
-            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(async () => await client.StartAnalyzeActionsAsync(s_batchDocuments, batchActions));
-            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         [RecordedTest]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -840,9 +840,7 @@ namespace Azure.AI.TextAnalytics.Tests
         public void AnalyzeOperationAnalyzeHealthcareEntitiesActionNotSupported()
         {
             TestDiagnostics = false;
-
             TextAnalyticsClient client = GetClient();
-
             TextAnalyticsActions batchActions = new()
             {
                 AnalyzeHealthcareEntitiesActions = new[]
@@ -853,6 +851,44 @@ namespace Azure.AI.TextAnalytics.Tests
 
             NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(async () => await client.StartAnalyzeActionsAsync(batchDocuments, batchActions));
             Assert.AreEqual("AnalyzeHealthcareEntitiesAction is not available in API version v3.1. Use service API version 2022-05-01 or newer.", ex.Message);
+        }
+
+        [RecordedTest]
+        [RetryOnInternalServerError]
+        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
+        public void AnalyzeOperationExtractiveSummarizeActionNotSupported()
+        {
+            TestDiagnostics = false;
+            TextAnalyticsClient client = GetClient();
+            TextAnalyticsActions batchActions = new()
+            {
+                ExtractiveSummarizeActions = new[]
+                {
+                    new ExtractiveSummarizeAction(),
+                },
+            };
+
+            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(async () => await client.StartAnalyzeActionsAsync(batchDocuments, batchActions));
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
+        }
+
+        [RecordedTest]
+        [RetryOnInternalServerError]
+        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
+        public void AnalyzeOperationAbstractiveSummarizeActionNotSupported()
+        {
+            TestDiagnostics = false;
+            TextAnalyticsClient client = GetClient();
+            TextAnalyticsActions batchActions = new()
+            {
+                AbstractiveSummarizeActions = new[]
+                {
+                    new AbstractiveSummarizeAction(),
+                },
+            };
+
+            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(async () => await client.StartAnalyzeActionsAsync(batchDocuments, batchActions));
+            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         private void ValidateOperationProperties(AnalyzeActionsOperation operation)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractiveSummarizeTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/ExtractiveSummarizeTests.cs
@@ -250,7 +250,6 @@ namespace Azure.AI.TextAnalytics.Tests
 
         [RecordedTest]
         [RetryOnInternalServerError]
-        [ServiceVersion(Min = TextAnalyticsClientOptions.ServiceVersion.V2022_10_01_Preview)]
         public async Task AnalyzeOperationExtractiveSummarize()
         {
             TextAnalyticsClient client = GetClient();
@@ -269,25 +268,6 @@ namespace Azure.AI.TextAnalytics.Tests
 
             ExtractiveSummarizeResultCollection extractiveSummarizeDocumentsResults = extractiveSummarizeActionsResults.FirstOrDefault().DocumentsResults;
             ValidateSummaryBatchResult(extractiveSummarizeDocumentsResults, ExtractiveSummarySentencesOrder.Offset);
-        }
-
-        [RecordedTest]
-        [RetryOnInternalServerError]
-        [ServiceVersion(Max = TextAnalyticsClientOptions.ServiceVersion.V2022_05_01)]
-        public void AnalyzeOperationExtractiveSummarizeActionNotSupported()
-        {
-            TestDiagnostics = false;
-            TextAnalyticsClient client = GetClient();
-            TextAnalyticsActions batchActions = new()
-            {
-                ExtractiveSummarizeActions = new[]
-                {
-                    new ExtractiveSummarizeAction(),
-                },
-            };
-
-            NotSupportedException ex = Assert.ThrowsAsync<NotSupportedException>(async () => await client.StartAnalyzeActionsAsync(s_batchDocuments, batchActions));
-            Assert.That(ex.Message.EndsWith("Use service API version 2022-10-01-preview or newer."));
         }
 
         [RecordedTest]


### PR DESCRIPTION
The `AnalyzeOperationExtractiveSummarizeActionNotSupported` and the `AnalyzeOperationAbstractiveSummarizeActionNotSupported` tests were not being invoked correctly due to the ServiceVersion attribute on both, the service class and the service methods themselves. Some small refactoring fixes the problem.