### PR TITLE
Revert change to signing environment

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -12,7 +12,7 @@ stages:
     dependsOn: ${{parameters.DependsOn}}
     jobs:
       - deployment: SignPackage
-        environment: ${{parameters.Environment}}
+        environment: esrp
         pool:
           name: azsdk-pool-mms-win-2022-general
           vmImage: windows-2022


### PR DESCRIPTION
The environments in archetype-release were unified to a single default "nuget" environment, but this caused signing to be behind the approval gate of that environment.   This PR swaps the environment back to it's original value.

https://github.com/Azure/azure-sdk-for-net/pull/36300/files#diff-9e9bbe0397a32a08d005a30ad3fe57bff227a7fd74dc17f3e852ec978a3a9e13L14
