### PR TITLE
Add constructor overloads to PlayOptions and PlayToAllOptions that accept single PlaySource as a param

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayOptions.cs
@@ -39,5 +39,14 @@ namespace Azure.Communication.CallAutomation
             PlaySources = playSources.ToList();
             PlayTo = playTo.ToList();
         }
+
+        /// <summary>
+        /// Creates a new PlayOptions object.
+        /// </summary>
+        public PlayOptions(PlaySource playSource, IEnumerable<CommunicationIdentifier> playTo)
+        {
+            PlaySources = new List<PlaySource> { playSource };
+            PlayTo = playTo.ToList();
+        }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayToAllOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayToAllOptions.cs
@@ -33,5 +33,12 @@ namespace Azure.Communication.CallAutomation
         {
             PlaySources = playSources.ToList();
         }
+
+        /// <summary>
+        /// Creates a new PlayToAllOptions object.
+        /// </summary>
+        public PlayToAllOptions(PlaySource playSource)
+        {
+            PlaySources = new List<PlaySource> { playSource };
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
@@ -18,13 +18,13 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         };
         private static readonly FileSource _fileSource = new FileSource(new System.Uri("file://path/to/file"));
 
-        private static readonly PlayOptions _fileOptions = new PlayOptions(new List<PlaySource> { _fileSource }, _target)
+        private static readonly PlayOptions _fileOptions = new PlayOptions(_fileSource, _target)
         {
             Loop = false,
             OperationContext = "context"
         };
 
-        private static readonly PlayToAllOptions _filePlayToAllOptions = new PlayToAllOptions(new List<PlaySource> { _fileSource })
+        private static readonly PlayToAllOptions _filePlayToAllOptions = new PlayToAllOptions(_fileSource )
         {
             Loop = false,
             OperationContext = "context"


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
