### PR TITLE
Use newer coverlet collector version

### DIFF
--- a/eng/CodeCoverage.targets
+++ b/eng/CodeCoverage.targets
@@ -94,14 +94,4 @@
   <ItemGroup>
     <SourceRoot Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))" />
   </ItemGroup>
-
-  <Target Name="CoverletGetPathMap"
-          DependsOnTargets="InitializeSourceRootMappedPaths"
-          Returns="@(_LocalTopLevelSourceRoot)"
-          Condition="'$(DeterministicSourcePaths)' == 'true' and $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '3.1'))">
-    <ItemGroup>
-      <_LocalTopLevelSourceRoot Include="@(SourceRoot)"
-                                Condition="'%(SourceRoot.NestedRoot)' == ''"/>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -174,7 +174,7 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230612.1" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20230131.1" PrivateAssets="All" />
-    <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20467.1" PrivateAssets="All" />

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -120,6 +120,11 @@ jobs:
           ArtifactPath: $(Build.ArtifactStagingDirectory)/test.binlog
           ArtifactName: binlog_$(Agent.JobName)
           CustomCondition: and(ne(variables['DiagnosticArguments'], ''), eq(variables['System.Debug'], 'true'))
+      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+        parameters:
+          ArtifactPath: $(Build.SourcesDirectory)/artifacts
+          ArtifactName: artifacts_$(Agent.JobName)
+          CustomCondition: and(ne(variables['DiagnosticArguments'], ''), eq(variables['System.Debug'], 'true'))
       - template: /eng/pipelines/templates/steps/upload-dumps.yml
       - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
         condition: and(succeededOrFailed(), eq(variables['CollectCoverage'], 'true'), eq(variables['coverage.collected'], 'true'))


### PR DESCRIPTION
The version of coverlet we're using requires a custom target in our Directory.build.targets or imports and it is failing to properly instrument all assemblies for coverage collection.  The newer version of coverlet collector depends on a target shipped in .NET SDK since 3.1 so we can simplify our coverage targes and improve collection.