### PR TITLE
[Storage] Add support for `Metadata` when calling `SyncUploadFromUriAsync`

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.17.0-beta.2 (Unreleased)
 
 ### Features Added
+- Added support for `Metadata` in `BlobSyncUploadFromUriOptions`.
 
 ### Breaking Changes
 

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.net6.0.cs
@@ -1120,6 +1120,7 @@ namespace Azure.Storage.Blobs.Models
         public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions DestinationConditions { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
         public Azure.HttpAuthorization SourceAuthentication { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions SourceConditions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -1120,6 +1120,7 @@ namespace Azure.Storage.Blobs.Models
         public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions DestinationConditions { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
         public Azure.HttpAuthorization SourceAuthentication { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions SourceConditions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.1.cs
@@ -1120,6 +1120,7 @@ namespace Azure.Storage.Blobs.Models
         public Azure.Storage.Blobs.Models.BlobCopySourceTagsMode? CopySourceTagsMode { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions DestinationConditions { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobHttpHeaders HttpHeaders { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } set { } }
         public Azure.HttpAuthorization SourceAuthentication { get { throw null; } set { } }
         public Azure.Storage.Blobs.Models.BlobRequestConditions SourceConditions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -3056,8 +3056,7 @@ namespace Azure.Storage.Blobs.Specialized
                             blobContentLanguage: options?.HttpHeaders?.ContentLanguage,
                             blobContentMD5: options?.HttpHeaders?.ContentHash,
                             blobCacheControl: options?.HttpHeaders?.CacheControl,
-                            // TODO service bug.  https://github.com/Azure/azure-sdk-for-net/issues/15969
-                            // metadata: options?.Metadata,
+                            metadata: options?.Metadata,
                             leaseId: options?.DestinationConditions?.LeaseId,
                             blobContentDisposition: options?.HttpHeaders?.ContentDisposition,
                             encryptionKey: ClientConfiguration.CustomerProvidedKey?.EncryptionKey,
@@ -3093,8 +3092,7 @@ namespace Azure.Storage.Blobs.Specialized
                             blobContentLanguage: options?.HttpHeaders?.ContentLanguage,
                             blobContentMD5: options?.HttpHeaders?.ContentHash,
                             blobCacheControl: options?.HttpHeaders?.CacheControl,
-                            // TODO service bug.  https://github.com/Azure/azure-sdk-for-net/issues/15969
-                            // metadata: options?.Metadata,
+                            metadata: options?.Metadata,
                             leaseId: options?.DestinationConditions?.LeaseId,
                             blobContentDisposition: options?.HttpHeaders?.ContentDisposition,
                             encryptionKey: ClientConfiguration.CustomerProvidedKey?.EncryptionKey,

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobSyncUploadFromUriOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobSyncUploadFromUriOptions.cs
@@ -26,11 +26,10 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         public BlobHttpHeaders HttpHeaders { get; set; }
 
-        // TODO service bug.  https://github.com/Azure/azure-sdk-for-net/issues/15969
-        ///// <summary>
-        ///// Optional custom metadata to set for this append blob.
-        ///// </summary>
-        //public Metadata Metadata { get; set; }
+        /// <summary>
+        /// Optional custom metadata to set for this append blob.
+        /// </summary>
+        public Metadata Metadata { get; set; }
 
         /// <summary>
         /// Options tags to set for this block blob.

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -2814,8 +2814,7 @@ namespace Azure.Storage.Blobs.Test
                     ContentLanguage = constants.ContentLanguage,
                     ContentType = constants.ContentType
                 },
-                // TODO service bug.  https://github.com/Azure/azure-sdk-for-net/issues/15969
-                // Metadata = metadata,
+                Metadata = metadata,
                 Tags = tags,
                 AccessTier = AccessTier.Hot
             };
@@ -2839,8 +2838,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(constants.ContentLanguage, response.Value.ContentLanguage);
             Assert.AreEqual(constants.ContentDisposition, response.Value.ContentDisposition);
             Assert.AreEqual(constants.CacheControl, response.Value.CacheControl);
-            // TODO service bug.  https://github.com/Azure/azure-sdk-for-net/issues/15969
-            //AssertDictionaryEquality(metadata, response.Value.Metadata);
+            AssertDictionaryEquality(metadata, response.Value.Metadata);
             Assert.AreEqual(tags.Count, response.Value.TagCount);
             Assert.AreEqual(AccessTier.Hot.ToString(), response.Value.AccessTier);
         }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/SyncUploadFromUriAsync_OverwriteSourceBlobProperties.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/SyncUploadFromUriAsync_OverwriteSourceBlobProperties.json
@@ -1,228 +1,256 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-75571179-fdd5-4d7a-8f4b-1eda5e33adb3?restype=container",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-1bc022de-73d3-6417-2fc2-e07a8a40bc74?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-efd5f4fa51c0384b88cba441cd490629-f08b59bc25458046-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
+        "Content-Length": "0",
+        "traceparent": "00-7a6c9cb7e890901fd6898013c385f0af-4051ceca2db362d8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "6578e128-3d67-b4aa-a6e6-3b68d25ac37f",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:39 GMT",
+        "x-ms-client-request-id": "76ec10b3-c1bf-820d-d25d-d53a8b76996c",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:47 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Date": "Thu, 05 Aug 2021 23:47:39 GMT",
-        "ETag": "\u00220x8D9586B697BF202\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:40 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "6578e128-3d67-b4aa-a6e6-3b68d25ac37f",
-        "x-ms-request-id": "19d0901b-601e-0003-6954-8a5459000000",
-        "x-ms-version": "2021-06-08"
+        "Content-Length": "0",
+        "Date": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "ETag": "\u00220x8DB69320C82B5C8\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76ec10b3-c1bf-820d-d25d-d53a8b76996c",
+        "x-ms-request-id": "9ecbbacf-c01e-002b-661a-9b5a0e000000",
+        "x-ms-version": "2023-01-03"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-75571179-fdd5-4d7a-8f4b-1eda5e33adb3/test-blob-241ea522-262c-0cac-43b7-e0ee163c6671",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-1bc022de-73d3-6417-2fc2-e07a8a40bc74/test-blob-fa5309b4-d552-a57d-90c4-6ef5d54d4b14",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "1024",
         "Content-Type": "application/octet-stream",
-        "traceparent": "00-73424410b95ce844b2adc0a59a42ca75-fea2002e213c114a-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
+        "traceparent": "00-fe70d59124e3582ae998422f1186affa-dadf3a49bbbc6c31-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "89585e49-da44-0dba-72d2-8043300834c0",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:39 GMT",
+        "x-ms-client-request-id": "a3d6c9d3-8f8e-1a78-c495-88f5202ca7d6",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:48 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
-      "RequestBody": "I2cbQP\u002BtZQE0ayKwXbyean/J70anRsTbWV86BP4B293ppcquICZyzCawSE8km2Itir0rZ3aGk92jQOefcmADM49Fxrjx70pZViIf9/10tr39DXpA1XNmYxHtC\u002BA\u002B0lnGrRW/39WqO5pz0hFUZ5zfLokqomXmwl4c3mOmA\u002BRpGoPJWUrotdfnU9HfzQJiEvx1Dd1WFC/03\u002Bq2owByAzi2CbeNiw1S93iyQk\u002BUB/VbucxnMfYGEwZT1HpfMRHWdU\u002BZKcNK1YfuIhZkpNHgYNj1WukzC9JCr/axObaT8sVn280A\u002B90xEeRFeA7fom41c3Shadcno2p9VnnNmZvQWi9Q/cgE32X6xEkF7pLEYg2He8ZB8YnuPzhjg6RkZHdJdB3ej6SlMZMPp6WNIrTXufRrRR7Vj2mmYr6QoVzAlWDSvHl05dNp4koyMkrjYByDi8qv\u002BR9Zc\u002BW0NyzmFZA3ThFFu2Y7YtMhAmPTo10ewgKhDRWSEZxAeEiTwK2mgsy6\u002BuM5nqS2Ryj2jve8hdCIlnUqRQh6pT11BEIeqKImen\u002BWGah55SRe68Xsm4KlhPN3Cio4fD3EP1Wlw5phmJ\u002BG0BN3JWwoD7BRzFpDjQm7z39Ppp147f5C0dlT1CGK/VMlZspvLV6GT/t557DjgbJL6vMaEfECDeMUNFST1TqPxs8GHSY\u002BS6IgyVeh/gZOX1AmB\u002Bktb\u002BthIlnnWvkK83rA6iDh3GOLDJ5R\u002BUiZYA7cxtUDbM1QYVfjpfvNV/GoFtbd4RTlbYLsmvpL23ajyMJKCpQjBoasb4jJ/TdovrWtqeNyu3/69lhSFtHSBYXgQNw4gkxdhQ9PMXGLHG9LhNxFnjKTMQxCUBM70O\u002B02WoC6L1aLztpTyPTIooObtroB5L1jWdTTQ7Q9jI4IbQfm1gGiDSy8FWg3E4Ovw6BNOE5U8ldv0sCr5quijkJMC5us4YyB\u002BWmNhY8VLEZRI7/TsFQ/s7rwdwMBNmZA2Ycl6sfoAuITy38kxyyIWqa6WoMrjt3uTJggvGqJgMMDDKwIL0G\u002BaSCd/\u002BUVGuxOaBychpujVQqpN54vx0Z3igq74fpAgCtk/DGiTc742TGrklQN7Ponn7dhXzfjTmGaJnWamTkxzegxN4qpwMd78B5sRDTyaZ1QVEIDHyEzgW2PyGdZXkA4ucSsHLUvvZ7wJa7Zdsps5/zYSgT27u6G/bZc2figIlHec8pwRgzoIJbjUzmyWgpjYyBqgNQ7AYrV5R7\u002B0uOmD8Mc\u002BwM//GGv8Glt05v1FKOr\u002BXbYNWF9ozI/WmDt6Q3zPQM2VV7HY2a\u002ButCqjS4vINB7UxlszhqhnxgRAKIAwgcbutaY/r9E5JXQGXqQ0xXD0HlQg==",
+      "RequestBody": "RDIWD8ezud6SR\u002BX7UxithRHBJbavHxluVB2XU/XJQjlUN7CiNzxMYRvp5wtgueJKUlqjoTG5hiUZp7uqHGboyQSrpxtoCk3VdMSbxjcNDZo6TACbJqEImrCKiY\u002BBoUW0AB4HtBLG4kcMzSxsHcDtDJogb89lTaNjowxq3YG\u002BVNN/58UYBVmIdGq5j1h0m33wnH31YDJ1T7N7pBEFXATFTnlZ7Tb71QZAl/tkrL5L7gePekEEyPOgCZgSnGFIghhm80DeG61G9cd2tMg2EKL1MLYJduHCwYWGuOSe6Dil\u002BBXj/rl9bNJZSIV5jRQqavj1HWyrPgs2ozG7V2LJqAyP0byzUxLpd8Pjry5cSTRwXE7sqMvM\u002BbkJrVuHwRVwkKB46rtYdhblC6WoyI/d2Vr9SvsU3P9BwtgCqqa3Yraucx6O4154GOU3Bp0mIzEqLNMAiXYaW7OgNyfjVcxwLqnv\u002BVVwTvb7hDIV3NViGp\u002Bm2H7Tttg/lBdq7aw3lcIZx9jzNircud3cBQREBH/ePhyIPH1OnXfQsGQ9BWBJw\u002B9v/BT9buR0yh6g9rDU\u002BpCXjK\u002BPrlhFyypgIobFnrN8k0EV1Qhq4M84E3JfrabG/LXUpnmxuhSWKjHqnExdrytqI2NuviWHLKzfV5vm5R2DmSXQ8Pg6y9gsfqvXgESD2mRG9IlDVz6QTXnN0WN5sEQTZgImjb4zMFiKQkB5sKxoXHw2oPGTP0LnQKN\u002Bbfl1s85mwxlBXE2mEsQxuRX9FpzMZXXmQw9SgCfAP00btMJfFI5yE\u002ByTJgAvkI4tYoYs6SkGsgiDj2\u002B\u002BE0PygRwAil0B0aSGiwOwOT51trOBJR6glFUjFAK624Qfs/\u002BpoaXjLwUwLJDhpV4lVnnKDtm8Pe4lUezH3HZbR/UfZ9cEBpiYkYatUfmNvu72/b2J8M2rYnYQg0\u002B4HFOO1eWawT2HIU/hMXxSD\u002Bz1l5L90N640VYodAVg84JI4HUzHnsT8vyxb9xtqL9QWVOKGuy8ukx01gOOck04Ji3MmFAHHvBw4aWVTGACSimX1xqx1tmWiyUpv0h4hX\u002BveEiuoA9uSTpiGThGJm3rcYvZ9pszhk9UNgwr3l6o\u002BFwl5tQYVKkaKY3fT7ygUGS3PU28no/ke/L4WWoCQ2vcuiHcIUCZ0x3hv8wOUzeTtOWnc6AQ61nMQWrhH/o\u002BF\u002BYhA5Sawy4kHWow29/C1ii6ZaWFWs/Ly87ID\u002BDVt7Qjoqfm7E\u002Bj\u002BPC3g1U24BB5CmpCJ7lUubwWVjjF0rNOT2W2DDg33OrYF2y0zdd6lOq\u002BTwV1k5D6zunrz5UX3SY8aDTvgNPXQS2AaQ9Mn\u002BvlnMJOBoKu2LvVuz5PTA1UwTlGeA==",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-MD5": "2lMOkiNxxFI0DuEBxpFeTA==",
-        "Date": "Thu, 05 Aug 2021 23:47:39 GMT",
-        "ETag": "\u00220x8D9586B69969F26\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:40 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "89585e49-da44-0dba-72d2-8043300834c0",
-        "x-ms-content-crc64": "l3hjoGsV\u002BdE=",
-        "x-ms-request-id": "19d0901e-601e-0003-6a54-8a5459000000",
+        "Content-Length": "0",
+        "Content-MD5": "Kc\u002BAW74cZR1GbZwVzBxFWg==",
+        "Date": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "ETag": "\u00220x8DB69320C8DAFF9\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a3d6c9d3-8f8e-1a78-c495-88f5202ca7d6",
+        "x-ms-content-crc64": "FYrYNRTXFSc=",
+        "x-ms-request-id": "9ecbbaf9-c01e-002b-7e1a-9b5a0e000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:48.2950649Z"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-75571179-fdd5-4d7a-8f4b-1eda5e33adb3/test-blob-7db28c79-47bb-bf4c-e928-28ab3165cd3b",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-1bc022de-73d3-6417-2fc2-e07a8a40bc74/test-blob-7ac7d414-4653-35b4-63ff-dfb462567036",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-b96c262b98c7d243a438148e5d1d0245-984119c10ad16340-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
+        "Content-Length": "0",
+        "traceparent": "00-ce727ececa214175754a8588dbfbd823-02ced5ef45ac6b3d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
         "x-ms-access-tier": "Hot",
-        "x-ms-blob-cache-control": "mfsncxnynhohgppnmwab",
-        "x-ms-blob-content-disposition": "slvvyssfbqbmpckkmhgj",
-        "x-ms-blob-content-encoding": "dtrfqbsjidtjagebjwni",
-        "x-ms-blob-content-language": "ehwwgcrdffaeqpxxspex",
-        "x-ms-blob-content-type": "ajwxvqlixiaptwfuvuxo",
+        "x-ms-blob-cache-control": "rpqtgcgbdgqqjoecttno",
+        "x-ms-blob-content-disposition": "kkvucqtawnvkkygtlnod",
+        "x-ms-blob-content-encoding": "lwaabphtyjirhkwgsuqo",
+        "x-ms-blob-content-language": "hfdpkggkhjpgfkcmkvtm",
+        "x-ms-blob-content-type": "jaaneddybybpvyvgskot",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b10d0f1c-5ce8-f0fd-9dc4-a6e9210fa712",
-        "x-ms-copy-source": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-75571179-fdd5-4d7a-8f4b-1eda5e33adb3/test-blob-241ea522-262c-0cac-43b7-e0ee163c6671",
+        "x-ms-client-request-id": "f881db46-a263-d5e9-2a70-4f805d17b7c8",
+        "x-ms-copy-source": "https://jalauzonnettest.blob.core.windows.net/test-container-1bc022de-73d3-6417-2fc2-e07a8a40bc74/test-blob-fa5309b4-d552-a57d-90c4-6ef5d54d4b14",
         "x-ms-copy-source-blob-properties": "false",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "x-ms-meta-Capital": "letter",
+        "x-ms-meta-foo": "bar",
+        "x-ms-meta-meta": "data",
+        "x-ms-meta-UPPER": "case",
         "x-ms-return-client-request-id": "true",
         "x-ms-tags": "tagKey0=tagValue0\u0026tagKey1=tagValue1",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B69DB70B9\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "b10d0f1c-5ce8-f0fd-9dc4-a6e9210fa712",
-        "x-ms-content-crc64": "l3hjoGsV\u002BdE=",
-        "x-ms-request-id": "19d0901f-601e-0003-6b54-8a5459000000",
+        "Content-Length": "0",
+        "Date": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "ETag": "\u00220x8DB69320CB11154\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f881db46-a263-d5e9-2a70-4f805d17b7c8",
+        "x-ms-content-crc64": "FYrYNRTXFSc=",
+        "x-ms-request-id": "9ecbbb12-c01e-002b-0e1a-9b5a0e000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:48.5269332Z"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-75571179-fdd5-4d7a-8f4b-1eda5e33adb3/test-blob-7db28c79-47bb-bf4c-e928-28ab3165cd3b",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-1bc022de-73d3-6417-2fc2-e07a8a40bc74/test-blob-7ac7d414-4653-35b4-63ff-dfb462567036",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-36489952afe76449a3413d85ad97441a-e44747d285186b47-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "21267865-83fb-46d8-c34d-26d72bb5a097",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "traceparent": "00-45bb9b499590a6a97ffe49d6363c2f34-c868e6412c3a3a7d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "45af3686-afaa-6372-3db1-17a25db6c25e",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:48 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
-        "Cache-Control": "mfsncxnynhohgppnmwab",
-        "Content-Disposition": "slvvyssfbqbmpckkmhgj",
-        "Content-Encoding": "dtrfqbsjidtjagebjwni",
-        "Content-Language": "ehwwgcrdffaeqpxxspex",
+        "Cache-Control": "rpqtgcgbdgqqjoecttno",
+        "Content-Disposition": "kkvucqtawnvkkygtlnod",
+        "Content-Encoding": "lwaabphtyjirhkwgsuqo",
+        "Content-Language": "hfdpkggkhjpgfkcmkvtm",
         "Content-Length": "1024",
-        "Content-MD5": "2lMOkiNxxFI0DuEBxpFeTA==",
-        "Content-Type": "ajwxvqlixiaptwfuvuxo",
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B69DB70B9\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "Content-MD5": "Kc\u002BAW74cZR1GbZwVzBxFWg==",
+        "Content-Type": "jaaneddybybpvyvgskot",
+        "Date": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "ETag": "\u00220x8DB69320CB11154\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "21267865-83fb-46d8-c34d-26d72bb5a097",
-        "x-ms-creation-time": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "x-ms-client-request-id": "45af3686-afaa-6372-3db1-17a25db6c25e",
+        "x-ms-creation-time": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-last-access-time": "Fri, 09 Jun 2023 21:39:48 GMT",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "19d09020-601e-0003-6c54-8a5459000000",
+        "x-ms-meta-Capital": "letter",
+        "x-ms-meta-foo": "bar",
+        "x-ms-meta-meta": "data",
+        "x-ms-meta-UPPER": "case",
+        "x-ms-request-id": "9ecbbbd2-c01e-002b-7c1a-9b5a0e000000",
         "x-ms-server-encrypted": "true",
         "x-ms-tag-count": "2",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:48.5269332Z"
       },
-      "ResponseBody": "I2cbQP\u002BtZQE0ayKwXbyean/J70anRsTbWV86BP4B293ppcquICZyzCawSE8km2Itir0rZ3aGk92jQOefcmADM49Fxrjx70pZViIf9/10tr39DXpA1XNmYxHtC\u002BA\u002B0lnGrRW/39WqO5pz0hFUZ5zfLokqomXmwl4c3mOmA\u002BRpGoPJWUrotdfnU9HfzQJiEvx1Dd1WFC/03\u002Bq2owByAzi2CbeNiw1S93iyQk\u002BUB/VbucxnMfYGEwZT1HpfMRHWdU\u002BZKcNK1YfuIhZkpNHgYNj1WukzC9JCr/axObaT8sVn280A\u002B90xEeRFeA7fom41c3Shadcno2p9VnnNmZvQWi9Q/cgE32X6xEkF7pLEYg2He8ZB8YnuPzhjg6RkZHdJdB3ej6SlMZMPp6WNIrTXufRrRR7Vj2mmYr6QoVzAlWDSvHl05dNp4koyMkrjYByDi8qv\u002BR9Zc\u002BW0NyzmFZA3ThFFu2Y7YtMhAmPTo10ewgKhDRWSEZxAeEiTwK2mgsy6\u002BuM5nqS2Ryj2jve8hdCIlnUqRQh6pT11BEIeqKImen\u002BWGah55SRe68Xsm4KlhPN3Cio4fD3EP1Wlw5phmJ\u002BG0BN3JWwoD7BRzFpDjQm7z39Ppp147f5C0dlT1CGK/VMlZspvLV6GT/t557DjgbJL6vMaEfECDeMUNFST1TqPxs8GHSY\u002BS6IgyVeh/gZOX1AmB\u002Bktb\u002BthIlnnWvkK83rA6iDh3GOLDJ5R\u002BUiZYA7cxtUDbM1QYVfjpfvNV/GoFtbd4RTlbYLsmvpL23ajyMJKCpQjBoasb4jJ/TdovrWtqeNyu3/69lhSFtHSBYXgQNw4gkxdhQ9PMXGLHG9LhNxFnjKTMQxCUBM70O\u002B02WoC6L1aLztpTyPTIooObtroB5L1jWdTTQ7Q9jI4IbQfm1gGiDSy8FWg3E4Ovw6BNOE5U8ldv0sCr5quijkJMC5us4YyB\u002BWmNhY8VLEZRI7/TsFQ/s7rwdwMBNmZA2Ycl6sfoAuITy38kxyyIWqa6WoMrjt3uTJggvGqJgMMDDKwIL0G\u002BaSCd/\u002BUVGuxOaBychpujVQqpN54vx0Z3igq74fpAgCtk/DGiTc742TGrklQN7Ponn7dhXzfjTmGaJnWamTkxzegxN4qpwMd78B5sRDTyaZ1QVEIDHyEzgW2PyGdZXkA4ucSsHLUvvZ7wJa7Zdsps5/zYSgT27u6G/bZc2figIlHec8pwRgzoIJbjUzmyWgpjYyBqgNQ7AYrV5R7\u002B0uOmD8Mc\u002BwM//GGv8Glt05v1FKOr\u002BXbYNWF9ozI/WmDt6Q3zPQM2VV7HY2a\u002ButCqjS4vINB7UxlszhqhnxgRAKIAwgcbutaY/r9E5JXQGXqQ0xXD0HlQg=="
+      "ResponseBody": "RDIWD8ezud6SR\u002BX7UxithRHBJbavHxluVB2XU/XJQjlUN7CiNzxMYRvp5wtgueJKUlqjoTG5hiUZp7uqHGboyQSrpxtoCk3VdMSbxjcNDZo6TACbJqEImrCKiY\u002BBoUW0AB4HtBLG4kcMzSxsHcDtDJogb89lTaNjowxq3YG\u002BVNN/58UYBVmIdGq5j1h0m33wnH31YDJ1T7N7pBEFXATFTnlZ7Tb71QZAl/tkrL5L7gePekEEyPOgCZgSnGFIghhm80DeG61G9cd2tMg2EKL1MLYJduHCwYWGuOSe6Dil\u002BBXj/rl9bNJZSIV5jRQqavj1HWyrPgs2ozG7V2LJqAyP0byzUxLpd8Pjry5cSTRwXE7sqMvM\u002BbkJrVuHwRVwkKB46rtYdhblC6WoyI/d2Vr9SvsU3P9BwtgCqqa3Yraucx6O4154GOU3Bp0mIzEqLNMAiXYaW7OgNyfjVcxwLqnv\u002BVVwTvb7hDIV3NViGp\u002Bm2H7Tttg/lBdq7aw3lcIZx9jzNircud3cBQREBH/ePhyIPH1OnXfQsGQ9BWBJw\u002B9v/BT9buR0yh6g9rDU\u002BpCXjK\u002BPrlhFyypgIobFnrN8k0EV1Qhq4M84E3JfrabG/LXUpnmxuhSWKjHqnExdrytqI2NuviWHLKzfV5vm5R2DmSXQ8Pg6y9gsfqvXgESD2mRG9IlDVz6QTXnN0WN5sEQTZgImjb4zMFiKQkB5sKxoXHw2oPGTP0LnQKN\u002Bbfl1s85mwxlBXE2mEsQxuRX9FpzMZXXmQw9SgCfAP00btMJfFI5yE\u002ByTJgAvkI4tYoYs6SkGsgiDj2\u002B\u002BE0PygRwAil0B0aSGiwOwOT51trOBJR6glFUjFAK624Qfs/\u002BpoaXjLwUwLJDhpV4lVnnKDtm8Pe4lUezH3HZbR/UfZ9cEBpiYkYatUfmNvu72/b2J8M2rYnYQg0\u002B4HFOO1eWawT2HIU/hMXxSD\u002Bz1l5L90N640VYodAVg84JI4HUzHnsT8vyxb9xtqL9QWVOKGuy8ukx01gOOck04Ji3MmFAHHvBw4aWVTGACSimX1xqx1tmWiyUpv0h4hX\u002BveEiuoA9uSTpiGThGJm3rcYvZ9pszhk9UNgwr3l6o\u002BFwl5tQYVKkaKY3fT7ygUGS3PU28no/ke/L4WWoCQ2vcuiHcIUCZ0x3hv8wOUzeTtOWnc6AQ61nMQWrhH/o\u002BF\u002BYhA5Sawy4kHWow29/C1ii6ZaWFWs/Ly87ID\u002BDVt7Qjoqfm7E\u002Bj\u002BPC3g1U24BB5CmpCJ7lUubwWVjjF0rNOT2W2DDg33OrYF2y0zdd6lOq\u002BTwV1k5D6zunrz5UX3SY8aDTvgNPXQS2AaQ9Mn\u002BvlnMJOBoKu2LvVuz5PTA1UwTlGeA=="
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-75571179-fdd5-4d7a-8f4b-1eda5e33adb3/test-blob-7db28c79-47bb-bf4c-e928-28ab3165cd3b",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-1bc022de-73d3-6417-2fc2-e07a8a40bc74/test-blob-7ac7d414-4653-35b4-63ff-dfb462567036",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-3bf104380dff62428c764755191c7b05-05b4e8c1ea0cf549-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "a9836283-86e9-2017-f229-73563bc84c0a",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "traceparent": "00-6d5007cf8f5f53f62c9e4aa3a0b2adf1-c945c560d4eea078-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "27fa98ab-7267-d21e-3743-c9c5ac7dc8da",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:48 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
-        "Cache-Control": "mfsncxnynhohgppnmwab",
-        "Content-Disposition": "slvvyssfbqbmpckkmhgj",
-        "Content-Encoding": "dtrfqbsjidtjagebjwni",
-        "Content-Language": "ehwwgcrdffaeqpxxspex",
+        "Cache-Control": "rpqtgcgbdgqqjoecttno",
+        "Content-Disposition": "kkvucqtawnvkkygtlnod",
+        "Content-Encoding": "lwaabphtyjirhkwgsuqo",
+        "Content-Language": "hfdpkggkhjpgfkcmkvtm",
         "Content-Length": "1024",
-        "Content-MD5": "2lMOkiNxxFI0DuEBxpFeTA==",
-        "Content-Type": "ajwxvqlixiaptwfuvuxo",
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B69DB70B9\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "Content-MD5": "Kc\u002BAW74cZR1GbZwVzBxFWg==",
+        "Content-Type": "jaaneddybybpvyvgskot",
+        "Date": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "ETag": "\u00220x8DB69320CB11154\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
         "x-ms-access-tier": "Hot",
-        "x-ms-access-tier-change-time": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "x-ms-access-tier-change-time": "Fri, 09 Jun 2023 21:39:48 GMT",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "a9836283-86e9-2017-f229-73563bc84c0a",
-        "x-ms-creation-time": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "x-ms-client-request-id": "27fa98ab-7267-d21e-3743-c9c5ac7dc8da",
+        "x-ms-creation-time": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-last-access-time": "Fri, 09 Jun 2023 21:39:48 GMT",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "19d09021-601e-0003-6d54-8a5459000000",
+        "x-ms-meta-Capital": "letter",
+        "x-ms-meta-foo": "bar",
+        "x-ms-meta-meta": "data",
+        "x-ms-meta-UPPER": "case",
+        "x-ms-request-id": "9ecbbc52-c01e-002b-431a-9b5a0e000000",
         "x-ms-server-encrypted": "true",
         "x-ms-tag-count": "2",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:48.5269332Z"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-75571179-fdd5-4d7a-8f4b-1eda5e33adb3?restype=container",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-1bc022de-73d3-6417-2fc2-e07a8a40bc74?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-e2ec2dca434d8746b2bec9eec851ebd9-bed834db0f268947-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "c9548940-f631-f7ad-cdf5-0e95c30b7fa6",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "traceparent": "00-a01bfdeec7758caabc012447f5b23b8d-153331e24f47cd38-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c4f6d388-9abc-acf6-fd3c-72223e16d43d",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:48 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "c9548940-f631-f7ad-cdf5-0e95c30b7fa6",
-        "x-ms-request-id": "19d09022-601e-0003-6e54-8a5459000000",
-        "x-ms-version": "2021-06-08"
+        "Content-Length": "0",
+        "Date": "Fri, 09 Jun 2023 21:39:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c4f6d388-9abc-acf6-fd3c-72223e16d43d",
+        "x-ms-request-id": "9ecbbc86-c01e-002b-611a-9b5a0e000000",
+        "x-ms-version": "2023-01-03"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-05T18:47:39.1317189-05:00",
-    "RandomSeed": "1076674783",
-    "Storage_TestConfigDefault": "ProductionTenant\nao4xscnapbl2prdev19a\nU2FuaXRpemVk\nhttps://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net\nhttps://ao4xscnapbl2prdev19a.file.core.windows.net\nhttps://ao4xscnapbl2prdev19a.queue.core.windows.net\nhttps://ao4xscnapbl2prdev19a.table.core.windows.net\n\n\n\n\nhttps://ao4xscnapbl2prdev19a-secondary.blob.core.windows.net\nhttps://ao4xscnapbl2prdev19a-secondary.file.core.windows.net\nhttps://ao4xscnapbl2prdev19a-secondary.queue.core.windows.net\nhttps://ao4xscnapbl2prdev19a-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/;QueueEndpoint=https://ao4xscnapbl2prdev19a.queue.core.windows.net/;FileEndpoint=https://ao4xscnapbl2prdev19a.file.core.windows.net/;BlobSecondaryEndpoint=https://ao4xscnapbl2prdev19a-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://ao4xscnapbl2prdev19a-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://ao4xscnapbl2prdev19a-secondary.file.core.windows.net/;AccountName=ao4xscnapbl2prdev19a;AccountKey=Kg==;\nkey-name1\n\n"
+    "DateTimeOffsetNow": "2023-06-09T14:39:47.9219375-07:00",
+    "RandomSeed": "1248651513",
+    "Storage_TestConfigDefault": "ProductionTenant\njalauzonnettest\nU2FuaXRpemVk\nhttps://jalauzonnettest.blob.core.windows.net\nhttps://jalauzonnettest.file.core.windows.net\nhttps://jalauzonnettest.queue.core.windows.net\nhttps://jalauzonnettest.table.core.windows.net\n\n\n\n\nhttps://jalauzonnettest-secondary.blob.core.windows.net\nhttps://jalauzonnettest-secondary.file.core.windows.net\nhttps://jalauzonnettest-secondary.queue.core.windows.net\nhttps://jalauzonnettest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jalauzonnettest.blob.core.windows.net/;QueueEndpoint=https://jalauzonnettest.queue.core.windows.net/;FileEndpoint=https://jalauzonnettest.file.core.windows.net/;BlobSecondaryEndpoint=https://jalauzonnettest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jalauzonnettest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jalauzonnettest-secondary.file.core.windows.net/;AccountName=jalauzonnettest;AccountKey=Sanitized\ntestscope1\n\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/SyncUploadFromUriAsync_OverwriteSourceBlobPropertiesAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/SyncUploadFromUriAsync_OverwriteSourceBlobPropertiesAsync.json
@@ -1,228 +1,256 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-7340152a-18c8-463b-a9f2-a42402dd677d?restype=container",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-3f647927-9ed7-a938-c0d7-7200938ecc51?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-9347a5299231f54bb8424329358ef8d0-de6e555c99e14448-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
+        "Content-Length": "0",
+        "traceparent": "00-9b3c8ee5a8fc1815b854e1c64993f024-0ba39629a6ee3bbc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "29b9170b-8750-5f40-b65b-7edd1c2b139a",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "x-ms-client-request-id": "e3f06f9b-c269-cb1f-4a94-163365349750",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:24 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B6A0EE3C4\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "29b9170b-8750-5f40-b65b-7edd1c2b139a",
-        "x-ms-request-id": "19d09023-601e-0003-6f54-8a5459000000",
-        "x-ms-version": "2021-06-08"
+        "Content-Length": "0",
+        "Date": "Fri, 09 Jun 2023 21:39:24 GMT",
+        "ETag": "\u00220x8DB6931FE8D446A\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e3f06f9b-c269-cb1f-4a94-163365349750",
+        "x-ms-request-id": "c24c9efd-801e-0048-5f1a-9bc7f5000000",
+        "x-ms-version": "2023-01-03"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-7340152a-18c8-463b-a9f2-a42402dd677d/test-blob-9c238c6a-c869-bc5b-9387-2fcf30d6902a",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-3f647927-9ed7-a938-c0d7-7200938ecc51/test-blob-7712a594-30e5-780f-a542-074d54ce0ea2",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "1024",
         "Content-Type": "application/octet-stream",
-        "traceparent": "00-ac4ec2b142ca2049a3688352ae996402-8c46026d8ccd5b40-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
+        "traceparent": "00-248d07bde83931e3430137a7db97e22a-fc17225bb1ea804c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b9881a3f-d4ad-24db-9b49-1b25459b375b",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "x-ms-client-request-id": "0cc051fc-8326-24be-cd4a-30bf7f63188e",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:24 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
-      "RequestBody": "5E36KVt790O8/ZXIV3Au38pTBNkSKHYsXgfC8oQly\u002B/rFuri3GfOXkvVLyWoZMNpSGRrnJ/CBbzWzcpUuAS\u002BlzKl3UGGTANjhaWOPflRg/lDWaoguS9QKREuCw6ceaZHF5jzA4eC4/tgCBb6NMjChUrQEV9and0DVbMwV0H1xgv/RiVhXYBywHauwLEYVvVIa4XEzGhH7Xm68K7UUou6akEL\u002Bu2jYSfJXlDoq90r6v6\u002B5\u002By7MfqjuFmrpm3SnW3r9FVvDVsIpQpd\u002Bm0XXkGcjwWvFWuf/jlHZ0KT97q698Di/beHu92jtkLhXTaMi1oXDxdnIogCS/UcKKUZdK1QowKsNGCKFdMoDF8ovaACutzoe\u002BijUtU44LHBapM3iUGUkbo04Fb5jflDPxUo2Y5UGm3JMfnFrVEtc1SvyapA8IMdlCzmztqG7u7uXxK/EAYjbFAmbldIzuRpBm0BScNPA0\u002BSC0RhbkyTQkIK100\u002BbmNNi1xaGoEr1MVIfcdshKUqn1vDLAXCwv4DkisVPveWKpcJtL1n9enNZzZ/GPGEJr6d3zjxekJei8ldVodVFZbOslIwY9Dnw6py9cTOQqkNf2xtd16/pK9Vqyj0Cp5id1GfsGaeVMPuthyNf4V9j0ggT9cb6J04Dg2i2ren8rkLEH5yL5FCbiqofsFCMSUq1xvg1LrHRo\u002B0Z6JZ/HkLR8Njgm8GCmC23eGscmnc9dzndwKbxx7\u002BRMnvvsfv6HGxnDf\u002B3q\u002B2JM27KfbZGtQl13HFcYV2b4CkZD2lF0yZx/Rv\u002B9Uy3hctMVM14J0oJSn1yeZVKnfsOi23WXpxEAyBImIBaR/\u002B8vlal0AyQY/ifD4Ur01lQ519gsCoe4WdvCBGtL07JrwJ99bt\u002B5I3uvmd1Nw7XWG\u002BHN/Fg\u002BdeVXd0vdsf643RplWCCrh2d0cKRsjHC6aoYV\u002B/h5jedqPVqqFfeD22F85syy2GuVKoR6SXuj0el0rRzFx8YGP08zCyrV8XF/8JVC/5Wz94IacMF0D0R7xlthNWjqzhObdrd9j91AzykDCkjWYOJDsKWKq0b0gjAKt0TPZLwYlSKBp3juRne02bGYYQT7pVV5HXSzUCLcpuR3YsiIcVps\u002BmUWVLlpZXo91cGFbBE7HxHvVkc3VTUPpQCEZtO/LGhnK3af1UCcD7gKhYpRVzrDTFOmqRsDNZUgFq\u002B41P6WjqlZHjCqm0nRQ0afPN\u002B6rl3FsSqACINNY/XRf76g4yrJc/bhCDkKKLEZ1VXUc/jFdXhR8yPUBnYmG7o6ySuLMGAbxcjYyaYUu5h5djMteOANG/pGTuAG9W2AuuyO32\u002BFjqT1uK4/7KvCTTeLWpBDCKLKPa0hNOFwBMBQ==",
+      "RequestBody": "8vnV9QteOmpfeD4mu9J2e4Z0MhPPc7KrvflBWBW83wWFA1pb\u002BRiWoxb6xCWrwV1jFp/MJG6pNH5GKTgRHOJVo5g4oLd3G4Jt3Y781K\u002BMAPuc3UF277uW3M7cFM/ghIY0pSCNciGl6/scX0bfrWDOuSg8dT6h37TdocTpmwayjVkHyC6P/47a9vJGWY90ty9uDVumow5IksZsr9BcvE/0atLt2OUxP7qaYn9MW4UkaeqVe46rC\u002BlKvzVoIk\u002B9fTmjUe\u002B9ht5KPc2gDEGP\u002BzdAR0blx0HBSF7ooxivyRxq3ORFqQmWZ\u002BIMSz7AC/\u002BousP9J9sI2Lb44QmQ1OPGmnOxNS9cSVIuquBk2XwDAD1fQOlVsqJBYgQuTccABZL/RrDKD9XPTHBwz3z6o/459ODLMZP6cOfRb9MqLfyLLqRNZZPLOfFoj/R45OMlRr4G9VjmNNT\u002BBdXJ\u002BJ8CpB505aHYrT5qbbvvY6GfgYwErCgUJDijpPnPTmC\u002BAkBRZurVA/5CTZmAm4ec99AyX4NIxEx37YDl0EGnCF7drGt7nv23yX6Owl6Pk4mxB60pnO/ddj3z2nhq7zO9m0Q7o\u002B4bIFjTe5UEuQLu51r2NMmTfmtu/zYtiMSFTNlL0ScZVO\u002BaleZUVSFa2Lw7BfIdc7tpKRzZzKO47ZiUTS\u002B7uejb1JNqXJ7iPyhKFCd58oLRZ9ge4agKQIdM4adNvwjynh7UXzFesxcch\u002Bn0j7d8P/sWw\u002BVWnNg/0ZQLHnr2lH8fWHYIpZNRcrTBAVm\u002BFbDQ0KKsN/wimwFFlI6cU5ScJfJq1DdBc5pnxVAxlJt/gLvjO07YSl2D/bx0wxAEtB8fJdtnVEF5j10IRHKs8QdmxhPTuRhGw9uU5td7za\u002BJYhAwEW\u002B/Fyx5aqzw0AXr1wy0Dfz8MfsH2WH/0m1q/cGtfuJhe9\u002BYpq/nWU5rVfPWqQ/Kxr\u002BzjDEVKTgNwES\u002BD23qQ1IjiVssHGdNFdesm4NuKSldnzYC\u002BvGwTFGniuZqKErhgRKhsx\u002B0nqpXZXdZaI20n5YaYG8250hgcj0KhJGA4uyNyxlwzHUKqQGMqpR6V\u002BPD8utPT8jaq5rJQUDhqRkY1oKKy5x0Q9IhD7ZuqTy05RtZRpGmMZIksyB/p4s0Kf/nc9MR8ItHT64YLj8RbAFdFVslh2OIcqXvZhh89JxG7Oa2hjZoovWPEvbijQNSEkYeIpIvD6GcXwAuIopyylsS0UFZWuXK9HNmlXVtpeSinFPSXdEKFt1FGic1OoBqHUia0LzB\u002BbdhVC0fyXksL7ocjIU2oG2JB7pkFEC9lbry\u002B3gs0tQo4KObcAmk601kGOttGK77NHzaEcgBXeV3o75zLM0A/13l9A==",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-MD5": "CmpfCmJ5cbMZWXFvsx7r0Q==",
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B6A1A27B4\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "b9881a3f-d4ad-24db-9b49-1b25459b375b",
-        "x-ms-content-crc64": "TqhQjJW21eU=",
-        "x-ms-request-id": "19d09027-601e-0003-7054-8a5459000000",
+        "Content-Length": "0",
+        "Content-MD5": "mP8ejbcePmTOk7Dud3rNEA==",
+        "Date": "Fri, 09 Jun 2023 21:39:24 GMT",
+        "ETag": "\u00220x8DB6931FE9782C3\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0cc051fc-8326-24be-cd4a-30bf7f63188e",
+        "x-ms-content-crc64": "FtGcFKTEPSM=",
+        "x-ms-request-id": "c24c9f45-801e-0048-041a-9bc7f5000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:24.8723405Z"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-7340152a-18c8-463b-a9f2-a42402dd677d/test-blob-eb1842d9-3e23-1b2d-da77-4435f0a39b18",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-3f647927-9ed7-a938-c0d7-7200938ecc51/test-blob-24655101-e99e-18e8-368d-1b5398a0bc03",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-8e62b4d71c512249b11324db3b7d4663-dd1c1c35600d1d4f-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
+        "Content-Length": "0",
+        "traceparent": "00-a49b3688c9aea0eb9d29cd746262643e-1e980da525a0d6ef-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
         "x-ms-access-tier": "Hot",
-        "x-ms-blob-cache-control": "wwnejxxlwmfbrgiowxhc",
-        "x-ms-blob-content-disposition": "yjnagecnbigwflopfyrb",
-        "x-ms-blob-content-encoding": "ggthholuilfhiyumjmwf",
-        "x-ms-blob-content-language": "vkkofiufqsjwgfusofsr",
-        "x-ms-blob-content-type": "rhfpdyngpcgrcmfvvfcy",
+        "x-ms-blob-cache-control": "xsntollybymgitkcogli",
+        "x-ms-blob-content-disposition": "rfxelkttxtwdwvrbvwnw",
+        "x-ms-blob-content-encoding": "bgucknsjnwerignruihe",
+        "x-ms-blob-content-language": "qqagciilbifrrnhkkvtx",
+        "x-ms-blob-content-type": "qkgbpetphygnojfjgnyb",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "fd0e2bde-9378-e058-a5c7-fe14a768f9dd",
-        "x-ms-copy-source": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-7340152a-18c8-463b-a9f2-a42402dd677d/test-blob-9c238c6a-c869-bc5b-9387-2fcf30d6902a",
+        "x-ms-client-request-id": "ad040634-d89c-27cd-2376-6218b45ded9c",
+        "x-ms-copy-source": "https://jalauzonnettest.blob.core.windows.net/test-container-3f647927-9ed7-a938-c0d7-7200938ecc51/test-blob-7712a594-30e5-780f-a542-074d54ce0ea2",
         "x-ms-copy-source-blob-properties": "false",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:24 GMT",
+        "x-ms-meta-Capital": "letter",
+        "x-ms-meta-foo": "bar",
+        "x-ms-meta-meta": "data",
+        "x-ms-meta-UPPER": "case",
         "x-ms-return-client-request-id": "true",
         "x-ms-tags": "tagKey0=tagValue0\u0026tagKey1=tagValue1",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B6A254B68\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "fd0e2bde-9378-e058-a5c7-fe14a768f9dd",
-        "x-ms-content-crc64": "TqhQjJW21eU=",
-        "x-ms-request-id": "19d09028-601e-0003-7154-8a5459000000",
+        "Content-Length": "0",
+        "Date": "Fri, 09 Jun 2023 21:39:24 GMT",
+        "ETag": "\u00220x8DB6931FEAFE938\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ad040634-d89c-27cd-2376-6218b45ded9c",
+        "x-ms-content-crc64": "FtGcFKTEPSM=",
+        "x-ms-request-id": "c24c9f74-801e-0048-1e1a-9bc7f5000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:25.0312504Z"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-7340152a-18c8-463b-a9f2-a42402dd677d/test-blob-eb1842d9-3e23-1b2d-da77-4435f0a39b18",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-3f647927-9ed7-a938-c0d7-7200938ecc51/test-blob-24655101-e99e-18e8-368d-1b5398a0bc03",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-0c62baad01f3634eb19b0646ce6d92be-c507b1bd355e7c40-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "1a4713c3-398c-aae2-8469-a3098c610ebe",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "traceparent": "00-41147e26256e7b684e3abbfa98608281-35b5955066cb1ecc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "798aca08-6b5f-aff1-56db-f522e95e774e",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:25 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
-        "Cache-Control": "wwnejxxlwmfbrgiowxhc",
-        "Content-Disposition": "yjnagecnbigwflopfyrb",
-        "Content-Encoding": "ggthholuilfhiyumjmwf",
-        "Content-Language": "vkkofiufqsjwgfusofsr",
+        "Cache-Control": "xsntollybymgitkcogli",
+        "Content-Disposition": "rfxelkttxtwdwvrbvwnw",
+        "Content-Encoding": "bgucknsjnwerignruihe",
+        "Content-Language": "qqagciilbifrrnhkkvtx",
         "Content-Length": "1024",
-        "Content-MD5": "CmpfCmJ5cbMZWXFvsx7r0Q==",
-        "Content-Type": "rhfpdyngpcgrcmfvvfcy",
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B6A254B68\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "Content-MD5": "mP8ejbcePmTOk7Dud3rNEA==",
+        "Content-Type": "qkgbpetphygnojfjgnyb",
+        "Date": "Fri, 09 Jun 2023 21:39:24 GMT",
+        "ETag": "\u00220x8DB6931FEAFE938\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "1a4713c3-398c-aae2-8469-a3098c610ebe",
-        "x-ms-creation-time": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "x-ms-client-request-id": "798aca08-6b5f-aff1-56db-f522e95e774e",
+        "x-ms-creation-time": "Fri, 09 Jun 2023 21:39:25 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-last-access-time": "Fri, 09 Jun 2023 21:39:25 GMT",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "19d09029-601e-0003-7254-8a5459000000",
+        "x-ms-meta-Capital": "letter",
+        "x-ms-meta-foo": "bar",
+        "x-ms-meta-meta": "data",
+        "x-ms-meta-UPPER": "case",
+        "x-ms-request-id": "c24ca01e-801e-0048-091a-9bc7f5000000",
         "x-ms-server-encrypted": "true",
         "x-ms-tag-count": "2",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:25.0312504Z"
       },
-      "ResponseBody": "5E36KVt790O8/ZXIV3Au38pTBNkSKHYsXgfC8oQly\u002B/rFuri3GfOXkvVLyWoZMNpSGRrnJ/CBbzWzcpUuAS\u002BlzKl3UGGTANjhaWOPflRg/lDWaoguS9QKREuCw6ceaZHF5jzA4eC4/tgCBb6NMjChUrQEV9and0DVbMwV0H1xgv/RiVhXYBywHauwLEYVvVIa4XEzGhH7Xm68K7UUou6akEL\u002Bu2jYSfJXlDoq90r6v6\u002B5\u002By7MfqjuFmrpm3SnW3r9FVvDVsIpQpd\u002Bm0XXkGcjwWvFWuf/jlHZ0KT97q698Di/beHu92jtkLhXTaMi1oXDxdnIogCS/UcKKUZdK1QowKsNGCKFdMoDF8ovaACutzoe\u002BijUtU44LHBapM3iUGUkbo04Fb5jflDPxUo2Y5UGm3JMfnFrVEtc1SvyapA8IMdlCzmztqG7u7uXxK/EAYjbFAmbldIzuRpBm0BScNPA0\u002BSC0RhbkyTQkIK100\u002BbmNNi1xaGoEr1MVIfcdshKUqn1vDLAXCwv4DkisVPveWKpcJtL1n9enNZzZ/GPGEJr6d3zjxekJei8ldVodVFZbOslIwY9Dnw6py9cTOQqkNf2xtd16/pK9Vqyj0Cp5id1GfsGaeVMPuthyNf4V9j0ggT9cb6J04Dg2i2ren8rkLEH5yL5FCbiqofsFCMSUq1xvg1LrHRo\u002B0Z6JZ/HkLR8Njgm8GCmC23eGscmnc9dzndwKbxx7\u002BRMnvvsfv6HGxnDf\u002B3q\u002B2JM27KfbZGtQl13HFcYV2b4CkZD2lF0yZx/Rv\u002B9Uy3hctMVM14J0oJSn1yeZVKnfsOi23WXpxEAyBImIBaR/\u002B8vlal0AyQY/ifD4Ur01lQ519gsCoe4WdvCBGtL07JrwJ99bt\u002B5I3uvmd1Nw7XWG\u002BHN/Fg\u002BdeVXd0vdsf643RplWCCrh2d0cKRsjHC6aoYV\u002B/h5jedqPVqqFfeD22F85syy2GuVKoR6SXuj0el0rRzFx8YGP08zCyrV8XF/8JVC/5Wz94IacMF0D0R7xlthNWjqzhObdrd9j91AzykDCkjWYOJDsKWKq0b0gjAKt0TPZLwYlSKBp3juRne02bGYYQT7pVV5HXSzUCLcpuR3YsiIcVps\u002BmUWVLlpZXo91cGFbBE7HxHvVkc3VTUPpQCEZtO/LGhnK3af1UCcD7gKhYpRVzrDTFOmqRsDNZUgFq\u002B41P6WjqlZHjCqm0nRQ0afPN\u002B6rl3FsSqACINNY/XRf76g4yrJc/bhCDkKKLEZ1VXUc/jFdXhR8yPUBnYmG7o6ySuLMGAbxcjYyaYUu5h5djMteOANG/pGTuAG9W2AuuyO32\u002BFjqT1uK4/7KvCTTeLWpBDCKLKPa0hNOFwBMBQ=="
+      "ResponseBody": "8vnV9QteOmpfeD4mu9J2e4Z0MhPPc7KrvflBWBW83wWFA1pb\u002BRiWoxb6xCWrwV1jFp/MJG6pNH5GKTgRHOJVo5g4oLd3G4Jt3Y781K\u002BMAPuc3UF277uW3M7cFM/ghIY0pSCNciGl6/scX0bfrWDOuSg8dT6h37TdocTpmwayjVkHyC6P/47a9vJGWY90ty9uDVumow5IksZsr9BcvE/0atLt2OUxP7qaYn9MW4UkaeqVe46rC\u002BlKvzVoIk\u002B9fTmjUe\u002B9ht5KPc2gDEGP\u002BzdAR0blx0HBSF7ooxivyRxq3ORFqQmWZ\u002BIMSz7AC/\u002BousP9J9sI2Lb44QmQ1OPGmnOxNS9cSVIuquBk2XwDAD1fQOlVsqJBYgQuTccABZL/RrDKD9XPTHBwz3z6o/459ODLMZP6cOfRb9MqLfyLLqRNZZPLOfFoj/R45OMlRr4G9VjmNNT\u002BBdXJ\u002BJ8CpB505aHYrT5qbbvvY6GfgYwErCgUJDijpPnPTmC\u002BAkBRZurVA/5CTZmAm4ec99AyX4NIxEx37YDl0EGnCF7drGt7nv23yX6Owl6Pk4mxB60pnO/ddj3z2nhq7zO9m0Q7o\u002B4bIFjTe5UEuQLu51r2NMmTfmtu/zYtiMSFTNlL0ScZVO\u002BaleZUVSFa2Lw7BfIdc7tpKRzZzKO47ZiUTS\u002B7uejb1JNqXJ7iPyhKFCd58oLRZ9ge4agKQIdM4adNvwjynh7UXzFesxcch\u002Bn0j7d8P/sWw\u002BVWnNg/0ZQLHnr2lH8fWHYIpZNRcrTBAVm\u002BFbDQ0KKsN/wimwFFlI6cU5ScJfJq1DdBc5pnxVAxlJt/gLvjO07YSl2D/bx0wxAEtB8fJdtnVEF5j10IRHKs8QdmxhPTuRhGw9uU5td7za\u002BJYhAwEW\u002B/Fyx5aqzw0AXr1wy0Dfz8MfsH2WH/0m1q/cGtfuJhe9\u002BYpq/nWU5rVfPWqQ/Kxr\u002BzjDEVKTgNwES\u002BD23qQ1IjiVssHGdNFdesm4NuKSldnzYC\u002BvGwTFGniuZqKErhgRKhsx\u002B0nqpXZXdZaI20n5YaYG8250hgcj0KhJGA4uyNyxlwzHUKqQGMqpR6V\u002BPD8utPT8jaq5rJQUDhqRkY1oKKy5x0Q9IhD7ZuqTy05RtZRpGmMZIksyB/p4s0Kf/nc9MR8ItHT64YLj8RbAFdFVslh2OIcqXvZhh89JxG7Oa2hjZoovWPEvbijQNSEkYeIpIvD6GcXwAuIopyylsS0UFZWuXK9HNmlXVtpeSinFPSXdEKFt1FGic1OoBqHUia0LzB\u002BbdhVC0fyXksL7ocjIU2oG2JB7pkFEC9lbry\u002B3gs0tQo4KObcAmk601kGOttGK77NHzaEcgBXeV3o75zLM0A/13l9A=="
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-7340152a-18c8-463b-a9f2-a42402dd677d/test-blob-eb1842d9-3e23-1b2d-da77-4435f0a39b18",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-3f647927-9ed7-a938-c0d7-7200938ecc51/test-blob-24655101-e99e-18e8-368d-1b5398a0bc03",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-854185add661f9448c426e4ee2d3986a-6816f84f710edb4b-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "94518bb1-de21-7151-3c1b-ba1f080d2843",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:40 GMT",
+        "traceparent": "00-d45e28e43bf24cd773f7cef0b125efca-9ca57f3f34b2e93c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea0fe775-73d2-783c-d419-012ee80bc67b",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:25 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
-        "Cache-Control": "wwnejxxlwmfbrgiowxhc",
-        "Content-Disposition": "yjnagecnbigwflopfyrb",
-        "Content-Encoding": "ggthholuilfhiyumjmwf",
-        "Content-Language": "vkkofiufqsjwgfusofsr",
+        "Cache-Control": "xsntollybymgitkcogli",
+        "Content-Disposition": "rfxelkttxtwdwvrbvwnw",
+        "Content-Encoding": "bgucknsjnwerignruihe",
+        "Content-Language": "qqagciilbifrrnhkkvtx",
         "Content-Length": "1024",
-        "Content-MD5": "CmpfCmJ5cbMZWXFvsx7r0Q==",
-        "Content-Type": "rhfpdyngpcgrcmfvvfcy",
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "ETag": "\u00220x8D9586B6A254B68\u0022",
-        "Last-Modified": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "Content-MD5": "mP8ejbcePmTOk7Dud3rNEA==",
+        "Content-Type": "qkgbpetphygnojfjgnyb",
+        "Date": "Fri, 09 Jun 2023 21:39:25 GMT",
+        "ETag": "\u00220x8DB6931FEAFE938\u0022",
+        "Last-Modified": "Fri, 09 Jun 2023 21:39:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
         "x-ms-access-tier": "Hot",
-        "x-ms-access-tier-change-time": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "x-ms-access-tier-change-time": "Fri, 09 Jun 2023 21:39:25 GMT",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "94518bb1-de21-7151-3c1b-ba1f080d2843",
-        "x-ms-creation-time": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "x-ms-client-request-id": "ea0fe775-73d2-783c-d419-012ee80bc67b",
+        "x-ms-creation-time": "Fri, 09 Jun 2023 21:39:25 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-last-access-time": "Fri, 09 Jun 2023 21:39:25 GMT",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "19d0902a-601e-0003-7354-8a5459000000",
+        "x-ms-meta-Capital": "letter",
+        "x-ms-meta-foo": "bar",
+        "x-ms-meta-meta": "data",
+        "x-ms-meta-UPPER": "case",
+        "x-ms-request-id": "c24ca079-801e-0048-3c1a-9bc7f5000000",
         "x-ms-server-encrypted": "true",
         "x-ms-tag-count": "2",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03",
+        "x-ms-version-id": "2023-06-09T21:39:25.0312504Z"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/test-container-7340152a-18c8-463b-a9f2-a42402dd677d?restype=container",
+      "RequestUri": "https://jalauzonnettest.blob.core.windows.net/test-container-3f647927-9ed7-a938-c0d7-7200938ecc51?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
-        "traceparent": "00-13b4455940e2db4b92e58f5169858e7f-3eaf358b26b94044-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.10.0-alpha.20210805.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "01588bd2-7a10-929d-5b2f-b2488d602a06",
-        "x-ms-date": "Thu, 05 Aug 2021 23:47:41 GMT",
+        "traceparent": "00-b1803fbc125d851e352f1fdf3a219558-05d35ce3e2276044-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230609.1 (.NET 6.0.16; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "01ada6da-8d4e-337c-848e-8670e92e6dcc",
+        "x-ms-date": "Fri, 09 Jun 2023 21:39:25 GMT",
         "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2021-06-08"
+        "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "Date": "Thu, 05 Aug 2021 23:47:41 GMT",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "01588bd2-7a10-929d-5b2f-b2488d602a06",
-        "x-ms-request-id": "19d0902b-601e-0003-7454-8a5459000000",
-        "x-ms-version": "2021-06-08"
+        "Content-Length": "0",
+        "Date": "Fri, 09 Jun 2023 21:39:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "01ada6da-8d4e-337c-848e-8670e92e6dcc",
+        "x-ms-request-id": "c24ca0cb-801e-0048-671a-9bc7f5000000",
+        "x-ms-version": "2023-01-03"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-05T18:47:40.7134089-05:00",
-    "RandomSeed": "1015480986",
-    "Storage_TestConfigDefault": "ProductionTenant\nao4xscnapbl2prdev19a\nU2FuaXRpemVk\nhttps://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net\nhttps://ao4xscnapbl2prdev19a.file.core.windows.net\nhttps://ao4xscnapbl2prdev19a.queue.core.windows.net\nhttps://ao4xscnapbl2prdev19a.table.core.windows.net\n\n\n\n\nhttps://ao4xscnapbl2prdev19a-secondary.blob.core.windows.net\nhttps://ao4xscnapbl2prdev19a-secondary.file.core.windows.net\nhttps://ao4xscnapbl2prdev19a-secondary.queue.core.windows.net\nhttps://ao4xscnapbl2prdev19a-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://ao4xscnapbl2prdev19a.blob.preprod.core.windows.net/;QueueEndpoint=https://ao4xscnapbl2prdev19a.queue.core.windows.net/;FileEndpoint=https://ao4xscnapbl2prdev19a.file.core.windows.net/;BlobSecondaryEndpoint=https://ao4xscnapbl2prdev19a-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://ao4xscnapbl2prdev19a-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://ao4xscnapbl2prdev19a-secondary.file.core.windows.net/;AccountName=ao4xscnapbl2prdev19a;AccountKey=Kg==;\nkey-name1\n\n"
+    "DateTimeOffsetNow": "2023-06-09T14:39:24.4225658-07:00",
+    "RandomSeed": "1800165914",
+    "Storage_TestConfigDefault": "ProductionTenant\njalauzonnettest\nU2FuaXRpemVk\nhttps://jalauzonnettest.blob.core.windows.net\nhttps://jalauzonnettest.file.core.windows.net\nhttps://jalauzonnettest.queue.core.windows.net\nhttps://jalauzonnettest.table.core.windows.net\n\n\n\n\nhttps://jalauzonnettest-secondary.blob.core.windows.net\nhttps://jalauzonnettest-secondary.file.core.windows.net\nhttps://jalauzonnettest-secondary.queue.core.windows.net\nhttps://jalauzonnettest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jalauzonnettest.blob.core.windows.net/;QueueEndpoint=https://jalauzonnettest.queue.core.windows.net/;FileEndpoint=https://jalauzonnettest.file.core.windows.net/;BlobSecondaryEndpoint=https://jalauzonnettest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jalauzonnettest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jalauzonnettest-secondary.file.core.windows.net/;AccountName=jalauzonnettest;AccountKey=Sanitized\ntestscope1\n\n"
   }
 }


### PR DESCRIPTION
Resolves #15969

This change adds the `Metadata` to `BlobSyncUploadFromUriOptions` to allow for specifying the metadata of the destination blob when calling `BlobClient.SyncUploadFromUriAsync`. This was previously not added due to a service bug which has since been fixed.