### PR TITLE
[AzureMonitorExporter] refactor ExceptionExtensions

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -55,7 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         {
             if (IsEnabled(eventLevel))
             {
-                WriteEvent(eventId, name, exception.LogAsyncException()?.ToInvariantString());
+                WriteEvent(eventId, name, exception.FlattenException()?.ToInvariantString());
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ExceptionExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ExceptionExtensions.cs
@@ -24,9 +24,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         }
 
-        internal static Exception? LogAsyncException(this Exception exception)
+        internal static Exception FlattenException(this Exception exception)
         {
-            return exception is AggregateException aggregateException ? aggregateException.InnerException : exception;
+            return exception is AggregateException aggregateException ? aggregateException.Flatten() : exception;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/Azure.Monitor.OpenTelemetry.Exporter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks);net48</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
@@ -97,7 +97,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal(expectedName, eventData.EventName);
 
             var message = EventSourceEventFormatting.Format(eventData);
-            Assert.Equal($"{name} - System.Exception: hello world_1", message);
+
+#if NETFRAMEWORK
+            var expectedMessage = $"{name} - System.AggregateException: One or more errors occurred. ---> System.Exception: hello world_1"
+                + Environment.NewLine + "   --- End of inner exception stack trace ---"
+                + Environment.NewLine + "---> (Inner Exception #0) System.Exception: hello world_1<---"
+                + Environment.NewLine
+                + Environment.NewLine + "---> (Inner Exception #1) System.Exception: hello world_2)<---"
+                + Environment.NewLine;
+#else
+            var expectedMessage = $"{name} - System.AggregateException: One or more errors occurred. (hello world_1) (hello world_2))"
+                + Environment.NewLine + " ---> System.Exception: hello world_1"
+                + Environment.NewLine + "   --- End of inner exception stack trace ---"
+                + Environment.NewLine + " ---> (Inner Exception #1) System.Exception: hello world_2)<---"
+                + Environment.NewLine;
+#endif
+
+            Assert.Equal(expectedMessage, message);
         }
 
         public class TestListener : EventListener

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ExceptionExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ExceptionExtensionsTests.cs
@@ -46,12 +46,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotSame(test, aggregateException);
 
 #if NETFRAMEWORK
-            Assert.Equal("One or more errors occurred.", test.Message);
-            Assert.Equal("System.AggregateException: One or more errors occurred. ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n---> (Inner Exception #0) System.Exception: hello world 1<---\r\n\r\n---> (Inner Exception #1) System.Exception: hello world 2)<---\r\n", test.ToString());
+            string expectedMessage = "One or more errors occurred.";
+            string expectedToString = "System.AggregateException: One or more errors occurred. ---> System.Exception: hello world 1"
+                + Environment.NewLine + "   --- End of inner exception stack trace ---"
+                + Environment.NewLine + "---> (Inner Exception #0) System.Exception: hello world 1<---"
+                + Environment.NewLine
+                + Environment.NewLine + "---> (Inner Exception #1) System.Exception: hello world 2)<---"
+                + Environment.NewLine;
 #else
-            Assert.Equal("One or more errors occurred. (hello world 1) (hello world 2))", test.Message);
-            Assert.Equal("System.AggregateException: One or more errors occurred. (hello world 1) (hello world 2))\r\n ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n ---> (Inner Exception #1) System.Exception: hello world 2)<---\r\n", test.ToString());
+            string expectedMessage = "One or more errors occurred. (hello world 1) (hello world 2))";
+            string expectedToString = "System.AggregateException: One or more errors occurred. (hello world 1) (hello world 2))"
+                + Environment.NewLine + " ---> System.Exception: hello world 1"
+                + Environment.NewLine + "   --- End of inner exception stack trace ---"
+                + Environment.NewLine + " ---> (Inner Exception #1) System.Exception: hello world 2)<---"
+                + Environment.NewLine;
 #endif
+
+            Assert.Equal(expectedMessage, test.Message);
+            Assert.Equal(expectedToString, test.ToString());
         }
 
         [Fact]
@@ -64,12 +76,28 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotSame(test, aggregateException);
 
 #if NETFRAMEWORK
-            Assert.Equal("One or more errors occurred.", test.Message);
-            Assert.Equal("System.AggregateException: One or more errors occurred. ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n---> (Inner Exception #0) System.Exception: hello world 1<---\r\n\r\n---> (Inner Exception #1) System.Exception: hello world 2<---\r\n\r\n---> (Inner Exception #2) System.Exception: hello world 3<---\r\n", test.ToString());
+            string expectedMessage = "One or more errors occurred.";
+            string expectedToString = "System.AggregateException: One or more errors occurred. ---> System.Exception: hello world 1"
+                + Environment.NewLine + "   --- End of inner exception stack trace ---"
+                + Environment.NewLine + "---> (Inner Exception #0) System.Exception: hello world 1<---"
+                + Environment.NewLine
+                + Environment.NewLine + "---> (Inner Exception #1) System.Exception: hello world 2<---"
+                + Environment.NewLine
+                + Environment.NewLine + "---> (Inner Exception #2) System.Exception: hello world 3<---"
+                + Environment.NewLine;
 #else
-            Assert.Equal("One or more errors occurred. (hello world 1) (hello world 2) (hello world 3)", test.Message);
-            Assert.Equal("System.AggregateException: One or more errors occurred. (hello world 1) (hello world 2) (hello world 3)\r\n ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n ---> (Inner Exception #1) System.Exception: hello world 2<---\r\n\r\n ---> (Inner Exception #2) System.Exception: hello world 3<---\r\n", test.ToString());
+            string expectedMessage = "One or more errors occurred. (hello world 1) (hello world 2) (hello world 3)";
+            string expectedToString = "System.AggregateException: One or more errors occurred. (hello world 1) (hello world 2) (hello world 3)"
+                + Environment.NewLine + " ---> System.Exception: hello world 1"
+                + Environment.NewLine + "   --- End of inner exception stack trace ---"
+                + Environment.NewLine + " ---> (Inner Exception #1) System.Exception: hello world 2<---"
+                + Environment.NewLine
+                + Environment.NewLine + " ---> (Inner Exception #2) System.Exception: hello world 3<---"
+                + Environment.NewLine;
 #endif
+
+            Assert.Equal(expectedMessage, test.Message);
+            Assert.Equal(expectedToString, test.ToString());
         }
 
         [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ExceptionExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ExceptionExtensionsTests.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Globalization;
 using System.Threading;
-
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
-
 using Xunit;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
@@ -36,6 +34,52 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             ExceptionExtensions.ToInvariantString(new Exception());
             Assert.Equal(this.originalUICulture, Thread.CurrentThread.CurrentUICulture);
+        }
+
+        [Fact]
+        public void VerifyFlattenException_HandlesAggregate()
+        {
+            var aggregateException = new AggregateException(new Exception("hello world 1"), new Exception("hello world 2)"));
+
+            var test = aggregateException.FlattenException();
+
+            Assert.NotSame(test, aggregateException);
+
+#if NETFRAMEWORK
+            Assert.Equal("One or more errors occurred.", test.Message);
+            Assert.Equal("System.AggregateException: One or more errors occurred. ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n---> (Inner Exception #0) System.Exception: hello world 1<---\r\n\r\n---> (Inner Exception #1) System.Exception: hello world 2)<---\r\n", test.ToString());
+#else
+            Assert.Equal("One or more errors occurred. (hello world 1) (hello world 2))", test.Message);
+            Assert.Equal("System.AggregateException: One or more errors occurred. (hello world 1) (hello world 2))\r\n ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n ---> (Inner Exception #1) System.Exception: hello world 2)<---\r\n", test.ToString());
+#endif
+        }
+
+        [Fact]
+        public void VerifyFlattenException_HandlesNestedAggregate()
+        {
+            var aggregateException = new AggregateException(new AggregateException(new Exception("hello world 1"), new Exception("hello world 2"), new Exception("hello world 3")));
+
+            var test = aggregateException.FlattenException();
+
+            Assert.NotSame(test, aggregateException);
+
+#if NETFRAMEWORK
+            Assert.Equal("One or more errors occurred.", test.Message);
+            Assert.Equal("System.AggregateException: One or more errors occurred. ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n---> (Inner Exception #0) System.Exception: hello world 1<---\r\n\r\n---> (Inner Exception #1) System.Exception: hello world 2<---\r\n\r\n---> (Inner Exception #2) System.Exception: hello world 3<---\r\n", test.ToString());
+#else
+            Assert.Equal("One or more errors occurred. (hello world 1) (hello world 2) (hello world 3)", test.Message);
+            Assert.Equal("System.AggregateException: One or more errors occurred. (hello world 1) (hello world 2) (hello world 3)\r\n ---> System.Exception: hello world 1\r\n   --- End of inner exception stack trace ---\r\n ---> (Inner Exception #1) System.Exception: hello world 2<---\r\n\r\n ---> (Inner Exception #2) System.Exception: hello world 3<---\r\n", test.ToString());
+#endif
+        }
+
+        [Fact]
+        public void VerifyFlattenException_HandlesNormalException()
+        {
+            var ex = new Exception("hello world");
+
+            var test = ex.FlattenException();
+
+            Assert.Same(ex, test);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
@@ -311,7 +311,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // The first exception is the AggregateException
             Assert.Equal("System.AggregateException", exceptionData.Exceptions[0].TypeName);
 
-#if NET462
+#if NETFRAMEWORK
             Assert.Equal("0", exceptionData.Exceptions[0].Message);
 #else
             Assert.Equal("0 (1) (2) (3) (4) (5) (6) (7) (8) (9) (10) (11) (12) (13) (14) (15)", exceptionData.Exceptions[0].Message);


### PR DESCRIPTION


### Changes
- replace `LogAsyncException` with `FlattenException`.
  The previous would have only logged the first exception of an `AggregateException`.
  There were no safeguards to confirm that the first exception was not itself a nested `AggregateException`.
- update all tests 