### PR TITLE
[Storage][DataMovement] Add support for resource options on resource containers

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 12.0.0-beta.3 (Unreleased)
 
 ### Features Added
+- Added `ResourceOptions` to `BlobStorageResourceContainerOptions` which allows setting resource specific options on all resources in a container transfer.
 
 ### Breaking Changes
+- Removed `Traits` and `States` from `BlobStorageResourceContainerOptions`.
 
 ### Bugs Fixed
 - Fixed bug where the extension methods `BlobContainerClient.StartUploadDirectoryAsync` and `StartDownloadToDirectoryAsync` throws an exception when attempting to lazy construct the `TransferManager`.
@@ -14,7 +16,7 @@
 ## 12.0.0-beta.2 (2023-04-26)
 - This release contains bug fixes to improve quality.
 - Added option to `BlobStorageResourceContainerOptions` to choose `BlobType` when uploading blobs.
-- Added the folloiwng extension methods to upload and download blob virtual directories using the `BlobContainerClient`:
+- Added the following extension methods to upload and download blob virtual directories using the `BlobContainerClient`:
     - `BlobContainerClient.StartDownloadToDirectoryAsync`
     - `BlobContainerClient.StartUploadDirectoryAsync`
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Breaking Changes
 - Removed `Traits` and `States` from `BlobStorageResourceContainerOptions`.
+- Removed `CopyMethod` from `BlobStorageResourceContainerOptions`. Use `ResouceOptions.CopyMethod` now.
 
 ### Bugs Fixed
 - Fixed bug where the extension methods `BlobContainerClient.StartUploadDirectoryAsync` and `StartDownloadToDirectoryAsync` throws an exception when attempting to lazy construct the `TransferManager`.

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
@@ -37,23 +37,12 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class AppendBlobStorageResourceOptions
+    public partial class AppendBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public AppendBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.AppendBlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public bool? ShouldSealDestination { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.AppendBlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class BlobStorageResourceContainer : Azure.Storage.DataMovement.StorageResourceContainer
     {
@@ -69,10 +58,24 @@ namespace Azure.Storage.DataMovement.Blobs
     {
         public BlobStorageResourceContainerOptions() { }
         public Azure.Storage.Blobs.Models.BlobType BlobType { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
         public string DirectoryPrefix { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobStates States { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobTraits Traits { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions ResourceOptions { get { throw null; } set { } }
+    }
+    public partial class BlobStorageResourceOptions
+    {
+        public BlobStorageResourceOptions() { }
+        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
+        public bool? CopySourceBlobProperties { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
+        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
+        public bool? LegalHold { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
+        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class BlockBlobStorageResource : Azure.Storage.DataMovement.StorageResource
     {
@@ -92,23 +95,11 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class BlockBlobStorageResourceOptions
+    public partial class BlockBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public BlockBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public bool? CopySourceBlobProperties { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class PageBlobStorageResource : Azure.Storage.DataMovement.StorageResource
     {
@@ -128,22 +119,11 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class PageBlobStorageResourceOptions
+    public partial class PageBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public PageBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.PageBlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public long? SequenceNumber { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.PageBlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
@@ -37,23 +37,12 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class AppendBlobStorageResourceOptions
+    public partial class AppendBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public AppendBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.AppendBlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public bool? ShouldSealDestination { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.AppendBlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class BlobStorageResourceContainer : Azure.Storage.DataMovement.StorageResourceContainer
     {
@@ -69,10 +58,24 @@ namespace Azure.Storage.DataMovement.Blobs
     {
         public BlobStorageResourceContainerOptions() { }
         public Azure.Storage.Blobs.Models.BlobType BlobType { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
         public string DirectoryPrefix { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobStates States { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobTraits Traits { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions ResourceOptions { get { throw null; } set { } }
+    }
+    public partial class BlobStorageResourceOptions
+    {
+        public BlobStorageResourceOptions() { }
+        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
+        public bool? CopySourceBlobProperties { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
+        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
+        public bool? LegalHold { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
+        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class BlockBlobStorageResource : Azure.Storage.DataMovement.StorageResource
     {
@@ -92,23 +95,11 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class BlockBlobStorageResourceOptions
+    public partial class BlockBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public BlockBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public bool? CopySourceBlobProperties { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class PageBlobStorageResource : Azure.Storage.DataMovement.StorageResource
     {
@@ -128,22 +119,11 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class PageBlobStorageResourceOptions
+    public partial class PageBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public PageBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.PageBlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public long? SequenceNumber { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.PageBlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.1.cs
@@ -37,23 +37,12 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class AppendBlobStorageResourceOptions
+    public partial class AppendBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public AppendBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.AppendBlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public bool? ShouldSealDestination { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.AppendBlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class BlobStorageResourceContainer : Azure.Storage.DataMovement.StorageResourceContainer
     {
@@ -69,10 +58,24 @@ namespace Azure.Storage.DataMovement.Blobs
     {
         public BlobStorageResourceContainerOptions() { }
         public Azure.Storage.Blobs.Models.BlobType BlobType { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
         public string DirectoryPrefix { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobStates States { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobTraits Traits { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions ResourceOptions { get { throw null; } set { } }
+    }
+    public partial class BlobStorageResourceOptions
+    {
+        public BlobStorageResourceOptions() { }
+        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
+        public bool? CopySourceBlobProperties { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
+        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
+        public bool? LegalHold { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
+        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
+        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class BlockBlobStorageResource : Azure.Storage.DataMovement.StorageResource
     {
@@ -92,23 +95,11 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class BlockBlobStorageResourceOptions
+    public partial class BlockBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public BlockBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public bool? CopySourceBlobProperties { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
     public partial class PageBlobStorageResource : Azure.Storage.DataMovement.StorageResource
     {
@@ -128,22 +119,11 @@ namespace Azure.Storage.DataMovement.Blobs
         public override System.Threading.Tasks.Task<Azure.Storage.DataMovement.Models.ReadStreamStorageResourceResult> ReadStreamAsync(long position = (long)0, long? length = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteFromStreamAsync(System.IO.Stream stream, long streamLength, bool overwrite, long position = (long)0, long completeLength = (long)0, Azure.Storage.DataMovement.Models.StorageResourceWriteToOffsetOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public partial class PageBlobStorageResourceOptions
+    public partial class PageBlobStorageResourceOptions : Azure.Storage.DataMovement.Blobs.BlobStorageResourceOptions
     {
         public PageBlobStorageResourceOptions() { }
-        public Azure.Storage.Blobs.Models.AccessTier? AccessTier { get { throw null; } set { } }
-        public Azure.Storage.DataMovement.Models.TransferCopyMethod CopyMethod { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.PageBlobRequestConditions DestinationConditions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobImmutabilityPolicy DestinationImmutabilityPolicy { get { throw null; } set { } }
-        public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public bool? LegalHold { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
-        public Azure.Storage.Blobs.Models.RehydratePriority? RehydratePriority { get { throw null; } set { } }
         public long? SequenceNumber { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.PageBlobRequestConditions SourceConditions { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }
-        public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
@@ -44,7 +44,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <summary>
         /// Returns the preferred method of how to perform service to service
         /// transfers. See <see cref="TransferCopyMethod"/>. This value can be set when specifying
-        /// the options bag, see <see cref="AppendBlobStorageResourceOptions.CopyMethod"/>
+        /// the options bag, see <see cref="BlobStorageResourceOptions.CopyMethod"/>
         /// </summary>
         public override TransferCopyMethod ServiceCopyMethod => _options?.CopyMethod ?? TransferCopyMethod.SyncCopy;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResourceOptions.cs
@@ -1,180 +1,49 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.DataMovement;
 using Azure.Storage.DataMovement.Models;
-using Metadata = System.Collections.Generic.IDictionary<string, string>;
-using Tags = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs
 {
     /// <summary>
-    /// Optional parameters for
+    /// Optional parameters specific to Append Blobs using
     /// <see cref="AppendBlobStorageResource"/>.
     /// </summary>
-    public class AppendBlobStorageResourceOptions
+    public class AppendBlobStorageResourceOptions : BlobStorageResourceOptions
     {
         /// <summary>
-        /// Optional. Defines the copy operation to take.
-        /// See <see cref="TransferCopyMethod"/>. Will default to <see cref="TransferCopyMethod.SyncCopy"/>.
+        /// Default constructor.
         /// </summary>
-        public TransferCopyMethod CopyMethod { get; set; }
+        public AppendBlobStorageResourceOptions()
+        {
+        }
+
+        internal AppendBlobStorageResourceOptions(BlobStorageResourceOptions other) : base(other)
+        {
+        }
 
         /// <summary>
-        /// Optional <see cref="BlobRequestConditions"/> to add conditions on
-        /// the copying of data to this blob.
+        /// Optional. See <see cref="BlobRequestConditions"/>.
+        /// Access conditions on the copying of data from this source storage resource blob.
         ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.</summary>
-        public AppendBlobRequestConditions DestinationConditions { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="BlobRequestConditions"/> to add
-        /// conditions on the copying of data from this source storage resource blob.
-        ///
-        /// This optional property will be applied to copy and download scenarios.
-        /// Only applies when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.ReadStreamAsync(long, long?, System.Threading.CancellationToken)"/>.
+        /// Applies to copy and download transfers.
         /// </summary>
         public AppendBlobRequestConditions SourceConditions { get; set; }
 
         /// <summary>
-        /// Optional standard HTTP header properties that can be set for the
-        /// new append blob.
+        /// Optional <see cref="BlobRequestConditions"/>.
+        /// Access conditions on the copying of data to this blob.
         ///
-        /// This optional property will applied to upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
+        /// Applies to copy and upload transfers.
         /// </summary>
-        public BlobHttpHeaders HttpHeaders { get; set; }
+        public AppendBlobRequestConditions DestinationConditions { get; set; }
 
         /// <summary>
-        /// Optional. Defines custom metadata to set for this block blob.
+        /// Optional. If the destination blob should be sealed.
         ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public Metadata Metadata { get; set; }
-#pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// Options tags to set for this destination append blob.
-        /// Not valid if <see cref="CopySourceTagsMode"/> is set to <see cref="BlobCopySourceTagsMode.Copy"/>.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public Tags Tags { get; set; }
-#pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// Optional. See <see cref="AccessTier"/>.
-        /// Indicates the tier to be set on the blob.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public AccessTier? AccessTier { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="RehydratePriority"/>
-        /// Indicates the priority with which to rehydrate an archived blob.
-        ///
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
-        /// </summary>
-        public RehydratePriority? RehydratePriority { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="BlobImmutabilityPolicy"/> to set on the blob.
-        /// Note that is parameter is only applicable to a blob within a container that
-        /// has immutable storage with versioning enabled.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// Will also apply when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
-        /// </summary>
-        public BlobImmutabilityPolicy DestinationImmutabilityPolicy { get; set; }
-
-        /// <summary>
-        /// Optional. Indicates if a legal hold should be placed on the blob.
-        /// Note that is parameter is only applicable to a blob within a container that
-        /// has immutable storage with versioning enabled.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public bool? LegalHold { get; set; }
-
-        /// <summary>
-        /// Optional.
-        /// If <see cref="BlobCopySourceTagsMode.Replace"/>, the tags on the destination blob will be set to <see cref="Tags"/>.
-        /// If <see cref="BlobCopySourceTagsMode.Copy"/>, the tags on the source blob will be copied to the destination blob.
-        /// Default is to replace.
-        ///
-        /// This optional property will be applied to copy scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public BlobCopySourceTagsMode? CopySourceTagsMode { get; set; }
-
-        /// <summary>
-        /// If the destination blob should be sealed.
-        ///
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
+        /// Applies to copy transfers when <see cref="BlobStorageResourceOptions.CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
         /// </summary>
         public bool? ShouldSealDestination { get; set; }
-
-        /// <summary>
-        /// Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// This operation does not allow <see cref="UploadTransferValidationOptions.PrecalculatedChecksum"/>
-        /// to be set.
-        ///
-        /// This optional property will applied to upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public UploadTransferValidationOptions UploadTransferValidationOptions { get; set; }
-
-        /// <summary>
-        /// Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// Set <see cref="DownloadTransferValidationOptions.AutoValidateChecksum"/> to false if you
-        /// would like to skip SDK checksum validation and validate the checksum found
-        /// in the <see cref="Response"/> object yourself.
-        /// Range must be provided explicitly, stating a range withing Azure
-        /// Storage size limits for requesting a transactional hash. See the
-        /// <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob">
-        /// REST documentation</a> for range limitation details.
-        ///
-        /// This optional property will applied to download scenarios.
-        /// Only applies when calling
-        /// <see cref="StorageResource.ReadStreamAsync(long, long?, System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public DownloadTransferValidationOptions DownloadTransferValidationOptions { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceContainer.cs
@@ -88,7 +88,6 @@ namespace Azure.Storage.DataMovement.Blobs
                     client,
                     length,
                     _options.ToAppendBlobStorageResourceOptions());
-                ;
             }
             else if (type == BlobType.Page)
             {

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceContainerOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceContainerOptions.cs
@@ -2,37 +2,16 @@
 // Licensed under the MIT License.
 
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.DataMovement.Models;
 
 namespace Azure.Storage.DataMovement.Blobs
 {
     /// <summary>
-    /// Options bag for <see cref="BlobStorageResourceContainer"/>.
+    /// Options parameters when using a <see cref="BlobStorageResourceContainer"/>.
     /// </summary>
     public class BlobStorageResourceContainerOptions
     {
         /// <summary>
-        /// Optional. The <see cref="BlobTraits"/> for when calling the
-        /// <see cref="BlobStorageResourceContainer.GetStorageResourcesAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public BlobTraits Traits { get; set; }
-
-        /// <summary>
-        /// Optional. The <see cref="BlobStates"/> for when calling the
-        /// <see cref="BlobStorageResourceContainer.GetStorageResourcesAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public BlobStates States { get; set; }
-
-        /// <summary>
-        /// Optional. Defines the copy operation to take.
-        /// See <see cref="TransferCopyMethod"/>. Defaults to <see cref="TransferCopyMethod.SyncCopy"/>.
-        ///
-        /// Only applies when calling <see cref="BlockBlobStorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public TransferCopyMethod CopyMethod { get; set; }
-
-        /// <summary>
-        /// The <see cref="BlobType"/> that will be used when uploading blobs to the destination.
+        /// Optional. The <see cref="Storage.Blobs.Models.BlobType"/> that will be used when uploading blobs to the destination.
         ///
         /// Defaults to <see cref="BlobType.Block"/>.
         /// </summary>
@@ -42,5 +21,10 @@ namespace Azure.Storage.DataMovement.Blobs
         /// Optional. The directory prefix within the Blob Storage Container to use in the transfer.
         /// </summary>
         public string DirectoryPrefix { get; set; }
+
+        /// <summary>
+        /// Optional. Additional options applied to each resource in the container.
+        /// </summary>
+        public BlobStorageResourceOptions ResourceOptions { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceOptions.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.DataMovement.Models;
+using Metadata = System.Collections.Generic.IDictionary<string, string>;
+using Tags = System.Collections.Generic.IDictionary<string, string>;
+
+namespace Azure.Storage.DataMovement.Blobs
+{
+    /// <summary>
+    /// Optional parameters for all Blob Storage resource types.
+    /// </summary>
+    public class BlobStorageResourceOptions
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public BlobStorageResourceOptions()
+        {
+        }
+
+        internal BlobStorageResourceOptions(BlobStorageResourceOptions other)
+        {
+            CopyMethod = other?.CopyMethod ?? TransferCopyMethod.None;
+            Metadata = other?.Metadata;
+            Tags = other?.Tags;
+            HttpHeaders = other?.HttpHeaders;
+            AccessTier = other?.AccessTier;
+            RehydratePriority = other?.RehydratePriority;
+            DestinationImmutabilityPolicy = other?.DestinationImmutabilityPolicy;
+            LegalHold = other?.LegalHold;
+            CopySourceTagsMode = other?.CopySourceTagsMode;
+            CopySourceBlobProperties = other?.CopySourceBlobProperties;
+            UploadTransferValidationOptions = other?.UploadTransferValidationOptions;
+            DownloadTransferValidationOptions = other?.DownloadTransferValidationOptions;
+        }
+
+        /// <summary>
+        /// Optional. See <see cref="TransferCopyMethod"/>.
+        /// Defines the copy operation to use. Defaults to <see cref="TransferCopyMethod.SyncCopy"/>.
+        ///
+        /// Applies to copy transfers.
+        /// </summary>
+        public TransferCopyMethod CopyMethod { get; set; }
+
+        /// <summary>
+        /// Optional. Defines custom metadata to set on the destination blob.
+        ///
+        /// Applies to upload and copy transfers.
+        /// </summary>
+#pragma warning disable CA2227 // Collection properties should be readonly
+        public Metadata Metadata { get; set; }
+#pragma warning restore CA2227 // Collection properties should be readonly
+
+        /// <summary>
+        /// Optional. Defines tags to set on the destination blob.
+        ///
+        /// Applies to upload and copy transfers.
+        /// </summary>
+#pragma warning disable CA2227 // Collection properties should be readonly
+        public Tags Tags { get; set; }
+#pragma warning restore CA2227 // Collection properties should be readonly
+
+        /// <summary>
+        /// Optional. Standard HTTP header properties that can be set for the new blob.
+        ///
+        /// Applies to upload transfers and copy transfers when <see cref="CopyMethod"/>
+        /// is set to <see cref="TransferCopyMethod.SyncCopy"/>.
+        /// </summary>
+        public BlobHttpHeaders HttpHeaders { get; set; }
+
+        /// <summary>
+        /// Optional. See <see cref="Storage.Blobs.Models.AccessTier"/>.
+        /// Indicates the access tier to be set on the destination blob.
+        ///
+        /// Applies to upload and copy transfers.
+        /// </summary>
+        public AccessTier? AccessTier { get; set; }
+
+        /// <summary>
+        /// Optional. See <see cref="Storage.Blobs.Models.RehydratePriority"/>.
+        /// Indicates the priority with which to rehydrate an archived blob.
+        ///
+        /// Applies to copy transfers when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
+        /// </summary>
+        public RehydratePriority? RehydratePriority { get; set; }
+
+        /// <summary>
+        /// Optional. See <see cref="BlobImmutabilityPolicy"/>.
+        ///
+        /// Applies to upload transfers and copy transfers when <see cref="CopyMethod"/>
+        /// is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
+        /// </summary>
+        public BlobImmutabilityPolicy DestinationImmutabilityPolicy { get; set; }
+
+        /// <summary>
+        /// Optional. Indicates if a legal hold should be placed on the blob.
+        ///
+        /// Applies to upload and copy transfers.
+        /// </summary>
+        public bool? LegalHold { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// If <see cref="BlobCopySourceTagsMode.Replace"/>, the tags on the destination blob will be set to <see cref="Tags"/>.
+        /// If <see cref="BlobCopySourceTagsMode.Copy"/>, the tags on the source blob will be copied to the destination blob.
+        /// Default is to replace.
+        ///
+        /// Applies to copy transfers.
+        /// </summary>
+        public BlobCopySourceTagsMode? CopySourceTagsMode { get; set; }
+
+        /// <summary>
+        /// Optional. The copy source blob properties behavior. If true, the properties
+        /// of the source blob will be copied to the new blob. Default is true.
+        ///
+        /// Applies to copy transfers when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.SyncCopy"/>.
+        /// </summary>
+        public bool? CopySourceBlobProperties { get; set; }
+
+        /// <summary>
+        /// Optional. Options for transfer validation settings on this operation.
+        /// When transfer validation options are set in the client, setting this parameter
+        /// acts as an override.
+        /// This operation does not allow <see cref="UploadTransferValidationOptions.PrecalculatedChecksum"/>
+        /// to be set.
+        ///
+        /// Applies to upload transfers.
+        /// </summary>
+        public UploadTransferValidationOptions UploadTransferValidationOptions { get; set; }
+
+        /// <summary>
+        /// Optional. Options for transfer validation settings on this operation.
+        /// When transfer validation options are set in the client, setting this parameter
+        /// acts as an override.
+        /// Set <see cref="DownloadTransferValidationOptions.AutoValidateChecksum"/> to false if you
+        /// would like to skip SDK checksum validation and validate the checksum found
+        /// in the <see cref="Response"/> object yourself.
+        /// Range must be provided explicitly, stating a range withing Azure
+        /// Storage size limits for requesting a transactional hash. See the
+        /// <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob">
+        /// REST documentation</a> for range limitation details.
+        ///
+        /// Applies to download transfers.
+        /// </summary>
+        public DownloadTransferValidationOptions DownloadTransferValidationOptions { get; set; }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
@@ -50,7 +50,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <summary>
         /// Returns the preferred method of how to perform service to service
         /// transfers. See <see cref="TransferCopyMethod"/>. This value can be set when specifying
-        /// the options bag, see <see cref="BlockBlobStorageResourceOptions.CopyMethod"/>.
+        /// the options bag, see <see cref="BlobStorageResourceOptions.CopyMethod"/>.
         /// </summary>
         public override TransferCopyMethod ServiceCopyMethod => _options?.CopyMethod ?? TransferCopyMethod.SyncCopy;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResourceOptions.cs
@@ -1,188 +1,41 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.DataMovement.Models;
-using Metadata = System.Collections.Generic.IDictionary<string, string>;
-using Tags = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs
 {
     /// <summary>
-    /// Optional parameters for
-    /// <see cref="BlockBlobStorageResourceOptions"/>.
+    /// Optional parameters specific to Block Blobs using
+    /// <see cref="BlockBlobStorageResource"/>.
     /// </summary>
-    public class BlockBlobStorageResourceOptions
+    public class BlockBlobStorageResourceOptions : BlobStorageResourceOptions
     {
         /// <summary>
-        /// Optional. Defines the copy operation to take.
-        /// See <see cref="TransferCopyMethod"/>. Defaults to <see cref="TransferCopyMethod.SyncCopy"/>.
-        ///
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
+        /// Default constructor.
         /// </summary>
-        public TransferCopyMethod CopyMethod { get; set; }
+        public BlockBlobStorageResourceOptions()
+        {
+        }
+
+        internal BlockBlobStorageResourceOptions(BlobStorageResourceOptions other) : base(other)
+        {
+        }
 
         /// <summary>
-        /// Optional. Defines custom metadata to set for this block blob.
+        /// Optional. See <see cref="BlobRequestConditions"/>.
+        /// Access conditions on the copying of data from this source storage resource blob.
         ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public Metadata Metadata { get; set; }
-#pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// Options tags to set on the destination blob.
-        /// Not valid if <see cref="CopySourceTagsMode"/> is set to <see cref="BlobCopySourceTagsMode.Copy"/>.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public Tags Tags { get; set; }
-#pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// Optional. See <see cref="AccessTier"/>.
-        /// Indicates the tier to be set on the blob.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public AccessTier? AccessTier { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="BlobRequestConditions"/> to add
-        /// conditions on the copying of data from this source storage resource blob.
-        ///
-        /// This optional property will be applied to copy and download scenarios.
-        /// Only applies when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.ReadStreamAsync(long, long?, System.Threading.CancellationToken)"/>.
+        /// Applies to copy and download transfers.
         /// </summary>
         public BlobRequestConditions SourceConditions { get; set; }
 
         /// <summary>
-        /// Optional <see cref="BlobRequestConditions"/> to add conditions on
-        /// the copying of data to this blob.
+        /// Optional <see cref="BlobRequestConditions"/>.
+        /// Access conditions on the copying of data to this blob.
         ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.</summary>
+        /// Applies to copy and upload transfers.
+        /// </summary>
         public BlobRequestConditions DestinationConditions { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="RehydratePriority"/>
-        /// Indicates the priority with which to rehydrate an archived blob.
-        ///
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
-        /// </summary>
-        public RehydratePriority? RehydratePriority { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="BlobImmutabilityPolicy"/> to set on the blob.
-        /// Note that is parameter is only applicable to a blob within a container that
-        /// has immutable storage with versioning enabled.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// Will also apply when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
-        /// </summary>
-        public BlobImmutabilityPolicy DestinationImmutabilityPolicy { get; set; }
-
-        /// <summary>
-        /// Optional. Indicates if a legal hold should be placed on the blob.
-        /// Note that is parameter is only applicable to a blob within a container that
-        /// has immutable storage with versioning enabled.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public bool? LegalHold { get; set; }
-
-        /// <summary>
-        /// Optional.
-        /// If <see cref="BlobCopySourceTagsMode.Replace"/>, the tags on the destination blob will be set to <see cref="Tags"/>.
-        /// If <see cref="BlobCopySourceTagsMode.Copy"/>, the tags on the source blob will be copied to the destination blob.
-        /// Default is to replace.
-        ///
-        /// This optional property will be applied to copy scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public BlobCopySourceTagsMode? CopySourceTagsMode { get; set; }
-
-        /// <summary>
-        /// The copy source blob properties behavior.  If true, the properties
-        /// of the source blob will be copied to the new blob.  Default is true.
-        ///
-        /// This optional property will be applied to sync copy scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when the <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.SyncCopy"/>.
-        /// </summary>
-        public bool? CopySourceBlobProperties { get; set; }
-
-        /// <summary>
-        /// Optional standard HTTP header properties that can be set for the
-        /// new block blob.
-        ///
-        /// This optional property will be applied to copy and upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// Will also apply when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when the <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.SyncCopy"/>.
-        /// </summary>
-        public BlobHttpHeaders HttpHeaders { get; set; }
-
-        /// <summary>
-        /// Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// This operation does not allow <see cref="UploadTransferValidationOptions.PrecalculatedChecksum"/>
-        /// to be set.
-        ///
-        /// This optional property will applied to upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public UploadTransferValidationOptions UploadTransferValidationOptions { get; set; }
-
-        /// <summary>
-        /// Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// Set <see cref="DownloadTransferValidationOptions.AutoValidateChecksum"/> to false if you
-        /// would like to skip SDK checksum validation and validate the checksum found
-        /// in the <see cref="Response"/> object yourself.
-        /// Range must be provided explicitly, stating a range withing Azure
-        /// Storage size limits for requesting a transactional hash. See the
-        /// <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob">
-        /// REST documentation</a> for range limitation details.
-        ///
-        /// This optional property will applied to download scenarios.
-        /// Only applies when calling
-        /// <see cref="StorageResource.ReadStreamAsync(long, long?, System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public DownloadTransferValidationOptions DownloadTransferValidationOptions { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -171,10 +171,7 @@ namespace Azure.Storage.DataMovement.Blobs
         internal static AppendBlobStorageResourceOptions ToAppendBlobStorageResourceOptions(
             this BlobStorageResourceContainerOptions options)
         {
-            return new AppendBlobStorageResourceOptions()
-            {
-                CopyMethod = (TransferCopyMethod)(options?.CopyMethod),
-            };
+            return new AppendBlobStorageResourceOptions(options?.ResourceOptions);
         }
 
         internal static BlobDownloadOptions ToBlobDownloadOptions(
@@ -281,10 +278,7 @@ namespace Azure.Storage.DataMovement.Blobs
         internal static BlockBlobStorageResourceOptions ToBlockBlobStorageResourceOptions(
             this BlobStorageResourceContainerOptions options)
         {
-            return new BlockBlobStorageResourceOptions()
-            {
-                CopyMethod = options != default ? options.CopyMethod : TransferCopyMethod.None,
-            };
+            return new BlockBlobStorageResourceOptions(options?.ResourceOptions);
         }
 
         internal static BlobDownloadOptions ToBlobDownloadOptions(this BlockBlobStorageResourceOptions options, HttpRange range)
@@ -433,10 +427,7 @@ namespace Azure.Storage.DataMovement.Blobs
         internal static PageBlobStorageResourceOptions ToPageBlobStorageResourceOptions(
             this BlobStorageResourceContainerOptions options)
         {
-            return new PageBlobStorageResourceOptions()
-            {
-                CopyMethod = (TransferCopyMethod)(options?.CopyMethod),
-            };
+            return new PageBlobStorageResourceOptions(options?.ResourceOptions);
         }
 
         internal static BlobDownloadOptions ToBlobDownloadOptions(

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
@@ -44,7 +44,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <summary>
         /// Returns the preferred method of how to perform service to service
         /// transfers. See <see cref="TransferCopyMethod"/>. This value can be set when specifying
-        /// the options bag, see <see cref="PageBlobStorageResourceOptions.CopyMethod"/>.
+        /// the options bag, see <see cref="BlobStorageResourceOptions.CopyMethod"/>.
         /// </summary>
         public override TransferCopyMethod ServiceCopyMethod => _options?.CopyMethod ?? TransferCopyMethod.SyncCopy;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResourceOptions.cs
@@ -1,188 +1,50 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.DataMovement;
-using Azure.Storage.DataMovement.Models;
-using Metadata = System.Collections.Generic.IDictionary<string, string>;
-using Tags = System.Collections.Generic.IDictionary<string, string>;
 
 namespace Azure.Storage.DataMovement.Blobs
 {
     /// <summary>
-    /// Optional parameters for
+    /// Optional parameters specific to Page Blobs using
     /// <see cref="PageBlobStorageResource"/>.
     /// </summary>
-    public class PageBlobStorageResourceOptions
+    public class PageBlobStorageResourceOptions : BlobStorageResourceOptions
     {
         /// <summary>
-        /// Optional. Defines the copy operation to take.
-        /// See <see cref="TransferCopyMethod"/>. Defaults to <see cref="TransferCopyMethod.SyncCopy"/>.
+        /// Default constructor.
         /// </summary>
-        public TransferCopyMethod CopyMethod { get; set; }
+        public PageBlobStorageResourceOptions()
+        {
+        }
+
+        internal PageBlobStorageResourceOptions(BlobStorageResourceOptions other) : base(other)
+        {
+        }
 
         /// <summary>
-        /// Optional. Defines custom metadata to set for this block blob.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public Metadata Metadata { get; set; }
-#pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// Options tags to set on the destination blob.
-        /// Not valid if <see cref="CopySourceTagsMode"/> is set to <see cref="BlobCopySourceTagsMode.Copy"/>.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public Tags Tags { get; set; }
-#pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// Optional. See <see cref="AccessTier"/>.
-        /// Indicates the tier to be set on the blob.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public AccessTier? AccessTier { get; set; }
-
-        /// <summary>
-        /// Optional user-controlled value that you can use to track requests.
+        /// Optional. User-controlled value that you can use to track requests.
         /// The value of the SequenceNumber must be between
         /// 0 and 2^63 - 1.  The default value is 0.
         ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
+        /// Applies to copy and upload transfers.
         /// </summary>
         public long? SequenceNumber { get; set; }
 
         /// <summary>
-        /// Optional standard HTTP header properties that can be set for the
-        /// new page blob.
+        /// Optional. See <see cref="BlobRequestConditions"/>.
+        /// Access conditions on the copying of data from this source storage resource blob.
         ///
-        /// This optional property will be applied to copy and upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// Will also apply when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when the <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.SyncCopy"/>.
-        /// </summary>
-        public BlobHttpHeaders HttpHeaders { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="BlobImmutabilityPolicy"/> to set on the blob.
-        /// Note that is parameter is only applicable to a blob within a container that
-        /// has immutable storage with versioning enabled.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// Will also apply when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
-        /// </summary>
-        public BlobImmutabilityPolicy DestinationImmutabilityPolicy { get; set; }
-
-        /// <summary>
-        /// Optional. Indicates if a legal hold should be placed on the blob.
-        /// Note that is parameter is only applicable to a blob within a container that
-        /// has immutable storage with versioning enabled.
-        ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public bool? LegalHold { get; set; }
-
-        /// <summary>
-        /// Optional.
-        /// If <see cref="BlobCopySourceTagsMode.Replace"/>, the tags on the destination blob will be set to <see cref="Tags"/>.
-        /// If <see cref="BlobCopySourceTagsMode.Copy"/>, the tags on the source blob will be copied to the destination blob.
-        /// Default is to replace.
-        ///
-        /// This optional property will be applied to copy scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public BlobCopySourceTagsMode? CopySourceTagsMode { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="BlobRequestConditions"/> to add
-        /// conditions on the copying of data from this source storage resource blob.
-        ///
-        /// This optional property will be applied to copy and download scenarios.
-        /// Only applies when calling
-        /// <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.ReadStreamAsync(long, long?, System.Threading.CancellationToken)"/>.
+        /// Applies to copy and download transfers.
         /// </summary>
         public PageBlobRequestConditions SourceConditions { get; set; }
 
         /// <summary>
-        /// Optional <see cref="BlobRequestConditions"/> to add conditions on
-        /// the copying of data to this blob.
+        /// Optional <see cref="BlobRequestConditions"/>.
+        /// Access conditions on the copying of data to this blob.
         ///
-        /// This optional property will be applied to copy scenarios and upload scenarios.
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>.
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
+        /// Applies to copy and upload transfers.
         /// </summary>
         public PageBlobRequestConditions DestinationConditions { get; set; }
-
-        /// <summary>
-        /// Optional. See <see cref="RehydratePriority"/>
-        /// Indicates the priority with which to rehydrate an archived blob.
-        ///
-        /// Only applies when calling <see cref="StorageResource.CopyBlockFromUriAsync(StorageResource, HttpRange, bool, long, StorageResourceCopyFromUriOptions, System.Threading.CancellationToken)"/>
-        /// and when <see cref="CopyMethod"/> is set to <see cref="TransferCopyMethod.AsyncCopy"/>.
-        /// </summary>
-        public RehydratePriority? RehydratePriority { get; set; }
-
-        /// <summary>
-        /// Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// This operation does not allow <see cref="UploadTransferValidationOptions.PrecalculatedChecksum"/>
-        /// to be set.
-        ///
-        /// This optional property will applied to upload scenarios.
-        /// Only applies to
-        /// <see cref="StorageResource.WriteFromStreamAsync(System.IO.Stream, long, bool, long, long, StorageResourceWriteToOffsetOptions, System.Threading.CancellationToken)"/>,
-        /// and <see cref="StorageResource.CompleteTransferAsync(System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public UploadTransferValidationOptions UploadTransferValidationOptions { get; set; }
-
-        /// <summary>
-        /// Options for transfer validation settings on this operation.
-        /// When transfer validation options are set in the client, setting this parameter
-        /// acts as an override.
-        /// Set <see cref="DownloadTransferValidationOptions.AutoValidateChecksum"/> to false if you
-        /// would like to skip SDK checksum validation and validate the checksum found
-        /// in the <see cref="Response"/> object yourself.
-        /// Range must be provided explicitly, stating a range withing Azure
-        /// Storage size limits for requesting a transactional hash. See the
-        /// <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob">
-        /// REST documentation</a> for range limitation details.
-        ///
-        /// This optional property will applied to download scenarios.
-        /// Only applies when calling
-        /// <see cref="StorageResource.ReadStreamAsync(long, long?, System.Threading.CancellationToken)"/>.
-        /// </summary>
-        public DownloadTransferValidationOptions DownloadTransferValidationOptions { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -527,8 +527,11 @@ namespace Azure.Storage.DataMovement.Tests
                 Argument.AssertNotNull(destinationContainer, nameof(destinationContainer));
                 BlobStorageResourceContainerOptions options = new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = transferType == TransferType.SyncCopy ? TransferCopyMethod.SyncCopy : TransferCopyMethod.AsyncCopy,
-                    DirectoryPrefix = GetNewBlobDirectoryName()
+                    DirectoryPrefix = GetNewBlobDirectoryName(),
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = transferType == TransferType.SyncCopy ? TransferCopyMethod.SyncCopy : TransferCopyMethod.AsyncCopy,
+                    }
                 };
                 SourceResource ??= await CreateBlobDirectorySourceResourceAsync(
                     size: size,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/ProgressHandlerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/ProgressHandlerTests.cs
@@ -220,7 +220,10 @@ namespace Azure.Storage.DataMovement.Tests
                 destination.Container,
                 new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = copyMethod
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = copyMethod
+                    }
                 });
 
             // Act / Assert
@@ -302,7 +305,10 @@ namespace Azure.Storage.DataMovement.Tests
                 destinationResource = new BlobStorageResourceContainer(destinationContainer.Container,
                     new BlobStorageResourceContainerOptions()
                     {
-                        CopyMethod = transferType == TransferType.AsyncCopy ? TransferCopyMethod.AsyncCopy : TransferCopyMethod.SyncCopy
+                        ResourceOptions = new BlobStorageResourceOptions()
+                        {
+                            CopyMethod = transferType == TransferType.AsyncCopy ? TransferCopyMethod.AsyncCopy : TransferCopyMethod.SyncCopy,
+                        }
                     });
             }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferAsyncCopyDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferAsyncCopyDirectoryTests.cs
@@ -68,8 +68,11 @@ namespace Azure.Storage.DataMovement.Tests
                 new BlobStorageResourceContainer(container,
                 new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = TransferCopyMethod.AsyncCopy,
                     DirectoryPrefix = destinationBlobPrefix,
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = TransferCopyMethod.AsyncCopy
+                    },
                 });
 
             DataTransfer transfer = await transferManager.StartTransferAsync(sourceResource, destinationResource, options);
@@ -470,7 +473,10 @@ namespace Azure.Storage.DataMovement.Tests
                 destination.Container,
                 new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = TransferCopyMethod.AsyncCopy,
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = TransferCopyMethod.AsyncCopy
+                    },
                 });
 
             // Act
@@ -532,8 +538,11 @@ namespace Azure.Storage.DataMovement.Tests
                 containerClient,
                 new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = TransferCopyMethod.AsyncCopy,
                     DirectoryPrefix = destBlobPrefix,
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = TransferCopyMethod.AsyncCopy
+                    },
                 });
 
             // If we want a failure condition to happen

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferSyncCopyDirectoryTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferSyncCopyDirectoryTests.cs
@@ -68,8 +68,11 @@ namespace Azure.Storage.DataMovement.Tests
                 new BlobStorageResourceContainer(container,
                 new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = TransferCopyMethod.SyncCopy,
                     DirectoryPrefix = destinationBlobPrefix,
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = TransferCopyMethod.SyncCopy
+                    },
                 });
 
             DataTransfer transfer = await transferManager.StartTransferAsync(sourceResource, destinationResource, options);
@@ -229,8 +232,11 @@ namespace Azure.Storage.DataMovement.Tests
             StorageResourceContainer sourceResource = new BlobStorageResourceContainer(test.Container,
                 new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = TransferCopyMethod.AsyncCopy,
                     DirectoryPrefix = dirName2,
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = TransferCopyMethod.SyncCopy
+                    },
                 });
 
             TransferManagerOptions managerOptions = new TransferManagerOptions()
@@ -496,8 +502,11 @@ namespace Azure.Storage.DataMovement.Tests
             StorageResourceContainer destinationResource = new BlobStorageResourceContainer(containerClient,
                 new BlobStorageResourceContainerOptions()
                 {
-                    CopyMethod = TransferCopyMethod.SyncCopy,
                     DirectoryPrefix = destBlobPrefix,
+                    ResourceOptions = new BlobStorageResourceOptions()
+                    {
+                        CopyMethod = TransferCopyMethod.SyncCopy
+                    },
                 });
 
             // If we want a failure condition to happen


### PR DESCRIPTION
This change adds a new property `ResourceOptions` to `BlobStorageResourceContainerOptions` which allows users to specify options specific to individual resources that will be applied to all resources in the container. `ResourceOptions` is a new type `BlobStorageResourceOptions` which is a base class of the existing `Block|Page|AppendBlobStorageResourceOptions` that contains all common properties from the existing options classes.

Other options related changes here:
- Removed `Traits` and `States` from container options as they were not being used and it was decided they were not needed.
- Refactored a lot of the docstrings for resource options to be more user friendly.
  - Removed references to what methods they are used in since those are called internally and likely don't make sense to customers.
  - Standardized format including around which transfer types each options applies to.