### PR TITLE
etag locking on blob resources

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
@@ -2,17 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.DataMovement;
 using Azure.Storage.DataMovement.Models;
 
 namespace Azure.Storage.DataMovement.Blobs
@@ -25,6 +20,7 @@ namespace Azure.Storage.DataMovement.Blobs
         private AppendBlobClient _blobClient;
         private AppendBlobStorageResourceOptions _options;
         private long? _length;
+        private ETag? _etagDownloadLock = default;
 
         /// <summary>
         /// Gets the URL of the storage resource.
@@ -113,7 +109,7 @@ namespace Azure.Storage.DataMovement.Blobs
             CancellationToken cancellationToken = default)
         {
             Response<BlobDownloadStreamingResult> response = await _blobClient.DownloadStreamingAsync(
-                _options.ToBlobDownloadOptions(new HttpRange(position, length)),
+                _options.ToBlobDownloadOptions(new HttpRange(position, length), _etagDownloadLock),
                 cancellationToken).ConfigureAwait(false);
             return response.Value.ToReadStreamStorageResourceInfo();
         }
@@ -263,8 +259,9 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <returns>Returns the properties of the Append Blob Storage Resource. See <see cref="StorageResourceProperties"/>.</returns>
         public override async Task<StorageResourceProperties> GetPropertiesAsync(CancellationToken cancellationToken = default)
         {
-            BlobProperties properties = await _blobClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            return properties.ToStorageResourceProperties();
+            Response<BlobProperties> response = await _blobClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            GrabEtag(response.GetRawResponse());
+            return response.Value.ToStorageResourceProperties();
         }
 
         /// <summary>
@@ -290,6 +287,14 @@ namespace Azure.Storage.DataMovement.Blobs
         public override async Task<bool> DeleteIfExistsAsync(CancellationToken cancellationToken = default)
         {
             return await _blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        private void GrabEtag(Response response)
+        {
+            if (_etagDownloadLock == default && response.TryExtractStorageEtag(out ETag etag))
+            {
+                _etagDownloadLock = etag;
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);netstandard2.1;net6.0</TargetFrameworks>
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
@@ -98,6 +98,7 @@
     <Compile Include="$(AzureStorageDataMovementSharedSources)ProgressMultipleParititonedStream.cs" LinkBase="Shared\DataMovement" />
     <Compile Include="$(AzureStorageDataMovementSharedSources)PathScanner.cs" LinkBase="Shared\DataMovement" />
     <Compile Include="$(AzureStorageDataMovementSharedSources)PathScannerFactory.cs" LinkBase="Shared\DataMovement" />
+    <Compile Include="$(AzureStorageDataMovementSharedSources)ResponseExtensions.cs" LinkBase="Shared\DataMovement" />
     <Compile Include="$(AzureStorageDataMovementSharedSources)StorageManagerTransferStatus.cs" LinkBase="Shared\DataMovement" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System.Runtime.CompilerServices;
+
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.DataMovement.Models;
 
@@ -176,14 +176,18 @@ namespace Azure.Storage.DataMovement.Blobs
 
         internal static BlobDownloadOptions ToBlobDownloadOptions(
             this AppendBlobStorageResourceOptions options,
-            HttpRange range)
+            HttpRange range,
+            ETag? etag)
         {
-            return new BlobDownloadOptions()
+            var result = new BlobDownloadOptions()
             {
                 Range = range,
                 Conditions = CreateRequestConditions(options?.SourceConditions, true),
                 TransferValidation = options?.DownloadTransferValidationOptions,
             };
+
+            result.Conditions.IfMatch ??= etag;
+            return result;
         }
 
         internal static AppendBlobCreateOptions ToCreateOptions(
@@ -281,14 +285,19 @@ namespace Azure.Storage.DataMovement.Blobs
             return new BlockBlobStorageResourceOptions(options?.ResourceOptions);
         }
 
-        internal static BlobDownloadOptions ToBlobDownloadOptions(this BlockBlobStorageResourceOptions options, HttpRange range)
+        internal static BlobDownloadOptions ToBlobDownloadOptions(
+            this BlockBlobStorageResourceOptions options,
+            HttpRange range,
+            ETag? etag)
         {
-            return new BlobDownloadOptions()
+            var result = new BlobDownloadOptions()
             {
                 Range = range,
                 Conditions = CreateRequestConditions(options?.SourceConditions),
                 TransferValidation = options?.DownloadTransferValidationOptions,
             };
+            result.Conditions.IfMatch ??= etag;
+            return result;
         }
 
         internal static BlobUploadOptions ToBlobUploadOptions(this BlockBlobStorageResourceOptions options, bool overwrite, long initialSize)
@@ -432,14 +441,17 @@ namespace Azure.Storage.DataMovement.Blobs
 
         internal static BlobDownloadOptions ToBlobDownloadOptions(
             this PageBlobStorageResourceOptions options,
-            HttpRange range)
+            HttpRange range,
+            ETag? etag)
         {
-            return new BlobDownloadOptions()
+            var result = new BlobDownloadOptions()
             {
                 Range = range,
                 Conditions = CreateRequestConditions(options?.SourceConditions, true),
                 TransferValidation = options?.DownloadTransferValidationOptions,
             };
+            result.Conditions.IfMatch ??= etag;
+            return result;
         }
 
         internal static PageBlobCreateOptions ToCreateOptions(

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StorageResourceEtagManagementTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/StorageResourceEtagManagementTests.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Storage.DataMovement.Blobs.Tests
+{
+    [TestFixture]
+    public class StorageResourceEtagManagementTests
+    {
+        [Test]
+        public async Task BlockBlobMaintainsEtagForDownloads()
+        {
+            ETag etag = new ETag("foo");
+            Mock<BlockBlobClient> mock = new();
+            mock.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(
+                    new BlobProperties(),
+                    new MockResponse(200).WithHeader(Constants.HeaderNames.ETag, etag.ToString()))));
+            mock.Setup(b => b.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(
+                    BlobsModelFactory.BlobDownloadStreamingResult(Stream.Null, new BlobDownloadDetails()),
+                    new MockResponse(201))));
+
+            BlockBlobStorageResource storageResource = new(mock.Object);
+            await storageResource.GetPropertiesAsync();
+            await storageResource.ReadStreamAsync();
+
+            mock.Verify(
+                b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.Verify(
+                b => b.DownloadStreamingAsync(
+                    It.Is<BlobDownloadOptions>(options => options.Conditions.IfMatch == etag),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public async Task PageBlobBlobMaintainsEtagForDownloads()
+        {
+            ETag etag = new ETag("foo");
+            Mock<PageBlobClient> mock = new();
+            mock.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(
+                    new BlobProperties(),
+                    new MockResponse(200).WithHeader(Constants.HeaderNames.ETag, etag.ToString()))));
+            mock.Setup(b => b.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(
+                    BlobsModelFactory.BlobDownloadStreamingResult(Stream.Null, new BlobDownloadDetails()),
+                    new MockResponse(201))));
+
+            PageBlobStorageResource storageResource = new(mock.Object);
+            await storageResource.GetPropertiesAsync();
+            await storageResource.ReadStreamAsync();
+
+            mock.Verify(
+                b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.Verify(
+                b => b.DownloadStreamingAsync(
+                    It.Is<BlobDownloadOptions>(options => options.Conditions.IfMatch == etag),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public async Task AppendBlobMaintainsEtagForDownloads()
+        {
+            ETag etag = new ETag("foo");
+            Mock<AppendBlobClient> mock = new();
+            mock.Setup(b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(
+                    new BlobProperties(),
+                    new MockResponse(200).WithHeader(Constants.HeaderNames.ETag, etag.ToString()))));
+            mock.Setup(b => b.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(
+                    BlobsModelFactory.BlobDownloadStreamingResult(Stream.Null, new BlobDownloadDetails()),
+                    new MockResponse(201))));
+
+            AppendBlobStorageResource storageResource = new(mock.Object);
+            await storageResource.GetPropertiesAsync();
+            await storageResource.ReadStreamAsync();
+
+            mock.Verify(
+                b => b.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.Verify(
+                b => b.DownloadStreamingAsync(
+                    It.Is<BlobDownloadOptions>(options => options.Conditions.IfMatch == etag),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+            mock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/ResponseExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/ResponseExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Storage.DataMovement
+{
+    internal static class ResponseExtensions
+    {
+        public static bool TryExtractStorageEtag(this Response response, out ETag etag)
+        {
+            if (response.Headers.TryGetValue(Constants.HeaderNames.ETag, out string rawEtag))
+            {
+                etag = new ETag(rawEtag);
+                return true;
+            }
+            etag = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Sets up blob resources to use etag locking.

Etag is determined on initial get properties fetch. Fetching etag upfront from a listing is for a future PR.