### PR TITLE
Fix cspell errors in Monitor SDKs

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1",
+  "version": "0.2",
   "language": "en_US",
   "languageId": "csharp",
   "dictionaries": [
@@ -31,6 +31,7 @@
     "*.sln",
     "*.user",
     ".vscode/cspell.json",
+    "assets.json",
     // These services are opted out of public API surface spell checking.
     // Spelling issues must be addressed before adding these back in.
     "sdk/agrifood/*/api/*.cs",
@@ -42,7 +43,8 @@
     "sdk/insights/*/api/*.cs",
     "sdk/machinelearningservices/*/api/*.cs",
     "sdk/modelsrepository/*/api/*.cs",
-    "sdk/monitor/*/api/*.cs",
+    "sdk/monitor/Azure.ResourceManager.Monitor/api/*.cs",
+    "sdk/monitor/Microsoft.Azure.Management.Monitor/**/*.cs",
     "sdk/objectanchors/*/api/*.cs",
     "sdk/purview/*/api/*.cs",
     "sdk/remoterendering/*/api/*.cs",
@@ -56,6 +58,7 @@
     "apos",
     "azsdk",
     "blazor",
+    "centralus",
     "contoso",
     "cref",
     "deduplication",
@@ -63,21 +66,27 @@
     "deserializes",
     "diagnoser",
     "dicom",
+    "distro",
     "dont",
     "dotnetcli",
     "dtmf",
+    "eastus",
     "epsg",
     "expando",
     "fhir",
     "finalizer",
     "finalizers",
     "hnsw",
+    "ienumerable",
     "illumos",
     "interventional",
     "ints",
     "kubernetes",
+    "kusto",
     "lucene",
     "mgmt",
+    "msal",
+    "northcentralus",
     "nunit",
     "odata",
     "onco",
@@ -95,6 +104,7 @@
     "retriable",
     "signup",
     "skus",
+    "southcentralus",
     "structs",
     "uints",
     "unbilled",
@@ -105,6 +115,7 @@
     "vcpus",
     "vmss",
     "vnet",
+    "westcentralus",
     "westus",
     "xunit"
   ],
@@ -364,8 +375,7 @@
     {
       "filename": "**/sdk/datashare/**/*.cs",
       "words": [
-        "adls",
-        "kusto"
+        "adls"
       ]
     },
     {
@@ -636,7 +646,6 @@
     {
       "filename": "**/sdk/kusto/**/*.cs",
       "words": [
-        "kusto",
         "tbps",
         "scsv",
         "sohsv",
@@ -668,6 +677,42 @@
         "deinterlace",
         "rtmp",
         "scms"
+      ]
+    },
+    {
+      "filename": "**/sdk/monitor/**/*",
+      "words": [
+        "AMPM",
+        "bcdr",
+        "cikey",
+        "faas",
+        "gzipped",
+        "gzipping",
+        "DDYYYYHHMMSS",
+        "hmac",
+        "HMACSHA",
+        "ikey",
+        "itsm",
+        "jdbc",
+        "jioindiacentral",
+        "jioindiawest",
+        "kaby",
+        "khtml",
+        "Localizable",
+        "Milli",
+        "msdocs",
+        "mslinks",
+        "myvm",
+        "onboarded",
+        "opinsights",
+        "OTELRESOURCE",
+        "otlp",
+        "TMPDIR",
+        "uaecentral",
+        "uaenorth",
+        "uksouth",
+        "ukwest",
+        "webwk"
       ]
     },
     {
@@ -1001,7 +1046,6 @@
     {
       "filename": "**/sdk/synapse/**/*.cs",
       "words": [
-        "kusto",
         "nchar",
         "ntext",
         "nvarchar",

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
 
         /// <summary>
         /// Get or sets the value of <see cref="TokenCredential" />.
-        /// If <see cref="TokenCredential" /> is not set, AAD authenication is disabled
+        /// If <see cref="TokenCredential" /> is not set, AAD authentication is disabled
         /// and Instrumentation Key from the Connection String will be used.
         /// </summary>
         /// <remarks>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/DistroWebAppLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests/DistroWebAppLiveTests.cs
@@ -40,7 +40,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Integration.Tests
         [SyncOnly] // This test cannot run concurrently with another test because OTel instruments the process and will cause side effects.
         public async Task VerifyDistro()
         {
-            // SETUP TELEMETRY CLIENT (FOR QUERIYNG LOG ANALYTICS)
+            // SETUP TELEMETRY CLIENT (FOR QUERYING LOG ANALYTICS)
             _logsQueryClient = InstrumentClient(new LogsQueryClient(
                 TestEnvironment.LogsEndpoint,
                 TestEnvironment.Credential,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -95,7 +95,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal static void AddActivityLinksToProperties(Activity activity, ref AzMonList UnMappedTags)
         {
             string msLinks = "_MS.links";
-            // max number of links that can fit in this json formatted string is 107. it is based on assumption that traceid and spanid will be of fixed length.
+            // max number of links that can fit in this json formatted string is 107. it is based on assumption that TraceId and SpanId will be of fixed length.
             // Keeping max at 100 for now.
             int maxLinks = MaxlinksAllowed;
 
@@ -173,26 +173,26 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         private static void AddTelemetryFromActivityEvents(Activity activity, TelemetryItem telemetryItem, List<TelemetryItem> telemetryItems)
         {
-            foreach (ref readonly var evnt in activity.EnumerateEvents())
+            foreach (ref readonly var @event in activity.EnumerateEvents())
             {
                 try
                 {
-                    if (evnt.Name == SemanticConventions.AttributeExceptionEventName)
+                    if (@event.Name == SemanticConventions.AttributeExceptionEventName)
                     {
-                        var exceptionData = GetExceptionDataDetailsOnTelemetryItem(evnt);
+                        var exceptionData = GetExceptionDataDetailsOnTelemetryItem(@event);
                         if (exceptionData != null)
                         {
-                            var exceptionTelemetryItem = new TelemetryItem("Exception", telemetryItem, activity.SpanId, activity.Kind, evnt.Timestamp);
+                            var exceptionTelemetryItem = new TelemetryItem("Exception", telemetryItem, activity.SpanId, activity.Kind, @event.Timestamp);
                             exceptionTelemetryItem.Data = exceptionData;
                             telemetryItems.Add(exceptionTelemetryItem);
                         }
                     }
                     else
                     {
-                        var messageData = GetTraceTelemetryData(evnt);
+                        var messageData = GetTraceTelemetryData(@event);
                         if (messageData != null)
                         {
-                            var traceTelemetryItem = new TelemetryItem("Message", telemetryItem, activity.SpanId, activity.Kind, evnt.Timestamp);
+                            var traceTelemetryItem = new TelemetryItem("Message", telemetryItem, activity.SpanId, activity.Kind, @event.Timestamp);
                             traceTelemetryItem.Data = messageData;
                             telemetryItems.Add(traceTelemetryItem);
                         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -35,7 +35,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal void TransmitFromStorage(object? sender, ElapsedEventArgs? e)
         {
-            // Only proces 10 files at a time so that we don't end up taking lot of cpu
+            // Only process 10 files at a time so that we don't end up taking lot of cpu
             // if the number of files are large.
             int fileCount = 10;
             while (fileCount > 0)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
@@ -33,7 +33,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             return new ValueTask<ExportResult>(Task.FromResult(ExportResult.Success));
         }
 
-        public ValueTask TransmitFromStorage(long maxFileToTransmit, bool aysnc, CancellationToken cancellationToken)
+        public ValueTask TransmitFromStorage(long maxFileToTransmit, bool async, CancellationToken cancellationToken)
         {
             throw new System.NotImplementedException();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -85,7 +85,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void TestExpliticOverride_PreservesSchema()
+        public void TestExplicitOverride_PreservesSchema()
         {
             RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=http://custom.contoso.com:444/",
@@ -94,7 +94,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void TestExpliticOverride_InvalidValue()
+        public void TestExplicitOverride_InvalidValue()
         {
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https:////custom.contoso.com",
@@ -103,7 +103,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void TestExpliticOverride_InvalidValue2()
+        public void TestExplicitOverride_InvalidValue2()
         {
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://www.~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
@@ -112,7 +112,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void TestExpliticOverride_InvalidValue3()
+        public void TestExplicitOverride_InvalidValue3()
         {
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",
@@ -121,7 +121,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void TestExpliticOverride_InvalidLocation()
+        public void TestExplicitOverride_InvalidLocation()
         {
             Assert.Throws<InvalidOperationException>(() => RunTest(
                 connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=ingestion.azuremonitor.com;Location=~!@#$%&^*()_{}{}><?<?>:L\":\"_+_+_",

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/MetricsTests.cs
@@ -39,18 +39,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var meterName = $"meterName{uniqueTestId}";
             using var meter = new Meter(meterName, "1.0");
 
-            var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
             if (asView)
             {
-                meterProviderBulider
+                meterProviderBuilder
                     // Rename an instrument to new name.
                     .AddView(instrumentName: "MyCounter", name: "MyCounterRenamed");
             }
 
-            var meterProvider = meterProviderBulider.Build();
+            var meterProvider = meterProviderBuilder.Build();
 
             // ACT
             var counter = meter.CreateCounter<long>("MyCounter");
@@ -85,18 +85,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var meterName = $"meterName{uniqueTestId}";
             using var meter = new Meter(meterName, "1.0");
 
-            var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
             if (asView)
             {
-                meterProviderBulider
+                meterProviderBuilder
                 // Change Histogram boundaries
                 .AddView(instrumentName: "MyHistogram", name: "MyHistogramRenamed");
             }
 
-            var meterProvider = meterProviderBulider.Build();
+            var meterProvider = meterProviderBuilder.Build();
 
             // ACT
             var histogram = meter.CreateHistogram<long>("MyHistogram");
@@ -133,7 +133,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void VerifyGuage(bool asView)
+        public void VerifyGauge(bool asView)
         {
             // SETUP
             var uniqueTestId = Guid.NewGuid();
@@ -141,20 +141,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var meterName = $"meterName{uniqueTestId}";
             using var meter = new Meter(meterName, "1.0");
 
-            var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
             if (asView)
             {
-                meterProviderBulider
-                    .AddView(instrumentName: "MyGuage", name: "MyGuageRenamed");
+                meterProviderBuilder
+                    .AddView(instrumentName: "MyGauge", name: "MyGaugeRenamed");
             }
 
-            var meterProvider = meterProviderBulider?.Build();
+            var meterProvider = meterProviderBuilder?.Build();
 
             // ACT
-            var myObservableGauge = meter.CreateObservableGauge("MyGuage", () =>
+            var myObservableGauge = meter.CreateObservableGauge("MyGauge", () =>
                 new Measurement<double>(
                     value: 123.45,
                     tags: new KeyValuePair<string, object?>("tag1", "value1")));
@@ -169,7 +169,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
 
             TelemetryItemValidationHelper.AssertMetricTelemetry(
                 telemetryItem: telemetryItem,
-                expectedMetricDataPointName: asView ? "MyGuageRenamed" : "MyGuage",
+                expectedMetricDataPointName: asView ? "MyGaugeRenamed" : "MyGauge",
                 expectedMetricDataPointValue: 123.45,
                 expectedMetricsProperties: new Dictionary<string, string> { { "tag1", "value1" } });
         }
@@ -185,17 +185,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var meterName = $"meterName{uniqueTestId}";
             using var meter = new Meter(meterName, "1.0");
 
-            var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems);
 
             if (asView)
             {
-                meterProviderBulider
+                meterProviderBuilder
                 .AddView(instrumentName: "MyUpDownCounter", name: "MyUpDownCounterRenamed");
             }
 
-            var meterProvider = meterProviderBulider.Build();
+            var meterProvider = meterProviderBuilder.Build();
 
             // ACT
             var upDownCounter = meter.CreateUpDownCounter<long>("MyUpDownCounter");
@@ -231,17 +231,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             var meterName = $"meterName{uniqueTestId}";
             using var meter = new Meter(meterName, "1.0");
 
-            var meterProviderBulider = Sdk.CreateMeterProviderBuilder()
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meterName)
                 .AddAzureMonitorMetricExporterForTest(out List<TelemetryItem> telemetryItems, out MetricReader metricReader);
 
             if (asView)
             {
-                meterProviderBulider
+                meterProviderBuilder
                 .AddView(instrumentName: "MyUpDownCounter", name: "MyUpDownCounterRenamed");
             }
 
-            using var meterProvider = meterProviderBulider.Build();
+            using var meterProvider = meterProviderBuilder.Build();
 
             // ACT
             var value = 1;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -169,7 +169,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // ASSERT
             Assert.True(telemetryItems.Any(), "Unit test failed to collect telemetry.");
             this.telemetryOutput.Write(telemetryItems);
-            var activityTelemetryItem = telemetryItems.First(x => x.Name == "RemoteDependency"); // TODO: Change to Single(). Still investigating random duplicate export which only repros on build server.
+            var activityTelemetryItem = telemetryItems.First(x => x.Name == "RemoteDependency"); // TODO: Change to Single(). Still investigating random duplicate export which only reproduces on build server.
 
             TelemetryItemValidationHelper.AssertActivity_As_DependencyTelemetry(
                 telemetryItem: activityTelemetryItem,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -58,7 +58,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void DependencyTypeisSetToInProcForInternalSpan()
+        public void DependencyTypeIsSetToInProcForInternalSpan()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity("Activity", ActivityKind.Internal);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryExceptionDataTests.cs
@@ -205,7 +205,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void ExceptionDataContainsExceptionDetailsofAllInnerExceptionsOfAggregateException()
+        public void ExceptionDataContainsExceptionDetailsOfAllInnerExceptionsOfAggregateException()
         {
             var logRecords = new List<LogRecord>();
             using var loggerFactory = LoggerFactory.Create(builder =>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -188,7 +188,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void AiLocationIpisSetAsHttpClientIpforHttpServerSpans()
+        public void AiLocationIpIsSetAsHttpClientIpForHttpServerSpans()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
@@ -207,7 +207,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void AiLocationIpisSetAsNetPeerIpForServerSpans()
+        public void AiLocationIpIsSetAsNetPeerIpForServerSpans()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(
@@ -226,7 +226,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         }
 
         [Fact]
-        public void AiUserAgentisSetAsHttpUserAgent()
+        public void AiUserAgentIsSetAsHttpUserAgent()
         {
             using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
             using var activity = activitySource.StartActivity(


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/23183

The Track 1 and 2 management plane libraries still need to be addressed. For now, they're marked as ignored.

Bumped the config version to 0.2 per a recommendation in VS Code.