### PR TITLE
:Fixes authentication issue if an Autorun value is set in registry

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
@@ -199,7 +199,7 @@ namespace Azure.Identity
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
-                argument = $"/c \"{command}\"";
+                argument = $"/d /c \"{command}\"";
             }
             else
             {

--- a/sdk/identity/Azure.Identity/src/Credentials/AzureDeveloperCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureDeveloperCliCredential.cs
@@ -189,7 +189,7 @@ namespace Azure.Identity
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
-                argument = $"/c \"{command}\"";
+                argument = $"/d /c \"{command}\"";
             }
             else
             {

--- a/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzurePowerShellCredential.cs
@@ -247,7 +247,7 @@ return $x.Objects.FirstChild.OuterXml
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName = Path.Combine(DefaultWorkingDirWindows, "cmd.exe");
-                argument = $"/c \"{powershellExe} \"{commandBase64}\" \"";
+                argument = $"/d /c \"{powershellExe} \"{commandBase64}\" \"";
             }
             else
             {


### PR DESCRIPTION
Fixes authentication issue if an Autorun value is set in HKLM\SOFTWARE\Microsoft\Command Processor on Windows

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
