### PR TITLE
[AzureMonitorExporter] ResourceProvider for Statsbeat (part1)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/DefaultVmMetadataProvider.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/DefaultVmMetadataProvider.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Text.Json;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
+{
+    internal class DefaultVmMetadataProvider : IVmMetadataProvider
+    {
+        public VmMetadataResponse? GetVmMetadataResponse()
+        {
+            try
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    httpClient.DefaultRequestHeaders.Add("Metadata", "True");
+                    var responseString = httpClient.GetStringAsync(StatsbeatConstants.AMS_Url);
+                    var vmMetadata = JsonSerializer.Deserialize<VmMetadataResponse>(responseString.Result);
+
+                    return vmMetadata;
+                }
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorExporterEventSource.Log.WriteInformational("Failed to get VM metadata details", ex);
+                return null;
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/IVmMetadataProvider.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/IVmMetadataProvider.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
+{
+    internal interface IVmMetadataProvider
+    {
+        public VmMetadataResponse? GetVmMetadataResponse();
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/ResourceProvider.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/ResourceProvider.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
+{
+    internal static class ResourceProvider
+    {
+        internal static ResourceProviderDetails GetResourceProviderDetails(IPlatform platform, IVmMetadataProvider vmMetadataProvider)
+        {
+            try
+            {
+                var appSvcWebsiteName = platform.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+                if (appSvcWebsiteName != null)
+                {
+                    var appSvcWebsiteHostName = platform.GetEnvironmentVariable("WEBSITE_HOME_STAMPNAME");
+
+                    return new ResourceProviderDetails
+                    {
+                        ResourceProvider = "appsvc",
+                        ResourceProviderId = string.IsNullOrEmpty(appSvcWebsiteHostName)
+                                                ? appSvcWebsiteName
+                                                : appSvcWebsiteName + "/" + appSvcWebsiteHostName,
+                        OperatingSystem = platform.GetOSPlatformName(),
+                    };
+                }
+
+                var functionsWorkerRuntime = platform.GetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME");
+                if (functionsWorkerRuntime != null)
+                {
+                    return new ResourceProviderDetails
+                    {
+                        ResourceProvider = "functions",
+                        ResourceProviderId = platform.GetEnvironmentVariable("WEBSITE_HOSTNAME"),
+                        OperatingSystem = platform.GetOSPlatformName(),
+                    };
+                }
+
+                var vmMetadata = vmMetadataProvider.GetVmMetadataResponse();
+                if (vmMetadata != null)
+                {
+                    return new ResourceProviderDetails
+                    {
+                        ResourceProvider = "vm",
+                        ResourceProviderId = vmMetadata.vmId + "/" + vmMetadata.subscriptionId,
+                        OperatingSystem = vmMetadata.osType?.ToLower(CultureInfo.InvariantCulture)
+                                            ?? platform.GetOSPlatformName(),
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorExporterEventSource.Log.WriteWarning("ErrorGettingResourceProviderData", ex);
+            }
+
+            return new ResourceProviderDetails
+            {
+                ResourceProvider = "unknown",
+                ResourceProviderId = "unknown",
+                OperatingSystem = platform.GetOSPlatformName(),
+            };
+        }
+
+        internal class ResourceProviderDetails
+        {
+            public string? ResourceProvider;
+
+            public string? ResourceProviderId;
+
+            public string? OperatingSystem;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockVmMetadataProvider.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockVmMetadataProvider.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
+{
+    internal class MockVmMetadataProvider : IVmMetadataProvider
+    {
+        public VmMetadataResponse? Response { get; set; } = null;
+
+        public VmMetadataResponse? GetVmMetadataResponse() => Response;
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceProviderTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceProviderTests.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class ResourceProviderTests
+    {
+        [Fact]
+        public void Verify_GetResourceProviderDetails_Default()
+        {
+            var platform = new MockPlatform();
+            platform.OSPlatformName = "UnitTest";
+
+            var resourceProviderDetails = ResourceProvider.GetResourceProviderDetails(platform, new MockVmMetadataProvider());
+
+            Assert.Equal("unknown", resourceProviderDetails.ResourceProvider);
+            Assert.Equal("unknown", resourceProviderDetails.ResourceProviderId);
+            Assert.Equal("UnitTest", resourceProviderDetails.OperatingSystem);
+        }
+
+        [Fact]
+        public void Verify_GetResourceProviderDetails_AppService1()
+        {
+            var platform = new MockPlatform();
+            platform.OSPlatformName = "UnitTest";
+            platform.SetEnvironmentVariable("WEBSITE_SITE_NAME", "testWebSite");
+
+            var resourceProviderDetails = ResourceProvider.GetResourceProviderDetails(platform, new MockVmMetadataProvider());
+
+            Assert.Equal("appsvc", resourceProviderDetails.ResourceProvider);
+            Assert.Equal("testWebSite", resourceProviderDetails.ResourceProviderId);
+            Assert.Equal("UnitTest", resourceProviderDetails.OperatingSystem);
+        }
+
+        [Fact]
+        public void Verify_GetResourceProviderDetails_AppService2()
+        {
+            var platform = new MockPlatform();
+            platform.OSPlatformName = "UnitTest";
+            platform.SetEnvironmentVariable("WEBSITE_SITE_NAME", "testWebSite");
+            platform.SetEnvironmentVariable("WEBSITE_HOME_STAMPNAME", "testStampName");
+
+            var resourceProviderDetails = ResourceProvider.GetResourceProviderDetails(platform, new MockVmMetadataProvider());
+
+            Assert.Equal("appsvc", resourceProviderDetails.ResourceProvider);
+            Assert.Equal("testWebSite/testStampName", resourceProviderDetails.ResourceProviderId);
+            Assert.Equal("UnitTest", resourceProviderDetails.OperatingSystem);
+        }
+
+        [Fact]
+        public void Verify_GetResourceProviderDetails_Functions()
+        {
+            var platform = new MockPlatform();
+            platform.OSPlatformName = "UnitTest";
+            platform.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "test");
+            platform.SetEnvironmentVariable("WEBSITE_HOSTNAME", "testHostName");
+
+            var resourceProviderDetails = ResourceProvider.GetResourceProviderDetails(platform, new MockVmMetadataProvider());
+
+            Assert.Equal("functions", resourceProviderDetails.ResourceProvider);
+            Assert.Equal("testHostName", resourceProviderDetails.ResourceProviderId);
+            Assert.Equal("UnitTest", resourceProviderDetails.OperatingSystem);
+        }
+
+        [Fact]
+        public void Verify_GetResourceProviderDetails_AzureVM()
+        {
+            var platform = new MockPlatform();
+
+            var vmMetadataProvider = new MockVmMetadataProvider
+            {
+                Response = new VmMetadataResponse
+                {
+                    osType = "UnitTest",
+                    vmId = "testVmId",
+                    subscriptionId = "testSubscriptionId",
+                }
+            };
+
+            var resourceProviderDetails = ResourceProvider.GetResourceProviderDetails(platform, vmMetadataProvider);
+
+            Assert.Equal("vm", resourceProviderDetails.ResourceProvider);
+            Assert.Equal("testVmId/testSubscriptionId", resourceProviderDetails.ResourceProviderId);
+            Assert.Equal("unittest", resourceProviderDetails.OperatingSystem);
+        }
+    }
+}


### PR DESCRIPTION
Superceeds #35384

### Goal
Increase test coverage and test reliability for the Exporter.
Statsbeat is the last class which doesn't have mocks for its external dependencies.

This first PR introduces a new `static class ResourceProvider` which uses interfaces to get details about AppService, Functions, or Azure VM. If this design is approved, I'll open a second PR to integrate these changes into the `AzureMonitorStatsbeat` class.

### Changes
- new static class `ResourceProvider`
  - this has full test coverage via a new test class `ResourceProviderTests` 
- new interface `IVmMetadataProvider`
  - new class `DefaultVmMetadataProvider` which will be used at runtime to collect information about an Azure VM.
  - new class `MockVmMetadataProvider` which is used in unit tests.
