### PR TITLE
Pass raw response to Response.FromValue()

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -4684,16 +4684,18 @@ namespace Azure.Storage.Blobs.Specialized
                         operationName)
                         .ConfigureAwait(false);
 
-                    if (BlobBaseClientExistsClassifier.IsResourceNotFoundResponse(response.GetRawResponse()))
+                    Response rawResponse = response.GetRawResponse();
+                    if (BlobBaseClientExistsClassifier.IsResourceNotFoundResponse(rawResponse))
                     {
-                        return Response.FromValue(false, default);
-                    }
-                    if (BlobBaseClientExistsClassifier.IsUsesCustomerSpecifiedEncryptionResponse(response.GetRawResponse()))
-                    {
-                        return Response.FromValue(true, default);
+                        return Response.FromValue(false, rawResponse);
                     }
 
-                    return Response.FromValue(true, response.GetRawResponse());
+                    if (BlobBaseClientExistsClassifier.IsUsesCustomerSpecifiedEncryptionResponse(rawResponse))
+                    {
+                        return Response.FromValue(true, rawResponse);
+                    }
+
+                    return Response.FromValue(true, rawResponse);
                 }
                 catch (Exception ex)
                 {
@@ -4898,7 +4900,7 @@ namespace Azure.Storage.Blobs.Specialized
             await GetPropertiesInternal(
                 conditions,
                 async: true,
-                new RequestContext() { CancellationToken = cancellationToken})
+                new RequestContext() { CancellationToken = cancellationToken })
                 .ConfigureAwait(false);
 
         /// <summary>
@@ -5511,7 +5513,7 @@ namespace Azure.Storage.Blobs.Specialized
 
                 // All BlobRequestConditions are valid.
                 conditions.ValidateConditionsNotPresent(
-                    invalidConditions:BlobRequestConditionProperty.None,
+                    invalidConditions: BlobRequestConditionProperty.None,
                     operationName: nameof(BlobBaseClient.CreateSnapshot),
                     parameterName: nameof(conditions));
 


### PR DESCRIPTION
Previously, some calls to Response.FromValue() were passing null in place of the raw response, which had caused https://github.com/Azure/azure-sdk-for-net/issues/27626.  It appears that the issue in the Azure.Core library was fixed in https://github.com/Azure/azure-sdk-for-net/pull/31790, but investigating the issue uncovered that the raw response might not be available to callers of BlobClient.ExistsAsync() for diagnostic purposes.  This PR makes the raw response available on the strongly-typed Response\<T\>.