### PR TITLE
Perf improvement activitytagprocessor

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityTagsProcessorBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityTagsProcessorBenchmarks.cs
@@ -9,16 +9,17 @@ using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using BenchmarkDotNet.Attributes;
 
 /*
-BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1778)
-Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
-.NET SDK=7.0.105
-  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1702)
+Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK=7.0.203
+  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
 
-Job=InProcess  Toolchain=InProcessEmitToolchain
 
-|                              Method    |     Mean |   Error |   StdDev |   Median |   Gen0 | Allocated |
-|--------------------------------------- |---------:|--------:|---------:|---------:|-------:|----------:|
-|     Benchmark_ActivityTagsProcessor    | 282.5 ns | 5.61 ns | 13.66 ns | 279.0 ns | 0.1335 |     560 B |
+|                             Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
+|----------------------------------- |---------:|--------:|--------:|-------:|----------:|
+|    Benchmark_ActivityTagsProcessor | 274.7 ns | 5.29 ns | 6.09 ns | 0.1187 |     560 B |
+| Benchmark_ActivityTagsProcessorNew | 189.9 ns | 3.25 ns | 2.88 ns | 0.0594 |     280 B |
 */
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityTagsProcessorNew.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ActivityTagsProcessorNew.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+{
+    internal struct ActivityTagsProcessorNew
+    {
+        internal static readonly HashSet<string> s_semantics = new HashSet<string>{
+            SemanticConventions.AttributeDbStatement,
+            SemanticConventions.AttributeDbSystem,
+            SemanticConventions.AttributeDbName,
+
+            // required
+            SemanticConventions.AttributeHttpMethod,
+            SemanticConventions.AttributeHttpUrl,
+            SemanticConventions.AttributeHttpStatusCode,
+            SemanticConventions.AttributeHttpScheme,
+            SemanticConventions.AttributeHttpHost,
+            SemanticConventions.AttributeHttpHostPort,
+            SemanticConventions.AttributeHttpTarget,
+            SemanticConventions.AttributeHttpUserAgent,
+            SemanticConventions.AttributeHttpClientIP,
+            SemanticConventions.AttributeHttpRoute,
+
+            // required
+            SemanticConventions.AttributeAzureNameSpace,
+
+            SemanticConventions.AttributePeerService,
+            SemanticConventions.AttributeNetPeerName,
+            SemanticConventions.AttributeNetPeerIp,
+            SemanticConventions.AttributeNetPeerPort,
+            SemanticConventions.AttributeNetTransport,
+            SemanticConventions.AttributeNetHostIp,
+            SemanticConventions.AttributeNetHostPort,
+            SemanticConventions.AttributeNetHostName,
+            SemanticConventions.AttributeComponent,
+            "otel.status_code",
+            "sampleRate",
+
+            SemanticConventions.AttributeRpcService,
+            // required
+            SemanticConventions.AttributeRpcSystem,
+            SemanticConventions.AttributeRpcStatus,
+
+            // required
+            SemanticConventions.AttributeFaasTrigger,
+            SemanticConventions.AttributeFaasExecution,
+            SemanticConventions.AttributeFaasColdStart,
+            SemanticConventions.AttributeFaasDocumentCollection,
+            SemanticConventions.AttributeFaasDocumentOperation,
+            SemanticConventions.AttributeFaasDocumentTime,
+            SemanticConventions.AttributeFaasDocumentName,
+            SemanticConventions.AttributeFaasCron,
+            SemanticConventions.AttributeFaasTime,
+
+            SemanticConventions.AttributeEndpointAddress,
+            // required
+            SemanticConventions.AttributeMessagingSystem,
+            SemanticConventions.AttributeMessagingDestination,
+            SemanticConventions.AttributeMessagingDestinationKind,
+            SemanticConventions.AttributeMessagingTempDestination,
+            SemanticConventions.AttributeMessagingUrl,
+
+            // Others
+            SemanticConventions.AttributeEnduserId
+        };
+
+        public AzMonList MappedTags;
+
+        public OperationType activityType { get; private set; }
+
+        public string? AzureNamespace { get; private set; } = null;
+
+        public string? EndUserId { get; private set; } = null;
+
+        public ActivityTagsProcessorNew()
+        {
+            MappedTags = AzMonList.Initialize();
+        }
+
+        public void CategorizeTags(Activity activity)
+        {
+            foreach (ref readonly var tag in activity.EnumerateTagObjects())
+            {
+                if (tag.Value == null)
+                {
+                    continue;
+                }
+
+                if (s_semantics.Contains(tag.Key))
+                {
+                    switch (tag.Key)
+                    {
+                        case SemanticConventions.AttributeHttpMethod:
+                            activityType = OperationType.Http;
+                            break;
+                        case SemanticConventions.AttributeDbSystem:
+                            activityType = OperationType.Db;
+                            break;
+                        case SemanticConventions.AttributeMessagingSystem:
+                            activityType = OperationType.Messaging;
+                            break;
+                        case SemanticConventions.AttributeAzureNameSpace:
+                            AzureNamespace = tag.Value.ToString();
+                            break;
+                        case SemanticConventions.AttributeEnduserId:
+                            EndUserId = tag.Value.ToString();
+                            continue;
+                    }
+
+                    AzMonList.Add(ref MappedTags, tag);
+                }
+            }
+        }
+
+        public void Return()
+        {
+            MappedTags.Return();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ProcessUnMappedTagsBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/ProcessUnMappedTagsBenchmarks.cs
@@ -25,13 +25,13 @@ Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 {
     [MemoryDiagnoser]
-    public class UnMappedTagsProcessingBenchmarks
+    public class ProcessUnMappedTagsBenchmarks
     {
         private Activity? _activity;
         private ChangeTrackingDictionary<string, string>? _properties;
         private ActivityTagsProcessor _tagsProcessor;
 
-        static UnMappedTagsProcessingBenchmarks()
+        static ProcessUnMappedTagsBenchmarks()
         {
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             Activity.ForceDefaultIdFormat = true;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/UnMappedTagsProcessingBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/UnMappedTagsProcessingBenchmarks.cs
@@ -9,6 +9,19 @@ using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 
 using BenchmarkDotNet.Attributes;
 
+/*
+BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1702)
+Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK=7.0.203
+  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+
+
+|                                         Method |     Mean |   Error |  StdDev | Allocated |
+|----------------------------------------------- |---------:|--------:|--------:|----------:|
+|    ProcessUnMappedTagsWithActivityTagProcessor | 101.4 ns | 0.69 ns | 0.65 ns |         - |
+| ProcessUnMappedTagsWithoutActivityTagProcessor | 211.2 ns | 3.18 ns | 2.65 ns |         - |
+*/
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 {
     [MemoryDiagnoser]


### PR DESCRIPTION
Activity tags are processed and saved in two separate arrays `MappedTags` (Maps to fields on TelemetryItem) and `UnMappedTags`(Maps to custom properties on TelemetryItem).

This PR shows a possible perf improvement by not saving UnMappedTags into a separate array and adding them directly to custom properties using the activity.

As shown in the benchmark results, the allocation is reduced by `50%` on the hot path as shown in `ActivityTagsProcessorBenchmarks`

Time to process the tags is however not improved here as time reduced by not adding `UnMappedTags` is compensated by time increase due to looping through the activity tags twice as shown in `ProcessUnMappedTagsBenchmarks`.
