### PR TITLE
[Text Analytics] Temporarily disable AAD check in `IsEnvironmentReadyAsync`

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsTestEnvironment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsTestEnvironment.cs
@@ -67,8 +67,9 @@ namespace Azure.AI.TextAnalytics.Tests
                 TextAnalyticsClient clientWithAzureKeyCredential = new(endpoint, azureKeyCredential, options);
                 await clientWithAzureKeyCredential.DetectLanguageAsync("Ready!");
 
-                TextAnalyticsClient clientWithTokenCredential = new(endpoint, Credential, options);
-                await clientWithTokenCredential.DetectLanguageAsync("Ready!");
+                // TODO: https://github.com/Azure/azure-sdk-for-net/issues/36799
+                // TextAnalyticsClient clientWithTokenCredential = new(endpoint, Credential, options);
+                // await clientWithTokenCredential.DetectLanguageAsync("Ready!");
             }
             catch (RequestFailedException e) when (e.Status == 401)
             {


### PR DESCRIPTION
This is only while we wait for AAD to be enabled in API version 2023-04-01.