### PR TITLE
Fix QueryMetrics test

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -469,7 +469,7 @@ var client = new MetricsQueryClient(new DefaultAzureCredential());
 
 Response<MetricsQueryResult> results = await client.QueryResourceAsync(
     resourceId,
-    new[] { "Query Success Rate", "Query Count" }
+    new[] { "AvailabilityRate_Query", "Query Count" }
 );
 
 foreach (MetricResult metric in results.Value.Metrics)

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
@@ -90,7 +90,7 @@ namespace Azure.Monitor.Query
         ///
         /// Response&lt;MetricsQueryResult&gt; results = await client.QueryResourceAsync(
         ///     resourceId,
-        ///     new[] { &quot;Query Success Rate&quot;, &quot;Query Count&quot; }
+        ///     new[] { &quot;AvailabilityRate_Query&quot;, &quot;Query Count&quot; }
         /// );
         ///
         /// foreach (MetricResult metric in results.Value.Metrics)
@@ -151,7 +151,7 @@ namespace Azure.Monitor.Query
         ///
         /// Response&lt;MetricsQueryResult&gt; results = await client.QueryResourceAsync(
         ///     resourceId,
-        ///     new[] { &quot;Query Success Rate&quot;, &quot;Query Count&quot; }
+        ///     new[] { &quot;AvailabilityRate_Query&quot;, &quot;Query Count&quot; }
         /// );
         ///
         /// foreach (MetricResult metric in results.Value.Metrics)

--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientSamples.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientSamples.cs
@@ -28,7 +28,7 @@ namespace Azure.Monitor.Query.Tests
 
             Response<MetricsQueryResult> results = await client.QueryResourceAsync(
                 resourceId,
-                new[] { "Query Success Rate", "Query Count" }
+                new[] { "AvailabilityRate_Query", "Query Count" }
             );
 
             foreach (MetricResult metric in results.Value.Metrics)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/36979

The `Query Success Rate` metric being used in the test was no longer valid. Selected a metric name from the following list:

Valid metrics: AvailabilityRate_Query,Query Count,Query Failure Count,Average_% Free Inodes,Average_% Free Space,Average_% Used Inodes,Average_% Used Space,Average_Disk Read Bytes/sec,Average_Disk Reads/sec,Average_Disk Transfers/sec,Average_Disk Write Bytes/sec,Average_Disk Writes/sec,Average_Free Megabytes,Average_Logical Disk Bytes/sec,Average_% Available Memory,Average_% Available Swap Space,Average_% Used Memory,Average_% Used Swap Space,Average_Available MBytes Memory,Average_Available MBytes Swap,Average_Page Reads/sec,Average_Page Writes/sec,Average_Pages/sec,Average_Used MBytes Swap Space,Average_Used Memory MBytes,Average_Total Bytes Transmitted,Average_Total Bytes Received,Average_Total Bytes,Average_Total Packets Transmitted,Average_Total Packets Received,Average_Total Rx Errors,Average_Total Tx Errors,Average_Total Collisions,Average_Avg. Disk sec/Read,Average_Avg. Disk sec/Transfer,Average_Avg. Disk sec/Write,Average_Physical Disk Bytes/sec,Average_Pct Privileged Time,Average_Pct User Time,Average_Used Memory kBytes,Average_Virtual Shared Memory,Average_% DPC Time,Average_% Idle Time,Average_% Interrupt Time,Average_% IO Wait Time,Average_% Nice Time,Average_% Privileged Time,Average_% Processor Time,Average_% User Time,Average_Free Physical Memory,Average_Free Space in Paging Files,Average_Free Virtual Memory,Average_Processes,Average_Size Stored In Paging Files,Average_Uptime,Average_Users,Average_Current Disk Queue Length,Average_Available MBytes,Average_% Committed Bytes In Use,Average_Bytes Received/sec,Average_Bytes Sent/sec,Average_Bytes Total/sec,Average_Processor Queue Length,Heartbeat,Update,Event