### PR TITLE
[AzureMonitorExporter] Process k8s attributes to detect RoleName for AKS

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AksResourceProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AksResourceProcessor.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals;
+
+internal class AksResourceProcessor
+{
+    private static readonly Dictionary<string, Action<AksResourceProcessor, string>> s_propertySetters = new(7)
+    {
+        { SemanticConventions.AttributeK8sCronJob, (parser, value) => parser.K8sCronjobName = value },
+        { SemanticConventions.AttributeK8sDaemonSet, (parser, value) => parser.K8sDaemonSetName = value },
+        { SemanticConventions.AttributeK8sDeployment, (parser, value) => parser.K8sDeploymentName = value },
+        { SemanticConventions.AttributeK8sJob, (parser, value) => parser.K8sJobName = value },
+        { SemanticConventions.AttributeK8sPod, (parser, value) => parser.K8sPodName = value },
+        { SemanticConventions.AttributeK8sReplicaSet, (parser, value) => parser.K8sReplicaSetName = value },
+        { SemanticConventions.AttributeK8sStatefulSet, (parser, value) => parser.K8sStatefulSetName = value }
+    };
+
+    public string? K8sCronjobName { get; set; } = null;
+
+    public string? K8sDaemonSetName { get; set; } = null;
+
+    public string? K8sDeploymentName { get; set; } = null;
+
+    public string? K8sJobName { get; set; } = null;
+
+    public string? K8sPodName { get; set; } = null;
+
+    public string? K8sReplicaSetName { get; set; } = null;
+
+    public string? K8sStatefulSetName { get; set; } = null;
+
+     public string? GetRoleName()
+    {
+        if (!string.IsNullOrEmpty(K8sDeploymentName))
+        {
+            return K8sDeploymentName;
+        }
+        else if (!string.IsNullOrEmpty(K8sReplicaSetName))
+        {
+            return K8sReplicaSetName;
+        }
+        else if (!string.IsNullOrEmpty(K8sStatefulSetName))
+        {
+            return K8sStatefulSetName;
+        }
+        else if (!string.IsNullOrEmpty(K8sJobName))
+        {
+            return K8sJobName;
+        }
+        else if (!string.IsNullOrEmpty(K8sCronjobName))
+        {
+            return K8sCronjobName;
+        }
+        else if (!string.IsNullOrEmpty(K8sDaemonSetName))
+        {
+            return K8sDaemonSetName;
+        }
+
+        return null;
+    }
+
+    public string? GetRoleInstance()
+    {
+        return string.IsNullOrEmpty(K8sPodName) ? null : K8sPodName;
+    }
+
+    public void MapAttributeToProperty(KeyValuePair<string, object> aksAttribute)
+    {
+        if (s_propertySetters.TryGetValue(aksAttribute.Key, out var setter))
+        {
+            if (aksAttribute.Value is string value)
+            {
+                setter(this, value);
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -9,90 +9,120 @@ using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry.Resources;
 
-namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals;
+
+internal static class ResourceExtensions
 {
-    internal static class ResourceExtensions
+    private const string AiSdkPrefixKey = "ai.sdk.prefix";
+    private const string DefaultServiceName = "unknown_service";
+    private const int Version = 2;
+
+    internal static AzureMonitorResource? CreateAzureMonitorResource(this Resource resource, string? instrumentationKey = null)
     {
-        private const string s_AiSdkPrefixKey = "ai.sdk.prefix";
-        private const int Version = 2;
-
-        internal static AzureMonitorResource? CreateAzureMonitorResource(this Resource resource, string? instrumentationKey = null)
+        if (resource == null)
         {
-            if (resource == null)
-            {
-                return null;
-            }
-
-            AzureMonitorResource azureMonitorResource = new AzureMonitorResource();
-            MetricsData? metricsData = null;
-            string? serviceName = null;
-            string? serviceNamespace = null;
-
-            if (instrumentationKey != null && resource.Attributes.Count() > 0)
-            {
-                metricsData = new MetricsData(Version);
-            }
-
-            foreach (var attribute in resource.Attributes)
-            {
-                switch (attribute.Key)
-                {
-                    case SemanticConventions.AttributeServiceName when attribute.Value is string _serviceName:
-                        serviceName = _serviceName;
-                        break;
-                    case SemanticConventions.AttributeServiceNamespace when attribute.Value is string _serviceNamespace:
-                        serviceNamespace = $"[{_serviceNamespace}]";
-                        break;
-                    case SemanticConventions.AttributeServiceInstance when attribute.Value is string _serviceInstance:
-                        azureMonitorResource.RoleInstance = _serviceInstance;
-                        break;
-                    case s_AiSdkPrefixKey when attribute.Value is string _aiSdkPrefixValue:
-                        SdkVersionUtils.SdkVersionPrefix = _aiSdkPrefixValue;
-                        continue;
-                }
-
-                if (metricsData != null && attribute.Key.Length <= SchemaConstants.MetricsData_Properties_MaxKeyLength && attribute.Value != null)
-                {
-                    // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
-                    metricsData.Properties.Add(new KeyValuePair<string, string>(attribute.Key, attribute.Value.ToString().Truncate(SchemaConstants.MetricsData_Properties_MaxValueLength) ?? "null"));
-                }
-            }
-
-            // TODO: Check if service.name as unknown_service should be sent.
-            if (serviceName != null && serviceNamespace != null)
-            {
-                azureMonitorResource.RoleName = string.Concat(serviceNamespace, "/", serviceName);
-            }
-            else
-            {
-                azureMonitorResource.RoleName = serviceName;
-            }
-
-            if (azureMonitorResource.RoleInstance == null)
-            {
-                try
-                {
-                    azureMonitorResource.RoleInstance = Dns.GetHostName();
-                }
-                catch (Exception ex)
-                {
-                    AzureMonitorExporterEventSource.Log.WriteError("ErrorInitializingRoleInstanceToHostName", ex);
-                }
-            }
-
-            if (metricsData != null)
-            {
-                azureMonitorResource.MetricTelemetry = new TelemetryItem(DateTime.UtcNow, azureMonitorResource, instrumentationKey!)
-                {
-                    Data = new MonitorBase
-                    {
-                        BaseType = "MetricData",
-                        BaseData = metricsData
-                    }
-                };
-            }
-
-            return azureMonitorResource;
+            return null;
         }
+
+        AzureMonitorResource azureMonitorResource = new AzureMonitorResource();
+        MetricsData? metricsData = null;
+        AksResourceProcessor? aksResourceProcessor = null;
+        string? serviceName = null;
+        string? serviceNamespace = null;
+        string? serviceInstance = null;
+        bool? hasDefaultServiceName = null;
+
+        if (instrumentationKey != null && resource.Attributes.Any())
+        {
+            metricsData = new MetricsData(Version);
+        }
+
+        foreach (var attribute in resource.Attributes)
+        {
+            switch (attribute.Key)
+            {
+                case SemanticConventions.AttributeServiceName when attribute.Value is string _serviceName:
+                    serviceName = _serviceName;
+                    if (serviceName.StartsWith(DefaultServiceName))
+                    {
+                        hasDefaultServiceName = true;
+                        break;
+                    }
+
+                    hasDefaultServiceName = false;
+                    break;
+                case SemanticConventions.AttributeServiceNamespace when attribute.Value is string _serviceNamespace:
+                    serviceNamespace = $"[{_serviceNamespace}]";
+                    break;
+                case SemanticConventions.AttributeServiceInstance when attribute.Value is string _serviceInstance:
+                    serviceInstance = _serviceInstance;
+                    break;
+                case AiSdkPrefixKey when attribute.Value is string _aiSdkPrefixValue:
+                    SdkVersionUtils.SdkVersionPrefix = _aiSdkPrefixValue;
+                    continue;
+                default:
+                    if (attribute.Key.StartsWith("k8s"))
+                    {
+                        aksResourceProcessor = aksResourceProcessor ?? new AksResourceProcessor();
+                        aksResourceProcessor.MapAttributeToProperty(attribute);
+                    }
+                    break;
+            }
+
+            if (metricsData != null && attribute.Key.Length <= SchemaConstants.MetricsData_Properties_MaxKeyLength && attribute.Value != null)
+            {
+                // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
+                metricsData.Properties.Add(new KeyValuePair<string, string>(attribute.Key, attribute.Value.ToString().Truncate(SchemaConstants.MetricsData_Properties_MaxValueLength) ?? "null"));
+            }
+        }
+
+        // TODO: Check if service.name as unknown_service should be sent.
+        if (serviceName != null && serviceNamespace != null)
+        {
+            azureMonitorResource.RoleName = string.Concat(serviceNamespace, "/", serviceName);
+        }
+        else
+        {
+            azureMonitorResource.RoleName = serviceName;
+        }
+
+        try
+        {
+            azureMonitorResource.RoleInstance = serviceInstance ?? Dns.GetHostName();
+        }
+        catch (Exception ex)
+        {
+            AzureMonitorExporterEventSource.Log.WriteError("ErrorInitializingRoleInstanceToHostName", ex);
+        }
+
+        if (aksResourceProcessor != null)
+        {
+            var aksRoleName = aksResourceProcessor.GetRoleName();
+            var aksRoleInstanceName = aksResourceProcessor.GetRoleInstance();
+
+            if (hasDefaultServiceName != false && aksRoleName != null)
+            {
+                azureMonitorResource.RoleName = aksRoleName;
+            }
+
+            if (serviceInstance == null && aksRoleInstanceName != null)
+            {
+                azureMonitorResource.RoleInstance = aksRoleInstanceName;
+            }
+        }
+
+        if (metricsData != null)
+        {
+            azureMonitorResource.MetricTelemetry = new TelemetryItem(DateTime.UtcNow, azureMonitorResource, instrumentationKey!)
+            {
+                Data = new MonitorBase
+                {
+                    BaseType = "MetricData",
+                    BaseData = metricsData
+                }
+            };
+        }
+
+        return azureMonitorResource;
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SemanticConventions.cs
@@ -30,9 +30,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const string AttributeFaasInstance = "faas.instance";
 
         public const string AttributeK8sCluster = "k8s.cluster.name";
+        public const string AttributeK8sCronJob = "k8s.cronjob.name";
+        public const string AttributeK8sDaemonSet = "k8s.daemonset.name";
+        public const string AttributeK8sDeployment = "k8s.deployment.name";
+        public const string AttributeK8sJob = "k8s.job.name";
         public const string AttributeK8sNamespace = "k8s.namespace.name";
         public const string AttributeK8sPod = "k8s.pod.name";
-        public const string AttributeK8sDeployment = "k8s.deployment.name";
+        public const string AttributeK8sReplicaSet = "k8s.replicaset.name";
+        public const string AttributeK8sStatefulSet = "k8s.statefulset.name";
 
         public const string AttributeHostHostname = "host.hostname";
         public const string AttributeHostId = "host.id";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AksResourceProcessorTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AksResourceProcessorTests.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests;
+
+public class AksResourceProcessorTests
+{
+    public static TheoryData<KeyValuePair<string, object>> K8sAttributesData
+    {
+        get
+        {
+            var data = new TheoryData<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>(SemanticConventions.AttributeK8sCronJob, "cronjobname"),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeK8sDaemonSet, "daemonsetname"),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeK8sDeployment, "deploymentname"),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeK8sJob, "jobname"),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeK8sPod, "podname"),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeK8sReplicaSet, "replicasetname"),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeK8sStatefulSet, "statefulsetname")
+            };
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(K8sAttributesData))]
+    public void AksResourceProcessor_MapsAttributeToProperty(KeyValuePair<string, object> attribute)
+    {
+        // Arrange
+        var aksResourceProcessor = new AksResourceProcessor();
+
+        // Act
+        aksResourceProcessor.MapAttributeToProperty(attribute);
+
+        // Assert
+        switch (attribute.Key)
+        {
+            case "k8s.deployment.name":
+                Assert.Equal(attribute.Value, aksResourceProcessor.K8sDeploymentName);
+                break;
+            case "k8s.replicaset.name":
+                Assert.Equal(attribute.Value, aksResourceProcessor.K8sReplicaSetName);
+                break;
+            case "k8s.statefulset.name":
+                Assert.Equal(attribute.Value, aksResourceProcessor.K8sStatefulSetName);
+                break;
+            case "k8s.job.name":
+                Assert.Equal(attribute.Value, aksResourceProcessor.K8sJobName);
+                break;
+            case "k8s.cronjob.name":
+                Assert.Equal(attribute.Value, aksResourceProcessor.K8sCronjobName);
+                break;
+            case "k8s.daemonset.name":
+                Assert.Equal(attribute.Value, aksResourceProcessor.K8sDaemonSetName);
+                break;
+            case "k8s.pod.name":
+                Assert.Equal(attribute.Value, aksResourceProcessor.K8sPodName);
+                break;
+            default:
+                Assert.True(false, $"Unexpected attribute key: {attribute.Key}");
+                break;
+        }
+    }
+
+    public static TheoryData<string?, string?, string?, string?, string?, string?, string?> RoleNameTestData()
+    {
+        var data = new TheoryData<string?, string?, string?, string?, string?, string?, string?>
+        {
+            { "my-deployment", null, null, null, null, null, "my-deployment" },
+            { null, "my-replicaset", null, null, null, null, "my-replicaset" },
+            { null, null, "my-statefulset", null, null, null, "my-statefulset" },
+            { null, null, null, "my-job", null, null, "my-job" },
+            { null, null, null, null, "my-cronjob", null, "my-cronjob" },
+            { null, null, null, null, null, "my-daemonset", "my-daemonset" },
+            { "my-deployment", "my-replicaset", null, null, null, null, "my-deployment" },
+            { null, null, "my-statefulset", "my-job", null, null, "my-statefulset" },
+            { null, null, null, null, "my-cronjob", "my-daemonset", "my-cronjob" },
+            { "my-deployment", "my-replicaset", "my-statefulset", null, "my-cronjob", "my-daemonset", "my-deployment" },
+            { null, null, null, null, null, null, null },
+            { "", "", "", "", "", "", null },
+            { "", "my-replicaset", "", "my-job", "my-cronjob", "", "my-replicaset" },
+            { "my-deployment", "", "", "", "my-cronjob", "my-daemonset", "my-deployment" }
+        };
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(RoleNameTestData))]
+    public void GetRoleName_ReturnsExpectedValue(string deployment, string replicaSet, string statefulSet, string job, string cronjob, string daemonSet, string expectedRoleName)
+    {
+        // Arrange
+        var aksResourceProcessor = new AksResourceProcessor();
+        aksResourceProcessor.K8sDeploymentName = deployment;
+        aksResourceProcessor.K8sReplicaSetName = replicaSet;
+        aksResourceProcessor.K8sStatefulSetName = statefulSet;
+        aksResourceProcessor.K8sJobName = job;
+        aksResourceProcessor.K8sCronjobName = cronjob;
+        aksResourceProcessor.K8sDaemonSetName = daemonSet;
+
+        // Act
+        var roleName = aksResourceProcessor.GetRoleName();
+
+        // Assert
+        Assert.Equal(expectedRoleName, roleName);
+    }
+
+    public static TheoryData<string?, string?> RoleInstanceTestData()
+    {
+        var data = new TheoryData<string?, string?>
+        {
+            { "my-pod", "my-pod" },
+            { null, null },
+            { string.Empty, null }
+        };
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(RoleInstanceTestData))]
+    public void GetRoleInstance_ReturnsExpectedValue(string podName, string expectedRoleInstance)
+    {
+        // Arrange
+        var aksResourceProcessor = new AksResourceProcessor();
+        aksResourceProcessor.K8sPodName = podName;
+
+        // Act
+        var roleInstance = aksResourceProcessor.GetRoleInstance();
+
+        // Assert
+        Assert.Equal(expectedRoleInstance, roleInstance);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AksResourceProcessorTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AksResourceProcessorTests.cs
@@ -62,9 +62,6 @@ public class AksResourceProcessorTests
             case "k8s.pod.name":
                 Assert.Equal(attribute.Value, aksResourceProcessor.K8sPodName);
                 break;
-            default:
-                Assert.True(false, $"Unexpected attribute key: {attribute.Key}");
-                break;
         }
     }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -181,6 +181,8 @@ public class ResourceExtensionsTests
             {SemanticConventions.AttributeServiceName, "my-service" },
             {SemanticConventions.AttributeServiceNamespace, "my-namespace" },
             {SemanticConventions.AttributeServiceInstance, "my-instance" },
+            {SemanticConventions.AttributeK8sDeployment, "my-deployment" },
+            {SemanticConventions.AttributeK8sPod, "my-pod" },
             { "foo", "bar" }
         };
 
@@ -204,11 +206,13 @@ public class ResourceExtensionsTests
             Assert.Equal("_OTELRESOURCE_", metricDataPoint?.Name);
             Assert.Equal(0, metricDataPoint?.Value);
 
-            Assert.Equal(4, metricsData?.Properties.Count);
+            Assert.Equal(6, metricsData?.Properties.Count);
 
             Assert.Equal("my-service", metricsData?.Properties[SemanticConventions.AttributeServiceName]);
             Assert.Equal("my-namespace", metricsData?.Properties[SemanticConventions.AttributeServiceNamespace]);
             Assert.Equal("my-instance", metricsData?.Properties[SemanticConventions.AttributeServiceInstance]);
+            Assert.Equal("my-deployment", metricsData?.Properties[SemanticConventions.AttributeK8sDeployment]);
+            Assert.Equal("my-pod", metricsData?.Properties[SemanticConventions.AttributeK8sPod]);
             Assert.Equal("bar", metricsData?.Properties["foo"]);
         }
     }
@@ -229,26 +233,6 @@ public class ResourceExtensionsTests
         // Assert
         Assert.Equal("my-deployment", azMonResource?.RoleName);
         Assert.Equal("my-pod", azMonResource?.RoleInstance);
-    }
-
-    [Fact]
-    public void ResourceWithKubernetesAndServiceAttributes()
-    {
-        // Arrange
-        var testAttributes = new Dictionary<string, object>
-        {
-            {SemanticConventions.AttributeServiceName, "my-service" },
-            {SemanticConventions.AttributeServiceInstance, "my-instance" },
-            {SemanticConventions.AttributeK8sDeployment, "my-deployment" },
-            {SemanticConventions.AttributeK8sPod, "my-pod" },
-        };
-
-        var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
-        var azMonResource = resource.CreateAzureMonitorResource();
-
-        // Assert
-        Assert.Equal("my-service", azMonResource?.RoleName);
-        Assert.Equal("my-instance", azMonResource?.RoleInstance);
     }
 
     [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -8,236 +8,312 @@ using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry.Resources;
 using Xunit;
 
-namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests;
+
+public class ResourceExtensionsTests
 {
-    public class ResourceExtensionsTests
+    private const string InstrumentationKey = "00000000-0000-0000-0000-000000000000";
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(InstrumentationKey)]
+    public void NullResource(string? instrumentationKey)
     {
-        private const string InstrumentationKey = "00000000-0000-0000-0000-000000000000";
+        Resource? resource = null;
+        var azMonResource = resource!.CreateAzureMonitorResource(instrumentationKey);
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData(InstrumentationKey)]
-        public void NullResource(string? instrumentationKey)
+        Assert.Null(azMonResource);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(InstrumentationKey)]
+    public void DefaultResource(string? instrumentationKey)
+    {
+        var resource = CreateTestResource();
+        var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
+
+        Assert.StartsWith("unknown_service", azMonResource?.RoleName);
+        Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
+        Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+    }
+
+    [Fact]
+    public void ServiceNameFromResource()
+    {
+        var resource = CreateTestResource(serviceName: "my-service");
+        var azMonResource = resource.CreateAzureMonitorResource();
+
+        Assert.Equal("my-service", azMonResource?.RoleName);
+        Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
+    }
+
+    [Fact]
+    public void ServiceInstanceFromResource()
+    {
+        var resource = CreateTestResource(serviceInstance: "my-instance");
+        var azMonResource = resource.CreateAzureMonitorResource();
+
+        Assert.StartsWith("unknown_service", azMonResource?.RoleName);
+        Assert.Equal("my-instance", azMonResource?.RoleInstance);
+    }
+
+    [Fact]
+    public void ServiceNamespaceFromResource()
+    {
+        var resource = CreateTestResource(serviceNamespace: "my-namespace");
+        var azMonResource = resource.CreateAzureMonitorResource();
+
+        Assert.StartsWith("[my-namespace]/unknown_service", azMonResource?.RoleName);
+        Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
+    }
+
+    [Fact]
+    public void ServiceNameAndInstanceFromResource()
+    {
+        var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
+        var azMonResource = resource.CreateAzureMonitorResource();
+
+        Assert.Equal("my-service", azMonResource?.RoleName);
+        Assert.Equal("my-instance", azMonResource?.RoleInstance);
+    }
+
+    [Fact]
+    public void ServiceNameAndInstanceAndNamespaceFromResource()
+    {
+        var resource = CreateTestResource(serviceName: "my-service", serviceNamespace: "my-namespace", serviceInstance: "my-instance");
+        var azMonResource = resource.CreateAzureMonitorResource();
+
+        Assert.Equal("[my-namespace]/my-service", azMonResource?.RoleName);
+        Assert.Equal("my-instance", azMonResource?.RoleInstance);
+    }
+
+    [Fact]
+    public void SetsSdkVersionPrefixFromResource()
+    {
+        // SDK version is static, preserve to clean up later.
+        var sdkVersion = SdkVersionUtils.s_sdkVersion;
+        var testAttributes = new Dictionary<string, object>
         {
-            Resource? resource = null;
-            var azMonResource = resource!.CreateAzureMonitorResource(instrumentationKey);
+            { "ai.sdk.prefix", "pre_" }
+        };
 
-            Assert.Null(azMonResource);
-        }
+        var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
+        _ = resource.CreateAzureMonitorResource();
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData(InstrumentationKey)]
-        public void DefaultResource(string? instrumentationKey)
+        Assert.StartsWith("pre_", SdkVersionUtils.s_sdkVersion);
+
+        // Clean up
+        SdkVersionUtils.s_sdkVersion = sdkVersion;
+    }
+
+    [Fact]
+    public void MissingPrefixResourceDoesNotSetSdkPrefix()
+    {
+        // SDK version is static, preserve to clean up later.
+        var sdkVersion = SdkVersionUtils.s_sdkVersion;
+
+        var resource = ResourceBuilder.CreateDefault().Build();
+        _ = resource.CreateAzureMonitorResource();
+
+        Assert.NotNull(SdkVersionUtils.s_sdkVersion);
+        Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);
+
+        // Clean up
+        SdkVersionUtils.s_sdkVersion = sdkVersion;
+    }
+
+    [Fact]
+    public void EmptyPrefixResourceDoesNotSetSdkPrefix()
+    {
+        // SDK version is static, preserve to clean up later.
+        var sdkVersion = SdkVersionUtils.s_sdkVersion;
+
+        var testAttributes = new Dictionary<string, object>
         {
-            var resource = CreateTestResource();
-            var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
+            { "ai.sdk.prefix", string.Empty }
+        };
 
-            Assert.StartsWith("unknown_service", azMonResource?.RoleName);
-            Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
-            Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
-        }
+        var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
+        _ = resource.CreateAzureMonitorResource();
 
-        [Fact]
-        public void ServiceNameFromResource()
+        Assert.NotNull(SdkVersionUtils.s_sdkVersion);
+        Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);
+
+        // Clean up
+        SdkVersionUtils.s_sdkVersion = sdkVersion;
+    }
+
+    [Fact]
+    public void SdkPrefixIsNotInResourceMetrics()
+    {
+        // SDK version is static, preserve to clean up later.
+        var sdkVersion = SdkVersionUtils.s_sdkVersion;
+        var testAttributes = new Dictionary<string, object>
         {
-            var resource = CreateTestResource(serviceName: "my-service");
-            var azMonResource = resource.CreateAzureMonitorResource();
+            {"foo", "bar" },
+            { "ai.sdk.prefix", "pre_" }
+        };
 
-            Assert.Equal("my-service", azMonResource?.RoleName);
-            Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
-        }
+        var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
+        var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
 
-        [Fact]
-        public void ServiceInstanceFromResource()
+        Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
+
+        var monitorBase = azMonResource.MetricTelemetry.Data;
+        var metricsData = monitorBase.BaseData as MetricsData;
+
+        var metricDataPoint = metricsData?.Metrics[0];
+        Assert.Equal("bar", metricsData?.Properties["foo"]);
+        Assert.False(metricsData?.Properties.ContainsKey("ai.sdk.prefix"));
+
+        // Clean up
+        SdkVersionUtils.s_sdkVersion = sdkVersion;
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(InstrumentationKey)]
+    public void MetricTelemetryHasAllResourceAttributes(string? instrumentationKey)
+    {
+        var testAttributes = new Dictionary<string, object>
         {
-            var resource = CreateTestResource(serviceInstance: "my-instance");
-            var azMonResource = resource.CreateAzureMonitorResource();
+            {SemanticConventions.AttributeServiceName, "my-service" },
+            {SemanticConventions.AttributeServiceNamespace, "my-namespace" },
+            {SemanticConventions.AttributeServiceInstance, "my-instance" },
+            { "foo", "bar" }
+        };
 
-            Assert.StartsWith("unknown_service", azMonResource?.RoleName);
-            Assert.Equal("my-instance", azMonResource?.RoleInstance);
-        }
+        var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
+        var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
 
-        [Fact]
-        public void ServiceNamespaceFromResource()
+        Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+
+        if (instrumentationKey != null)
         {
-            var resource = CreateTestResource(serviceNamespace: "my-namespace");
-            var azMonResource = resource.CreateAzureMonitorResource();
-
-            Assert.StartsWith("[my-namespace]/unknown_service", azMonResource?.RoleName);
-            Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
-        }
-
-        [Fact]
-        public void ServiceNameAndInstanceFromResource()
-        {
-            var resource = CreateTestResource(serviceName: "my-service", serviceInstance: "my-instance");
-            var azMonResource = resource.CreateAzureMonitorResource();
-
-            Assert.Equal("my-service", azMonResource?.RoleName);
-            Assert.Equal("my-instance", azMonResource?.RoleInstance);
-        }
-
-        [Fact]
-        public void ServiceNameAndInstanceAndNamespaceFromResource()
-        {
-            var resource = CreateTestResource(serviceName: "my-service", serviceNamespace: "my-namespace", serviceInstance: "my-instance");
-            var azMonResource = resource.CreateAzureMonitorResource();
-
-            Assert.Equal("[my-namespace]/my-service", azMonResource?.RoleName);
-            Assert.Equal("my-instance", azMonResource?.RoleInstance);
-        }
-
-        [Fact]
-        public void SetsSdkVersionPrefixFromResource()
-        {
-            // SDK version is static, preserve to clean up later.
-            var sdkVersion = SdkVersionUtils.s_sdkVersion;
-            var testAttributes = new Dictionary<string, object>
-            {
-                { "ai.sdk.prefix", "pre_" }
-            };
-
-            var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-            _ = resource.CreateAzureMonitorResource();
-
-            Assert.StartsWith("pre_", SdkVersionUtils.s_sdkVersion);
-
-            // Clean up
-            SdkVersionUtils.s_sdkVersion = sdkVersion;
-        }
-
-        [Fact]
-        public void MissingPrefixResourceDoesNotSetSdkPrefix()
-        {
-            // SDK version is static, preserve to clean up later.
-            var sdkVersion = SdkVersionUtils.s_sdkVersion;
-
-            var resource = ResourceBuilder.CreateDefault().Build();
-            _ = resource.CreateAzureMonitorResource();
-
-            Assert.NotNull(SdkVersionUtils.s_sdkVersion);
-            Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);
-
-            // Clean up
-            SdkVersionUtils.s_sdkVersion = sdkVersion;
-        }
-
-        [Fact]
-        public void EmptyPrefixResourceDoesNotSetSdkPrefix()
-        {
-            // SDK version is static, preserve to clean up later.
-            var sdkVersion = SdkVersionUtils.s_sdkVersion;
-
-            var testAttributes = new Dictionary<string, object>
-            {
-                { "ai.sdk.prefix", string.Empty }
-            };
-
-            var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-            _ = resource.CreateAzureMonitorResource();
-
-            Assert.NotNull(SdkVersionUtils.s_sdkVersion);
-            Assert.DoesNotContain("_", SdkVersionUtils.s_sdkVersion);
-
-            // Clean up
-            SdkVersionUtils.s_sdkVersion = sdkVersion;
-        }
-
-        [Fact]
-        public void SdkPrefixIsNotInResourceMetrics()
-        {
-            // SDK version is static, preserve to clean up later.
-            var sdkVersion = SdkVersionUtils.s_sdkVersion;
-            var testAttributes = new Dictionary<string, object>
-            {
-                {"foo", "bar" },
-                { "ai.sdk.prefix", "pre_" }
-            };
-
-            var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-            var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
-
             Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
+            Assert.Equal(3, azMonResource.MetricTelemetry.Tags.Count);
+            Assert.NotNull(azMonResource.MetricTelemetry.Data);
 
             var monitorBase = azMonResource.MetricTelemetry.Data;
             var metricsData = monitorBase.BaseData as MetricsData;
 
+            Assert.NotNull(metricsData?.Metrics);
+
             var metricDataPoint = metricsData?.Metrics[0];
+            Assert.Equal("_OTELRESOURCE_", metricDataPoint?.Name);
+            Assert.Equal(0, metricDataPoint?.Value);
+
+            Assert.Equal(4, metricsData?.Properties.Count);
+
+            Assert.Equal("my-service", metricsData?.Properties[SemanticConventions.AttributeServiceName]);
+            Assert.Equal("my-namespace", metricsData?.Properties[SemanticConventions.AttributeServiceNamespace]);
+            Assert.Equal("my-instance", metricsData?.Properties[SemanticConventions.AttributeServiceInstance]);
             Assert.Equal("bar", metricsData?.Properties["foo"]);
-            Assert.False(metricsData?.Properties.ContainsKey("ai.sdk.prefix"));
-
-            // Clean up
-            SdkVersionUtils.s_sdkVersion = sdkVersion;
         }
+    }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData(InstrumentationKey)]
-        public void MetricTelemetryHasAllResourceAttributes(string? instrumentationKey)
+    [Fact]
+    public void ResourceWithKubernetesAttributes()
+    {
+        // Arrange
+        var testAttributes = new Dictionary<string, object>
         {
-            var testAttributes = new Dictionary<string, object>
-            {
-                {"service.name", "my-service" },
-                {"service.namespace", "my-namespace" },
-                {"service.instance.id", "my-instance" },
-                { "foo", "bar" }
-            };
+            {SemanticConventions.AttributeK8sDeployment, "my-deployment" },
+            {SemanticConventions.AttributeK8sPod, "my-pod" },
+        };
 
-            var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
-            var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
+        var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
+        var azMonResource = resource.CreateAzureMonitorResource();
 
-            Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+        // Assert
+        Assert.Equal("my-deployment", azMonResource?.RoleName);
+        Assert.Equal("my-pod", azMonResource?.RoleInstance);
+    }
 
-            if (instrumentationKey != null)
-            {
-                Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
-                Assert.Equal(3, azMonResource.MetricTelemetry.Tags.Count);
-                Assert.NotNull(azMonResource.MetricTelemetry.Data);
-
-                var monitorBase = azMonResource.MetricTelemetry.Data;
-                var metricsData = monitorBase.BaseData as MetricsData;
-
-                Assert.NotNull(metricsData?.Metrics);
-
-                var metricDataPoint = metricsData?.Metrics[0];
-                Assert.Equal("_OTELRESOURCE_", metricDataPoint?.Name);
-                Assert.Equal(0, metricDataPoint?.Value);
-
-                Assert.Equal(4, metricsData?.Properties.Count);
-
-                Assert.Equal("my-service", metricsData?.Properties["service.name"]);
-                Assert.Equal("my-namespace", metricsData?.Properties["service.namespace"]);
-                Assert.Equal("my-instance", metricsData?.Properties["service.instance.id"]);
-                Assert.Equal("bar", metricsData?.Properties["foo"]);
-            }
-        }
-
-        /// <summary>
-        /// If SERVICE.NAME is not defined, it will fall-back to "unknown_service".
-        /// (https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#semantic-attributes-with-sdk-provided-default-value).
-        /// </summary>
-        /// <remarks>
-        /// An alternative way to get an instance of a Resource is as follows:
-        /// <code>
-        /// var resourceAttributes = new Dictionary<string, object> { { "service.name", "my-service" }, { "service.namespace", "my-namespace" }, { "service.instance.id", "my-instance" } };
-        /// var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
-        /// var tracerProvider = Sdk.CreateTracerProviderBuilder().SetResourceBuilder(resourceBuilder).Build();
-        /// var resource = tracerProvider.GetResource();
-        /// </code>
-        /// </remarks>
-        private static Resource CreateTestResource(string? serviceName = null, string? serviceNamespace = null, string? serviceInstance = null)
+    [Fact]
+    public void ResourceWithKubernetesAndServiceAttributes()
+    {
+        // Arrange
+        var testAttributes = new Dictionary<string, object>
         {
-            var testAttributes = new Dictionary<string, object>();
+            {SemanticConventions.AttributeServiceName, "my-service" },
+            {SemanticConventions.AttributeServiceInstance, "my-instance" },
+            {SemanticConventions.AttributeK8sDeployment, "my-deployment" },
+            {SemanticConventions.AttributeK8sPod, "my-pod" },
+        };
 
-            if (serviceName != null)
-                testAttributes.Add("service.name", serviceName);
-            if (serviceNamespace != null)
-                testAttributes.Add("service.namespace", serviceNamespace);
-            if (serviceInstance != null)
-                testAttributes.Add("service.instance.id", serviceInstance);
+        var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
+        var azMonResource = resource.CreateAzureMonitorResource();
 
-            return ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-        }
+        // Assert
+        Assert.Equal("my-service", azMonResource?.RoleName);
+        Assert.Equal("my-instance", azMonResource?.RoleInstance);
+    }
+
+    [Fact]
+    public void ResourceWithKubernetesServiceAndCustomAttributes()
+    {
+        // Arrange
+        var testAttributes = new Dictionary<string, object>
+        {
+            {SemanticConventions.AttributeServiceName, "my-service" },
+            {SemanticConventions.AttributeServiceInstance, "my-instance" },
+            {SemanticConventions.AttributeK8sDeployment, "my-deployment" },
+            {SemanticConventions.AttributeK8sPod, "my-pod" },
+            { "foo", "bar" }
+        };
+
+        var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
+        var azMonResource = resource.CreateAzureMonitorResource();
+
+        // Assert
+        Assert.Equal("my-service", azMonResource?.RoleName);
+        Assert.Equal("my-instance", azMonResource?.RoleInstance);
+    }
+
+    [Fact]
+    public void ResourceWithEmptyKubernetesAttributes()
+    {
+        // Arrange
+        var testAttributes = new Dictionary<string, object>
+        {
+            {SemanticConventions.AttributeK8sDeployment, string.Empty },
+            {SemanticConventions.AttributeK8sPod, string.Empty },
+        };
+
+        var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
+        var azMonResource = resource.CreateAzureMonitorResource();
+
+        // Assert
+        Assert.Null(azMonResource?.RoleName);
+        Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
+    }
+
+    /// <summary>
+    /// If SERVICE.NAME is not defined, it will fall-back to "unknown_service".
+    /// (https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#semantic-attributes-with-sdk-provided-default-value).
+    /// </summary>
+    /// <remarks>
+    /// An alternative way to get an instance of a Resource is as follows:
+    /// <code>
+    /// var resourceAttributes = new Dictionary<string, object> { { SemanticConventions.AttributeServiceInstance, "my-service" }, { SemanticConventions.AttributeServiceNamespace, "my-namespace" }, { SemanticConventions.AttributeServiceInstance, "my-instance" } };
+    /// var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+    /// var tracerProvider = Sdk.CreateTracerProviderBuilder().SetResourceBuilder(resourceBuilder).Build();
+    /// var resource = tracerProvider.GetResource();
+    /// </code>
+    /// </remarks>
+    private static Resource CreateTestResource(string? serviceName = null, string? serviceNamespace = null, string? serviceInstance = null)
+    {
+        var testAttributes = new Dictionary<string, object>();
+
+        if (serviceName != null)
+            testAttributes.Add(SemanticConventions.AttributeServiceName, serviceName);
+        if (serviceNamespace != null)
+            testAttributes.Add(SemanticConventions.AttributeServiceNamespace, serviceNamespace);
+        if (serviceInstance != null)
+            testAttributes.Add(SemanticConventions.AttributeServiceInstance, serviceInstance);
+
+        return ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
     }
 }


### PR DESCRIPTION
**Role name**

*  If `service.name` does not starts with "unknown_service" and AKS attributes are set, use the `service.name` attribute to generate the role name.
*  If `service.name` does not exist or is present and starts with "unknown_service", follow the AKS attribute logic to generate the role name. Refer OTel Kubernetes [resource](https://github.com/open-telemetry/semantic-conventions/blob/main/specification/resource/semantic_conventions/k8s.md)
*  Use the following AKS attribute logic to populate cloud role name
 ```pseudo
if (!Strings.isNullOrEmpty(k8s.deployment.name)) {
    ai.cloud.role = k8s.deployment.name;
} else if (!Strings.isNullOrEmpty(k8s.replicaset.name)) {
    ai.cloud.role = k8s.replicaset.name;
} else if (!Strings.isNullOrEmpty(k8s.statefulset.name)) {
    ai.cloud.role = k8s.statefulset.name;
} else if (!Strings.isNullOrEmpty(k8s.job.name)) {
    ai.cloud.role = k8s.job.name;
} else if (!Strings.isNullOrEmpty(k8s.cronjob.name)) {
    ai.cloud.role = k8s.cronjob.name;
} else if (!Strings.isNullOrEmpty(k8s.daemonset.name)) {
    ai.cloud.role = k8s.daemonset.name;
}

 ```

**Role Instance**

* if `service.instance.id` is not empty nor null, use it for role instance
* else if `service.instance.id` is empty or null, use [k8s.pod.name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/k8s.md#pod) 
* else if `k8s.pod.name` is not set, use the default hostname (i.e. the machine name).
