### PR TITLE
[Event Hubs] June Release Prep

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.10.0-beta.1 (Unreleased)
+## 5.9.2 (2023-06-06)
 
 ### Features Added
 
@@ -9,6 +9,10 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- The reference for the AMQP transport library, `Microsoft.Azure.Amqp`, has been bumped to 2.6.2.  This resolves a potential issue opening TLS connections on .NET 6+.
+
+- It is now possible to create an `EventData` instance from an `AmqpAnnotatedMessage`.
 
 ## 5.9.1 (2024-05-09)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 5.9.2 (2023-06-06)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 
 - The reference for the AMQP transport library, `Microsoft.Azure.Amqp`, has been bumped to 2.6.2.  This resolves a potential issue opening TLS connections on .NET 6+.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - It is now possible to create an `EventData` instance from an `AmqpAnnotatedMessage`.
 
-## 5.9.1 (2024-05-09)
+## 5.9.1 (2023-05-09)
 
 ### Bugs Fixed
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.10.0-beta.1</Version>
+    <Version>5.9.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.9.1</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -6,15 +6,11 @@
 
 - Added support for binding to `EventData` with the Event Hubs trigger in Functions using the isolated process model.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed a race condition when Function instances are scaling that could cause a checkpoint to be written before the Function code was invoked to process events.  This would result in the new owner for the partition skipping those events causing them to go unprocessed.
 
 - Fixed an issue that could cause the trigger to miss that a cancellation token has been signaled, slowing down responsiveness to scaling and shutdown.
-
-### Other Changes
 
 ## 5.3.0 (2023-04-11)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 ### Features Added
 
+- Added support for binding to `EventData` with the Event Hubs trigger in Functions using the isolated process model.
+
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Fixed a race condition when Function instances are scaling that could cause a checkpoint to be written before the Function code was invoked to process events.  This would result in the new owner for the partition skipping those events causing them to go unprocessed.
+
+- Fixed an issue that could cause the trigger to miss that a cancellation token has been signaled, slowing down responsiveness to scaling and shutdown.
 
 ### Other Changes
 


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the core Event Hubs package for the June 2023 release.