### PR TITLE
Restoring stress project reference

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" /-->
+    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj">
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/src/Azure.Messaging.EventHubs.Stress.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj">
+    <ProjectReference Include="..\..\src\Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\..\Azure.Messaging.EventHubs.Processor\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary 

Restoring the Event Hubs project reference for the stress tests that had been temporarily removed to resolve versioning conflicts.   This will be committed once the releases have completed.