### PR TITLE
Fix daily onboarding

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -417,6 +417,11 @@ function EnsureCustomSource($package) {
       -Source CustomPackageSource `
       -AllVersions `
       -AllowPrereleaseVersions
+
+      if (!$? -or !$existingVersions) { 
+        Write-Host "Failed to find package $($package.Name) in custom source $customPackageSource"
+        return $package
+      }
   }
   catch {
     Write-Error $_ -ErrorAction Continue


### PR DESCRIPTION
There are instances where we don't correctly detect failures coming from `Find-Package` and writes bad information into the onboarding configuration. 

This fix checks for a failure in the previous cmdlet execution and also checks for an empty result. Local testing shows that this alleviates the problem.