### PR TITLE
Update the behavior of CancellationToken in ProcessSessionMessageEventArgs

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -10,7 +10,7 @@ Thank you to our developer community members who helped to make the Service Bus 
 ### Features Added
 
 - `ProcessMessageEventArgs` provides a `MessageLockCancellationToken` that gets cancelled when the `ServiceBusReceivedMessage.LockUntil` time expired or the processor detected the lock was lost.
-- `ProcessSessionMessageEventArgs` and `ProcessSessionEventArgs` provide a `SessionLockCancellationToken` that gets cancelled when the `ServiceBusSessionProcessor.SessionLockedUntil` time expired or the session processor detected the lock was lost.
+- `ProcessSessionMessageEventArgs` provides a `SessionLockCancellationToken` that gets cancelled when the `ServiceBusSessionProcessor.SessionLockedUntil` time expired or the session processor detected the lock was lost.
 
 ### Breaking Changes
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -60,7 +60,6 @@ namespace Azure.Messaging.ServiceBus
         public string FullyQualifiedNamespace { get { throw null; } }
         public string Identifier { get { throw null; } }
         public string SessionId { get { throw null; } }
-        public System.Threading.CancellationToken SessionLockCancellationToken { get { throw null; } }
         public System.DateTimeOffset SessionLockedUntil { get { throw null; } }
         public virtual System.Threading.Tasks.Task<System.BinaryData> GetSessionStateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual void ReleaseSession() { }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
@@ -21,24 +21,6 @@ namespace Azure.Messaging.ServiceBus
         public CancellationToken CancellationToken { get; }
 
         /// <summary>
-        /// The <see cref="System.Threading.CancellationToken"/> instance is cancelled when the lock renewal failed to
-        /// renew the lock, or the <see cref="ServiceBusSessionProcessorOptions.MaxAutoLockRenewalDuration"/> has elapsed,
-        /// or when the session lock has been lost, or if <see cref="ReleaseSession"/> is called.
-        /// </summary>
-        public CancellationToken SessionLockCancellationToken
-        {
-            get
-            {
-                if (_manager != null)
-                {
-                    return _manager.SessionLockCancellationToken;
-                }
-                // for mocking
-                return _sessionReceiver.SessionLockedUntil < DateTimeOffset.UtcNow ? new CancellationToken(true) : default;
-            }
-        }
-
-        /// <summary>
         /// The <see cref="ServiceBusSessionReceiver"/> that will be used for setting and getting session state.
         /// </summary>
         private readonly ServiceBusSessionReceiver _sessionReceiver;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -417,14 +417,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             mockProcessor.SessionInitializingAsync += args =>
             {
                 sessionOpenCalled = true;
-                Assert.IsTrue(args.SessionLockCancellationToken.IsCancellationRequested);
                 return Task.CompletedTask;
             };
 
             mockProcessor.SessionClosingAsync += args =>
             {
                 sessionCloseCalled = true;
-                Assert.IsTrue(args.SessionLockCancellationToken.IsCancellationRequested);
                 return Task.CompletedTask;
             };
 


### PR DESCRIPTION
- Reverting the behavior of CancellationToken to be as it was previously to avoid breaking anyone ([test pipeline](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2839026&view=ms.vss-test-web.build-test-results-tab&runId=41328331&resultId=100324&paneView=debug) started failing). The expiration behavior will only apply to the new SessionCancellationToken property.
- Removed SessionCancellationToken from the ProcessSessionEventArgs because the associated event is only triggered when opening or closing a session.
- Also adding tests to resolve https://github.com/Azure/azure-sdk-for-net/issues/36893

fyi @danielmarbach 