### PR TITLE
`TransferManager` lifetime `DiagnosticScope`

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManagerOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManagerOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using Azure.Storage.DataMovement.Models;
 
 namespace Azure.Storage.DataMovement
@@ -10,6 +11,16 @@ namespace Azure.Storage.DataMovement
     /// </summary>
     public class TransferManagerOptions
     {
+        /// <summary>
+        /// Define ClientOptions to get access to Azure.Core functionality
+        /// bound to ClientOptions class. Don't want to expose everything
+        /// that comes with client options, so keep this private.
+        /// </summary>
+        internal class TransferManagerClientOptions : ClientOptions
+        {
+        }
+        internal TransferManagerClientOptions ClientOptions { get; } = new();
+
         /// <summary>
         /// Optional. Sets the way errors during a transfer will be handled.
         /// Default is <see cref="ErrorHandlingOptions.StopOnAllFailures"/>.
@@ -26,5 +37,11 @@ namespace Azure.Storage.DataMovement
         /// transfer state so transfers can be resumed.
         /// </summary>
         public TransferCheckpointerOptions CheckpointerOptions { get; set; }
+
+        /// <summary>
+        /// Defines the diagnostic options for transfer management. This is separate from
+        /// diagnostic options provided in storage resources.
+        /// </summary>
+        public DiagnosticsOptions Diagnostics => ClientOptions.Diagnostics;
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,0,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,0,30).json
@@ -1,0 +1,294 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1a1350d29c0abb2c69caf3e5dfb19633-d03dd845e4f92b23-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "50965e59-a934-2364-fc52-f9275124966f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:28 GMT",
+        "ETag": "\u00220x8DB71C7E14384A3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "50965e59-a934-2364-fc52-f9275124966f",
+        "x-ms-request-id": "68283997-501e-009a-2ab0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-a0caad0d-6568-cbeb-bddb-ccc44e792eb1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-859319e48e11204f81eefd73076f4880-831d3c1ebe05d0d3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f97e8c80-31f5-b352-d20d-f61162439e29",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:28 GMT",
+        "ETag": "\u00220x8DB71C7E14CE7FB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f97e8c80-31f5-b352-d20d-f61162439e29",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "682839ed-501e-009a-78b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-137c9a8a-731a-73b9-6a55-0fa24092e9fb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-d7a7280d6581a00c8595fb20792d4fbe-fd9fc460ef5f8552-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c8926cc1-91ca-c036-7edb-53c44c378f01",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:28 GMT",
+        "ETag": "\u00220x8DB71C7E15328A5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c8926cc1-91ca-c036-7edb-53c44c378f01",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283a1d-501e-009a-24b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-a0caad0d-6568-cbeb-bddb-ccc44e792eb1",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1aa4a762b9caaacb1d115591e32e0d2d-58478fb913c7b768-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f5506152-d5b0-af5f-30a7-8c365cec94c7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E14CE7FB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f5506152-d5b0-af5f-30a7-8c365cec94c7",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68283a5a-501e-009a-5db0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-eba72736-9969-f455-72cb-9259dca0d582",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-970336ab0cc1d76e3ee783a24761cf4e-e53186f1bf6876ad-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ea718709-99e6-1350-185e-4850fe8274ef",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-a0caad0d-6568-cbeb-bddb-ccc44e792eb1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E16D8A97\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ea718709-99e6-1350-185e-4850fe8274ef",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283a90-501e-009a-11b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-137c9a8a-731a-73b9-6a55-0fa24092e9fb",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3b3fc8b5a7208927825219352453c704-be8ba1c27e6a91ab-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d42c40a6-aa7a-82e0-2022-5099f84b3732",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E15328A5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d42c40a6-aa7a-82e0-2022-5099f84b3732",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68283afc-501e-009a-7bb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-b79c4723-82a8-9a55-f457-361255498a2b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-1092fa3e45690e6c5671292822f83770-6079250a378f27d1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "beaa0546-9f55-5f74-51ab-2cda163a1979",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee/test-blob-137c9a8a-731a-73b9-6a55-0fa24092e9fb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E17ACF1E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "beaa0546-9f55-5f74-51ab-2cda163a1979",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283b2a-501e-009a-24b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-ec167705-e591-c62e-e6c5-58d571b0c3ee?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-739fa37b0421828da2b72aba7ace4603-00bcbaa6fa751b94-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f2536bf7-79a1-addd-88c2-131386758b79",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f2536bf7-79a1-addd-88c2-131386758b79",
+        "x-ms-request-id": "68283c31-501e-009a-1eb0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1594191669",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,0,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,0,30)Async.json
@@ -1,0 +1,294 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-28b3b85b03711d7f97ac40265097778c-cc3d5d7230fccf4b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "29a20beb-892c-0123-8e99-295df6360669",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E4DECCB3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "29a20beb-892c-0123-8e99-295df6360669",
+        "x-ms-request-id": "993d724c-d01e-0002-79b0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-ccad2e4f-d2b3-8539-aa77-f1cda14f6aac",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-c8068453c4b658262b5b2d92a509a54d-a8489173d70f725f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c3ce97ac-5ae9-fa7e-a428-fcc7bffc1c95",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E4E58D73\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c3ce97ac-5ae9-fa7e-a428-fcc7bffc1c95",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d7275-d01e-0002-1db0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-23b4738a-be1b-fac7-c10d-d6fe40bddc00",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-5a96b117c751ab6cd04e4e374f559640-40083ce8c31cabed-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "64f99e50-806d-4003-72f6-0b6c0a6b01d5",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E4EC9146\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "64f99e50-806d-4003-72f6-0b6c0a6b01d5",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d729c-d01e-0002-42b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-ccad2e4f-d2b3-8539-aa77-f1cda14f6aac",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9694bc6cc0ea80744b00b9d596c6865d-3e13c2ac491fae14-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2076a7d5-b802-5828-8eda-356fa53d1ede",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E4E58D73\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2076a7d5-b802-5828-8eda-356fa53d1ede",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d72e5-d01e-0002-08b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-23b4738a-be1b-fac7-c10d-d6fe40bddc00",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5e51ac86fdaf503462fdd1afc47634f5-fbdc9c5f927e2e2f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6296b58d-e0f4-c7d2-93cd-1e1c859756b0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E4EC9146\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6296b58d-e0f4-c7d2-93cd-1e1c859756b0",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e88d1e-e01e-007b-04b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-63baf1dd-c979-18a2-d11d-7fb59855603f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-15f21e81938de0b866a855a44c40e774-b1a1ad8bca136ded-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "efe15c43-bba6-31ea-099d-425b86401000",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-ccad2e4f-d2b3-8539-aa77-f1cda14f6aac",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E4FF5338\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "efe15c43-bba6-31ea-099d-425b86401000",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d7303-d01e-0002-25b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-82d37d2f-e281-914d-66b2-0aa6fb3b44ed",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-77c32d1410dc059cf9fba93b26ae07b2-5999b6a1d7a34449-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "29d9bd7c-67b5-cb0a-b093-c39650d1aa0a",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4/test-blob-23b4738a-be1b-fac7-c10d-d6fe40bddc00",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E504A99F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "29d9bd7c-67b5-cb0a-b093-c39650d1aa0a",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e88d57-e01e-007b-3ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-274ac5f0-fcb1-fc58-d31f-c9a02fbee7f4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-00d7b90b3c566e954a31bd57fea59afc-d1b5cd04bd314740-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c8df0f18-e766-3e4a-bb75-bcd4060da9b7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c8df0f18-e766-3e4a-bb75-bcd4060da9b7",
+        "x-ms-request-id": "16e88e64-e01e-007b-34b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "775423668",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,100,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,100,30).json
@@ -1,0 +1,376 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f2fd11d3352dcac2347298e2ce089a00-e6bd23c12519b52f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2937904b-a1ee-7c8f-63fa-c16ede034b8b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E264F744\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2937904b-a1ee-7c8f-63fa-c16ede034b8b",
+        "x-ms-request-id": "16e87b67-e01e-007b-34b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-046c7c20-f072-baf0-9306-152773ddd0da",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-39b3b89a326f668c62b29d0e0f1d84bc-736aa7db87bd107c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e11ceaa3-13a0-f1c3-70c1-f8ef50255a86",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ZCjZL9ujZ9Xmu\u002BJBSVbuVk5tRDOnOenzmo9kyp0viLb8dUjePXXkmdVCtAjgbjXG0E\u002BWOCrKZSs\u002B5pVMPp04tjIsRdMOEBjYiKtdZITgEyxZnvpNmVCMMRAcoFfgmFo4Cv7Wsw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1P/gqRqkaIcimIvowuZBIA==",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E26BE98F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e11ceaa3-13a0-f1c3-70c1-f8ef50255a86",
+        "x-ms-content-crc64": "hHOzYb8jpzA=",
+        "x-ms-request-id": "16e87ba8-e01e-007b-70b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-8ff80bc4-f0e7-c06a-c1ab-c281d3aae872",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-a2c90e587e2fac4cc38ccf2bef72ab08-5ecd1893b45136e0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6c88b598-9db2-7943-d08d-950b527acfdc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "SSU9LHGfl2PvBGPLJW/TymnUa0fF/tqz6ZcKY68YdlLN9qAm4wvR1gBUfHbZW1IwyLLJVfVsC0tKiULZlDOz1o0Q/i/OrOZeA5RHcYFj2o5E2Zv9TiFdYOtV21nI90LMoaXoyQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "4LeF6q26nNCKju3f/wY78g==",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E272ED6D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6c88b598-9db2-7943-d08d-950b527acfdc",
+        "x-ms-content-crc64": "7vnHbN7GMZ0=",
+        "x-ms-request-id": "16e87bf4-e01e-007b-32b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-046c7c20-f072-baf0-9306-152773ddd0da",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0df7b01ef42d211241dc0fabec315d66-c35bed24511be3c6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "eb338762-7c1d-bf16-dfe8-4a3ed6460eaa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "1P/gqRqkaIcimIvowuZBIA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E26BE98F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "eb338762-7c1d-bf16-dfe8-4a3ed6460eaa",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e87c23-e01e-007b-5cb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-8ff80bc4-f0e7-c06a-c1ab-c281d3aae872",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5cf3b6c8f8c6fe1d675cdf1d860ec4f4-04085958807c4c11-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "535b6efa-449d-e663-2e6e-a31132b4e48f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "4LeF6q26nNCKju3f/wY78g==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E272ED6D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "535b6efa-449d-e663-2e6e-a31132b4e48f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "682843c7-501e-009a-2fb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-ba0c890b-edc9-5b28-9f7d-96e88c670985",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-cd15695322de9293e2b3a56e4e3e25ac-cf01f4e24685888c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "caa982e3-e347-febe-fb72-418e34f30c87",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-046c7c20-f072-baf0-9306-152773ddd0da",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E283DAE0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "caa982e3-e347-febe-fb72-418e34f30c87",
+        "x-ms-content-crc64": "hHOzYb8jpzA=",
+        "x-ms-request-id": "16e87c3d-e01e-007b-73b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-d3a9e72a-bc0b-30a3-12ac-43c62d6fe6e9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-35b28e1226d82689bd506ba7e83d7c11-0b7cd9e5caa87671-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c6945314-b898-a9ea-2ea0-7019687fbb8f",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-8ff80bc4-f0e7-c06a-c1ab-c281d3aae872",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E28A1B82\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c6945314-b898-a9ea-2ea0-7019687fbb8f",
+        "x-ms-content-crc64": "7vnHbN7GMZ0=",
+        "x-ms-request-id": "68284402-501e-009a-66b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-ba0c890b-edc9-5b28-9f7d-96e88c670985",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-99c5936833f81ddaafd43f9881616972-525cfe27aeaa8f1e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dffc084d-1e20-e0f6-2c1e-a1cbdf3b6e72",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E283DAE0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "1P/gqRqkaIcimIvowuZBIA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "dffc084d-1e20-e0f6-2c1e-a1cbdf3b6e72",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "682844d3-501e-009a-2fb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "ZCjZL9ujZ9Xmu\u002BJBSVbuVk5tRDOnOenzmo9kyp0viLb8dUjePXXkmdVCtAjgbjXG0E\u002BWOCrKZSs\u002B5pVMPp04tjIsRdMOEBjYiKtdZITgEyxZnvpNmVCMMRAcoFfgmFo4Cv7Wsw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58/test-blob-d3a9e72a-bc0b-30a3-12ac-43c62d6fe6e9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e60ba3b30d23af7934f559ce3dde0f75-ccc7c3c500ad1b34-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "60cb8934-dc82-176f-e2fc-9b7aedb6ccdf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E28A1B82\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "4LeF6q26nNCKju3f/wY78g==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "60cb8934-dc82-176f-e2fc-9b7aedb6ccdf",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68284591-501e-009a-60b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "SSU9LHGfl2PvBGPLJW/TymnUa0fF/tqz6ZcKY68YdlLN9qAm4wvR1gBUfHbZW1IwyLLJVfVsC0tKiULZlDOz1o0Q/i/OrOZeA5RHcYFj2o5E2Zv9TiFdYOtV21nI90LMoaXoyQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8bcdac4f-887f-060b-11b6-a6441f1f1a58?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a65ccb34fb738a1850c041d522afb5b-dd4fd4515450cc9e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5696a931-0e6f-23f0-86de-be6cbe88991a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5696a931-0e6f-23f0-86de-be6cbe88991a",
+        "x-ms-request-id": "682845d6-501e-009a-16b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "702753620",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,100,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,100,30)Async.json
@@ -1,0 +1,376 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1fe1e3d2b56e6f5d4f4dcc1f055bae5c-c0540ab01584db5d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "95313568-6723-c05d-f3bd-1cdfa3ff829a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E6157CAD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "95313568-6723-c05d-f3bd-1cdfa3ff829a",
+        "x-ms-request-id": "69fc9d70-201e-0029-3fb0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-1381c11e-991a-a3e8-9c2d-e9d4d86d50ec",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-5e45bac128788edae996886e0bac34ff-86d5a0f45358939d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fb3461f5-e8fd-f2fb-057c-45f18894d674",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "YAWLOEBeU8qnLRttPS1QCiLG/t5jWnLeVtyEzj044P1V9SDvnV\u002BcqOiMqtI9BADNPhP/j9smqQaTrOFk2oWMbkweF0cMYW3DKVb21rCfoVHbt5AqOVEhLkwaW/B9OM1iADyGHw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "AbUoGGQZvJfBsBEvNn9Bmg==",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E61C323C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fb3461f5-e8fd-f2fb-057c-45f18894d674",
+        "x-ms-content-crc64": "xcesjFoclG0=",
+        "x-ms-request-id": "69fc9d97-201e-0029-61b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-83d7d808-cf8d-807a-2012-b618680882a4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-64130a0dc44c237092725a918c67287c-ead67467f8e4371f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2bb135dc-e9a4-ffb4-c218-2ce882da385e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "A0wOPJT4Xfx3nBSfRieJosplRH7vu2xCMPhGfMU/nuL9lDhTKlQMOsJ3Stk3ioPaecK3zFRElkjfywubsuA3OP0yorLvNXd1WQq8eHCSC6V0awMCh9GNuP3vc15IcIfhPxLbBQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "AFvFn8uTcLh278YADOh4jA==",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E6246E6E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2bb135dc-e9a4-ffb4-c218-2ce882da385e",
+        "x-ms-content-crc64": "EDilqtPQkFI=",
+        "x-ms-request-id": "69fc9dbf-201e-0029-06b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-1381c11e-991a-a3e8-9c2d-e9d4d86d50ec",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-48b977e0eafe2a597b1c1aa2fd48fdda-16a59ed4b9ecf0c7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0a044049-af60-fe61-1ceb-8132168ac7ad",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "AbUoGGQZvJfBsBEvNn9Bmg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E61C323C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0a044049-af60-fe61-1ceb-8132168ac7ad",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fc9df5-201e-0029-34b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-83d7d808-cf8d-807a-2012-b618680882a4",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-beaabb04cb326a2f2373d3942cabb458-b164c21bea0be5c1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "419f497a-2ed5-07fd-a5be-86943f842fd4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "AFvFn8uTcLh278YADOh4jA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E6246E6E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "419f497a-2ed5-07fd-a5be-86943f842fd4",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d67c6b-401e-00a9-2eb0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-32bb9ac9-2b99-cfed-4c8e-f8f67e88e885",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-89c2b0395f289336e045caf99e818ca1-36788409ad9fea96-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ccb8e502-85ea-b6d8-7c8e-15eafd32ddf9",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-1381c11e-991a-a3e8-9c2d-e9d4d86d50ec",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6344A97\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ccb8e502-85ea-b6d8-7c8e-15eafd32ddf9",
+        "x-ms-content-crc64": "xcesjFoclG0=",
+        "x-ms-request-id": "69fc9e17-201e-0029-53b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-cad7306d-fe28-4e0c-4601-f208e2d03a94",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-e673e9e1161b75c3658ed7c11b95e93d-e2e2226a134f3fe0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "59913e79-62cc-f6e9-a943-2001cf4ec848",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-83d7d808-cf8d-807a-2012-b618680882a4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E63C11A2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "59913e79-62cc-f6e9-a943-2001cf4ec848",
+        "x-ms-content-crc64": "EDilqtPQkFI=",
+        "x-ms-request-id": "64d67c87-401e-00a9-47b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-32bb9ac9-2b99-cfed-4c8e-f8f67e88e885",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6681cc9c2eab4c13e66ca719da092e28-051bbab2293253eb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "be717069-83a0-da2c-0fed-8e972b09c6c0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6344A97\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "AbUoGGQZvJfBsBEvNn9Bmg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "be717069-83a0-da2c-0fed-8e972b09c6c0",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d67d18-401e-00a9-4ab0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "YAWLOEBeU8qnLRttPS1QCiLG/t5jWnLeVtyEzj044P1V9SDvnV\u002BcqOiMqtI9BADNPhP/j9smqQaTrOFk2oWMbkweF0cMYW3DKVb21rCfoVHbt5AqOVEhLkwaW/B9OM1iADyGHw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e/test-blob-cad7306d-fe28-4e0c-4601-f208e2d03a94",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-956c4dd2f87d0f70ed44ef3764c945d4-ec37c65ec3a8d0f8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5e98ab2e-09dc-87a7-67de-da2e7fd48bd1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E63C11A2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "AFvFn8uTcLh278YADOh4jA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5e98ab2e-09dc-87a7-67de-da2e7fd48bd1",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d67de4-401e-00a9-01b0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "A0wOPJT4Xfx3nBSfRieJosplRH7vu2xCMPhGfMU/nuL9lDhTKlQMOsJ3Stk3ioPaecK3zFRElkjfywubsuA3OP0yorLvNXd1WQq8eHCSC6V0awMCh9GNuP3vc15IcIfhPxLbBQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-8d538428-0d20-4347-0747-e13fb9bf659e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-515472a9d76f6d0fef8628520bfd916e-6e5d646de6212445-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7f69cfb5-6771-07e3-d75a-a7726059ecfd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7f69cfb5-6771-07e3-d75a-a7726059ecfd",
+        "x-ms-request-id": "64d67e17-401e-00a9-30b0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1265414898",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,1024,300).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,1024,300).json
@@ -1,0 +1,376 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-324f97116336bc8b1c5fdd3524bfff80-86aa8bad6a1d28a8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0a23417d-badc-13b1-ca08-4bdc3e8bc16f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E3964602\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a23417d-badc-13b1-ca08-4bdc3e8bc16f",
+        "x-ms-request-id": "16e8839a-e01e-007b-41b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-0125371e-0e37-4f97-2167-49bbb1ed394d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-270a8834a5b6e18d1c7877b6bab3937f-9498c2cae30a5aa2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "40a3a304-b408-b15d-4a1e-f009cdbf9e20",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "T2BZda1ZVmrbNkDKLTxTFqkdpS4SF\u002BdwtvXtGn/P8FoUyVaa6Yo\u002BMsaF9TMUjDCZlqBOyRPDgTd46L63bDvrC0XltWPmuS0e33JojCK0WyrFU4PegSdHUEgeIQDMhsaLmuntLtfMs91zL\u002BmgW/QVxIyU8hi3DIoenmQbyJgtUlis3PI4xi1T\u002BKCma1E9pvVTCFxzN5St1I1ezo9ysepFRdyQ9H4C3P1fQfl4EKE44fdvx787uhrE/ghk2vid4Ea1YSV0rLJ2UCteE/aaNcPrJeyYA\u002BorCYvCzPZ2nQIFwWCywq58wzVF\u002BHaT3KYkKchFebQLBdxcileZsuC8/7IpWVKV6HMUb2G3Uwpzly3lnaItMSRN\u002BryDVThX4hFViPjEaoNUjkFVMApTU7LS6fIqtBU9j86N216WEpI7vYxQYsoRry2pkQ9h1wAa\u002BqcJsWxFLC37F/kqNo4lvXyvGnJ9AvDnwDrEgCMF3LfNc\u002BG2jGAl9ZFeVEvQ53ifhNOTsb2Nnfi2IfExgKsK9jtCXMOtbjEciSThH62lF9jBJftQcir6P9bpAGpu83TlVF4PjYq18hahdyeYq31KEQoYcFuwuoMQRx3tw27HrZWw/MtPlYlODDPlrvsCYZNYnu5fVoMZNZna/0VtyC6o2smR6K\u002By\u002BnuAymMnyguIDeaJlCR/Z1cSlscxdJZD4UMFPdQxcHnkpaNz34wf8WqOUfFf5DMJKHJyf1HngYblPOkgIo03VpxspO\u002BAC4jL8qRdoiKk4/wQ\u002BxRhv/En/SMdjqKi/8/dV/tV8z9EiBzqpo2tit5jQFjsECZ41ZerRafLYn3lKPPVf0snT/C9y3P4dhhkenJEuk1Jtu\u002BoZIFkqa6YeCWeBX6a1wqTO/FoLkSzgF9\u002BR8o0h6gvm3EDLBrJw6VCJVNNWXGayaJnsX9c4Yer9eQi5mHjY/F9b2kMlqvvyXhLJQnwZibu5H0ozNUo07rpWDc2p91EX8Jiz\u002BoHjTP3eOcHEbt\u002Buo69NAHku5YbVJuuIz1zuSKaB8ZHjpY85lZKMFTuIcL\u002Ba52oeHLbX6MrR3pOWGn1g77EbAn1Niz3gU2rmopBLDPZsLefy0Gvv6ciG0Yc7o3tVK2VKrW4CDRxsPckMMUZ6hpHdKixVbd9FKxi0xvl25LAvUXcqwJ\u002BIaeDLhpJio/hCDEs1XnlO/71GBUIVjUZi9RkZHKAPD4YyFMALiedM4odgMrquQYZ2oJG55PtdcpxaqJF5CYdYczyEwwl5AzXWOSL69VrLtLOS4nvOVWrK1OIj8SEV05jAB/996b68/Z2bo\u002BuYYr1BjvQd5mcLSd3R\u002Be5nVVIUgCVJ\u002Bu2bTcs01iTeMrF/MnIk4iItOC1xw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "2EpuVosKBmunCfRSrOgHBQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E39D37FC\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "40a3a304-b408-b15d-4a1e-f009cdbf9e20",
+        "x-ms-content-crc64": "fIkpoZTxrYE=",
+        "x-ms-request-id": "16e883c5-e01e-007b-68b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-6e27f570-816a-58ba-6494-55d55ac375af",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-8bc2635d8a4631fae2922665eac59c09-e3626cf9820574e8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "8e1ab787-56ba-a69e-fcc0-e0dacbe07cbd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "1pj2aGeSq40p37o72/7vDaJjGYUah8wnKDd3oPs3DOmVTPVOCVd94o0\u002BqTIMSQmkrhWnYyp/lE/LzkAwGwqS8tPQpY8IoQNL5Tb43N2ZG98u0/HlkKi/FbimgjoXTceCq7deO6N5mw0RW330h7dxMrJgAkcYrGIrEY/XYh7JNJhvdTAmO\u002BA7tDfk0zQqy44ANFCHtkt/av9VMykTojjuSCflhBGGS/fSJU0PNNgtAEYB1i3OQX1N8Asx0Qe2KBL/9YsMRUZ8eelZtZH9bzUmJzPiEcsLIAeqmJMFVXrvG/07ED5NILr/hV1EdYvsT4HVCqnU0xZG89WDYq2zdiNvaZmTwl732QZ444xuxqp7vUgSMEvQG0jn9R1pyb4NTA451QvyWI0j3jCjW/CJ2C0qCKVkoEbYn05RrM1BjQ9Ia5Z\u002BNfGfiWS67lEaLL9XXRzvPsEZqKvHYDa9oKvA4lEgW/BaC6M7i35AqbL1vXKO\u002Bk6wUU5OL8LqttS74ei5\u002BgwA\u002BdHP/VJ5s7NC2P750qLDLqZcEJEC0iwtb1TOgKmWh6\u002Bl9MSgv/z8Np2aC1bE8OMx97NBXOl7/SeloY39qjMKrFFPVN3eIm6pYNrzZ8bVaX5wnYn1VCrFKfac\u002Bx5v/otqkF8EdJwGUtREl/sPh5ZgzzcOjA2pFFcniSrmQSdQOmFOidZm0fTiaku0sL0vtaFgPCznYHF\u002BwHsH3etyHxCt9F2ZwP6/\u002Bf1CLCLC9WOa99OIhgX7aNnw0MlbX/QJcEs6B7xflfWjoEIupDRPu8oXbeUX6ZgLsYuDqe80ZJoJOLzWh\u002B2nOmLe5eXDzcOloBT\u002BQ/IP8YayLlYw3OsFbjynJGx3eTPdcDKCOQSzR\u002BTI3gjaNiCo\u002Bkc1I1mXd1522HapHKhXLSfhIdO/jLeC/\u002BdxaP3jKjgb/iokQVXaRvjUC2CNCSs7cLDh\u002BRVN6G2PsyNxJQ9gk64\u002BjR1\u002BM\u002BvRBtra64BW9Pa7NfhNAjAizRa8lY4yaSDpc3iyT3wOvTzFD/M6c/3sOL8ttfAXE5B9G78HwZ5dnp268HcHpKR5rXe7h/I96FoZz1zOBbMw0mDnNDS8B/yeaHBWf4KF5ZQaswh4XIueQDNl7fFBjpnqih4WIG9wvaZ6HB\u002BB5mjXk\u002BrItFKqt3bUSfMAVhkLXdnXbPVkbsQkqfVh/T9sHFnKjloGedpHP9OoQtZ8b2eNb79FqnpzcyUmpApcSbk2aC2ZNsi\u002BBeT/jy0ivCzuqDqO046AJ3HfVxs14NTP6/UZcdmp4jmfzmnaRRpNUbf4N/zQznUrtUG7ut\u002BsiSUPL6Q3CEpSRMUA7wUkpeFWkgZkPKjY/xyA7ruY7idZ8kREyxV2FUhspQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "0RlQCR9azyQf\u002Bih5J0Ptsg==",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3A462D7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8e1ab787-56ba-a69e-fcc0-e0dacbe07cbd",
+        "x-ms-content-crc64": "wjDexEeB4vM=",
+        "x-ms-request-id": "16e883f3-e01e-007b-10b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-0125371e-0e37-4f97-2167-49bbb1ed394d",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4b9060c88a64aee119d76d2746dd6ea8-06493b466b3d784d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5eeee593-dd2d-9ceb-9828-e2af26359484",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "2EpuVosKBmunCfRSrOgHBQ==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E39D37FC\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5eeee593-dd2d-9ceb-9828-e2af26359484",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e88420-e01e-007b-3bb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-b5c17cac-3481-6ef6-a9d3-e97571f562dc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-21af7de3173982f03bd2f5d5bcf29cd3-6aa069b568266047-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e54617c9-1ef1-198f-ab18-09075b60c175",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-0125371e-0e37-4f97-2167-49bbb1ed394d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3B50236\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e54617c9-1ef1-198f-ab18-09075b60c175",
+        "x-ms-content-crc64": "fIkpoZTxrYE=",
+        "x-ms-request-id": "16e8843d-e01e-007b-58b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-6e27f570-816a-58ba-6494-55d55ac375af",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2c09eb56e93f2af35fdcf0543473cb3b-3e2ae75b27147917-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0ee68f02-aeef-8b92-8b37-0bae8cf8ee47",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "0RlQCR9azyQf\u002Bih5J0Ptsg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E3A462D7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0ee68f02-aeef-8b92-8b37-0bae8cf8ee47",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68284de1-501e-009a-24b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-496cfecf-5263-9d04-7ccd-9da2b9c1f55e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-4985cfed5ac151241553b032cc65de1f-27e09c3cf5e50b8b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "cc050e49-b37a-f486-72c9-d920345171ed",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-6e27f570-816a-58ba-6494-55d55ac375af",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3BE019A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc050e49-b37a-f486-72c9-d920345171ed",
+        "x-ms-content-crc64": "wjDexEeB4vM=",
+        "x-ms-request-id": "68284e19-501e-009a-58b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-b5c17cac-3481-6ef6-a9d3-e97571f562dc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-164dfbcd4a6a72e6f8276ea05a626343-3a3641eb06455fd1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7d65c918-22f2-bdcd-e6e9-557fe7da54c5",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3B50236\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "2EpuVosKBmunCfRSrOgHBQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7d65c918-22f2-bdcd-e6e9-557fe7da54c5",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68284ea5-501e-009a-5cb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "T2BZda1ZVmrbNkDKLTxTFqkdpS4SF\u002BdwtvXtGn/P8FoUyVaa6Yo\u002BMsaF9TMUjDCZlqBOyRPDgTd46L63bDvrC0XltWPmuS0e33JojCK0WyrFU4PegSdHUEgeIQDMhsaLmuntLtfMs91zL\u002BmgW/QVxIyU8hi3DIoenmQbyJgtUlis3PI4xi1T\u002BKCma1E9pvVTCFxzN5St1I1ezo9ysepFRdyQ9H4C3P1fQfl4EKE44fdvx787uhrE/ghk2vid4Ea1YSV0rLJ2UCteE/aaNcPrJeyYA\u002BorCYvCzPZ2nQIFwWCywq58wzVF\u002BHaT3KYkKchFebQLBdxcileZsuC8/7IpWVKV6HMUb2G3Uwpzly3lnaItMSRN\u002BryDVThX4hFViPjEaoNUjkFVMApTU7LS6fIqtBU9j86N216WEpI7vYxQYsoRry2pkQ9h1wAa\u002BqcJsWxFLC37F/kqNo4lvXyvGnJ9AvDnwDrEgCMF3LfNc\u002BG2jGAl9ZFeVEvQ53ifhNOTsb2Nnfi2IfExgKsK9jtCXMOtbjEciSThH62lF9jBJftQcir6P9bpAGpu83TlVF4PjYq18hahdyeYq31KEQoYcFuwuoMQRx3tw27HrZWw/MtPlYlODDPlrvsCYZNYnu5fVoMZNZna/0VtyC6o2smR6K\u002By\u002BnuAymMnyguIDeaJlCR/Z1cSlscxdJZD4UMFPdQxcHnkpaNz34wf8WqOUfFf5DMJKHJyf1HngYblPOkgIo03VpxspO\u002BAC4jL8qRdoiKk4/wQ\u002BxRhv/En/SMdjqKi/8/dV/tV8z9EiBzqpo2tit5jQFjsECZ41ZerRafLYn3lKPPVf0snT/C9y3P4dhhkenJEuk1Jtu\u002BoZIFkqa6YeCWeBX6a1wqTO/FoLkSzgF9\u002BR8o0h6gvm3EDLBrJw6VCJVNNWXGayaJnsX9c4Yer9eQi5mHjY/F9b2kMlqvvyXhLJQnwZibu5H0ozNUo07rpWDc2p91EX8Jiz\u002BoHjTP3eOcHEbt\u002Buo69NAHku5YbVJuuIz1zuSKaB8ZHjpY85lZKMFTuIcL\u002Ba52oeHLbX6MrR3pOWGn1g77EbAn1Niz3gU2rmopBLDPZsLefy0Gvv6ciG0Yc7o3tVK2VKrW4CDRxsPckMMUZ6hpHdKixVbd9FKxi0xvl25LAvUXcqwJ\u002BIaeDLhpJio/hCDEs1XnlO/71GBUIVjUZi9RkZHKAPD4YyFMALiedM4odgMrquQYZ2oJG55PtdcpxaqJF5CYdYczyEwwl5AzXWOSL69VrLtLOS4nvOVWrK1OIj8SEV05jAB/996b68/Z2bo\u002BuYYr1BjvQd5mcLSd3R\u002Be5nVVIUgCVJ\u002Bu2bTcs01iTeMrF/MnIk4iItOC1xw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96/test-blob-496cfecf-5263-9d04-7ccd-9da2b9c1f55e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f6ba0163f4072a43bb8bf41f4aa3e7fe-bcdc5c73b18abfe3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6b07e1a5-f3ec-93fb-a2cd-a6a0b23259ba",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3BE019A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "0RlQCR9azyQf\u002Bih5J0Ptsg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6b07e1a5-f3ec-93fb-a2cd-a6a0b23259ba",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68284f22-501e-009a-55b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "1pj2aGeSq40p37o72/7vDaJjGYUah8wnKDd3oPs3DOmVTPVOCVd94o0\u002BqTIMSQmkrhWnYyp/lE/LzkAwGwqS8tPQpY8IoQNL5Tb43N2ZG98u0/HlkKi/FbimgjoXTceCq7deO6N5mw0RW330h7dxMrJgAkcYrGIrEY/XYh7JNJhvdTAmO\u002BA7tDfk0zQqy44ANFCHtkt/av9VMykTojjuSCflhBGGS/fSJU0PNNgtAEYB1i3OQX1N8Asx0Qe2KBL/9YsMRUZ8eelZtZH9bzUmJzPiEcsLIAeqmJMFVXrvG/07ED5NILr/hV1EdYvsT4HVCqnU0xZG89WDYq2zdiNvaZmTwl732QZ444xuxqp7vUgSMEvQG0jn9R1pyb4NTA451QvyWI0j3jCjW/CJ2C0qCKVkoEbYn05RrM1BjQ9Ia5Z\u002BNfGfiWS67lEaLL9XXRzvPsEZqKvHYDa9oKvA4lEgW/BaC6M7i35AqbL1vXKO\u002Bk6wUU5OL8LqttS74ei5\u002BgwA\u002BdHP/VJ5s7NC2P750qLDLqZcEJEC0iwtb1TOgKmWh6\u002Bl9MSgv/z8Np2aC1bE8OMx97NBXOl7/SeloY39qjMKrFFPVN3eIm6pYNrzZ8bVaX5wnYn1VCrFKfac\u002Bx5v/otqkF8EdJwGUtREl/sPh5ZgzzcOjA2pFFcniSrmQSdQOmFOidZm0fTiaku0sL0vtaFgPCznYHF\u002BwHsH3etyHxCt9F2ZwP6/\u002Bf1CLCLC9WOa99OIhgX7aNnw0MlbX/QJcEs6B7xflfWjoEIupDRPu8oXbeUX6ZgLsYuDqe80ZJoJOLzWh\u002B2nOmLe5eXDzcOloBT\u002BQ/IP8YayLlYw3OsFbjynJGx3eTPdcDKCOQSzR\u002BTI3gjaNiCo\u002Bkc1I1mXd1522HapHKhXLSfhIdO/jLeC/\u002BdxaP3jKjgb/iokQVXaRvjUC2CNCSs7cLDh\u002BRVN6G2PsyNxJQ9gk64\u002BjR1\u002BM\u002BvRBtra64BW9Pa7NfhNAjAizRa8lY4yaSDpc3iyT3wOvTzFD/M6c/3sOL8ttfAXE5B9G78HwZ5dnp268HcHpKR5rXe7h/I96FoZz1zOBbMw0mDnNDS8B/yeaHBWf4KF5ZQaswh4XIueQDNl7fFBjpnqih4WIG9wvaZ6HB\u002BB5mjXk\u002BrItFKqt3bUSfMAVhkLXdnXbPVkbsQkqfVh/T9sHFnKjloGedpHP9OoQtZ8b2eNb79FqnpzcyUmpApcSbk2aC2ZNsi\u002BBeT/jy0ivCzuqDqO046AJ3HfVxs14NTP6/UZcdmp4jmfzmnaRRpNUbf4N/zQznUrtUG7ut\u002BsiSUPL6Q3CEpSRMUA7wUkpeFWkgZkPKjY/xyA7ruY7idZ8kREyxV2FUhspQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-841bc1f5-9d29-25cd-f5a5-23a5af8e8c96?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d7f9aae8704d1f1038bdc5f809e1b94e-dc771056e086ba32-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "05d927a3-e9d2-e3d9-1703-563beb178e2a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "05d927a3-e9d2-e3d9-1703-563beb178e2a",
+        "x-ms-request-id": "68284f48-501e-009a-79b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1830298646",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,1024,300)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(2,1024,300)Async.json
@@ -1,0 +1,376 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1fa7c68b73d20e6f5f36f571cba918a8-194fce28c212226f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "993c8330-8564-8659-0e83-1466dbde4cde",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E74D7A09\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "993c8330-8564-8659-0e83-1466dbde4cde",
+        "x-ms-request-id": "146bfe55-a01e-0055-13b0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-b7b80e62-a405-396b-01a8-feb82f5cfc95",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-822d5f53c938b180b5ed378479cd077b-08c6bc3ccfe2f278-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c9fc1cab-196e-0c2b-7d71-ac216366f8fa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3EUQpMzJQ3HAiC9KBj4PTmXaCXwONkLH5cMcSsCmt6Hc2HYU6s2OPthfXEyOIfsbtr\u002BXzUr/yqYDSb8JrfmwGtCObi7I\u002BmOXS8qjrtr1OcTIAJMAD\u002BpW3Q3QEKEOhZHfr0F8/7LNU7tc/4F/WxzLDhD7QKxlrwvmN5Ag9\u002BrBicY5xP\u002BYeDkR\u002B63YpA9o14LxBAKREkXlef82lscirFvRmna7RpYcM5XW6kX\u002BjQv7fWAOLvPnMHaBU0sAYuJx705SBgqYrJHs1NFsuij/5\u002Bz0OhhnE35n6moAOvJKHNCzZfv2rIcAY9HOIlkienVNgWxeDCjJCtvQ6hugl3GeobcAuVUtCTtl89ZHmPEkRW/0s7mG7BCo6VofJsFrYMtfMIChIcEfH3cw\u002BRhRgXHpq6Ssq\u002BS4GLSnWM/6DuN5\u002BpML6GhwgiSu1ZNCVfL4V2fpNXocvrTnpxfL\u002BsnxJBGUt/\u002BERpkIeSiA/tZQdcLCrgFnEdhoXTvfJEFQpIhbvLCCrZ7zcxDO4LxRm8DdljFVCUvHiRI5K1nDpSJYuNSgJUIlzsgkzjvwmTAbFsF7AY0P\u002B5o8kzKdSYJEL83udijnsXZ\u002Bt8hpMToQ1/DhHRWYSKSUSLw5ZJEPiIVF359uASMINGVK/UnFpspgLLxBuyxtrOcpWi1rrU3kbi9CI1GbotXN2eivTUtazqHy2TjVzcxZ2DK4RKb1nIYYZo4ZgoN4xIrmdOJDvV6bz4uLedMUDqBj6Uoe4l0v1zxil\u002Be8QEweeRWu71npFhvUHHUbaSOyA1fttpk4WeEst5yl4CV3344/bQC\u002BZh9HedMvSsbnE20ZsJSPzomy5R8zgTi8RDX1XD3m2/wj85w4pj3FCQ8bRKMujDCR6BAFjIjgi\u002BXmijWeOe6IAThx9rz3VyhM7dsQFzyVjbcEY3Ms4U50Qmi3URsHJ88gkkNqvZZ0mpHnuJ\u002Bsz3OoUf19mdZ6Wx/p/bNUPwUNRMUL8IX5KtAgkMjiRSmvx3L0D/8eio75pTYjgb/jIFuL2nPaoN/uricsXAgNmBb2OjZAXzAG77o2EkpO1akRPXBtVmq11SaTBmDY8i2F6wwgLUaJosArheu5o46UoNh\u002BGh\u002BYoEKsQWUPrFnPLvyNsCY\u002BLahiiJuvQtB/\u002BzGX/mWIWtcO7UvKdOvhefVnW1fuLPJoVnIvG5KD6F1xLUYzeK7zR9Qlf8Pac7m9gQ6lSOZ5kM8/LqjzWD5EigXtWEelrQFHcxSDyKwvjuK4cpqD3p93\u002BJx29EkFAO\u002BV4PS97BtyF9MNXtXS9cciD6DFOuWkwatldmCqLrm4QXIl7ei3caHHRVrHdoDJpALVVOSoQMYJ8R9JWHW6yOkaVRxjrAffag==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "cSUBEAWgWJfq45S2SfxcQg==",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7543663\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c9fc1cab-196e-0c2b-7d71-ac216366f8fa",
+        "x-ms-content-crc64": "SL8bZhGPmU8=",
+        "x-ms-request-id": "146bfe67-a01e-0055-22b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-278b21f6-cb3c-93dd-1f52-09085947372c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-3d26be7eac2af15c78fcc53e40e577ac-4601f8dee2c45d0a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "47d44578-4b78-864b-955c-b07e4882ef25",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0bbmZ7K7AvDIOJATTZTuFLLEdq9QXnroVGmJGPJHr42j9lZ76CKlSAyIzL8MHskC/SG8929HT3I8/RNJMur\u002BgIkDcFY\u002BciuQHi6jyJG63DWfhhrRircdW6fkP\u002BoOWxUhiUw1CK5zxIv1LNlBo4bggSHdqqzPLfXR5hSuWjJAgcIYgT5FhNOHK8GO217e27ghA73IMbFpUlxXYyKZxWpYtKsWKSFHm/xOVn7rQFKW8wpcjFZ0eFARri/i7SCw7WZWNiazyLKW2WfBetoyfhEJwHAYPDgT4zxaBXryZa3bnmkYlAor4ypXxrPvs/523jAe2C2wmLAtQlLpWMM4pHS55dtwGekH3txFwHaFJDA\u002B5CZJ1IyAKwW46lG4QYpnHiI\u002BNc4iBcRGFvpQatc6qB4hq3Sc79DoObnWuC\u002BYTpxS3qFUR\u002B5iHN9iA72RL8EufkIylpYWyy9RVfwUTE2Vrshd/os15WEwv4\u002BUOewTVgn4pznsZbcGPBJyAvHyTs\u002BSzFT0NDE1\u002BJjgAtcGgZFDPv/yG6QTqEgQV8J5w\u002BNwPnG/AmyXHiLYw6\u002BgC2Pg/7qALsPy/zIrfiQM5NxvuzW1cMRlR34lrCDcGVj1c53lL1cH\u002BZUgfT4/k4RIijlFaQd66pqeerg8W4GiFebZNgqHJrSEaMKflfKFJrP63CHmlrBRe4gCRrWfyp0TfWhYZV15wWSFwQFE2lWoGFMEQn9gvH41iLuChd//5Z0ljBiKLcFWgRq9YdWuDaAzWi5hm4ges8DpIt2i9zyEhtxjH009HeuSrsBkoluphnoaTiqxnUkUBtlXoArks4ndOdr5S\u002B5T9jxCz\u002BzHuhBlQJtiiKgR0uiSThh05X3grfo3hmmArzuMx1jub85dTUzI8V9vgSvhzGfyZ/zV3hC/YSHxkDOn5ZFf1cFPI2MZNQHMrPMdcSzPVboCjkg/tuhHLw2ta7wYIAzOD6tpkakE2DL6CTIcovD0Ijt5pVdIHx/YCPNVbMlFtIvnTmKAZcMQ/bUWRa22Ko0duEmBnnu1hu\u002BMkYm1rmxotVWnNVOOdLx3aKehMtpxIt1mOLOAwxUPMchy89Q6W09IrZBYD/U5j0ONCjXTE1MUG2\u002BsTna56PE/lwOLG4HnPQ1YWIRKGRLnLahv87nfPB50XdhljQzYj8WeGHjxrXPCpcwoe7rPygFcxCDNSfU3YFrlF72pgq8Af8m\u002BqwCa9oA0rU3st8BjpZPWCcnsC0bQZrgdC5W1GCIdKPzxEB4Awc6gmJynSqmagnIq03nmFHOC7kVIferqf5Qqz4/EcZR01Uj6S3KpKBsOgokji0WpNhOIbiHZuEPjtRkHfHsa1RDdtv4w68gB2cUpOvpgxvNOgA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1wCnIeTjdS4rU6Z1mTai4A==",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E75A9E13\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "47d44578-4b78-864b-955c-b07e4882ef25",
+        "x-ms-content-crc64": "6vM2faiQzmI=",
+        "x-ms-request-id": "146bfe7c-a01e-0055-36b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-b7b80e62-a405-396b-01a8-feb82f5cfc95",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-36b52e3456272a9032a8d62a594cee8e-a8ca21b7401758f3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "80e84d45-071f-4e07-30b5-6c16ea9fbc94",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "cSUBEAWgWJfq45S2SfxcQg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7543663\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "80e84d45-071f-4e07-30b5-6c16ea9fbc94",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfe9b-a01e-0055-51b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-278b21f6-cb3c-93dd-1f52-09085947372c",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-984e561e4e32706b468744c74f9acbb2-5f67df4947fbb9d2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fb382842-6e9a-b106-f493-6ee3a1543141",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "1wCnIeTjdS4rU6Z1mTai4A==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E75A9E13\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fb382842-6e9a-b106-f493-6ee3a1543141",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d8335-d01e-0002-17b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-ba707f86-2453-96a1-3025-98b39a63e0b9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-697fcb033c4581918e397def93b2c83b-6a0d9f6c10629360-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "920c57bc-6f81-afdb-4553-4818ae9e0709",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-278b21f6-cb3c-93dd-1f52-09085947372c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E76E9852\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "920c57bc-6f81-afdb-4553-4818ae9e0709",
+        "x-ms-content-crc64": "6vM2faiQzmI=",
+        "x-ms-request-id": "993d8367-d01e-0002-43b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-c058e275-faa5-8c96-1703-98bb86a056b1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-332e5c433d1e9be5f784823f66b8a780-7864d4b9b3b6283e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c2d30ed7-c066-38fa-2c36-bb2ae730c885",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-b7b80e62-a405-396b-01a8-feb82f5cfc95",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E770BAE4\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c2d30ed7-c066-38fa-2c36-bb2ae730c885",
+        "x-ms-content-crc64": "SL8bZhGPmU8=",
+        "x-ms-request-id": "146bfea3-a01e-0055-59b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-c058e275-faa5-8c96-1703-98bb86a056b1",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c264d49a20555369947f86238346c86c-8a1b6fb4a593e55c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "906e8125-3623-1704-492d-f23920f729bf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E770BAE4\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "cSUBEAWgWJfq45S2SfxcQg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "906e8125-3623-1704-492d-f23920f729bf",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfefe-a01e-0055-26b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3EUQpMzJQ3HAiC9KBj4PTmXaCXwONkLH5cMcSsCmt6Hc2HYU6s2OPthfXEyOIfsbtr\u002BXzUr/yqYDSb8JrfmwGtCObi7I\u002BmOXS8qjrtr1OcTIAJMAD\u002BpW3Q3QEKEOhZHfr0F8/7LNU7tc/4F/WxzLDhD7QKxlrwvmN5Ag9\u002BrBicY5xP\u002BYeDkR\u002B63YpA9o14LxBAKREkXlef82lscirFvRmna7RpYcM5XW6kX\u002BjQv7fWAOLvPnMHaBU0sAYuJx705SBgqYrJHs1NFsuij/5\u002Bz0OhhnE35n6moAOvJKHNCzZfv2rIcAY9HOIlkienVNgWxeDCjJCtvQ6hugl3GeobcAuVUtCTtl89ZHmPEkRW/0s7mG7BCo6VofJsFrYMtfMIChIcEfH3cw\u002BRhRgXHpq6Ssq\u002BS4GLSnWM/6DuN5\u002BpML6GhwgiSu1ZNCVfL4V2fpNXocvrTnpxfL\u002BsnxJBGUt/\u002BERpkIeSiA/tZQdcLCrgFnEdhoXTvfJEFQpIhbvLCCrZ7zcxDO4LxRm8DdljFVCUvHiRI5K1nDpSJYuNSgJUIlzsgkzjvwmTAbFsF7AY0P\u002B5o8kzKdSYJEL83udijnsXZ\u002Bt8hpMToQ1/DhHRWYSKSUSLw5ZJEPiIVF359uASMINGVK/UnFpspgLLxBuyxtrOcpWi1rrU3kbi9CI1GbotXN2eivTUtazqHy2TjVzcxZ2DK4RKb1nIYYZo4ZgoN4xIrmdOJDvV6bz4uLedMUDqBj6Uoe4l0v1zxil\u002Be8QEweeRWu71npFhvUHHUbaSOyA1fttpk4WeEst5yl4CV3344/bQC\u002BZh9HedMvSsbnE20ZsJSPzomy5R8zgTi8RDX1XD3m2/wj85w4pj3FCQ8bRKMujDCR6BAFjIjgi\u002BXmijWeOe6IAThx9rz3VyhM7dsQFzyVjbcEY3Ms4U50Qmi3URsHJ88gkkNqvZZ0mpHnuJ\u002Bsz3OoUf19mdZ6Wx/p/bNUPwUNRMUL8IX5KtAgkMjiRSmvx3L0D/8eio75pTYjgb/jIFuL2nPaoN/uricsXAgNmBb2OjZAXzAG77o2EkpO1akRPXBtVmq11SaTBmDY8i2F6wwgLUaJosArheu5o46UoNh\u002BGh\u002BYoEKsQWUPrFnPLvyNsCY\u002BLahiiJuvQtB/\u002BzGX/mWIWtcO7UvKdOvhefVnW1fuLPJoVnIvG5KD6F1xLUYzeK7zR9Qlf8Pac7m9gQ6lSOZ5kM8/LqjzWD5EigXtWEelrQFHcxSDyKwvjuK4cpqD3p93\u002BJx29EkFAO\u002BV4PS97BtyF9MNXtXS9cciD6DFOuWkwatldmCqLrm4QXIl7ei3caHHRVrHdoDJpALVVOSoQMYJ8R9JWHW6yOkaVRxjrAffag=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541/test-blob-ba707f86-2453-96a1-3025-98b39a63e0b9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3f6382284233ab27484a59b994e1bc4a-00ad20fe2d31f5c0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2df2bce3-7730-7ee5-1cc7-32b1ad514d08",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E76E9852\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "1wCnIeTjdS4rU6Z1mTai4A==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2df2bce3-7730-7ee5-1cc7-32b1ad514d08",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bff6a-a01e-0055-77b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "0bbmZ7K7AvDIOJATTZTuFLLEdq9QXnroVGmJGPJHr42j9lZ76CKlSAyIzL8MHskC/SG8929HT3I8/RNJMur\u002BgIkDcFY\u002BciuQHi6jyJG63DWfhhrRircdW6fkP\u002BoOWxUhiUw1CK5zxIv1LNlBo4bggSHdqqzPLfXR5hSuWjJAgcIYgT5FhNOHK8GO217e27ghA73IMbFpUlxXYyKZxWpYtKsWKSFHm/xOVn7rQFKW8wpcjFZ0eFARri/i7SCw7WZWNiazyLKW2WfBetoyfhEJwHAYPDgT4zxaBXryZa3bnmkYlAor4ypXxrPvs/523jAe2C2wmLAtQlLpWMM4pHS55dtwGekH3txFwHaFJDA\u002B5CZJ1IyAKwW46lG4QYpnHiI\u002BNc4iBcRGFvpQatc6qB4hq3Sc79DoObnWuC\u002BYTpxS3qFUR\u002B5iHN9iA72RL8EufkIylpYWyy9RVfwUTE2Vrshd/os15WEwv4\u002BUOewTVgn4pznsZbcGPBJyAvHyTs\u002BSzFT0NDE1\u002BJjgAtcGgZFDPv/yG6QTqEgQV8J5w\u002BNwPnG/AmyXHiLYw6\u002BgC2Pg/7qALsPy/zIrfiQM5NxvuzW1cMRlR34lrCDcGVj1c53lL1cH\u002BZUgfT4/k4RIijlFaQd66pqeerg8W4GiFebZNgqHJrSEaMKflfKFJrP63CHmlrBRe4gCRrWfyp0TfWhYZV15wWSFwQFE2lWoGFMEQn9gvH41iLuChd//5Z0ljBiKLcFWgRq9YdWuDaAzWi5hm4ges8DpIt2i9zyEhtxjH009HeuSrsBkoluphnoaTiqxnUkUBtlXoArks4ndOdr5S\u002B5T9jxCz\u002BzHuhBlQJtiiKgR0uiSThh05X3grfo3hmmArzuMx1jub85dTUzI8V9vgSvhzGfyZ/zV3hC/YSHxkDOn5ZFf1cFPI2MZNQHMrPMdcSzPVboCjkg/tuhHLw2ta7wYIAzOD6tpkakE2DL6CTIcovD0Ijt5pVdIHx/YCPNVbMlFtIvnTmKAZcMQ/bUWRa22Ko0duEmBnnu1hu\u002BMkYm1rmxotVWnNVOOdLx3aKehMtpxIt1mOLOAwxUPMchy89Q6W09IrZBYD/U5j0ONCjXTE1MUG2\u002BsTna56PE/lwOLG4HnPQ1YWIRKGRLnLahv87nfPB50XdhljQzYj8WeGHjxrXPCpcwoe7rPygFcxCDNSfU3YFrlF72pgq8Af8m\u002BqwCa9oA0rU3st8BjpZPWCcnsC0bQZrgdC5W1GCIdKPzxEB4Awc6gmJynSqmagnIq03nmFHOC7kVIferqf5Qqz4/EcZR01Uj6S3KpKBsOgokji0WpNhOIbiHZuEPjtRkHfHsa1RDdtv4w68gB2cUpOvpgxvNOgA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0abbaea8-f17a-cb17-f3a8-bdbbab796541?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4ea8c3a0ef57be4fc7af7b88a41ff6b2-25828cf60de37543-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "64568b7c-fc04-cb8f-d3e8-8bf963a96e7b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "64568b7c-fc04-cb8f-d3e8-8bf963a96e7b",
+        "x-ms-request-id": "146bff81-a01e-0055-09b0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1453675480",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,0,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,0,30).json
@@ -1,0 +1,746 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-79d1ed65bbe226e94fe56157ad00e250-9cbe58ef54a28a1a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "06e113de-d812-8ddd-183b-5ade7055047a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1AE44B3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "06e113de-d812-8ddd-183b-5ade7055047a",
+        "x-ms-request-id": "68283cf0-501e-009a-4eb0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-0bd45ff6-ebbd-d0ea-0bfb-8c3306ab2a3b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-dae8d79d3032c3d22d0f233fdc954044-efa816e58989f901-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e452fffb-8bca-8d41-8c0b-225a03a102e2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1B4C252\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e452fffb-8bca-8d41-8c0b-225a03a102e2",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283d36-501e-009a-0cb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-c8efea93-4a30-679c-bbc2-f99bebf65252",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-72a9a8fb344a36268026e9e7b8c72494-1d86359d7d83e7e5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "44891adf-5633-736b-cfca-490df30c4c21",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1BCFE87\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "44891adf-5633-736b-cfca-490df30c4c21",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283d73-501e-009a-42b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-ea4a14c2-32e7-f2e8-2811-fa174baa866c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-36fed2b7065f94ea073f2aba4d1a94da-eb96e116cfe750f8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e87b755f-be18-86af-449a-358475a1f514",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1C4C593\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e87b755f-be18-86af-449a-358475a1f514",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283dbb-501e-009a-06b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-864a1e11-3b65-ac4a-c26c-50faf24fe415",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-5b4930f428f8000f0be45b60240ea2d5-63eb11aeb0f0ec75-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7dad8ae0-6491-2209-a7b3-c05dc400c6af",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1CCB3A3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7dad8ae0-6491-2209-a7b3-c05dc400c6af",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283dfd-501e-009a-45b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-f27039a8-3f60-6154-01fc-a01f4f851b11",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-8847524cd4c484bf60cf68a29485e117-9ef66aea4c8fe471-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "eaa4dc47-77f4-8083-3fc8-a3dfe5562196",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1D3426D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "eaa4dc47-77f4-8083-3fc8-a3dfe5562196",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283e42-501e-009a-02b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-cc898c3b-cbab-86ed-ca9e-277ae1ed00d9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-185770377e835babd9215aa00772a84c-d34287ba605def63-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e8154cbf-db5b-fdbb-2b35-98c1fc4cd46b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1D934FD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e8154cbf-db5b-fdbb-2b35-98c1fc4cd46b",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283e78-501e-009a-30b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-0bd45ff6-ebbd-d0ea-0bfb-8c3306ab2a3b",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-34c86d83afee9673fec19ff767c12009-b1a9266b4139e0af-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9820e170-3840-ac3a-8957-b7e5e20c4412",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1B4C252\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9820e170-3840-ac3a-8957-b7e5e20c4412",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68283ec7-501e-009a-7db0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-126ee52c-943a-d10c-cae9-84689b2a5c3d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-d0d165728193a2dbcc88398522ccc25f-7c0e493bc16e73d3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1a5197c7-3b2c-3c2b-8196-fc3a5973ea01",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-0bd45ff6-ebbd-d0ea-0bfb-8c3306ab2a3b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:29 GMT",
+        "ETag": "\u00220x8DB71C7E1E9AD43\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1a5197c7-3b2c-3c2b-8196-fc3a5973ea01",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283f04-501e-009a-34b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-c8efea93-4a30-679c-bbc2-f99bebf65252",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-13762913548474f63a478b5ce83622de-7ece6ae85801763d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4b1d1515-29bb-e2e5-2549-d565d6f6547f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E1BCFE87\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4b1d1515-29bb-e2e5-2549-d565d6f6547f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d63a4-d01e-0002-24b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-ea4a14c2-32e7-f2e8-2811-fa174baa866c",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d6b0ecbd17d837bcb8b9318adaf2f6e6-ce01758009d1e56c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a92c976c-10d1-bf29-92e2-41d790e76cf4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E1C4C593\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a92c976c-10d1-bf29-92e2-41d790e76cf4",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68283f53-501e-009a-7db0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-65be3f50-18c5-dc69-4be9-27c118d97f13",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7a4326c407fceb4acd179526bcd534d7-b741f6845225b23d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "44242c39-9f56-f546-93ff-46b8429ec7ba",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-c8efea93-4a30-679c-bbc2-f99bebf65252",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E1F7B4F5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "44242c39-9f56-f546-93ff-46b8429ec7ba",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d63be-d01e-0002-3bb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-6af2c6fc-0916-a7d6-80b8-02c24785ea9f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-e237155ac217da854753b07886399d4b-2c3b1509c1e06c27-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ab4c54b3-1e72-0ce8-fcd9-f3884521ad8d",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-ea4a14c2-32e7-f2e8-2811-fa174baa866c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E1FB84FB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ab4c54b3-1e72-0ce8-fcd9-f3884521ad8d",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68283f78-501e-009a-20b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-864a1e11-3b65-ac4a-c26c-50faf24fe415",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1afb5799eba90e9a9e99cacaa828ac4f-8c41a0edaa23ce36-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3c23d9ac-c09b-cc82-c790-73bf634a6b12",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E1CCB3A3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3c23d9ac-c09b-cc82-c790-73bf634a6b12",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d6400-d01e-0002-75b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-f27039a8-3f60-6154-01fc-a01f4f851b11",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fd2a576b0097e12c05be8633e812f210-c31766f007ac79fd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c4beb7c5-ff6e-c715-4fa7-e2d1dedb6d63",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E1D3426D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c4beb7c5-ff6e-c715-4fa7-e2d1dedb6d63",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68283feb-501e-009a-0fb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-a22aea41-9b2e-1413-7b91-c6506c4ab9f1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-594eebcf5768ca1c4f0f884c7204fa90-e5f8cca389c25dd0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6cdc9f01-70fd-40f2-4050-48fe6998b179",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-864a1e11-3b65-ac4a-c26c-50faf24fe415",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E204F97D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6cdc9f01-70fd-40f2-4050-48fe6998b179",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d641b-d01e-0002-0bb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-cc898c3b-cbab-86ed-ca9e-277ae1ed00d9",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b9819777f30d1fb31f76be83cb4c32d3-f29db18ec060f871-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "61a42c40-bba2-978a-64d9-f95e19b27b09",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E1D934FD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "61a42c40-bba2-978a-64d9-f95e19b27b09",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e878db-e01e-007b-5cb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-d56c716a-f238-4626-6817-e50d15a795c6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7a52448a6380cf799f0c9a82be3ee2e3-81ee89e083ddf832-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b1387d2c-edd9-0f0a-4deb-b1b1d162a723",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-f27039a8-3f60-6154-01fc-a01f4f851b11",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E20CC087\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b1387d2c-edd9-0f0a-4deb-b1b1d162a723",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68284013-501e-009a-35b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-2d8088fe-dcaf-61e4-b2dd-ee8543853a35",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-dea426ecda197e7fe8e18f24c525fb98-b5aab442f983a98b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a470ef53-46bd-2380-5249-05c7e321e1a1",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae/test-blob-cc898c3b-cbab-86ed-ca9e-277ae1ed00d9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "ETag": "\u00220x8DB71C7E21CEACA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a470ef53-46bd-2380-5249-05c7e321e1a1",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e87904-e01e-007b-80b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-34bde116-96fa-73ec-f7d1-8fcedc1250ae?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3e5f329b4e5ba543fe535ec7e261314d-c2f3690fba74b030-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2a0b115b-d641-694b-caac-0063f74d6bdb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:30 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2a0b115b-d641-694b-caac-0063f74d6bdb",
+        "x-ms-request-id": "16e87adf-e01e-007b-32b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1979466375",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,0,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,0,30)Async.json
@@ -1,0 +1,746 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0dba1492ba0751260c28a53c806863ce-a2ef2041ccd259ae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "61ecd36a-fe9c-58c0-a49d-03305fc06051",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E5514A2B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "61ecd36a-fe9c-58c0-a49d-03305fc06051",
+        "x-ms-request-id": "16e88f78-e01e-007b-35b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-047b2834-7563-44f6-024f-57f37b723717",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-ed23ada0e947e33d0a6af3e8f39a5791-474da7a671942975-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3c9e297e-caf4-705d-496b-0fa399af6459",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E55DB90D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3c9e297e-caf4-705d-496b-0fa399af6459",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e88fbd-e01e-007b-70b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-2926132f-f1f0-9f08-9e0d-e8ad9fcc134a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-8e419f99ab8808e061a1e8422288eaa3-a9c7a99a980a6f2c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f68d2e39-aed8-9894-821f-8c3bd1644387",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "ETag": "\u00220x8DB71C7E565801D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f68d2e39-aed8-9894-821f-8c3bd1644387",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e89007-e01e-007b-32b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-77195734-cb07-f53a-dda8-5e4da7cddd32",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-f20586d253f0f4b24d14f51ce3df6b61-ea1e97ab89f5dfb7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6a6a1fcf-6d21-1481-da64-b58dbc33fde3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E56C35E9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6a6a1fcf-6d21-1481-da64-b58dbc33fde3",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e8902d-e01e-007b-55b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-4b01eb65-369a-4361-20db-66558c48a436",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-69ab4c260a56c7536bd3a248281df3b0-aedee6354aca5eec-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b16b67dc-d8fa-f266-2438-51d30a437988",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E5747213\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b16b67dc-d8fa-f266-2438-51d30a437988",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e89078-e01e-007b-1db0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-23bf0c3b-bf59-6410-d931-4c4792baf8d1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-d071ad4c9f339c512375dc4d3dc1b90a-a04f61f6a39f4e17-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "54b0bb59-4bc7-67e9-4e81-629e1ee36e19",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E57C872E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "54b0bb59-4bc7-67e9-4e81-629e1ee36e19",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e890b5-e01e-007b-58b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-b347b630-c7cb-fdb0-f6d5-572c65e46894",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-53f2384b5bbf31dfd46d89b0e9801cb5-4a7d34f0f5f72d29-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4e7a9add-2592-87c0-27c9-889358af4084",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E582C7DA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4e7a9add-2592-87c0-27c9-889358af4084",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e890e1-e01e-007b-03b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-047b2834-7563-44f6-024f-57f37b723717",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-231233e6633e33186c65865b478c2872-76097185cae3080f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "84c0b7c0-2069-ba86-f3ad-8129aa52c869",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E55DB90D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "84c0b7c0-2069-ba86-f3ad-8129aa52c869",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e89129-e01e-007b-47b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-2926132f-f1f0-9f08-9e0d-e8ad9fcc134a",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-93865946c9484bbb306f879be9c14d81-13bcddb77ff33d35-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a1d2d72b-bcef-611b-6e2f-8b972f9a7a83",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E565801D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a1d2d72b-bcef-611b-6e2f-8b972f9a7a83",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e89149-e01e-007b-64b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-9a112803-b90e-a6d8-db9d-7269ea19b165",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-29d965f93abc24761e8eb1b32db77698-433632a61772e193-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d3fe3929-2780-0e79-a824-6783b5cdfc3c",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-047b2834-7563-44f6-024f-57f37b723717",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E5967405\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d3fe3929-2780-0e79-a824-6783b5cdfc3c",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d76ac-d01e-0002-0eb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-77195734-cb07-f53a-dda8-5e4da7cddd32",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5f13f3037b73e2085d1f3d9608d73785-5b837d89e3ca9fe8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f66e9c5f-a69b-9f02-57e3-9634617aca84",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E56C35E9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f66e9c5f-a69b-9f02-57e3-9634617aca84",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8916a-e01e-007b-03b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-4b01eb65-369a-4361-20db-66558c48a436",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-92d3a2186f9400cd8aa9e3d795fb6745-48ea28ace5a047da-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "18237b6a-065e-33a0-f29d-c02eaeba025e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E5747213\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "18237b6a-065e-33a0-f29d-c02eaeba025e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68285de7-501e-009a-2eb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-23bf0c3b-bf59-6410-d931-4c4792baf8d1",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ae5d658073d3cda5bf336ad95a21c088-b5c785281e7c6503-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b84a87d5-1df0-d708-a534-cac846fbb110",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E57C872E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b84a87d5-1df0-d708-a534-cac846fbb110",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8918d-e01e-007b-22b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-d62594e2-f100-736b-5cc1-2d8467e3fef4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-efb3550a7ab745b64fc4d595a3f427d9-9972f7e25745352a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e5c9f5e4-b156-8f25-d105-c0a9f6af3590",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-2926132f-f1f0-9f08-9e0d-e8ad9fcc134a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E59F2558\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e5c9f5e4-b156-8f25-d105-c0a9f6af3590",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d76f2-d01e-0002-51b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-b347b630-c7cb-fdb0-f6d5-572c65e46894",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-463fe3d3ce60dda3468ccbf062eec20d-310030bc9df6292c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6fd4a37e-7c65-7c9f-93cd-6624980a1ddb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E582C7DA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6fd4a37e-7c65-7c9f-93cd-6624980a1ddb",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68285e0e-501e-009a-52b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-6a44b7c8-5ea9-77c3-dda1-d82e544713dd",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-23648e49519a2819fa14725a6a8d8c5d-bccfc5cff0e0af6a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a24a9800-4127-daab-7aeb-7c6354bbe818",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-77195734-cb07-f53a-dda8-5e4da7cddd32",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E5A6773E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a24a9800-4127-daab-7aeb-7c6354bbe818",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "16e891be-e01e-007b-4eb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-d049f223-92bf-1293-bc9d-3e4c8c543ef7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-6c107971809e56a5a3d648fc5bdb5978-5b0df097be2339cd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ff24124c-7ac0-88b4-9ea3-c64cfa88c5ec",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-4b01eb65-369a-4361-20db-66558c48a436",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E5A73A6D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ff24124c-7ac0-88b4-9ea3-c64cfa88c5ec",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "993d772a-d01e-0002-06b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-32a07e9e-47d5-84bb-d0ae-f85f193d1f14",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-99d3a37eb8d64ce359bd7b6070cac0d2-f3c54f09eee71b43-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4216157e-e897-cd57-7e87-6f302cae0c2e",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-23bf0c3b-bf59-6410-d931-4c4792baf8d1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E5A935F5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4216157e-e897-cd57-7e87-6f302cae0c2e",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "68285e54-501e-009a-11b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-74604fae-2d9a-3535-2331-ad0c1f76ea89",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-277d31939e588b8b03b9314e5bc14d52-887a220884f14988-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e4cd60af-8371-f855-2675-5e940250e1ef",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4/test-blob-b347b630-c7cb-fdb0-f6d5-572c65e46894",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "ETag": "\u00220x8DB71C7E5B457DD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e4cd60af-8371-f855-2675-5e940250e1ef",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "69fc9ae6-201e-0029-6db0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-62c2ffe6-2488-d7c0-9bff-b191fcdc52a4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7e916bcbf74d95dcfe48a4362b8829ff-69d74871821c7e38-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cb80e078-27e0-71bd-86c1-415c31b5d740",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb80e078-27e0-71bd-86c1-415c31b5d740",
+        "x-ms-request-id": "69fc9d19-201e-0029-6db0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1856739878",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,100,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,100,30).json
@@ -1,0 +1,992 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-a1e578592ef02417f16673abc13ed810-cd58fd19e302fcdf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "649c273d-96d1-393c-3c92-b7249c6c1f80",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2C446B1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "649c273d-96d1-393c-3c92-b7249c6c1f80",
+        "x-ms-request-id": "68284609-501e-009a-47b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-35ac0908-7dd7-2ce8-6e4f-eebb3f02e824",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-017680833f18a24cb3e7dfeda3fabbfa-e0d2d24c68aa5a9c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c4c27e80-c508-421c-a0a6-44070a1c43e0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "H8pFzetQUTM9bVx2APNTAEw5Xk6zYxtwDkZyFIE7LACqVDYwF2NrmbeQQqEmGo7tWE78sKyjxbyu1L6l3jyyAUBczKu9IunpzcWWIiB6SvS3hLwzP3xTB456gkKkxrt63kBgyg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ohwWfjzdY2wIdXrmjkYZ3Q==",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2CA2864\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c4c27e80-c508-421c-a0a6-44070a1c43e0",
+        "x-ms-content-crc64": "pUqJ0lALwgw=",
+        "x-ms-request-id": "6828463c-501e-009a-78b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-84bad657-740a-5e34-6aa4-9e44c8ee1047",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-351953f6c18b931162f988b40b200111-f7868a4d32d19d21-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "467b968e-1363-2cef-b4f1-f89d4b1a15ab",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "pD0fP7NuTCM0eA2YYXrcrT78EVw7Ec2WYrK2v/QNtAMa\u002B/BMIpGvPueqRt\u002BOsqOPwFxiN1yvhpNwidwAt40uJ8MKfmWJkIqtTdJ0kMrtB7APJ/6Yq32manVc25m0r4Zaex8bgw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "natboaMAopkRGCEIs78fww==",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2D0B71A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "467b968e-1363-2cef-b4f1-f89d4b1a15ab",
+        "x-ms-content-crc64": "phMNRExq34I=",
+        "x-ms-request-id": "6828467a-501e-009a-30b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-835db78e-3335-c034-3f70-f581a780fa3a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-8daadbff024818f8e79996992b8f4498-1a046ce203385659-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a5c83e28-1411-62e1-8e1f-9499c42ec5b0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ziK0wJhCzUIZ6d2KIKMIM\u002BDt2Pc/8F/0f4X/YZ4t0bFyaRAeakazKhqOlizVDzH5HTkIXpZvk97CwEASQmyj7BgsF7eT6smaOq3csFkzHnBTBkNlJHIaA9YxW6oFoOiu66kUqQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "6MCr4l7zc\u002BPcpJ\u002B7RMr8lg==",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2D71ECA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a5c83e28-1411-62e1-8e1f-9499c42ec5b0",
+        "x-ms-content-crc64": "oiJfL8Qluyk=",
+        "x-ms-request-id": "682846bf-501e-009a-71b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-c6cc92a9-9ab2-9375-d54e-ca33dea36480",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-73461dc67e85b4dee6f66ba5732779c1-e4fe2e21feeeefba-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9168e09c-3126-b350-785d-1ed22ef5c91e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "F91mO4C8CTqz/pUlV5NNh2tk8gBQ0NGZix5VD8DBnYfjp5Nwe/75FQKBUgcsKmkSsiU4zp/TRkcMza9iZ/l68mAOQbD/3Qxsatz\u002Bz37JbWC0Q12aic/nEGBMZK5Ol64JBmCnHg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zm7E1HYHINRxZW3pnpkZvA==",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2DD5F72\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9168e09c-3126-b350-785d-1ed22ef5c91e",
+        "x-ms-content-crc64": "M3YJCqBgw/8=",
+        "x-ms-request-id": "682846ee-501e-009a-1cb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-882da73f-64a5-23ef-a1f9-459a7eb2b6ea",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-baf203a50243299a3ac8d7b3f5f2162f-e9b2d03f428f7ba5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "95041ba5-2ff0-e246-f41d-ba40d0737a83",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "K1dS0/ivDTHc2xxi/ZGhJBmBMJ8DMFTwgg0adG0sr6OCJ9XXtNiV\u002BuImLqj1VxuMgMWAGRvSlvsCYVHqlJnDryt439a8yW9B7Da93QGs\u002ByryjfOnq5aIsJDZ1VKHq2VJYn58fA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "GnAaF1wSTPDMVNBXee\u002B1uw==",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2E3A019\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "95041ba5-2ff0-e246-f41d-ba40d0737a83",
+        "x-ms-content-crc64": "lVt27MYHd6I=",
+        "x-ms-request-id": "68284727-501e-009a-4bb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-369a64aa-4a21-f394-41c9-ade76900e19b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-5aae1c4486062efa40b931bcae711315-373734a9be57575c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c1c0bac2-9319-f3f0-d170-7dbd091cf1d2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "15cdLWsmXJO3J5C1tRzhLRG5G\u002Bgnjf18D\u002BbImUzLLwZ8G7lVLtnBOEc\u002BU0VLP1GCmcCf\u002BJbYcUmaoB6FXsJG6/iJOJpjjP44\u002BOOh6Dm3MM\u002BURQCMKzZwpKlvuo27O9mF92dNwQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "og5B0QHwRKHAOimaOIKFsg==",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2EA07C6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1c0bac2-9319-f3f0-d170-7dbd091cf1d2",
+        "x-ms-content-crc64": "0Gx/ykKN9bM=",
+        "x-ms-request-id": "68284758-501e-009a-7bb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-35ac0908-7dd7-2ce8-6e4f-eebb3f02e824",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fc8b2ceff8da8ee27be4f4c933fe0c77-f9f360f21440c27a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3cc2c14a-8ba7-73a8-c62b-3b50e943a91a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "ohwWfjzdY2wIdXrmjkYZ3Q==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2CA2864\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3cc2c14a-8ba7-73a8-c62b-3b50e943a91a",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68284793-501e-009a-32b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-84bad657-740a-5e34-6aa4-9e44c8ee1047",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e02e10932e6c9837e8b370eec5636f4c-231660a66ee73859-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d9fd4197-61d0-e3c1-1199-3a31fef61777",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "natboaMAopkRGCEIs78fww==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2D0B71A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d9fd4197-61d0-e3c1-1199-3a31fef61777",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e87f6a-e01e-007b-60b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-0042750c-7152-4494-a3a8-24b855da1422",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-2409f1f78ed39bbf040149c10c5e33ff-4e4c071149b6d1ae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "48721053-b459-de2b-c655-15fbb779daf3",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-35ac0908-7dd7-2ce8-6e4f-eebb3f02e824",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2F8F9BB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "48721053-b459-de2b-c655-15fbb779daf3",
+        "x-ms-content-crc64": "pUqJ0lALwgw=",
+        "x-ms-request-id": "682847bd-501e-009a-59b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-835db78e-3335-c034-3f70-f581a780fa3a",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1fbda699b5dd9d7ddd68d8dd406919b6-442c5cb7785e8a5a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "df29c1ba-a292-1ffb-7594-41a15fd35376",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "6MCr4l7zc\u002BPcpJ\u002B7RMr8lg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2D71ECA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "df29c1ba-a292-1ffb-7594-41a15fd35376",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e87fa5-e01e-007b-17b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-7a89e097-2d09-f45e-123a-46dbb707baa1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9afa9851c96c5effd85b3c5b6de0789a-cd0e7722df0dd641-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "75641f08-017b-b222-91a5-10c6e2b437d8",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-84bad657-740a-5e34-6aa4-9e44c8ee1047",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E301D209\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "75641f08-017b-b222-91a5-10c6e2b437d8",
+        "x-ms-content-crc64": "phMNRExq34I=",
+        "x-ms-request-id": "682847f4-501e-009a-0fb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-c6cc92a9-9ab2-9375-d54e-ca33dea36480",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-afe31362a8315c05263cd5071bc14866-57625e98e0ddeef7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e1770ac9-32c7-adeb-5b53-b98a85015661",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "zm7E1HYHINRxZW3pnpkZvA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2DD5F72\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e1770ac9-32c7-adeb-5b53-b98a85015661",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828483a-501e-009a-52b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-098ea918-b670-3897-d055-927826dc9d66",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-556a5deeae3457809f004ad4507c9c00-0760fdc5abd9e8f7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "200c7e29-588b-3846-d96b-f271370ec6d5",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-835db78e-3335-c034-3f70-f581a780fa3a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E307EBAC\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "200c7e29-588b-3846-d96b-f271370ec6d5",
+        "x-ms-content-crc64": "oiJfL8Qluyk=",
+        "x-ms-request-id": "16e87fd1-e01e-007b-41b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-882da73f-64a5-23ef-a1f9-459a7eb2b6ea",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-26e6f3770cceeb0f27721b9a716cbccc-c95fd359c6b6723e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "79eb26ef-2959-92c9-eafd-ce1e98ee10ce",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "GnAaF1wSTPDMVNBXee\u002B1uw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E2E3A019\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "79eb26ef-2959-92c9-eafd-ce1e98ee10ce",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e88001-e01e-007b-6eb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-89508ab5-6777-de92-174d-ed182ab88d9b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-720f9cbe2d42c1bd5a79ae04faee0106-d85c2cb67cd288ba-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2da70b9f-e597-410e-4ce1-eb7a2f13bd4d",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-c6cc92a9-9ab2-9375-d54e-ca33dea36480",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E31027D1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2da70b9f-e597-410e-4ce1-eb7a2f13bd4d",
+        "x-ms-content-crc64": "M3YJCqBgw/8=",
+        "x-ms-request-id": "6828485f-501e-009a-74b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-0042750c-7152-4494-a3a8-24b855da1422",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c5a4a9eca358992bc71e7ec96809d19b-f202ee18c1373f8f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "088a821d-4428-1bf4-444b-f20ae2c7adb1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E2F8F9BB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "ohwWfjzdY2wIdXrmjkYZ3Q==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "088a821d-4428-1bf4-444b-f20ae2c7adb1",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d6931-d01e-0002-15b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "H8pFzetQUTM9bVx2APNTAEw5Xk6zYxtwDkZyFIE7LACqVDYwF2NrmbeQQqEmGo7tWE78sKyjxbyu1L6l3jyyAUBczKu9IunpzcWWIiB6SvS3hLwzP3xTB456gkKkxrt63kBgyg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-369a64aa-4a21-f394-41c9-ade76900e19b",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-857bd5ed9f7d44f69d4f11051b636198-89f4b868d27f3aff-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "66ee189e-96c6-1d4d-8b2c-4dbd558bd31d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "og5B0QHwRKHAOimaOIKFsg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:31 GMT",
+        "ETag": "\u00220x8DB71C7E2EA07C6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "66ee189e-96c6-1d4d-8b2c-4dbd558bd31d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "682848c6-501e-009a-52b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-ac9f83ee-0b4c-e0b2-4850-aab39be6ce35",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-011668bcbb386d7744b5b2e5b762bd01-e2c1d1ae46348f6b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "16017c1c-0864-c6a6-8f91-95c9947f0c5d",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-882da73f-64a5-23ef-a1f9-459a7eb2b6ea",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E316DD99\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "16017c1c-0864-c6a6-8f91-95c9947f0c5d",
+        "x-ms-content-crc64": "lVt27MYHd6I=",
+        "x-ms-request-id": "16e8802a-e01e-007b-14b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-2d26e09c-31b7-b129-17af-f223c87f0d17",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9eae41c0f9f30783eee0f5cc21111861-71e58c7652874f31-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7c2bb911-a690-1e96-8d1d-27f0b745dca1",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-369a64aa-4a21-f394-41c9-ade76900e19b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E31EF2B5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7c2bb911-a690-1e96-8d1d-27f0b745dca1",
+        "x-ms-content-crc64": "0Gx/ykKN9bM=",
+        "x-ms-request-id": "16e8805c-e01e-007b-44b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-7a89e097-2d09-f45e-123a-46dbb707baa1",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2f405faa162abd252cebbed96970212f-e805a2c3740dbbaa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9babbc56-5760-4a8d-5f23-3310d1cc5f32",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E301D209\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "natboaMAopkRGCEIs78fww==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9babbc56-5760-4a8d-5f23-3310d1cc5f32",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e880b6-e01e-007b-13b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "pD0fP7NuTCM0eA2YYXrcrT78EVw7Ec2WYrK2v/QNtAMa\u002B/BMIpGvPueqRt\u002BOsqOPwFxiN1yvhpNwidwAt40uJ8MKfmWJkIqtTdJ0kMrtB7APJ/6Yq32manVc25m0r4Zaex8bgw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-098ea918-b670-3897-d055-927826dc9d66",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6803a0975709e8721813b3cde1a47d48-e53e080e8319f581-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fa99169c-419a-f641-c0f0-9a998a9bd38e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E307EBAC\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "6MCr4l7zc\u002BPcpJ\u002B7RMr8lg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fa99169c-419a-f641-c0f0-9a998a9bd38e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8813f-e01e-007b-16b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "ziK0wJhCzUIZ6d2KIKMIM\u002BDt2Pc/8F/0f4X/YZ4t0bFyaRAeakazKhqOlizVDzH5HTkIXpZvk97CwEASQmyj7BgsF7eT6smaOq3csFkzHnBTBkNlJHIaA9YxW6oFoOiu66kUqQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-89508ab5-6777-de92-174d-ed182ab88d9b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a24e65f9f9b85060693187632a36b621-0189875ddbb63ce0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ba74b1b1-6533-b098-06fd-8d4f403bc971",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E31027D1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "zm7E1HYHINRxZW3pnpkZvA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ba74b1b1-6533-b098-06fd-8d4f403bc971",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e881e7-e01e-007b-34b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "F91mO4C8CTqz/pUlV5NNh2tk8gBQ0NGZix5VD8DBnYfjp5Nwe/75FQKBUgcsKmkSsiU4zp/TRkcMza9iZ/l68mAOQbD/3Qxsatz\u002Bz37JbWC0Q12aic/nEGBMZK5Ol64JBmCnHg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-ac9f83ee-0b4c-e0b2-4850-aab39be6ce35",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-76fedc97d7b2f394302c66f00dafe5ae-9f39ddaa0c75e389-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d8e7d95e-1827-125b-2256-5e19a5813bab",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E316DD99\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "GnAaF1wSTPDMVNBXee\u002B1uw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d8e7d95e-1827-125b-2256-5e19a5813bab",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e882ac-e01e-007b-6ab0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "K1dS0/ivDTHc2xxi/ZGhJBmBMJ8DMFTwgg0adG0sr6OCJ9XXtNiV\u002BuImLqj1VxuMgMWAGRvSlvsCYVHqlJnDryt439a8yW9B7Da93QGs\u002ByryjfOnq5aIsJDZ1VKHq2VJYn58fA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905/test-blob-2d26e09c-31b7-b129-17af-f223c87f0d17",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6c94443a08ae11e4acda245477d941ca-9bbdba54145ce3f4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "66f1a13c-f053-9a4a-372f-db41ae50c4c4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "ETag": "\u00220x8DB71C7E31EF2B5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "og5B0QHwRKHAOimaOIKFsg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "66f1a13c-f053-9a4a-372f-db41ae50c4c4",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8833f-e01e-007b-70b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "15cdLWsmXJO3J5C1tRzhLRG5G\u002Bgnjf18D\u002BbImUzLLwZ8G7lVLtnBOEc\u002BU0VLP1GCmcCf\u002BJbYcUmaoB6FXsJG6/iJOJpjjP44\u002BOOh6Dm3MM\u002BURQCMKzZwpKlvuo27O9mF92dNwQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-a2fd82ac-7769-7567-06c0-e2f8aca7d905?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8b5f292263bee39ec12e413d226de41b-7cd73f3bb8c0bff3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "03ddbf58-d590-9e57-d38b-6b62b7e6f6f6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "03ddbf58-d590-9e57-d38b-6b62b7e6f6f6",
+        "x-ms-request-id": "16e88369-e01e-007b-16b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1085331878",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,100,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,100,30)Async.json
@@ -1,0 +1,992 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1bd54f65a60fe4e06e768d7308bcc6e6-e7802bf3c728a96f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "78a1fb5a-bbfe-cac5-2fae-dd6d33e6defd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E673101E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "78a1fb5a-bbfe-cac5-2fae-dd6d33e6defd",
+        "x-ms-request-id": "64d67e48-401e-00a9-5db0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-8e1316a2-e2fc-da81-9170-c70dd1386164",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-303198a84c0480a7383decb9f91d20b8-fd903215a3ba5ce8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "53cc0b48-37e0-6fd5-b9a3-22f75d9eadaa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2PkLKXkFEwKXDgWCeHxsCUKKG0ku/JmhzMDAxz4meE8P0vSJ6D4lgXsi4WDeAbFDw4eCNXnTAdtgal24REzDcZa2c6aH4iEEZZrNCxs4w8oPfQO3pEPWPNEYKX7hbTwvXnDKJw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "vX6AT5rPO\u002BT0akXr3z/Msw==",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E67C4587\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "53cc0b48-37e0-6fd5-b9a3-22f75d9eadaa",
+        "x-ms-content-crc64": "prigSKgxukY=",
+        "x-ms-request-id": "64d67e9a-401e-00a9-24b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-76bad875-3331-be40-c0f1-0cfdf9cd8cd1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-6334f9d98b68f923bea79e51ef43c0f5-50f79d6547880b33-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5f72670d-bf08-a65b-2677-9c42a2300ba2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ZdZvANwUd/bBCV34jpI/i5pD9tsepjGCFYdI3pZvIFLoI9VeAPSqjyK5KwZmvuJDUp6OmE\u002BZFL\u002Bk7OtUzJlfUugLD2u94IulmWa4ZXsqHFelBIv44IgDTw8WuRMJVsOIWdgeWw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "c31ijhc02SdPX\u002BQjWhh1aQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E682AD33\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5f72670d-bf08-a65b-2677-9c42a2300ba2",
+        "x-ms-content-crc64": "tVQrsw5ZSNM=",
+        "x-ms-request-id": "64d67ec7-401e-00a9-4eb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-c3b59abe-0410-7769-7ac7-e78ef3b7f9f6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-1721e49936cb3a318a81bb419d556891-b20385f866cadbb6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "619220ff-5a08-3dc0-8b2c-8ac418cdf8e6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "P6AUAZ529C6qT2cJF/ORa\u002BOFrDTFMs2zkVS3B2M2HN1KEOBsT2SGqarM3xW3mBx7GbhVSV3lygzTYHBKv\u002B3KczOJvwYSJBt\u002B/wKK\u002BVK4/Pk3PO2q4dKAZEbUme/0O\u002Bq8AWzhLg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "GHozVoH/\u002BF3y5ZO58EvjMw==",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6898A10\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "619220ff-5a08-3dc0-8b2c-8ac418cdf8e6",
+        "x-ms-content-crc64": "y\u002Brqv2f4xf8=",
+        "x-ms-request-id": "64d67ef2-401e-00a9-76b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-5bf8784c-682b-6ecb-d555-ce0ad684e0c3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-88f32301a350e42b0b137fa775fb7b16-440368dccc0b1e39-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f4402d03-86ce-db9c-a69d-3845686fdbdc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "rtzSrudl\u002BVtJurFkdcCgMM5/GVP/2oBOBHIPrjtYiM9EV1wqix9Xg5chdws7iT5nZ0mnSbyq1tNcg6p0Vkof8TLhIB5jdaWuKJW83WJ0E3o0qEfysD4SmYGIzgd14i1MAobZWg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "mNbel0Hc7ftrBS9\u002BrbVR\u002Bg==",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E69018C6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f4402d03-86ce-db9c-a69d-3845686fdbdc",
+        "x-ms-content-crc64": "epNuPEZK2Js=",
+        "x-ms-request-id": "64d67f1d-401e-00a9-1fb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-374ff6e3-9d82-7054-6e42-fb694cb2ca08",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-356ef604c39b1afb44f4caa659232d15-ffd387a0659e7677-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e29dce0f-fa3b-ee4c-97ce-6ab6421cdbf6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "qUIkJ8osc40Q16eDJSIafEkpClfVU4MDVTbc6vRfLXrzWcUgZ9gDC2HJBifvBsx3cChMZole2VW/INGUT4iZsKksj8td\u002BRVxJv71C01bFE9pZXnLE8fxlX9vYUYGb7zZL1Z9ww==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "X7AKzHNu/dU4ysEWn\u002BkdJw==",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E69CC118\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e29dce0f-fa3b-ee4c-97ce-6ab6421cdbf6",
+        "x-ms-content-crc64": "fRysEr6MvMU=",
+        "x-ms-request-id": "64d67f7d-401e-00a9-79b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-80b115f8-31d4-55a5-ce47-eeba365fa1f6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "100",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-c1caa88caccb695c877bba49ddf98079-26b9d61405886495-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ecc003db-88be-be29-4d7b-1aaf0696e838",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3DMgFgntPJYu6wQUrZ1728I65UXoRYA1ipB5stGnst/\u002BwztwJZmCKZxiSug\u002B355tBQ/gZXlwA5ez6ot5dInFhzkkFuliCrYouLuphfuY96vyDK3Cx0xljcCjvToOCLQTncOuGg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "wGbrcFXkMUDGkpNYupHx5Q==",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6A39DE2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ecc003db-88be-be29-4d7b-1aaf0696e838",
+        "x-ms-content-crc64": "6npyi2Zehfg=",
+        "x-ms-request-id": "64d67f9b-401e-00a9-15b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-8e1316a2-e2fc-da81-9170-c70dd1386164",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dcd709fb0b63b86a0938cede14f4224c-da5c104ebe96ed2a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9a374c81-c203-405b-8a4d-acdd9dfeb731",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "vX6AT5rPO\u002BT0akXr3z/Msw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E67C4587\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9a374c81-c203-405b-8a4d-acdd9dfeb731",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d67fc2-401e-00a9-3cb0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-76bad875-3331-be40-c0f1-0cfdf9cd8cd1",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2f08ef06babcf475d47a17fe64119ef3-447dc444a47ac926-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ba2dec34-4e5e-2634-80a2-b2b3078b72a0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "c31ijhc02SdPX\u002BQjWhh1aQ==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E682AD33\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ba2dec34-4e5e-2634-80a2-b2b3078b72a0",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fca0cb-201e-0029-3fb0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-c3b59abe-0410-7769-7ac7-e78ef3b7f9f6",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-987358a6fbb23ceee553c30583450412-dff9b6ef97dc5904-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b1a90196-fcd0-45d2-2f0a-965a96b4210d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "GHozVoH/\u002BF3y5ZO58EvjMw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6898A10\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b1a90196-fcd0-45d2-2f0a-965a96b4210d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68286736-501e-009a-52b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-5bf8784c-682b-6ecb-d555-ce0ad684e0c3",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2d6fdf57adc16fca4c0ffc447945de14-ec3247f3a46fca04-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "88355959-1b96-7d2a-db33-6acd9fd26ae3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "mNbel0Hc7ftrBS9\u002BrbVR\u002Bg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E69018C6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "88355959-1b96-7d2a-db33-6acd9fd26ae3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d7ddf-d01e-0002-23b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-fcaa23e6-c168-ae73-2488-ede96c622123",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-ab8547fa50608c03e47e82f51253b782-3edec4f74c16494c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "061d0d25-c1e2-f3d0-c269-736799d7a130",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-8e1316a2-e2fc-da81-9170-c70dd1386164",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6B43D41\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "061d0d25-c1e2-f3d0-c269-736799d7a130",
+        "x-ms-content-crc64": "prigSKgxukY=",
+        "x-ms-request-id": "64d67fe6-401e-00a9-5fb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-374ff6e3-9d82-7054-6e42-fb694cb2ca08",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-eb0c20693a304031668dffe52e569b70-5fd29a6f22a5ed0e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "785b2a67-2ac4-3a41-0c8e-9339f935eefe",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "X7AKzHNu/dU4ysEWn\u002BkdJw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E69CC118\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "785b2a67-2ac4-3a41-0c8e-9339f935eefe",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e89980-e01e-007b-56b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-c111c68a-5fd3-b2ef-51f9-693baf993a0f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-2f92d559021237549bca800ce419f87a-dc85fb21db7025db-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3f0e2771-19a2-d299-c795-ede9e5a0e3f4",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-76bad875-3331-be40-c0f1-0cfdf9cd8cd1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6B8F786\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3f0e2771-19a2-d299-c795-ede9e5a0e3f4",
+        "x-ms-content-crc64": "tVQrsw5ZSNM=",
+        "x-ms-request-id": "69fca0e6-201e-0029-56b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-298305a1-cd07-379f-a102-5c4c43bce86b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-21d6aa0fef1b35c011365c3a31e62a15-9f8641c971bd4514-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "bb8206e2-6b45-0e30-d14c-749107447805",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-c3b59abe-0410-7769-7ac7-e78ef3b7f9f6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6B94593\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bb8206e2-6b45-0e30-d14c-749107447805",
+        "x-ms-content-crc64": "y\u002Brqv2f4xf8=",
+        "x-ms-request-id": "6828675d-501e-009a-77b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-80b115f8-31d4-55a5-ce47-eeba365fa1f6",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8a86ca43ec2af80b9a5b7c5b21044073-123b8c9bc94e45bc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f256b898-33b3-4bb8-19f5-e620d68dce64",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-MD5": "wGbrcFXkMUDGkpNYupHx5Q==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6A39DE2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f256b898-33b3-4bb8-19f5-e620d68dce64",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d7e10-d01e-0002-51b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-6f30ca25-df4d-8623-33f8-ab6f5838fe8b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-b2e3618323fe605e1e3baf8b26fc42ef-cd9e59da2267a201-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4ff90542-85ee-3d52-31fa-78f21459447e",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-5bf8784c-682b-6ecb-d555-ce0ad684e0c3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:37 GMT",
+        "ETag": "\u00220x8DB71C7E6BCEE89\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4ff90542-85ee-3d52-31fa-78f21459447e",
+        "x-ms-content-crc64": "epNuPEZK2Js=",
+        "x-ms-request-id": "64d6802e-401e-00a9-21b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-6647de4e-f8de-bc1c-26da-1fd003a36e94",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-2dfb77ebc03cda11a68727492544b75d-f97d641062b3bb68-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d1de150c-7f93-9e75-ac92-135deb00d334",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-374ff6e3-9d82-7054-6e42-fb694cb2ca08",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6BF863C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d1de150c-7f93-9e75-ac92-135deb00d334",
+        "x-ms-content-crc64": "fRysEr6MvMU=",
+        "x-ms-request-id": "16e899b1-e01e-007b-7fb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-e516fd10-ca69-c2c1-e2fc-f50f2230de69",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-663aa30549e2afb2d4110a2591411b5b-33dac038f77f42e5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fee5674b-737a-36ea-f466-799db1ba48c4",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-80b115f8-31d4-55a5-ce47-eeba365fa1f6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6C2BA19\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fee5674b-737a-36ea-f466-799db1ba48c4",
+        "x-ms-content-crc64": "6npyi2Zehfg=",
+        "x-ms-request-id": "993d7e40-d01e-0002-7fb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-fcaa23e6-c168-ae73-2488-ede96c622123",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8bf2fe2fd92f5476c4912660272a4f2a-1a29c0105ec1497e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8411dad8-d41b-adb9-46d2-3c9d4704cb33",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6B43D41\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "vX6AT5rPO\u002BT0akXr3z/Msw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "8411dad8-d41b-adb9-46d2-3c9d4704cb33",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfc6a-a01e-0055-6eb0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "2PkLKXkFEwKXDgWCeHxsCUKKG0ku/JmhzMDAxz4meE8P0vSJ6D4lgXsi4WDeAbFDw4eCNXnTAdtgal24REzDcZa2c6aH4iEEZZrNCxs4w8oPfQO3pEPWPNEYKX7hbTwvXnDKJw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-c111c68a-5fd3-b2ef-51f9-693baf993a0f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-efdeca247d44452f5aae2e1b1a64878c-6c75d6da0acb92f3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d7c4d1e8-c3a8-c5a9-787e-0c1b4070026f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6B8F786\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "c31ijhc02SdPX\u002BQjWhh1aQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d7c4d1e8-c3a8-c5a9-787e-0c1b4070026f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfcc9-a01e-0055-3cb0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "ZdZvANwUd/bBCV34jpI/i5pD9tsepjGCFYdI3pZvIFLoI9VeAPSqjyK5KwZmvuJDUp6OmE\u002BZFL\u002Bk7OtUzJlfUugLD2u94IulmWa4ZXsqHFelBIv44IgDTw8WuRMJVsOIWdgeWw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-298305a1-cd07-379f-a102-5c4c43bce86b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3c1a7aed110bfb28b3422a1cedc9d85d-82c8bded37dc0ab7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76b43d91-f43f-b88a-1c21-755a5a2e8de9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6B94593\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "GHozVoH/\u002BF3y5ZO58EvjMw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "76b43d91-f43f-b88a-1c21-755a5a2e8de9",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfd20-a01e-0055-09b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "P6AUAZ529C6qT2cJF/ORa\u002BOFrDTFMs2zkVS3B2M2HN1KEOBsT2SGqarM3xW3mBx7GbhVSV3lygzTYHBKv\u002B3KczOJvwYSJBt\u002B/wKK\u002BVK4/Pk3PO2q4dKAZEbUme/0O\u002Bq8AWzhLg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-6f30ca25-df4d-8623-33f8-ab6f5838fe8b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e313b137669354cadc2ce75084d4c253-6cf1346f744d1671-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "038ae261-8cbb-a02f-2498-13ed1a751661",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6BCEE89\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "mNbel0Hc7ftrBS9\u002BrbVR\u002Bg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "038ae261-8cbb-a02f-2498-13ed1a751661",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfd6d-a01e-0055-4bb0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "rtzSrudl\u002BVtJurFkdcCgMM5/GVP/2oBOBHIPrjtYiM9EV1wqix9Xg5chdws7iT5nZ0mnSbyq1tNcg6p0Vkof8TLhIB5jdaWuKJW83WJ0E3o0qEfysD4SmYGIzgd14i1MAobZWg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-6647de4e-f8de-bc1c-26da-1fd003a36e94",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9736470e1c912244d699b2e18af3485c-4550301337b5f8be-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "78f89ba5-8aa4-0a2d-ece4-bb32fd033d8d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "ETag": "\u00220x8DB71C7E6BF863C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "X7AKzHNu/dU4ysEWn\u002BkdJw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "78f89ba5-8aa4-0a2d-ece4-bb32fd033d8d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfdcd-a01e-0055-21b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "qUIkJ8osc40Q16eDJSIafEkpClfVU4MDVTbc6vRfLXrzWcUgZ9gDC2HJBifvBsx3cChMZole2VW/INGUT4iZsKksj8td\u002BRVxJv71C01bFE9pZXnLE8fxlX9vYUYGb7zZL1Z9ww=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f/test-blob-e516fd10-ca69-c2c1-e2fc-f50f2230de69",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-97deac46c443ae34c07a464674407c57-b2e18052bf27a6f1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7f482078-9d7c-2cbd-14dd-4035802d8248",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-range": "bytes=0-99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "100",
+        "Content-Range": "bytes 0-99/100",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E6C2BA19\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "wGbrcFXkMUDGkpNYupHx5Q==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7f482078-9d7c-2cbd-14dd-4035802d8248",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:38 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146bfe1c-a01e-0055-64b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3DMgFgntPJYu6wQUrZ1728I65UXoRYA1ipB5stGnst/\u002BwztwJZmCKZxiSug\u002B355tBQ/gZXlwA5ez6ot5dInFhzkkFuliCrYouLuphfuY96vyDK3Cx0xljcCjvToOCLQTncOuGg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7f31ccb2-68ab-3b90-8808-3e1471d2ab3f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-828da4a42022bebaf82ac5138fb0b09b-9c4d07bd25805b27-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ddb9bdf0-bebb-9f10-2881-41630d89a455",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ddb9bdf0-bebb-9f10-2881-41630d89a455",
+        "x-ms-request-id": "146bfe42-a01e-0055-03b0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1576766397",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,1024,300).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,1024,300).json
@@ -1,0 +1,992 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-574d55b9a02216c3ae1618798619ec44-6f4e818c87fdab8b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c9837029-f6cc-834f-a40c-cc94897ecc54",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3F2AF28\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c9837029-f6cc-834f-a40c-cc94897ecc54",
+        "x-ms-request-id": "68284f7b-501e-009a-28b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-04559924-9fe4-916d-705c-5e61f945b816",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-39efb7747ac3b04a1c8d84928ef1267a-15e62dbcf959c773-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c3929662-21ba-8a32-3e08-32673c5d73a3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "y1I8pCxRRAa\u002B\u002BQZQKVjZHy5oNkMtZ1B6lwrVnVq3\u002B/9WBJpDOzPEJP/cvUAQpTtxU9uTPyzVjmQBwQwie6esB/4H\u002BSS9luP7pBFEUakPafLPZEl\u002BI7vSgXY2QXkmoalYMLZCCasWs733mJsakT268VcaUxZdLeNDNHiuhlRp1AJo7CHzzWBGuLCMh4sguPA4e1AiC06T\u002BgLT/9QyaCxojsOYsaUbxyP305tl0KZXInuIdQoER8i01fEeH86LFFCEJPjHhwZLHbQsKjeyLSpce9xZqvIhZEb65Nyz/KhVa79K4aytkJp0PVhW1xyRAafGwqPxMmpdYsCyzKMqlyAM1754aEx9rutB5Gyay4wqaeI07DoEYzlV7X/s\u002B8P3SqY3SgBdGJlbSRO3sE79w5Y0h2LA9armB3OFInrNkbMoSpnGYoGLzFFJ2aMmTLPrWCnouHNgNlT8UUKN2PYejrhgj2W0N2AVqLsRdxwGv7vAmspQ5NhAxxNEyhE\u002B/fRaKkrrxr1NNiHJ0g\u002B3Tr849ZGHzT0szanfH8dSb2xP16rHt0zRGvn9cmOphxLJiHlTDNR/tzC2Ll2gDKb2\u002B8a0evpk8JdzZtqXiVragkaXFpdO/2OYzyB6EYjuMQ5TB3ed9AwXZJjh36X56C3V26sXCfYOp/tiG6va6t4PhDXMRILjPY45f7H/bB\u002B\u002BnubypDXc1ycYRF97OthhPXq50ltvLaOr8Z4d3YlEDzvcpH3E50WpMqwOswAiaAO110I3RZrETnBDR7KWvvqd0zQkn5VbnVU0EJ\u002BuYXmjiYmbaAZHDcqgGFUMgKCSEnSycODL/chtWTrtAzX7Fe33n74o\u002Blb0VsZqg4dATxy1of0r/PGZ2IvALg7LWgmUpQJoFeHhaRcdvhoZYHpBLQoeOGE30Bn8XcczZ8xHKPy81t2E1zo70zflDT3Xf3gQfwAErSKoXNXobLcZrgFK1ZUdXYqcvFXP42QqUsLcJN1PIujLQ3vaFHkIm2uCISQ1mjenuSLudMOrNMm9fQoSDEfZyowZf5IaQ0kQlCDpTcJA9LeLNGu7YK4lIA6xHJZu9Y8kqFaYHBukjXXY3d\u002BiwecHfYlTh9jbHmnd9F6EaCayop6RxaRrp9ib5qb14oPOgl8nqp8NG262SYrsuie9ICVOJjtAEfxCnNWwuKAx5TvmDnH/XL2HpYYw2nwZfuyw3saBprxHjnFj5A7JXGLOhWNPBqu2vcNnx4C0EDZ/KB3o/9nZrz5/noD/nHevvUgkYVUYyndA\u002BSACGt88k34747zw4F2J9NUkz2grtyFMtwo3kK7gZ12lpwW515VfQgsCw7i7vtzrmm2A9PoPFUL\u002BtmLVBALPW3xeSzhXzw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ku9RxWzSIAyRy6/Cco29Qw==",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3F90626\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c3929662-21ba-8a32-3e08-32673c5d73a3",
+        "x-ms-content-crc64": "mE8LQlIwzqA=",
+        "x-ms-request-id": "68284faf-501e-009a-59b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-46731bb6-a6b7-2e0f-e666-7730493bc506",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-25d90002cd1d1443eb9f078f56790647-4ce6570ad2e7a091-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0fa0e834-ee8b-2de7-9991-993fface72bf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "YlixkVMaukoBFWYmt8eye\u002BYl6z8yJzO4LEzw/FXcv4/sdftMyfoLVoIwTT1cIOY/X358A6CyCzol\u002BGUGKr30JFXXOULLZrLsGZW9Atn2XAxmsJ3XYLzuOmrBJ9CVBSvEOynnheajc/jMkOkL9QhgLpxYoHogHcSZ6P/YCj/hVhRp\u002BcewD9clwj2kC8/S40VhYPg0PGSxpB5lTZzny2m56jnUofxBrx/FM908exH0xgW6d6lGrRmvt1SoS8E6PffU6yCW/kFIILHZbwiHdCgMcIaXLFS/cj0fJOmnmGRdivXmaI/xXsjDcVb4bT4RKEMrnNo7oxGjFHnjdtlYoYdMe\u002BQSoAyZGxK91Lr9xwT\u002BDvyme/uJIufkQ1QWDejva9DOq/JZ/oc3koHIfc9WpU105GfcsSaMw1n9Ll23gg0qzmnqLhsSpRB0b\u002Bh6waQYjZ0GoiiAErmpQuiYW9Apfw9zna9lbHcyYj9XaEI9EQK05aDAseDkqbuvQOszeUlASvDZBiP1siEm1D/pKap3bDHl5HYvac0ujvTztiuL/uj1Fx1RZArfvzN/mdyg\u002BoARN9O6TZXTEOAiqncvAvv1m9VX9BGMJQgmBiRCsNDxjpNz4X9Y0LFTIgY8L7mSr704iv4GSQZuhRHLlEZwkGAQMBvkuyB8nMokBNELT/ZOk1ZnCiXR6kSNBFxtjTxq4pGmK/6drvScvO004kU0YzUbfAHwCYY6P0bXVrfEDg\u002BOuiFAZCP3sORiy044nQj/WKEnURA7etkLa\u002By3xlg9163dpicj9P4RJMscjT04AqE\u002B1/4Wnb3/U0BINfk3P\u002BqMJfOhW/fg22SiFS1FHuyb02lKee5aJzrv3lPm278F2uThkGdKl6eqXvyZc4ePuTRTrGKP7Mb7Mf64sXyk\u002Bf\u002BlnDtIY42FUDvCoBvywLOyYCQeky9cde4e5l9pkeUqBmT89NdMR1WnzlsmzUyrCHFLBlFYhWbQSCZNKX0uHL9Vl5m29szbZRjOdsTTNqehc93tHYuU0oD9K6uw/x3YebKc0Day9BGlb6A4iQ\u002Bi/RJ\u002Bq7agQP40wMUYuMsgK2b79vwRN2Zx737LSK7qXEhxWy6ZMVRnNzm0aA9xmTtGhEQ6PZISkMWrDbs31PhPSWR8p1ydhvkSlL7DXc9WAFVChcNpsB\u002B2Xsto7SSYL2NBZB6q9fHfqf1LKKnUTzL2VQ1m9E405ZhExkmQNZnUeWRagviwqwtjY9zFHoh24Q6ZcZgWMTsVDH6FZS6oTnRkdq5Eec05RqkCApFybscQzuQ798MAvkcpRXV6KkXcuxRoYajaMWhAXyvuFC6po563dZdKbFewY7hmGzRYvxtjJUd8CQweNZx7\u002BpeYEQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "h59GBFcy3R9Jqpg5mSLsFw==",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E40009FE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0fa0e834-ee8b-2de7-9991-993fface72bf",
+        "x-ms-content-crc64": "TZ12qlv8kbU=",
+        "x-ms-request-id": "68284fe4-501e-009a-0bb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-30d05225-8e71-89f0-02f1-596f97ee895f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-a993cfa97384a6dfc4d387508fb81e6d-f76e87753506d9dd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a330325d-7061-3661-05a5-bb11bfbdcf94",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vuGOysdaDw\u002B0H6Uu0/Isp3\u002BYoZiAvN4qY\u002BYp4Y\u002B\u002BRLOs0NurGypDnRePqewyKdcmzAh6C0UITwIDY2bgMC5/9tvygQMXgYtUVQSB8RLy\u002BDoPAxWHRDhuo4DZqLjEY2zpELMQQKfTD0t9JbVAh17vEGss0CwZ\u002BLGig92DPdjTkPGXl\u002BFf4biSO/PJCR6DLRwi6ZdNl5JA0BgBbrzJUNFyqpXEqPB9kC6ympU5T\u002B6SH1XBYFNAhvhfV8fJXXP8yOoiV1\u002BJvoUspVlpmvz9BoEpb09mCO99MSSdZFEpszK7tdKqFveOCWDQlbv61\u002Bv7YlBFn\u002B4jlr/6pCY77FozA/EnreQqUvCJm2bvlXM0g1k4oQIA4xRElx8Sr3LRUx0GnZLK0ioG0Q9gvASINABMxiHMAkpYMx/c4hXEF6N9t0dI6fjhabAvMdDyoCYQvGMfxuhRBVDSrWpy7u8UQbls4wW8P0sIal1wnNB6ZZL5zCaypVG6LLL3djuOb3vAG/AWhb0hU3wXFluK4Gh/V0fXeCHJYptosbZTxMgQefvir4HgZODV13ipmo/1L0tJdx/zt/ZZ97lUrtMGzo60B5xfqDHnn/NnAaGpH8cMcoJrCU2pHcIFibjIjLUMzwnp9ZPylYcZYdgsi7VUsNjxRztRmsRBC\u002BraWh94HhM9WzGYvyk0Gtz6Uad0fJEMsNjg1kR5ujREp\u002BqoGDtooUPF7i\u002BDvPCuvS1fV0gczI5YzalGmEjOw6H8Uxc/iwKgkrBkr41hifToMRkXGmPsJ9tbUEqSIQj69iuOh2jYbjIqvsSYuB0A9kS1Xmcvt6k9ECw84zu3DXCoabhi0wGLD8Lm7VueVG\u002B9W1kG3cOhyz\u002BCUHY8nIr3crFT705knSNCKU6kSMpNn7y9f4jhsDCtB5154IOLT3M473qqS2QgWL02xLN0/IN1NLG5fx0CFcGApuiw672gttrbbFhPo1NYnCbLq\u002Bx8OAoaA6vR0c9VNdq4KaR7cGwAlQ7YmJAqJZFdYeL2N2nVBG7elugRzuUKhTZ\u002Bl3mv3Cu5yxXeo595794adHDtX/5w4iU2ndqE7scozhNarI4XrYS3PWxT92DOZKYJ9lp0HSY3DbRUeD9RNNxOtdWMHkNQA8brNSKSHerEaDgzevdttLDsI57ZwjVEZgiPBUKLQkZjufOTiecEpPDJkBAHHbrk4AEkn/uldkCRps8aAxeoOCXy0MEE2irI6H\u002BtDzIkPUhNqyRBZqJKvkKyAuIY6aHYIVfqFUz54AbWXLd892cObWmHzFjyZtKDpxJ\u002BUtdIsP7e1O3aOSf8VMseawnrzsbbpJV4kR1I5rqFZ246eo4ujqy4niJ5MzNCi3eN1PvImNlLog==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Ueut0ZbT7MyC7rDlcKuErA==",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E40671AA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a330325d-7061-3661-05a5-bb11bfbdcf94",
+        "x-ms-content-crc64": "LPCcg8b21A4=",
+        "x-ms-request-id": "68285033-501e-009a-53b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-6edeb553-850b-7e9c-8a26-1e7e283d4835",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-4143ac54632dea2968d60f0981804107-341e812eec77b512-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6e97a199-8fa0-6006-45a3-ac39a7fb83c4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\u002BG/m/ie2Rz3gaWlikSPKeDMXY3098mC0z21DnIQt5kg3HjKjcUAPOS/wmoq3Zraz2IfhUPH6uwUOMS65c6u4s4IhKnLwJgbzBylOTFjV/Wm3j8P9S5ZXPWMtlEARVcaEOOYIljtDwrGB7kjHrG\u002BsODTEAuPnu2jrye0Pw5HF4bFjyRRxzGctc80SfF1Oj5HzgFsLTFPinXx\u002BHcxOM/4fuwyWZOJaO2zNl44W1D4KnTlbG0M2uZVegCyX86\u002Ba3j/O8sFRuCuvmUXvPrXFzMg\u002Bc4CS8he76QF2OOO1w0i8MrhOSOJ9ueUOrIL\u002BRnvfmLRkWX8vCOwnEgi/2n9I\u002BdX9Mwv9d4PmwLmbhEaUvaOFl58vUWrIjSrMJjXZvd9lxrKtARNv4iEwfpjFlISmklVlOkPgGKhrNKbhMFBODALaNb6T57yQFbR\u002B/9LRAvilJZPgdIOcha0JQcxtjrHQ4nGW617GEquZ1CSOYhjWmjKtOwu9bZd/PrAQiaXvI4cCrR1gOhaa3xLoR59eDSKUM6eZv1KmE3TZF6yttYkFqbGci7T7dV8bE1z41CX4IDGNe1X\u002BVWM1XJmohiNq7CqJ4p7twoFumb5Ifqz1rj9O4fZ7HzkzB1NNZy8bUu47sScybvKHCl6vH\u002BKWtte3P61aWaUt7szwVdtKn1tSUkbQDMyFwz9Nx9aYzABWnFB7lieBwfhIDsNaQRgWPGsCXM2cxqkLMnxtDZLPlCHMmbiKzwkz0JFNiP4IKoEnNoprlW8yutamb2SrE7RmeXqijqhfi21hz4w8Tz6rAwf6RtYHY/6xmd/i41\u002BliL3c5g6DZpvZx6sdCcbj9muY\u002B2xcsczdXxV78PXIfacNvEfOX2gvJ5xrIH8r6Vo4zqJ0SujySNbw/4f4CHamEUkDEEx/FJcCaNPQ8JBNsnW7QyJSVDO/GnRw3mDgNh8lxQ81KNkNubkLceEVIldGo0wRPcRUVL0WRPXYDjY3IjGzqiuBF4qbropoRuJRqfgcKTsTzvla0XBSH\u002BPkNKqC1E\u002BwYngsxYvCdY866w3axZr8vOX7I1M4WNi7Lvimt3ng5nKSoUeA8GSvUFhqIOZid1pJ53jFh7D8dwmfcZaTHL4VWgSbRyNTfMyATNP6zjjyWLeeXdABG17Blik\u002B4X7NGzSaVMXhxy829WqrRDvdAqnQrRjf9b/uEz\u002Bl2bH5FZtNsjCfX3lyEJGHZ2dlVtYj5JSAbTNm7iZ0rEGGO\u002B1\u002BPODPXpEKPaIwXZyHV41XiL1ogvQceadn58MKKrI37NSjCCqGlfhEGKbxTw\u002BX3paYHSOEHrn4YcM5Z3bNABPv\u002BHHH5E5j0PLEI2lOKymX0AgscQyPs84bqqdnTS6Bdw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "8Y4gsjrrhAoTQEekwx95Sg==",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E40FBF2A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6e97a199-8fa0-6006-45a3-ac39a7fb83c4",
+        "x-ms-content-crc64": "kvUxRvcm/MA=",
+        "x-ms-request-id": "68285075-501e-009a-14b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-a73b5896-8875-27a5-2be9-43c54d9f97f7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-cb32fd7046511ba3a4da2308da634fc7-aa01524e204729e1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5cf062f2-ea1f-8d79-5af4-333cfafda480",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "5RoRyt8AUY9vWx9OEYd5IpQ4z6WbK2wbdUqoXuyPI52Nl991NuBYjw4ccc2WPv/yvGExvr6eUrmt9VWVV/Ki4DeCwHmnA\u002By030CWfrmehTZKtaKLXWXe70Umx0GLwzcceZGVFH2GSrh1fN5\u002BB9P/Dm8eS6FQF4PSo9E0gTyqKRwIegQoCXC4w2vpFeCGX\u002BhxJ7jRbHeVzGIOw3GsUsl8ylPCdozO1gX/Zoc2ZgGiTEPpwlqD2b2kcq6iGkX/C3GibUuNw\u002Blbo1Cz0gXwX2Vha3ctw5Bv\u002BPCWHQTeLLzA/1sVlPm1FYhajR8J0Ae3tBNIQK7O0kjhMnRa9qblfXaU8tKq2spsq1bu0jVwZSfp3mnxluwN8i0SNGGEWh7idRCodd41DdlI3JRX3/8ScM1NcRg99OeKhgCkl6Zp51E4DF0lyO9JtNGPqLlXthMtAMOUN\u002BkFpYEoHu/dkHUz3/RDHtKi7KjdA71HrUstMs/tdpfi1LBnMmfc/KkAbCNbW8nFFJdAixMatjQsvvc1\u002B\u002Bwf8BndUApE3Otrxu//3JeZ61KCZx43rOuExx57O3RwpgG94HwKfQq\u002BgTir1cUjG9mdktKks5PN50MuWYnsyKB3\u002BiDuQvwaj25Hw\u002Bbmi9cmYKxE3qiiy/Jt7/g53COB0riXNNqlNNndggJjXe\u002Bs51xrB/jcqOn31C8tgFMD4bNKxvEuTlf9gCvTZlylPm4CwAeczdQqpCnPn1\u002BqeLSG2aBPGZb\u002BfpgEbofNCUGNUpbBKr9LZxPfHyHHXq/3Ugh3TIy7ViTXBEJul19NXZroQU3J6U30OnKMb/l1Nx/oDRx\u002BVby00ftx6iV93M\u002B0ksKG3x1iLWm6gxIaLuYrYs0iholDzgjdM29RV/4ndl6j2N037lgCht\u002Byw9KqmqMURohYW1ZFccO6qautENZqkwy0d1YJ9HN0H/\u002BpkAs2M5nMPBF1zxsHXWcafUWsVXUJRzDF9iNNC1IU4ztXm\u002BC3hHUS4NPF9MTxrBnv7ncuyMqJoEjbcDx1fzG\u002BYevfsMGGYvjPmXSiQ1Js00kJXRza5htxzfuX3BM5nGGiBpPYEfxXaIx\u002BXy5W51z2b5zyayEU5HrPbuLG7obllvwTAD2/k8JNsfWQXIfsG\u002BaeoWx2RjA/jSIYCaMZkXkFmMkxQ\u002BcfNtzapLosg4fz4lP8J00Zbk/L03IbpooeNCB7isO9u9j/f2qQnKF2EwqaJCZQHWos7Cp5ZW90BJBSu3CasPnENSd7/KfiidKtVcBngIFjzhe1T56ZRFVoinvaPuAx3GIQ1e7\u002B1CDCSWNYzBCvDIMO7uxZ5GFaK/HSE3IsCErxfHhdV6qSZfr38wU6QHhEuH34y0/z1/gAtg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "coZL0Kdw0/B\u002BUANRM\u002BchhA==",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E415FFC3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5cf062f2-ea1f-8d79-5af4-333cfafda480",
+        "x-ms-content-crc64": "7Qv703xhgfE=",
+        "x-ms-request-id": "682850b3-501e-009a-4db0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-93dc18dc-575c-9ffa-b551-a64b707161c5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-2925dd805fcb94f95a6bf523685ab06b-34ebd53d76c225e5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "44fa5c20-f211-6c5b-a0fd-07ba7d0b9822",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "pVNQ3ZJU1Jz/jBw4//VNt9lzZ2wcAjNk4fEtdOT5O01GXwnnbZ89OnRdI78vhp3fSg\u002BpNj7hjaMg6/ugJmC3BlHO8qDsZUk5Niz3v99zNFtUTirVUAUOZNJlx4GjnBQUph1uYJP98uTGb/8S6s3DrLegTNg14bVMwI3Ohp7HlZoY4hnCBdPIVltFDuAF/HoEohrKA0873sRnIqAFL2tG/tll\u002BgezAafj2PV88NLURsQTyeSD/JJK3ANVWuMzwifv/w8HoAFyUKFz5ytZv\u002B7xktvc8WaHwgJHGh4DXqbErxXOjPDCzabCoHhDEBVm8BwVY8cHV9DBaDwNv4XibvL6rzcWizL9LsU1GVDtQ7Ls4CkC7vrevVhEDSS0tQ0g3zGGSGHdUGXpFzUC0T1/0ySJIN9b4ID3HPHe0X4OSXm3FDkeZ/tRD4/EGNbF2\u002BsaxDkAKpQuxf\u002Bxjitv/n/n2868SrwEYGspOBFPl8ipMkAGxA1EDh7kiU86bdjP4RAQ3DwICZAuFmPN1vKC3i02B1zraTpxo82w18FtyfOTWVYBPruMoSmv162pdzcsYqohA2V85HjVnjluWDHPwUxwOn2bgaByqmYzO5GNyCuWhHQXS8aNFnXdK6CBHUj34BZgODy6kOAKrln\u002BSKnnSNYN2NS8uHWG4iMHvlYA8YwdPFp7LI/v3POUDJxtjs7M9uLKdEV0Oieg2lYZstKKCr3M4QxOaxtGHvvgKKvYGVNVO8dzNXxHqAIy2lI51SkhCgLfoK3BfYrHg1VJlBF8x8ECw3cKFtRAhTgKG5HJDUjRvh6p\u002BXilk709rLIn/RTwthORNhKyFvMunht1t2H5/nYNeNXy085IXS\u002B5zWkiGYgjGWV\u002BN9Y2HqcqeltcMNxbQ647GYQ\u002B/eNESNni\u002BEmKDISTUZ78e8af11ktyFhy7CxTXom65gAD5RuCOe79VCVeoG7Xyd4\u002BX8jom0IrEDWK0lysjprAzyWEkGyCeULXooMzzyfqmyJOFf7A0kq919Tm\u002BGeSUcWLndBIUzhyu\u002BWGEPm/\u002BEENoDY5XXic//3bxriXnIHaRVC9qDFXoUjp21kYOsFR/t\u002BS2FgwWPNM7p7TbYx/2h9kq8uoAU8Ptv7uT4Efg8U7icfZBMMpquxccLmTgzS7agE6tI72qPyPgyJZQghxLWrZmOPFptVcOwHfS5CWfDPJMuWA5M82ReHKSoGhz2fj6kNPuepR9sMr3XmNFlxs\u002BQbvkA8j8UiaolMB\u002BltTu2uZ\u002B2FNRsJIdzwhVAdWqS6FXlB7sj5YwPn6tBaXUPtn2CIN8xv7HrJDphnSAZ1BRPklfJsL2AksQDtnUpKssCdBuXzkSbUTiT\u002BeNwslhb5cuXAdcg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1MwXMr\u002BA5cXSd/vvT\u002B6UXA==",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E41D51B2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "44fa5c20-f211-6c5b-a0fd-07ba7d0b9822",
+        "x-ms-content-crc64": "shgXhYnmwRY=",
+        "x-ms-request-id": "682850ee-501e-009a-7fb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-04559924-9fe4-916d-705c-5e61f945b816",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4863bcbeee4e077eb371c05fb4f2e7bc-e357e4f0251c135b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d3b76f4-d875-e160-04ef-5f1bd9f86288",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "ku9RxWzSIAyRy6/Cco29Qw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E3F90626\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5d3b76f4-d875-e160-04ef-5f1bd9f86288",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828513f-501e-009a-4fb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-46731bb6-a6b7-2e0f-e666-7730493bc506",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0c283a0bab45b3b29695715ed81bc244-3cdfa40d5d460aaf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "05335f01-5b31-f7b8-5151-d82bd27d86e0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "h59GBFcy3R9Jqpg5mSLsFw==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E40009FE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "05335f01-5b31-f7b8-5151-d82bd27d86e0",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e887a3-e01e-007b-7ab0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-3ed823a9-e2b2-cbe9-10b6-422142d731ea",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-5331e6fbf260ed49f51f450274c8d29d-20f00fc81f2f61b4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "06c6d3e7-3bcf-b6ac-de72-dd6d1daf8f0a",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-04559924-9fe4-916d-705c-5e61f945b816",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E4359117\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "06c6d3e7-3bcf-b6ac-de72-dd6d1daf8f0a",
+        "x-ms-content-crc64": "mE8LQlIwzqA=",
+        "x-ms-request-id": "6828516d-501e-009a-7cb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-0fa2268f-b561-3fd8-5d9c-f223e15ab7b9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-18a3b4191db9876103618d0274acac0c-ecb18bdc9147b167-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "bd6bc18d-8a7b-75d8-b448-2f46856a710e",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-46731bb6-a6b7-2e0f-e666-7730493bc506",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E43D5820\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bd6bc18d-8a7b-75d8-b448-2f46856a710e",
+        "x-ms-content-crc64": "TZ12qlv8kbU=",
+        "x-ms-request-id": "16e887ee-e01e-007b-3cb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-30d05225-8e71-89f0-02f1-596f97ee895f",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8edb1bd54660311d1d658d844119761e-ec1a77094963d099-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "119e7d31-c912-7764-5f96-d95f3e2103d2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "Ueut0ZbT7MyC7rDlcKuErA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E40671AA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "119e7d31-c912-7764-5f96-d95f3e2103d2",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "682851df-501e-009a-69b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-6edeb553-850b-7e9c-8a26-1e7e283d4835",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ab7023bb8b26b01ce83f8c9eebba0128-6a467cf7e11cda68-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "98a0a501-fa0c-af05-70e0-fb7ac405b939",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "8Y4gsjrrhAoTQEekwx95Sg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E40FBF2A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "98a0a501-fa0c-af05-70e0-fb7ac405b939",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e88848-e01e-007b-0eb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-291c7e88-58c6-f945-2e11-82a514d95cde",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-5f3331c1deb0af8c058a242702a41f93-b55ae21e3a7c27db-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0814a6bf-60cc-47fb-876b-fedf7d1354d7",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-30d05225-8e71-89f0-02f1-596f97ee895f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E4498B56\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0814a6bf-60cc-47fb-876b-fedf7d1354d7",
+        "x-ms-content-crc64": "LPCcg8b21A4=",
+        "x-ms-request-id": "68285228-501e-009a-2cb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-a73b5896-8875-27a5-2be9-43c54d9f97f7",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-613d6ebe1f7340e1ce68e9ceb957e746-8e471fe29edbd02a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fdc5079c-e127-c6c6-237c-da981b60aedb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "coZL0Kdw0/B\u002BUANRM\u002BchhA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:33 GMT",
+        "ETag": "\u00220x8DB71C7E415FFC3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fdc5079c-e127-c6c6-237c-da981b60aedb",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68285287-501e-009a-07b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-49bbbc20-51cf-f364-4b99-e015f0c6e9b6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f52d54a0fbcf65c612070c9a4328d71c-3764677948fb75ce-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d7ddc6b5-bc73-acca-f0f0-04790a28ab91",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-6edeb553-850b-7e9c-8a26-1e7e283d4835",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E44F7DE8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d7ddc6b5-bc73-acca-f0f0-04790a28ab91",
+        "x-ms-content-crc64": "kvUxRvcm/MA=",
+        "x-ms-request-id": "16e88877-e01e-007b-37b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-3ed823a9-e2b2-cbe9-10b6-422142d731ea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-caca85abe6f75eab269f22190c103801-d1df632a3a17f696-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "02dc55dd-ad62-cd69-c3f1-f2ed1016c66b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E4359117\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "ku9RxWzSIAyRy6/Cco29Qw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "02dc55dd-ad62-cd69-c3f1-f2ed1016c66b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d6e73-d01e-0002-5db0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "y1I8pCxRRAa\u002B\u002BQZQKVjZHy5oNkMtZ1B6lwrVnVq3\u002B/9WBJpDOzPEJP/cvUAQpTtxU9uTPyzVjmQBwQwie6esB/4H\u002BSS9luP7pBFEUakPafLPZEl\u002BI7vSgXY2QXkmoalYMLZCCasWs733mJsakT268VcaUxZdLeNDNHiuhlRp1AJo7CHzzWBGuLCMh4sguPA4e1AiC06T\u002BgLT/9QyaCxojsOYsaUbxyP305tl0KZXInuIdQoER8i01fEeH86LFFCEJPjHhwZLHbQsKjeyLSpce9xZqvIhZEb65Nyz/KhVa79K4aytkJp0PVhW1xyRAafGwqPxMmpdYsCyzKMqlyAM1754aEx9rutB5Gyay4wqaeI07DoEYzlV7X/s\u002B8P3SqY3SgBdGJlbSRO3sE79w5Y0h2LA9armB3OFInrNkbMoSpnGYoGLzFFJ2aMmTLPrWCnouHNgNlT8UUKN2PYejrhgj2W0N2AVqLsRdxwGv7vAmspQ5NhAxxNEyhE\u002B/fRaKkrrxr1NNiHJ0g\u002B3Tr849ZGHzT0szanfH8dSb2xP16rHt0zRGvn9cmOphxLJiHlTDNR/tzC2Ll2gDKb2\u002B8a0evpk8JdzZtqXiVragkaXFpdO/2OYzyB6EYjuMQ5TB3ed9AwXZJjh36X56C3V26sXCfYOp/tiG6va6t4PhDXMRILjPY45f7H/bB\u002B\u002BnubypDXc1ycYRF97OthhPXq50ltvLaOr8Z4d3YlEDzvcpH3E50WpMqwOswAiaAO110I3RZrETnBDR7KWvvqd0zQkn5VbnVU0EJ\u002BuYXmjiYmbaAZHDcqgGFUMgKCSEnSycODL/chtWTrtAzX7Fe33n74o\u002Blb0VsZqg4dATxy1of0r/PGZ2IvALg7LWgmUpQJoFeHhaRcdvhoZYHpBLQoeOGE30Bn8XcczZ8xHKPy81t2E1zo70zflDT3Xf3gQfwAErSKoXNXobLcZrgFK1ZUdXYqcvFXP42QqUsLcJN1PIujLQ3vaFHkIm2uCISQ1mjenuSLudMOrNMm9fQoSDEfZyowZf5IaQ0kQlCDpTcJA9LeLNGu7YK4lIA6xHJZu9Y8kqFaYHBukjXXY3d\u002BiwecHfYlTh9jbHmnd9F6EaCayop6RxaRrp9ib5qb14oPOgl8nqp8NG262SYrsuie9ICVOJjtAEfxCnNWwuKAx5TvmDnH/XL2HpYYw2nwZfuyw3saBprxHjnFj5A7JXGLOhWNPBqu2vcNnx4C0EDZ/KB3o/9nZrz5/noD/nHevvUgkYVUYyndA\u002BSACGt88k34747zw4F2J9NUkz2grtyFMtwo3kK7gZ12lpwW515VfQgsCw7i7vtzrmm2A9PoPFUL\u002BtmLVBALPW3xeSzhXzw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-93dc18dc-575c-9ffa-b551-a64b707161c5",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cf4d0d49bef036a403a9e43dd361da16-d0e4195d801bbb65-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c5bb8a59-ac83-4d78-75e8-4e183b9bba01",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "1MwXMr\u002BA5cXSd/vvT\u002B6UXA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E41D51B2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c5bb8a59-ac83-4d78-75e8-4e183b9bba01",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d6eaf-d01e-0002-13b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-c49989ff-07ba-3623-e1a8-e14f32322a84",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7e4b979f89f7d5c0f294c65e1544b02a-dc5195d3bbd9e385-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "85943351-015b-8ce7-411e-3403b28d34e3",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-a73b5896-8875-27a5-2be9-43c54d9f97f7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E45F8121\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "85943351-015b-8ce7-411e-3403b28d34e3",
+        "x-ms-content-crc64": "7Qv703xhgfE=",
+        "x-ms-request-id": "16e888ed-e01e-007b-27b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-2502133f-6e9e-36ea-1a28-de2d782f0968",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-5ce85de905d19297d543d7621a358af2-eabf28954b286739-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "08c6c5f1-3407-33a5-b8c7-2bd944602a23",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-93dc18dc-575c-9ffa-b551-a64b707161c5",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E465C1C9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "08c6c5f1-3407-33a5-b8c7-2bd944602a23",
+        "x-ms-content-crc64": "shgXhYnmwRY=",
+        "x-ms-request-id": "993d6ef4-d01e-0002-57b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-0fa2268f-b561-3fd8-5d9c-f223e15ab7b9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a00c001192a9924e94a3e1b28977ba02-2072b062159967b1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ed11fb99-2cc6-0bdc-3ec3-7c1f07ed9bc6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E43D5820\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "h59GBFcy3R9Jqpg5mSLsFw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ed11fb99-2cc6-0bdc-3ec3-7c1f07ed9bc6",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d6f2d-d01e-0002-0db0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "YlixkVMaukoBFWYmt8eye\u002BYl6z8yJzO4LEzw/FXcv4/sdftMyfoLVoIwTT1cIOY/X358A6CyCzol\u002BGUGKr30JFXXOULLZrLsGZW9Atn2XAxmsJ3XYLzuOmrBJ9CVBSvEOynnheajc/jMkOkL9QhgLpxYoHogHcSZ6P/YCj/hVhRp\u002BcewD9clwj2kC8/S40VhYPg0PGSxpB5lTZzny2m56jnUofxBrx/FM908exH0xgW6d6lGrRmvt1SoS8E6PffU6yCW/kFIILHZbwiHdCgMcIaXLFS/cj0fJOmnmGRdivXmaI/xXsjDcVb4bT4RKEMrnNo7oxGjFHnjdtlYoYdMe\u002BQSoAyZGxK91Lr9xwT\u002BDvyme/uJIufkQ1QWDejva9DOq/JZ/oc3koHIfc9WpU105GfcsSaMw1n9Ll23gg0qzmnqLhsSpRB0b\u002Bh6waQYjZ0GoiiAErmpQuiYW9Apfw9zna9lbHcyYj9XaEI9EQK05aDAseDkqbuvQOszeUlASvDZBiP1siEm1D/pKap3bDHl5HYvac0ujvTztiuL/uj1Fx1RZArfvzN/mdyg\u002BoARN9O6TZXTEOAiqncvAvv1m9VX9BGMJQgmBiRCsNDxjpNz4X9Y0LFTIgY8L7mSr704iv4GSQZuhRHLlEZwkGAQMBvkuyB8nMokBNELT/ZOk1ZnCiXR6kSNBFxtjTxq4pGmK/6drvScvO004kU0YzUbfAHwCYY6P0bXVrfEDg\u002BOuiFAZCP3sORiy044nQj/WKEnURA7etkLa\u002By3xlg9163dpicj9P4RJMscjT04AqE\u002B1/4Wnb3/U0BINfk3P\u002BqMJfOhW/fg22SiFS1FHuyb02lKee5aJzrv3lPm278F2uThkGdKl6eqXvyZc4ePuTRTrGKP7Mb7Mf64sXyk\u002Bf\u002BlnDtIY42FUDvCoBvywLOyYCQeky9cde4e5l9pkeUqBmT89NdMR1WnzlsmzUyrCHFLBlFYhWbQSCZNKX0uHL9Vl5m29szbZRjOdsTTNqehc93tHYuU0oD9K6uw/x3YebKc0Day9BGlb6A4iQ\u002Bi/RJ\u002Bq7agQP40wMUYuMsgK2b79vwRN2Zx737LSK7qXEhxWy6ZMVRnNzm0aA9xmTtGhEQ6PZISkMWrDbs31PhPSWR8p1ydhvkSlL7DXc9WAFVChcNpsB\u002B2Xsto7SSYL2NBZB6q9fHfqf1LKKnUTzL2VQ1m9E405ZhExkmQNZnUeWRagviwqwtjY9zFHoh24Q6ZcZgWMTsVDH6FZS6oTnRkdq5Eec05RqkCApFybscQzuQ798MAvkcpRXV6KkXcuxRoYajaMWhAXyvuFC6po563dZdKbFewY7hmGzRYvxtjJUd8CQweNZx7\u002BpeYEQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-291c7e88-58c6-f945-2e11-82a514d95cde",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ad1d0b7d99bf98c95f72eb1eba02e3ea-cec875ceec6b5fe4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4940fa63-3c4e-0d5c-c41b-a4824483167e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E4498B56\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "Ueut0ZbT7MyC7rDlcKuErA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4940fa63-3c4e-0d5c-c41b-a4824483167e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d7009-d01e-0002-5db0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "vuGOysdaDw\u002B0H6Uu0/Isp3\u002BYoZiAvN4qY\u002BYp4Y\u002B\u002BRLOs0NurGypDnRePqewyKdcmzAh6C0UITwIDY2bgMC5/9tvygQMXgYtUVQSB8RLy\u002BDoPAxWHRDhuo4DZqLjEY2zpELMQQKfTD0t9JbVAh17vEGss0CwZ\u002BLGig92DPdjTkPGXl\u002BFf4biSO/PJCR6DLRwi6ZdNl5JA0BgBbrzJUNFyqpXEqPB9kC6ympU5T\u002B6SH1XBYFNAhvhfV8fJXXP8yOoiV1\u002BJvoUspVlpmvz9BoEpb09mCO99MSSdZFEpszK7tdKqFveOCWDQlbv61\u002Bv7YlBFn\u002B4jlr/6pCY77FozA/EnreQqUvCJm2bvlXM0g1k4oQIA4xRElx8Sr3LRUx0GnZLK0ioG0Q9gvASINABMxiHMAkpYMx/c4hXEF6N9t0dI6fjhabAvMdDyoCYQvGMfxuhRBVDSrWpy7u8UQbls4wW8P0sIal1wnNB6ZZL5zCaypVG6LLL3djuOb3vAG/AWhb0hU3wXFluK4Gh/V0fXeCHJYptosbZTxMgQefvir4HgZODV13ipmo/1L0tJdx/zt/ZZ97lUrtMGzo60B5xfqDHnn/NnAaGpH8cMcoJrCU2pHcIFibjIjLUMzwnp9ZPylYcZYdgsi7VUsNjxRztRmsRBC\u002BraWh94HhM9WzGYvyk0Gtz6Uad0fJEMsNjg1kR5ujREp\u002BqoGDtooUPF7i\u002BDvPCuvS1fV0gczI5YzalGmEjOw6H8Uxc/iwKgkrBkr41hifToMRkXGmPsJ9tbUEqSIQj69iuOh2jYbjIqvsSYuB0A9kS1Xmcvt6k9ECw84zu3DXCoabhi0wGLD8Lm7VueVG\u002B9W1kG3cOhyz\u002BCUHY8nIr3crFT705knSNCKU6kSMpNn7y9f4jhsDCtB5154IOLT3M473qqS2QgWL02xLN0/IN1NLG5fx0CFcGApuiw672gttrbbFhPo1NYnCbLq\u002Bx8OAoaA6vR0c9VNdq4KaR7cGwAlQ7YmJAqJZFdYeL2N2nVBG7elugRzuUKhTZ\u002Bl3mv3Cu5yxXeo595794adHDtX/5w4iU2ndqE7scozhNarI4XrYS3PWxT92DOZKYJ9lp0HSY3DbRUeD9RNNxOtdWMHkNQA8brNSKSHerEaDgzevdttLDsI57ZwjVEZgiPBUKLQkZjufOTiecEpPDJkBAHHbrk4AEkn/uldkCRps8aAxeoOCXy0MEE2irI6H\u002BtDzIkPUhNqyRBZqJKvkKyAuIY6aHYIVfqFUz54AbWXLd892cObWmHzFjyZtKDpxJ\u002BUtdIsP7e1O3aOSf8VMseawnrzsbbpJV4kR1I5rqFZ246eo4ujqy4niJ5MzNCi3eN1PvImNlLog=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-49bbbc20-51cf-f364-4b99-e015f0c6e9b6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8e60267377c13d6bb765611ce31ff843-8db634f1859dbdb5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0cbb957b-52ad-7777-95cf-c2cfff6feb9e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E44F7DE8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "8Y4gsjrrhAoTQEekwx95Sg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0cbb957b-52ad-7777-95cf-c2cfff6feb9e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d70bd-d01e-0002-05b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "\u002BG/m/ie2Rz3gaWlikSPKeDMXY3098mC0z21DnIQt5kg3HjKjcUAPOS/wmoq3Zraz2IfhUPH6uwUOMS65c6u4s4IhKnLwJgbzBylOTFjV/Wm3j8P9S5ZXPWMtlEARVcaEOOYIljtDwrGB7kjHrG\u002BsODTEAuPnu2jrye0Pw5HF4bFjyRRxzGctc80SfF1Oj5HzgFsLTFPinXx\u002BHcxOM/4fuwyWZOJaO2zNl44W1D4KnTlbG0M2uZVegCyX86\u002Ba3j/O8sFRuCuvmUXvPrXFzMg\u002Bc4CS8he76QF2OOO1w0i8MrhOSOJ9ueUOrIL\u002BRnvfmLRkWX8vCOwnEgi/2n9I\u002BdX9Mwv9d4PmwLmbhEaUvaOFl58vUWrIjSrMJjXZvd9lxrKtARNv4iEwfpjFlISmklVlOkPgGKhrNKbhMFBODALaNb6T57yQFbR\u002B/9LRAvilJZPgdIOcha0JQcxtjrHQ4nGW617GEquZ1CSOYhjWmjKtOwu9bZd/PrAQiaXvI4cCrR1gOhaa3xLoR59eDSKUM6eZv1KmE3TZF6yttYkFqbGci7T7dV8bE1z41CX4IDGNe1X\u002BVWM1XJmohiNq7CqJ4p7twoFumb5Ifqz1rj9O4fZ7HzkzB1NNZy8bUu47sScybvKHCl6vH\u002BKWtte3P61aWaUt7szwVdtKn1tSUkbQDMyFwz9Nx9aYzABWnFB7lieBwfhIDsNaQRgWPGsCXM2cxqkLMnxtDZLPlCHMmbiKzwkz0JFNiP4IKoEnNoprlW8yutamb2SrE7RmeXqijqhfi21hz4w8Tz6rAwf6RtYHY/6xmd/i41\u002BliL3c5g6DZpvZx6sdCcbj9muY\u002B2xcsczdXxV78PXIfacNvEfOX2gvJ5xrIH8r6Vo4zqJ0SujySNbw/4f4CHamEUkDEEx/FJcCaNPQ8JBNsnW7QyJSVDO/GnRw3mDgNh8lxQ81KNkNubkLceEVIldGo0wRPcRUVL0WRPXYDjY3IjGzqiuBF4qbropoRuJRqfgcKTsTzvla0XBSH\u002BPkNKqC1E\u002BwYngsxYvCdY866w3axZr8vOX7I1M4WNi7Lvimt3ng5nKSoUeA8GSvUFhqIOZid1pJ53jFh7D8dwmfcZaTHL4VWgSbRyNTfMyATNP6zjjyWLeeXdABG17Blik\u002B4X7NGzSaVMXhxy829WqrRDvdAqnQrRjf9b/uEz\u002Bl2bH5FZtNsjCfX3lyEJGHZ2dlVtYj5JSAbTNm7iZ0rEGGO\u002B1\u002BPODPXpEKPaIwXZyHV41XiL1ogvQceadn58MKKrI37NSjCCqGlfhEGKbxTw\u002BX3paYHSOEHrn4YcM5Z3bNABPv\u002BHHH5E5j0PLEI2lOKymX0AgscQyPs84bqqdnTS6Bdw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-c49989ff-07ba-3623-e1a8-e14f32322a84",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6e84b4579cf096a30c1a358e6e3c0191-d62d2caa91c3d45c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "af078fe5-09c7-c6d0-214f-63241976f79a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E45F8121\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "coZL0Kdw0/B\u002BUANRM\u002BchhA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "af078fe5-09c7-c6d0-214f-63241976f79a",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d7159-d01e-0002-1ab0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "5RoRyt8AUY9vWx9OEYd5IpQ4z6WbK2wbdUqoXuyPI52Nl991NuBYjw4ccc2WPv/yvGExvr6eUrmt9VWVV/Ki4DeCwHmnA\u002By030CWfrmehTZKtaKLXWXe70Umx0GLwzcceZGVFH2GSrh1fN5\u002BB9P/Dm8eS6FQF4PSo9E0gTyqKRwIegQoCXC4w2vpFeCGX\u002BhxJ7jRbHeVzGIOw3GsUsl8ylPCdozO1gX/Zoc2ZgGiTEPpwlqD2b2kcq6iGkX/C3GibUuNw\u002Blbo1Cz0gXwX2Vha3ctw5Bv\u002BPCWHQTeLLzA/1sVlPm1FYhajR8J0Ae3tBNIQK7O0kjhMnRa9qblfXaU8tKq2spsq1bu0jVwZSfp3mnxluwN8i0SNGGEWh7idRCodd41DdlI3JRX3/8ScM1NcRg99OeKhgCkl6Zp51E4DF0lyO9JtNGPqLlXthMtAMOUN\u002BkFpYEoHu/dkHUz3/RDHtKi7KjdA71HrUstMs/tdpfi1LBnMmfc/KkAbCNbW8nFFJdAixMatjQsvvc1\u002B\u002Bwf8BndUApE3Otrxu//3JeZ61KCZx43rOuExx57O3RwpgG94HwKfQq\u002BgTir1cUjG9mdktKks5PN50MuWYnsyKB3\u002BiDuQvwaj25Hw\u002Bbmi9cmYKxE3qiiy/Jt7/g53COB0riXNNqlNNndggJjXe\u002Bs51xrB/jcqOn31C8tgFMD4bNKxvEuTlf9gCvTZlylPm4CwAeczdQqpCnPn1\u002BqeLSG2aBPGZb\u002BfpgEbofNCUGNUpbBKr9LZxPfHyHHXq/3Ugh3TIy7ViTXBEJul19NXZroQU3J6U30OnKMb/l1Nx/oDRx\u002BVby00ftx6iV93M\u002B0ksKG3x1iLWm6gxIaLuYrYs0iholDzgjdM29RV/4ndl6j2N037lgCht\u002Byw9KqmqMURohYW1ZFccO6qautENZqkwy0d1YJ9HN0H/\u002BpkAs2M5nMPBF1zxsHXWcafUWsVXUJRzDF9iNNC1IU4ztXm\u002BC3hHUS4NPF9MTxrBnv7ncuyMqJoEjbcDx1fzG\u002BYevfsMGGYvjPmXSiQ1Js00kJXRza5htxzfuX3BM5nGGiBpPYEfxXaIx\u002BXy5W51z2b5zyayEU5HrPbuLG7obllvwTAD2/k8JNsfWQXIfsG\u002BaeoWx2RjA/jSIYCaMZkXkFmMkxQ\u002BcfNtzapLosg4fz4lP8J00Zbk/L03IbpooeNCB7isO9u9j/f2qQnKF2EwqaJCZQHWos7Cp5ZW90BJBSu3CasPnENSd7/KfiidKtVcBngIFjzhe1T56ZRFVoinvaPuAx3GIQ1e7\u002B1CDCSWNYzBCvDIMO7uxZ5GFaK/HSE3IsCErxfHhdV6qSZfr38wU6QHhEuH34y0/z1/gAtg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db/test-blob-2502133f-6e9e-36ea-1a28-de2d782f0968",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1ddf3f67762bb7068680ae2a9f99ed51-a06521a1a4d0245d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "70e98752-3c67-87d7-4d74-1b12ebcf6d3e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "ETag": "\u00220x8DB71C7E465C1C9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "1MwXMr\u002BA5cXSd/vvT\u002B6UXA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "70e98752-3c67-87d7-4d74-1b12ebcf6d3e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d71c3-d01e-0002-7eb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "pVNQ3ZJU1Jz/jBw4//VNt9lzZ2wcAjNk4fEtdOT5O01GXwnnbZ89OnRdI78vhp3fSg\u002BpNj7hjaMg6/ugJmC3BlHO8qDsZUk5Niz3v99zNFtUTirVUAUOZNJlx4GjnBQUph1uYJP98uTGb/8S6s3DrLegTNg14bVMwI3Ohp7HlZoY4hnCBdPIVltFDuAF/HoEohrKA0873sRnIqAFL2tG/tll\u002BgezAafj2PV88NLURsQTyeSD/JJK3ANVWuMzwifv/w8HoAFyUKFz5ytZv\u002B7xktvc8WaHwgJHGh4DXqbErxXOjPDCzabCoHhDEBVm8BwVY8cHV9DBaDwNv4XibvL6rzcWizL9LsU1GVDtQ7Ls4CkC7vrevVhEDSS0tQ0g3zGGSGHdUGXpFzUC0T1/0ySJIN9b4ID3HPHe0X4OSXm3FDkeZ/tRD4/EGNbF2\u002BsaxDkAKpQuxf\u002Bxjitv/n/n2868SrwEYGspOBFPl8ipMkAGxA1EDh7kiU86bdjP4RAQ3DwICZAuFmPN1vKC3i02B1zraTpxo82w18FtyfOTWVYBPruMoSmv162pdzcsYqohA2V85HjVnjluWDHPwUxwOn2bgaByqmYzO5GNyCuWhHQXS8aNFnXdK6CBHUj34BZgODy6kOAKrln\u002BSKnnSNYN2NS8uHWG4iMHvlYA8YwdPFp7LI/v3POUDJxtjs7M9uLKdEV0Oieg2lYZstKKCr3M4QxOaxtGHvvgKKvYGVNVO8dzNXxHqAIy2lI51SkhCgLfoK3BfYrHg1VJlBF8x8ECw3cKFtRAhTgKG5HJDUjRvh6p\u002BXilk709rLIn/RTwthORNhKyFvMunht1t2H5/nYNeNXy085IXS\u002B5zWkiGYgjGWV\u002BN9Y2HqcqeltcMNxbQ647GYQ\u002B/eNESNni\u002BEmKDISTUZ78e8af11ktyFhy7CxTXom65gAD5RuCOe79VCVeoG7Xyd4\u002BX8jom0IrEDWK0lysjprAzyWEkGyCeULXooMzzyfqmyJOFf7A0kq919Tm\u002BGeSUcWLndBIUzhyu\u002BWGEPm/\u002BEENoDY5XXic//3bxriXnIHaRVC9qDFXoUjp21kYOsFR/t\u002BS2FgwWPNM7p7TbYx/2h9kq8uoAU8Ptv7uT4Efg8U7icfZBMMpquxccLmTgzS7agE6tI72qPyPgyJZQghxLWrZmOPFptVcOwHfS5CWfDPJMuWA5M82ReHKSoGhz2fj6kNPuepR9sMr3XmNFlxs\u002BQbvkA8j8UiaolMB\u002BltTu2uZ\u002B2FNRsJIdzwhVAdWqS6FXlB7sj5YwPn6tBaXUPtn2CIN8xv7HrJDphnSAZ1BRPklfJsL2AksQDtnUpKssCdBuXzkSbUTiT\u002BeNwslhb5cuXAdcg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e3ab41a7-a052-833a-de49-f19db63a70db?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d6271b688f18471e7df41759fac222c8-0af55b28b945850c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "92d10c4a-878c-ba32-5406-25dadca041d1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "92d10c4a-878c-ba32-5406-25dadca041d1",
+        "x-ms-request-id": "993d71f1-d01e-0002-2ab0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1586980704",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,1024,300)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferSyncCopyTests/BlockBlobToBlockBlob_SmallMultiple(6,1024,300)Async.json
@@ -1,0 +1,992 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-baef902e5955a3917408f68cde664af7-537e73d37673f665-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c65cc436-2ba4-47f5-3e6f-e349174c4ca4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7AD664F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c65cc436-2ba4-47f5-3e6f-e349174c4ca4",
+        "x-ms-request-id": "146bff90-a01e-0055-17b0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-9e19c324-4f3d-0e79-13df-21a3760fad6e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-847f99264f617ce400ab3d3a4b8aa06a-f5f6a47cd77686da-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0445d1f9-ff6c-1563-a84f-2428304812a8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "6W1MhDLyOIHv1tErO/71I1bWlXPXvDkjiLXU6OVu0Fr6xaC9IfaHPwzVxTk2dsKF18gbq0uMUSwzKPx8HU\u002BbgQV3MXZeNwFfTlVnAvcA7BLzTxAdUyUPbXN0ivj6CyK8OUQzvkRLJ6DGu131JU81Mzvpic4/fi7gaMQD6a0IZUMzqsmyzC7NpyhwVpfIGUcjP1a9EIJTfboWU1Z/SD3yvlUawnuGgmcNG\u002BGmzyiWGE9936pXS1TA3ywOm3jYTl7qfZhCrVfLnbzvr/Wgra6SgDsGAmmTm3IBWeJPd\u002BfuNc2Cu1KPVGr3skHuZ5tfHzJ\u002BfBo90Uv1V\u002BElQVR1eyXUAHonHvJcAizQDlAnpTTXoTmv0fvMsGSBjWNwahMWgjYcGWYhNwFAInnubcL7zrKtTp8axaoqCFAVpZGO65gZuowZC4vNtWo4b6\u002BB3UOihr6wwxtz\u002B72L8RAWC5FwsTbg1LI14cMm35g14VX7qCoMcx/S3ih8pb7Ojhl7tqnYyL54oAmRbKX7ieOCPhpnkEjmCphyndIOYy/0ZlOpqynvXBmXgwghewd611RE\u002BmekZ/7RlawRZSrraTzZnQVSUd26k\u002BEA0AxAxI\u002BQ\u002BMZ9yWnHT/9U2BZ93ffuqxnLR94CJ4V3imaFo5fxkNAdgG1kbZ/TEU0F/XnHPLbqEiTzdXyxjtBBBj8DQqxoY0dFX1yJij15\u002BDWQ/CoLr02wmpBz/RtTbPKcI2dgz8\u002BgnZkxgd1ZYYjmen1HIJKlNVfxU6gb9GYs8fNq7WfWGChm716R2i1wVjkIjIOeDEtf9u0Qb3wnhagyBZDp73MhD2FU4DAzFFspgPxuEmfjjuWnCvZ5xqmrP2q1XtSdh2fF530hSSsbLOKS5u5/uHJBT3aqQeR9qEi4qaHGfbWGi/mVqCvqwUW5jN4T5uC6K4b3dA5d80WCSD80aZ\u002BJVa4sDFr06RBHVo0x8LUFacFo/X0bzgmmKJi0EmDrtVilLzcw59qFxkF2sB6ALAKQfd5\u002BzGsiboakheTCQNavW6E1jMF91ILn4zc7pR7rJfyWI5WCbensg8Gwi2H1w4VqxlR8S59AEqhcluk05slouV/oKx1BLe63SAkAzUkg8R\u002By0N7JbtpcVRHtJtb/uJz3R9ECDZdoKZlmxQKWQEReO6XJghXrnkuFi9UMUwYXuJBsCIZ3HuOHSadEY6nXxhTMjuoxNjaHDKiGfYLCXNaSTgxyKTi\u002B5x3BQThupjuircXBP8Uc5YFa5fvd8aFhxe3RsRWcZZzcDafMcPT\u002BGWZt48\u002B8ARwRdmmLGEQ84PV8X3xKnPQlBkcp5DEdT3SNW8yVcA3RpcTRwDusEU1Xny2xUBF3s3xxR92Ikxzq8w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "swdWQtRbfXFg01yBlFKLPQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7B3FB97\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0445d1f9-ff6c-1563-a84f-2428304812a8",
+        "x-ms-content-crc64": "M47/xqp\u002B2\u002BU=",
+        "x-ms-request-id": "146bffa2-a01e-0055-24b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-53b3cd78-e1aa-c091-0024-2108d571fc1a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-259e08724e20e95af0cf7a64016997dd-b622ca3f0e5f6cec-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "594d7171-8f31-294c-3342-9a222dc773b0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "oKr/4O9w1J7hsBueKZ\u002BNgJdkBCk2FYCPtFSuJJIzRvOz7sazePHa/nzbkTaj\u002BzXAFQ2e7ejnjooqcCyawrAMrWko6jrY2gemigWsW4NJ7Lge7g\u002BFlFgKzF88iQjEPzzMz\u002BTMexD65zsF\u002BGPjOjMG4IRzfNOghhgQHR7bnFH\u002B4UrJ4IuffHCoJAbTf5z1J5ErNqiDUcNoK0nLvF7xHkvqBhYZGlqoZmMTy1fNzAZ8G/WNsGaoe5CGYLRC1MAStgW76XiF2w02g89EcIZsm15CT6BoZG7lQYuGk7mmZZKjABRSEuON9kDnVi2WZAoKGcRV/4UgqlGX1ajt/kdUkB08oW9xGol7tVhfgA5BTtyBfHn0UGYNglbDujw6oPj4k8UPWcKbmP872UoswClDVobLa4LOXz\u002B3Lx8Zrl9MQRRgZ\u002B1JMfUa5uN5uHcb4MEtf2S1bzR1KjSFWCqjgeqg75g1zFk8\u002BiWRsYWeVKbIm05d7C77l9Lg6j25w9jKdmT42cnf5RNo8IU/I72u19WNvbzcRpW8pFjGVeIcgzZMxjshpXrc6bY69PuovHMUMRJnKwYb7i/OPDVxGY8xTG1O8lyCjTFbsNQGoVGaE\u002BjlsSPPtFcwMdgLUmlFa88mCaiNWckWkqThDHoxFU3eNChMjGdrYZcWHsGEdzrHFUUE4JipDLoezh9/7ajd/huLLR5B\u002Bd5ouqcRdzsIkRpqGvY1LTW0NCduLb1I7HPuOR\u002Bl\u002BUkchhxmnCXxl5V\u002BFj0EFdOxp9Hm1vj208shH80zIj4cY5jQTZPazpEPw52S7xd/Q9egPJFOviJRJrNQRHxXvnRXYrKlM8dA19lA1xNaY\u002BOzodz2k\u002BatzqR1fyfgiYkUtwQoO41k2g8QX2S3DecP9sLPnKOgYSuOqpQOMLSfX01PKx8OMihWT8fM5jOB9cC8ZYhlEOzmdFbZmpD4VqpbcAAXaOLIAMSaeE3b03v3DLXUUcorOk5gaLbINJeXXvgccHUzaozd9GTEy5efCqHb4Y3bJATgMDWxtgAs/8wsAhpUv2IFxKIo9l1lZm\u002B3wV0V7VIJuznzPEA/gbSLsfSYl8h9Sks\u002B1h3rsi2nesnG\u002BvSiFhF5IkbgYYIixULunUVpzM\u002BmOncR1xc1HggMTMJ3eYe/6JriH3WBnOnJGxDa/RXnPq36H8B9kT/6QwQ91BTAq0u7LrSrhq1aJZ2NSLsGWyDzJQ4UfVnHQlda6NtwQ8jUCXDFH85hPLcAoPoi70iE8\u002BjjSq4Gqy7y8\u002BxcUJ3S6eHVuT5KQTxRkelWFNxepVIO1vXyjPkZzl1C0iviBesaLbYZTDYKOrGrkbnFr5dRk02aTXqo313ovOrgB24Qb4v9O\u002BYmRQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "xJH3e4hKuymr9kLa6BWcNg==",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7BA1534\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "594d7171-8f31-294c-3342-9a222dc773b0",
+        "x-ms-content-crc64": "rIX7IgwYioM=",
+        "x-ms-request-id": "146bffb6-a01e-0055-35b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-9666e5b7-d05b-e672-4b4e-b2c50952d02f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-7e7905c9cc9bc1f29c19b0eb2041b653-daee146c391d1d05-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "218b806b-03b2-7229-0044-89cba5e5791e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "9tjQfveLWaqro1yBcaNUWyrgy940M4rG0I2fgHRhmP\u002BAhILSRR5F\u002B76oV1i9VZNDBHAC/HX4A8JNCa5q7Nk2SQpdAOwggRUMms8gjNwxCXr5XHwEX5yJiIDAhTxw2w/kcg1OYFWnIoJb9WGl13flHAAzcI9dMepu03drYPzYm7\u002B/OxrO46glUjn5qGk647EJ2mk8PGp/h0Aj34zdPMKGglqi5pxdFzhXDh5WZImBNO/GYYWTnF9UQLPaqwQcRxV3cyYPl/0UrMMw5C5MKSO3oqqdF9o88uX6Tabpg2w0O8YI3vBicZ3xsrXCYrgxBxaQIglZfzA7OoBAFElXKylX/KlnREoyVDANq2Qleo8tyUaPWGBi2ryVzaRvIV1TmYeLa2YOycPLXc7YTNPLFcDxE0sDyNLJ9CLt0XemwzLTuRHdmQ8pHv\u002BDxPuRio3oybfjfg4RUNG0wnZEIPdLJJqbBZLC7nyxyPRLfwPWN2qUBQfAwkQkwWk/KdaY5P0IN59h9YT6Jds6MrYZxtDN3YoMsBvvi2FVd0MpgsWlGOP2Q0hkdUHlmd8shZCOCvuYcUtLizTiGKw\u002BC31B0aMWlRnSIoOIaWhJJxY7wwbRx2xIkRB5WY2vFCqcJmnEpMg8FfB2u\u002Bh4EAjiAmMdplWlbEMQ\u002BECSnDuMIw1Y60P\u002BhYNO/64VWwyEz4AIl1cqkW7V9rkls6uIqni16pfaHyTE433gz6amjxE3jCm/iQXjYZGfg/WK2NLYxlU1YHB0qrBbRLTZSsLHLman7iaByCBz0YgFO5svOgqrBwhRcS\u002BgwuJ4Y0VRChfP11WP4uqrVv00wo/ob24ULAmpLUK5dbw3ByxECWTaIsZwNmNGoFggALALHa6fuFNzZDc7p9zVFmGYV9u9Zk2ZWaDIdzkLzoyxiS2RrlgOl07Z0aQtnnrqmx8BrUh8YpljcsMO10AaaJarih6vQ2gIisCM5JWoa7ol3twZCSBDNCaTLjuV/8ANv2kOgRRcO1e3\u002BSOH8H4EugYI6PlkAV52Z1X3GxUsc4oAfiQsmuqmyKKEYRD9u0Snj3M1jRbGqb4KmBq/ZSBCi4WYh3FZ1yAcYSBW359OeKsRT4ui9uVzOdVmIgLP5mOCQtWKZDTSTrhSGSv2cMkeux9urhWUn5WgJE6c87UdTHq805zKxBN3PgHST925fcgLR2biYThN7aJA6UDlNVoDNc2wOZwtVPYL9m8UwVC45qaFkatOOupCb\u002Bb5idrTkQimzxoPCEMs3vNw12rIOCtSiAOZYKSvtPribsq2M8ocOGVnbvE2qN1jWLO43mOAeTa6pwHXOTBj9xsgLZp5daooVJ8FYco5HOAlNgfx99aWYfWT/IzIRA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "wig5SiyZYxhnWvAuYzO1tg==",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7C07CE8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "218b806b-03b2-7229-0044-89cba5e5791e",
+        "x-ms-content-crc64": "TKQqKeCbhwg=",
+        "x-ms-request-id": "146bffc8-a01e-0055-47b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-49d175c2-f999-42f9-3158-9e182e7138a2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-12054d984b72d45d39a12cef1428169f-e2dd93587dda84f0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "eb310560-53ad-cfb3-2773-6600a35f4378",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AhXzRIApXGO\u002BSdv/eM2PvpAzrvitgOMKZYvdFPK1xhQagJ2ORoDDulC8Tt4esZgEpCKkTv9xMoEy6N70S0dxCYLG5PgvAXgPb/On8DIE7LPz2XDPEXcUqU4bW12iz28JS0VbV8yf1KKqld8MyUFPLfwqAHLWofgLsjuqE6UabaCEnqXsqZXnUwTOJXuYCN8MzC1hd879MqpNUKWQ9cD8kCc\u002BiCucYoRnQ6xtCHt8cqlbnkd3ufbRh2v7n1jvVl5D0ZRUWoC0cGqp\u002BjMhjyku0N77NFd5hNcxbAC/oMIrd\u002B1OKTfmKBgppy3czr7DsPdBzM569CEHyky9I\u002B1/9M\u002BnfYNG02XyR6jF0o0pnLYYbrwJftTzsYPLR1/rKQQrqrNdNVA7fN2RT4UmtCKU3S2WpLUwdnb7s8wAeowGBx2jmifZy2dl3fHfdy5OzfxgN2kyVYRP\u002BjQ9YoGDOwJQi0hnghn6uhHFMMfDUP5HrObQn0Ii07KZVKDznGnm4qHujuvm50viZn1XbSS8i6k19rWbs5zALreVzS55Bh6o3k0m1cISYMWa7TjFy2aN3Mj2vqWzSy8ELmA0URkdaWBfro7XlrbnIpbvAMVk\u002BmNRCPFmg0d49JIeIaZh3g6sfYTXZhzXtkYRDpsPw0tpoDP94kgot\u002BYY5rn7uHQPhUSHQ4JBjJRGeVGqVHSsaDFHtYBzZPvGhMaev39i2/7RAohXiIDIJxSftmn2fWNxbH6ItAL0nCFIwb\u002B8o80V5J1T2VHrVeCxf41s062SzwZjLFMB2Sf73WVnDsbAC4RGitLMo6MRhhed1zV1h8h0tvK4WXZ5Ewp1WPzrhEYZ8HMJJUnaxitjUqU8YwHyhlWd8ljUB7INzXbHVkqmJQLQhOfCbGF/mfDGVQfQPbAJg9GmTpHuRenA\u002B1jSEm/gvCyja98aMBrzHVhnDbKrPI/FvtN5ANZw4j79AXAJrIaA5ZjaLdLR7lK3sjE4hjc2Fb7JDVScZ7xWM4mgHC6p6nHS5igZ0A\u002B99NCAwU2lN1sHx\u002ByyP58y5H3cg/lIMdIjDcfAZp8OHUSuDBiDHKZvsfstmFVC96vRnwKqPE0VdMP\u002BXLOF5dC7\u002BKmnAzOGrsfWbdL\u002BGph84RYc7secY\u002BD3mZdVhb/z6cwqcqCsmvR3SvA70896F1krgXqcaPYJHpTIsGqcMSkH44MG06j30EYipaPXYY8RfIE9KgREVoHVIVML4\u002BqK2xnHM/BLdESxM7E0esNTMrwEtjPoXgYlwo0CMLFU7OxcmMmJEC6fxgg9jPdSENu9ge\u002BWBi22oXwSoXBiSUOSXEbE1\u002BH5ySKNZPArq9IP0rKyRK/CvuW/pvZMdm6\u002BPXzEqi\u002Bwjjn5ww==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "WA2dSIYZP/DoZia4MozosA==",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7C6E49D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "eb310560-53ad-cfb3-2773-6600a35f4378",
+        "x-ms-content-crc64": "1xqOJtHVvYc=",
+        "x-ms-request-id": "146bffdd-a01e-0055-57b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-91eb06e3-17a8-a712-5bcc-075c2fccb7ae",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-d96aba7bc0ad3e8132869b953835ec01-4821e7f28ed72e7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e6d078dc-1aef-6ba2-a593-e3888242d2c9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vx9XfoywFsYLp0LNtZXrk7IQae9lT\u002BiMKDAbG6i9oc6wD73wdaKvx4eNUerBxdU4VNazCIv2RW83ylZclfodTQZzHabX\u002Bh0PYKJn1/79y2Na48bSCplDucpNuapMUjGMbwPkTacvYFq4pKfojm1xOf/yAbI0S0NsMGPciUFzwg1w22f6GH27K4JsGmbxWitc3H\u002BrWlB/WCTAdxxEUtcYReGZd7MFdiGBNtYvxzDde9Y4f6zCyGi88YNDOqFhd9irVNWEWOJ4VmZdKSN6T5D04/xFDNMqVXx53IYvwjx/IL/\u002BhHNaWCL0vyhGZJ5EQqLyTlekG2oFgf5YC3tcSJQq3gljfMsdmYrZUUyq4/HeNJnkPXPk2wVV\u002BAJ0AkynmHeUHIaV4MbW1LXMy8kdW50NetfheAsgRQIDDoPIqZY9MrnVFcdqSFTTDWi\u002BFxA7N51lZoh1xSBsc9aDkdFDDSsej5gQSEXVozGDDmqiYi3yyNblY0IOx2yZaaLw5reCj/88n4h3Ku9Yj8NW8ra1yRGpkMj7XarpD8csd96i5Lx5AX9qZsKke57njdN\u002Bt9W146CRR1buhzFUU4/BS7MQtaoH3PE3SmJOBBUqE9DXaljxdpQ\u002BEZ1li3lNFhMz4jDq1tcod9rjfpg9Q0JBw3Nhfek3z9Qe0aMNoVF36jRPGiHkPzz4rvN9Dfj7Ac5aJMcG65kq\u002BxNbywU0G9WJbJNk7SggXIM2ac71usHcI8/Vsn2Jcf6bJR8OiHQ3xJMd86FklxOmOchD0ILKNEFRfqg1X2hY//uUyMgJEtMP/qU62MYgeIu7L3i0RaB80PHevQrLAmUqxfOm0M5LnCf0NNHdkFt6MAYceS/wo7paGPjWK1TJRPtADxPTeae8cJJRwBHPn0CVY4wDrok1OiE5TLjWdXHSKu/VnYBIprZeYAmdnuKoi3m3QcfHxpZyCtTxmS3v5vogfpUh\u002BQG/Tb3VpE6Al5w\u002BkcE\u002BHjOqCmRZYpKsVg2Jb3kOfCBNhpF3\u002BPQK8SJH8nM4swhssMfHdnMxyJZvE/awTDXUcRp78QovxyY/oBlBEXAfc6MEHL6xRwasG776COX9WqXtc4BYvML\u002BPOmhh9Za77YmT59TqzB2IioUz9VMNb9AQkVzVJ7vx7fhBd/VEMAvUiwI07hFqq51dlBWQ\u002B3ssgcqYESQ5poXN4jocqVQoRJq5HypRGEG\u002BpiX/t5OmIPK9FPYqq97n2uR8JwwXTcIJdQ97F5wQm6lI2Ws\u002Bei8yJ4EHX1Rd/Zi70URGFPE1p1gjtkJEKwlWbLlModJzqWD1Cf\u002BKz\u002B6tq3e2v0YXioa4E3ITGoOs7jx38TLbERvGSCfjkMrxqpdptcrKjWvDPqIyg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "bp2\u002BjaaVxDxDyBT4DO4wRA==",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7CD9A59\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e6d078dc-1aef-6ba2-a593-e3888242d2c9",
+        "x-ms-content-crc64": "/iAwpO9FSQg=",
+        "x-ms-request-id": "146bffec-a01e-0055-65b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-6045f154-b39f-be81-eb24-64023259b8da",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "traceparent": "00-e19f589763fbbb161ac1588222f54e5e-197ce8278c70e842-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "15c6f27c-7f17-7b93-7d37-ceb38c15174a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "tJ4q7o29CyttvPghdboKN1Djb5GCvw1qvp1X\u002BiPDDgY/vzmHgyl/D1bostwymMKi3yz1CxUTofSRwDDwZhEIqq3y4rWBgrMmZF87mgwxNybbtBr2zQLxKx1E9sP5j6hE3wcvQLYMIFx5zqe12AfoYIgKFLL3EdyqAbeXPYzvLdS29roEAfdvzpO9ff5aO1IWXJY773r2Tc0rhT//dOPQiaHT/uJM416RmkYeOZTeT8VkgeH2tD1ZwKjt2Xu3cFqv7fRdhzxvyXk3qVU02BQ5TTZ5mvIC2dVjej46Xwni2inrb0yggMiJ9bdnvwvoJOiUs4xFPtZnrRQe\u002BQz9NWlvVM8rSWnHmcxt8KU7mhnKe1VWpax9nZtThME4gYe7i79N\u002BGs7vNt/zBnA104wLBL6VH63po\u002B98rcz2MSnjxhEsmTl7aKujr5619iSvcVNIlevPSwJBOUvkAWzCOQW1z0BeyXqSz9wTMbAPM\u002B3KjXy5bZs91LsO65\u002Btlyc\u002BobZY/\u002BbkUKgY9cYP/FlSccWeGXQwSIuqeDrFT92a5Xi01FA5tjPG5nzUYLeVLdghvLnaD33yzhjqrofsHwCKfhBNmufJWLuRl3M3W\u002BgT1Uoio5MjwJX6wcY3DsesGod8CiJnB1LwWGQ\u002BCLgKu7Jw1tk9ibttZr26ktkhkgnz5byruxHFrI43MgtvJbgd8AZTxngurlELzqNk7LS5zsYaCmL7XwBga2oLBldwPkEFnKKSjYvRhTcrX\u002ByuoIAZfWNFFNsVIlEF85rN46g5m9BiH0/R50E6SIUr0D8T8cqqMYk0Kyll8HpRjJnww6GPMcQcDEEwB1YiSoxWKVJR8gHQI/HfBbCnPG8VgFqnCYTjXN47N6VJeipy0eBcz8cn/5pYIJ/v7\u002BxTdRASGkc7ewEHsoy0FvqcRqnHrDOQSixn7cCADyjlM6zx54JVd1\u002BjN5afVV16c6jf\u002B5n16EO4gysjqiyGe2wYIn7fgm84Bw9KJHSdMPSPLboX4BNO7wtpOWSXcc0zHPxqhzMeWrF5p/SKa4PPG5I2lHyyblsYyXNztokKoJUCVwd4cmnBsNLI3ngehENHWh3SYN1QQO6hEf3/6qQobwdfSBS8lukodSOp6ZAi\u002BgTv7FyrOD/38dZY1yCsAYYuoG9w/3xuyoM06iv55pcevlf40D5HvTbHZ5Z\u002BY/\u002BIfDNdewkg8fqIgOGZdk3T/cs/OliI8zGHpyN4aVfl8KbDbG34nGtOPcxdME8c7gbo86mLPylm/4kBlZQl6Ehi4pB6lcogG2GfsTyMa4Liqvjcj3XuGvF9XGyk9saXaFVEOg2\u002Bohg8yNgH604s2pPGHurbCRjSdMfe/TldeyRbCEinCDF1A==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ojuBkETKZVOp7bNXVxfXPg==",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7D40211\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "15c6f27c-7f17-7b93-7d37-ceb38c15174a",
+        "x-ms-content-crc64": "Koj\u002BZyPC\u002BPg=",
+        "x-ms-request-id": "146bfffc-a01e-0055-72b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-9e19c324-4f3d-0e79-13df-21a3760fad6e",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-30a826f02ec417bed18a559aecf0f537-77034d29ffc19eed-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "aaa62ffc-af5a-10bc-8f07-01e3a8e53077",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "swdWQtRbfXFg01yBlFKLPQ==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7B3FB97\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "aaa62ffc-af5a-10bc-8f07-01e3a8e53077",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146c0028-a01e-0055-19b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-53b3cd78-e1aa-c091-0024-2108d571fc1a",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-93d5b0b1cbcb5cd5658bbc5677a80fc9-8d6090bdacfbff90-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5cb79dc6-6c6f-daef-87db-f9e2a4652a55",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "xJH3e4hKuymr9kLa6BWcNg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7BA1534\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5cb79dc6-6c6f-daef-87db-f9e2a4652a55",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993d8691-d01e-0002-31b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-9666e5b7-d05b-e672-4b4e-b2c50952d02f",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ccd86d3ae16ffd9f5087f0f78aeb804f-1a10d22550b274bc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0b1d956b-d32d-bd07-cdff-ae98ed253243",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "wig5SiyZYxhnWvAuYzO1tg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7C07CE8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0b1d956b-d32d-bd07-cdff-ae98ed253243",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146c003a-a01e-0055-29b0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-49d175c2-f999-42f9-3158-9e182e7138a2",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3de53849381632811b55f7ad1a5e267e-35092dae87bb726c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a23c2ef9-23ae-aafb-5f24-a88f25f9ffba",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "WA2dSIYZP/DoZia4MozosA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7C6E49D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a23c2ef9-23ae-aafb-5f24-a88f25f9ffba",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d686f9-401e-00a9-50b0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-91eb06e3-17a8-a712-5bcc-075c2fccb7ae",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6f4219d204fbadc2304124a7233d71e8-a69abbbcd4b9a29c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d401078-85e8-7955-c1f2-ee60bfc5cb68",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "bp2\u002BjaaVxDxDyBT4DO4wRA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7CD9A59\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5d401078-85e8-7955-c1f2-ee60bfc5cb68",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68287244-501e-009a-1fb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-6045f154-b39f-be81-eb24-64023259b8da",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c85133045fb50add48a77ee7e384a505-cbd718943cb07fcd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9fbf7085-149e-0283-9433-e567bec91e59",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-MD5": "ojuBkETKZVOp7bNXVxfXPg==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7D40211\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9fbf7085-149e-0283-9433-e567bec91e59",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fca939-201e-0029-76b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-03e11015-3f66-ab87-6229-edccf19d1365",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-b33c409b7d4ca17f90a03e69c06d6578-11bd20316552ea10-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0f764b5b-1e48-5e27-70ca-54398b252803",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-9e19c324-4f3d-0e79-13df-21a3760fad6e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7E84A64\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0f764b5b-1e48-5e27-70ca-54398b252803",
+        "x-ms-content-crc64": "M47/xqp\u002B2\u002BU=",
+        "x-ms-request-id": "16e8a181-e01e-007b-76b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-4260ff11-7a95-3dae-0db1-7e389903f851",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7c6cfee2e5e7415ee127855571fc55f7-ce6da218a0117d5a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4655e307-d99f-01f9-f66c-9dee4fd65331",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-49d175c2-f999-42f9-3158-9e182e7138a2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7ECDD94\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4655e307-d99f-01f9-f66c-9dee4fd65331",
+        "x-ms-content-crc64": "1xqOJtHVvYc=",
+        "x-ms-request-id": "64d68721-401e-00a9-73b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-1e462d14-b3eb-1448-699a-fe75c5b5cc4e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-a2730fff07a1adc1e62076af30299e14-e8045f9b14f55e33-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1ffc293a-b7ae-f0af-9d20-92dab65e7897",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-9666e5b7-d05b-e672-4b4e-b2c50952d02f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7ECDD94\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ffc293a-b7ae-f0af-9d20-92dab65e7897",
+        "x-ms-content-crc64": "TKQqKeCbhwg=",
+        "x-ms-request-id": "146c0048-a01e-0055-36b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-3dc4efa1-d72b-3002-842d-a583b2107501",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-c7f6d28b3cd0fb0cf78f8cfb1b3543fa-d98c43848e512727-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "14179f64-a1b9-f3d2-db89-ecf9c99a3431",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-53b3cd78-e1aa-c091-0024-2108d571fc1a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7ED79C7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "14179f64-a1b9-f3d2-db89-ecf9c99a3431",
+        "x-ms-content-crc64": "rIX7IgwYioM=",
+        "x-ms-request-id": "993d86c9-d01e-0002-67b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-c4b7ebb4-f456-ed7a-a7af-d491d98c6acf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-db8672983390db2f2c29bc97f1bdda1d-820ff0cb863829df-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "db5f7bb9-d874-acba-9988-6a50346cb715",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-91eb06e3-17a8-a712-5bcc-075c2fccb7ae",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7F2F732\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "db5f7bb9-d874-acba-9988-6a50346cb715",
+        "x-ms-content-crc64": "/iAwpO9FSQg=",
+        "x-ms-request-id": "68287272-501e-009a-49b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-b3725760-32af-9a6c-7e08-1139350f7b65",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-13cd26c384b9710efb99d98f721c6b00-07daafd4d3bfa861-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d334fec6-7876-4bbc-4787-4c204da27fa8",
+        "x-ms-copy-source": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-6045f154-b39f-be81-eb24-64023259b8da",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:39 GMT",
+        "ETag": "\u00220x8DB71C7E7F2A91D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d334fec6-7876-4bbc-4787-4c204da27fa8",
+        "x-ms-content-crc64": "Koj\u002BZyPC\u002BPg=",
+        "x-ms-request-id": "69fca965-201e-0029-1eb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-03e11015-3f66-ab87-6229-edccf19d1365",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-70d52a1dbd2264c6f1bdab328e93d937-c869efaf82155937-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "35898b76-e338-1d9f-37fb-1139489f024f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7E84A64\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "swdWQtRbfXFg01yBlFKLPQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "35898b76-e338-1d9f-37fb-1139489f024f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fca9fb-201e-0029-27b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "6W1MhDLyOIHv1tErO/71I1bWlXPXvDkjiLXU6OVu0Fr6xaC9IfaHPwzVxTk2dsKF18gbq0uMUSwzKPx8HU\u002BbgQV3MXZeNwFfTlVnAvcA7BLzTxAdUyUPbXN0ivj6CyK8OUQzvkRLJ6DGu131JU81Mzvpic4/fi7gaMQD6a0IZUMzqsmyzC7NpyhwVpfIGUcjP1a9EIJTfboWU1Z/SD3yvlUawnuGgmcNG\u002BGmzyiWGE9936pXS1TA3ywOm3jYTl7qfZhCrVfLnbzvr/Wgra6SgDsGAmmTm3IBWeJPd\u002BfuNc2Cu1KPVGr3skHuZ5tfHzJ\u002BfBo90Uv1V\u002BElQVR1eyXUAHonHvJcAizQDlAnpTTXoTmv0fvMsGSBjWNwahMWgjYcGWYhNwFAInnubcL7zrKtTp8axaoqCFAVpZGO65gZuowZC4vNtWo4b6\u002BB3UOihr6wwxtz\u002B72L8RAWC5FwsTbg1LI14cMm35g14VX7qCoMcx/S3ih8pb7Ojhl7tqnYyL54oAmRbKX7ieOCPhpnkEjmCphyndIOYy/0ZlOpqynvXBmXgwghewd611RE\u002BmekZ/7RlawRZSrraTzZnQVSUd26k\u002BEA0AxAxI\u002BQ\u002BMZ9yWnHT/9U2BZ93ffuqxnLR94CJ4V3imaFo5fxkNAdgG1kbZ/TEU0F/XnHPLbqEiTzdXyxjtBBBj8DQqxoY0dFX1yJij15\u002BDWQ/CoLr02wmpBz/RtTbPKcI2dgz8\u002BgnZkxgd1ZYYjmen1HIJKlNVfxU6gb9GYs8fNq7WfWGChm716R2i1wVjkIjIOeDEtf9u0Qb3wnhagyBZDp73MhD2FU4DAzFFspgPxuEmfjjuWnCvZ5xqmrP2q1XtSdh2fF530hSSsbLOKS5u5/uHJBT3aqQeR9qEi4qaHGfbWGi/mVqCvqwUW5jN4T5uC6K4b3dA5d80WCSD80aZ\u002BJVa4sDFr06RBHVo0x8LUFacFo/X0bzgmmKJi0EmDrtVilLzcw59qFxkF2sB6ALAKQfd5\u002BzGsiboakheTCQNavW6E1jMF91ILn4zc7pR7rJfyWI5WCbensg8Gwi2H1w4VqxlR8S59AEqhcluk05slouV/oKx1BLe63SAkAzUkg8R\u002By0N7JbtpcVRHtJtb/uJz3R9ECDZdoKZlmxQKWQEReO6XJghXrnkuFi9UMUwYXuJBsCIZ3HuOHSadEY6nXxhTMjuoxNjaHDKiGfYLCXNaSTgxyKTi\u002B5x3BQThupjuircXBP8Uc5YFa5fvd8aFhxe3RsRWcZZzcDafMcPT\u002BGWZt48\u002B8ARwRdmmLGEQ84PV8X3xKnPQlBkcp5DEdT3SNW8yVcA3RpcTRwDusEU1Xny2xUBF3s3xxR92Ikxzq8w=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-3dc4efa1-d72b-3002-842d-a583b2107501",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-be18b3816d66a21b9387ccf26e889b8d-910e9823a17248b7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1a9f701-4a18-1e6f-fd00-c3d43ca4dd1b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7ED79C7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "xJH3e4hKuymr9kLa6BWcNg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c1a9f701-4a18-1e6f-fd00-c3d43ca4dd1b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcaac6-201e-0029-61b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "oKr/4O9w1J7hsBueKZ\u002BNgJdkBCk2FYCPtFSuJJIzRvOz7sazePHa/nzbkTaj\u002BzXAFQ2e7ejnjooqcCyawrAMrWko6jrY2gemigWsW4NJ7Lge7g\u002BFlFgKzF88iQjEPzzMz\u002BTMexD65zsF\u002BGPjOjMG4IRzfNOghhgQHR7bnFH\u002B4UrJ4IuffHCoJAbTf5z1J5ErNqiDUcNoK0nLvF7xHkvqBhYZGlqoZmMTy1fNzAZ8G/WNsGaoe5CGYLRC1MAStgW76XiF2w02g89EcIZsm15CT6BoZG7lQYuGk7mmZZKjABRSEuON9kDnVi2WZAoKGcRV/4UgqlGX1ajt/kdUkB08oW9xGol7tVhfgA5BTtyBfHn0UGYNglbDujw6oPj4k8UPWcKbmP872UoswClDVobLa4LOXz\u002B3Lx8Zrl9MQRRgZ\u002B1JMfUa5uN5uHcb4MEtf2S1bzR1KjSFWCqjgeqg75g1zFk8\u002BiWRsYWeVKbIm05d7C77l9Lg6j25w9jKdmT42cnf5RNo8IU/I72u19WNvbzcRpW8pFjGVeIcgzZMxjshpXrc6bY69PuovHMUMRJnKwYb7i/OPDVxGY8xTG1O8lyCjTFbsNQGoVGaE\u002BjlsSPPtFcwMdgLUmlFa88mCaiNWckWkqThDHoxFU3eNChMjGdrYZcWHsGEdzrHFUUE4JipDLoezh9/7ajd/huLLR5B\u002Bd5ouqcRdzsIkRpqGvY1LTW0NCduLb1I7HPuOR\u002Bl\u002BUkchhxmnCXxl5V\u002BFj0EFdOxp9Hm1vj208shH80zIj4cY5jQTZPazpEPw52S7xd/Q9egPJFOviJRJrNQRHxXvnRXYrKlM8dA19lA1xNaY\u002BOzodz2k\u002BatzqR1fyfgiYkUtwQoO41k2g8QX2S3DecP9sLPnKOgYSuOqpQOMLSfX01PKx8OMihWT8fM5jOB9cC8ZYhlEOzmdFbZmpD4VqpbcAAXaOLIAMSaeE3b03v3DLXUUcorOk5gaLbINJeXXvgccHUzaozd9GTEy5efCqHb4Y3bJATgMDWxtgAs/8wsAhpUv2IFxKIo9l1lZm\u002B3wV0V7VIJuznzPEA/gbSLsfSYl8h9Sks\u002B1h3rsi2nesnG\u002BvSiFhF5IkbgYYIixULunUVpzM\u002BmOncR1xc1HggMTMJ3eYe/6JriH3WBnOnJGxDa/RXnPq36H8B9kT/6QwQ91BTAq0u7LrSrhq1aJZ2NSLsGWyDzJQ4UfVnHQlda6NtwQ8jUCXDFH85hPLcAoPoi70iE8\u002BjjSq4Gqy7y8\u002BxcUJ3S6eHVuT5KQTxRkelWFNxepVIO1vXyjPkZzl1C0iviBesaLbYZTDYKOrGrkbnFr5dRk02aTXqo313ovOrgB24Qb4v9O\u002BYmRQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-1e462d14-b3eb-1448-699a-fe75c5b5cc4e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9fe50e9b39f41391bba53d7d14e82822-b585260c32bdab5c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "50379e57-40f5-d837-19c5-8b26533a3c7c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7ECDD94\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "wig5SiyZYxhnWvAuYzO1tg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "50379e57-40f5-d837-19c5-8b26533a3c7c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcab3a-201e-0029-45b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "9tjQfveLWaqro1yBcaNUWyrgy940M4rG0I2fgHRhmP\u002BAhILSRR5F\u002B76oV1i9VZNDBHAC/HX4A8JNCa5q7Nk2SQpdAOwggRUMms8gjNwxCXr5XHwEX5yJiIDAhTxw2w/kcg1OYFWnIoJb9WGl13flHAAzcI9dMepu03drYPzYm7\u002B/OxrO46glUjn5qGk647EJ2mk8PGp/h0Aj34zdPMKGglqi5pxdFzhXDh5WZImBNO/GYYWTnF9UQLPaqwQcRxV3cyYPl/0UrMMw5C5MKSO3oqqdF9o88uX6Tabpg2w0O8YI3vBicZ3xsrXCYrgxBxaQIglZfzA7OoBAFElXKylX/KlnREoyVDANq2Qleo8tyUaPWGBi2ryVzaRvIV1TmYeLa2YOycPLXc7YTNPLFcDxE0sDyNLJ9CLt0XemwzLTuRHdmQ8pHv\u002BDxPuRio3oybfjfg4RUNG0wnZEIPdLJJqbBZLC7nyxyPRLfwPWN2qUBQfAwkQkwWk/KdaY5P0IN59h9YT6Jds6MrYZxtDN3YoMsBvvi2FVd0MpgsWlGOP2Q0hkdUHlmd8shZCOCvuYcUtLizTiGKw\u002BC31B0aMWlRnSIoOIaWhJJxY7wwbRx2xIkRB5WY2vFCqcJmnEpMg8FfB2u\u002Bh4EAjiAmMdplWlbEMQ\u002BECSnDuMIw1Y60P\u002BhYNO/64VWwyEz4AIl1cqkW7V9rkls6uIqni16pfaHyTE433gz6amjxE3jCm/iQXjYZGfg/WK2NLYxlU1YHB0qrBbRLTZSsLHLman7iaByCBz0YgFO5svOgqrBwhRcS\u002BgwuJ4Y0VRChfP11WP4uqrVv00wo/ob24ULAmpLUK5dbw3ByxECWTaIsZwNmNGoFggALALHa6fuFNzZDc7p9zVFmGYV9u9Zk2ZWaDIdzkLzoyxiS2RrlgOl07Z0aQtnnrqmx8BrUh8YpljcsMO10AaaJarih6vQ2gIisCM5JWoa7ol3twZCSBDNCaTLjuV/8ANv2kOgRRcO1e3\u002BSOH8H4EugYI6PlkAV52Z1X3GxUsc4oAfiQsmuqmyKKEYRD9u0Snj3M1jRbGqb4KmBq/ZSBCi4WYh3FZ1yAcYSBW359OeKsRT4ui9uVzOdVmIgLP5mOCQtWKZDTSTrhSGSv2cMkeux9urhWUn5WgJE6c87UdTHq805zKxBN3PgHST925fcgLR2biYThN7aJA6UDlNVoDNc2wOZwtVPYL9m8UwVC45qaFkatOOupCb\u002Bb5idrTkQimzxoPCEMs3vNw12rIOCtSiAOZYKSvtPribsq2M8ocOGVnbvE2qN1jWLO43mOAeTa6pwHXOTBj9xsgLZp5daooVJ8FYco5HOAlNgfx99aWYfWT/IzIRA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-4260ff11-7a95-3dae-0db1-7e389903f851",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7b1925abe03edaebb464532a7cdcff71-7fe85f87cfebc586-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9d7d7671-8d6d-cd25-63d8-042a70070c42",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7ECDD94\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "WA2dSIYZP/DoZia4MozosA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9d7d7671-8d6d-cd25-63d8-042a70070c42",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcabd3-201e-0029-48b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "AhXzRIApXGO\u002BSdv/eM2PvpAzrvitgOMKZYvdFPK1xhQagJ2ORoDDulC8Tt4esZgEpCKkTv9xMoEy6N70S0dxCYLG5PgvAXgPb/On8DIE7LPz2XDPEXcUqU4bW12iz28JS0VbV8yf1KKqld8MyUFPLfwqAHLWofgLsjuqE6UabaCEnqXsqZXnUwTOJXuYCN8MzC1hd879MqpNUKWQ9cD8kCc\u002BiCucYoRnQ6xtCHt8cqlbnkd3ufbRh2v7n1jvVl5D0ZRUWoC0cGqp\u002BjMhjyku0N77NFd5hNcxbAC/oMIrd\u002B1OKTfmKBgppy3czr7DsPdBzM569CEHyky9I\u002B1/9M\u002BnfYNG02XyR6jF0o0pnLYYbrwJftTzsYPLR1/rKQQrqrNdNVA7fN2RT4UmtCKU3S2WpLUwdnb7s8wAeowGBx2jmifZy2dl3fHfdy5OzfxgN2kyVYRP\u002BjQ9YoGDOwJQi0hnghn6uhHFMMfDUP5HrObQn0Ii07KZVKDznGnm4qHujuvm50viZn1XbSS8i6k19rWbs5zALreVzS55Bh6o3k0m1cISYMWa7TjFy2aN3Mj2vqWzSy8ELmA0URkdaWBfro7XlrbnIpbvAMVk\u002BmNRCPFmg0d49JIeIaZh3g6sfYTXZhzXtkYRDpsPw0tpoDP94kgot\u002BYY5rn7uHQPhUSHQ4JBjJRGeVGqVHSsaDFHtYBzZPvGhMaev39i2/7RAohXiIDIJxSftmn2fWNxbH6ItAL0nCFIwb\u002B8o80V5J1T2VHrVeCxf41s062SzwZjLFMB2Sf73WVnDsbAC4RGitLMo6MRhhed1zV1h8h0tvK4WXZ5Ewp1WPzrhEYZ8HMJJUnaxitjUqU8YwHyhlWd8ljUB7INzXbHVkqmJQLQhOfCbGF/mfDGVQfQPbAJg9GmTpHuRenA\u002B1jSEm/gvCyja98aMBrzHVhnDbKrPI/FvtN5ANZw4j79AXAJrIaA5ZjaLdLR7lK3sjE4hjc2Fb7JDVScZ7xWM4mgHC6p6nHS5igZ0A\u002B99NCAwU2lN1sHx\u002ByyP58y5H3cg/lIMdIjDcfAZp8OHUSuDBiDHKZvsfstmFVC96vRnwKqPE0VdMP\u002BXLOF5dC7\u002BKmnAzOGrsfWbdL\u002BGph84RYc7secY\u002BD3mZdVhb/z6cwqcqCsmvR3SvA70896F1krgXqcaPYJHpTIsGqcMSkH44MG06j30EYipaPXYY8RfIE9KgREVoHVIVML4\u002BqK2xnHM/BLdESxM7E0esNTMrwEtjPoXgYlwo0CMLFU7OxcmMmJEC6fxgg9jPdSENu9ge\u002BWBi22oXwSoXBiSUOSXEbE1\u002BH5ySKNZPArq9IP0rKyRK/CvuW/pvZMdm6\u002BPXzEqi\u002Bwjjn5ww=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-c4b7ebb4-f456-ed7a-a7af-d491d98c6acf",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e09e0a15513f9acde4be219a779bad37-424925484bad5251-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dcb4c670-9ebd-a30e-d88a-9061825994c2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7F2F732\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "bp2\u002BjaaVxDxDyBT4DO4wRA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "dcb4c670-9ebd-a30e-d88a-9061825994c2",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcac45-201e-0029-2fb0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "vx9XfoywFsYLp0LNtZXrk7IQae9lT\u002BiMKDAbG6i9oc6wD73wdaKvx4eNUerBxdU4VNazCIv2RW83ylZclfodTQZzHabX\u002Bh0PYKJn1/79y2Na48bSCplDucpNuapMUjGMbwPkTacvYFq4pKfojm1xOf/yAbI0S0NsMGPciUFzwg1w22f6GH27K4JsGmbxWitc3H\u002BrWlB/WCTAdxxEUtcYReGZd7MFdiGBNtYvxzDde9Y4f6zCyGi88YNDOqFhd9irVNWEWOJ4VmZdKSN6T5D04/xFDNMqVXx53IYvwjx/IL/\u002BhHNaWCL0vyhGZJ5EQqLyTlekG2oFgf5YC3tcSJQq3gljfMsdmYrZUUyq4/HeNJnkPXPk2wVV\u002BAJ0AkynmHeUHIaV4MbW1LXMy8kdW50NetfheAsgRQIDDoPIqZY9MrnVFcdqSFTTDWi\u002BFxA7N51lZoh1xSBsc9aDkdFDDSsej5gQSEXVozGDDmqiYi3yyNblY0IOx2yZaaLw5reCj/88n4h3Ku9Yj8NW8ra1yRGpkMj7XarpD8csd96i5Lx5AX9qZsKke57njdN\u002Bt9W146CRR1buhzFUU4/BS7MQtaoH3PE3SmJOBBUqE9DXaljxdpQ\u002BEZ1li3lNFhMz4jDq1tcod9rjfpg9Q0JBw3Nhfek3z9Qe0aMNoVF36jRPGiHkPzz4rvN9Dfj7Ac5aJMcG65kq\u002BxNbywU0G9WJbJNk7SggXIM2ac71usHcI8/Vsn2Jcf6bJR8OiHQ3xJMd86FklxOmOchD0ILKNEFRfqg1X2hY//uUyMgJEtMP/qU62MYgeIu7L3i0RaB80PHevQrLAmUqxfOm0M5LnCf0NNHdkFt6MAYceS/wo7paGPjWK1TJRPtADxPTeae8cJJRwBHPn0CVY4wDrok1OiE5TLjWdXHSKu/VnYBIprZeYAmdnuKoi3m3QcfHxpZyCtTxmS3v5vogfpUh\u002BQG/Tb3VpE6Al5w\u002BkcE\u002BHjOqCmRZYpKsVg2Jb3kOfCBNhpF3\u002BPQK8SJH8nM4swhssMfHdnMxyJZvE/awTDXUcRp78QovxyY/oBlBEXAfc6MEHL6xRwasG776COX9WqXtc4BYvML\u002BPOmhh9Za77YmT59TqzB2IioUz9VMNb9AQkVzVJ7vx7fhBd/VEMAvUiwI07hFqq51dlBWQ\u002B3ssgcqYESQ5poXN4jocqVQoRJq5HypRGEG\u002BpiX/t5OmIPK9FPYqq97n2uR8JwwXTcIJdQ97F5wQm6lI2Ws\u002Bei8yJ4EHX1Rd/Zi70URGFPE1p1gjtkJEKwlWbLlModJzqWD1Cf\u002BKz\u002B6tq3e2v0YXioa4E3ITGoOs7jx38TLbERvGSCfjkMrxqpdptcrKjWvDPqIyg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836/test-blob-b3725760-32af-9a6c-7e08-1139350f7b65",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-106bdf929281861e9adda67d72a81988-1f1dece68d8299cc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a9ba3036-3052-3684-8854-f3560bb14dc1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E7F2A91D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "ojuBkETKZVOp7bNXVxfXPg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a9ba3036-3052-3684-8854-f3560bb14dc1",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcacb6-201e-0029-15b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "tJ4q7o29CyttvPghdboKN1Djb5GCvw1qvp1X\u002BiPDDgY/vzmHgyl/D1bostwymMKi3yz1CxUTofSRwDDwZhEIqq3y4rWBgrMmZF87mgwxNybbtBr2zQLxKx1E9sP5j6hE3wcvQLYMIFx5zqe12AfoYIgKFLL3EdyqAbeXPYzvLdS29roEAfdvzpO9ff5aO1IWXJY773r2Tc0rhT//dOPQiaHT/uJM416RmkYeOZTeT8VkgeH2tD1ZwKjt2Xu3cFqv7fRdhzxvyXk3qVU02BQ5TTZ5mvIC2dVjej46Xwni2inrb0yggMiJ9bdnvwvoJOiUs4xFPtZnrRQe\u002BQz9NWlvVM8rSWnHmcxt8KU7mhnKe1VWpax9nZtThME4gYe7i79N\u002BGs7vNt/zBnA104wLBL6VH63po\u002B98rcz2MSnjxhEsmTl7aKujr5619iSvcVNIlevPSwJBOUvkAWzCOQW1z0BeyXqSz9wTMbAPM\u002B3KjXy5bZs91LsO65\u002Btlyc\u002BobZY/\u002BbkUKgY9cYP/FlSccWeGXQwSIuqeDrFT92a5Xi01FA5tjPG5nzUYLeVLdghvLnaD33yzhjqrofsHwCKfhBNmufJWLuRl3M3W\u002BgT1Uoio5MjwJX6wcY3DsesGod8CiJnB1LwWGQ\u002BCLgKu7Jw1tk9ibttZr26ktkhkgnz5byruxHFrI43MgtvJbgd8AZTxngurlELzqNk7LS5zsYaCmL7XwBga2oLBldwPkEFnKKSjYvRhTcrX\u002ByuoIAZfWNFFNsVIlEF85rN46g5m9BiH0/R50E6SIUr0D8T8cqqMYk0Kyll8HpRjJnww6GPMcQcDEEwB1YiSoxWKVJR8gHQI/HfBbCnPG8VgFqnCYTjXN47N6VJeipy0eBcz8cn/5pYIJ/v7\u002BxTdRASGkc7ewEHsoy0FvqcRqnHrDOQSixn7cCADyjlM6zx54JVd1\u002BjN5afVV16c6jf\u002B5n16EO4gysjqiyGe2wYIn7fgm84Bw9KJHSdMPSPLboX4BNO7wtpOWSXcc0zHPxqhzMeWrF5p/SKa4PPG5I2lHyyblsYyXNztokKoJUCVwd4cmnBsNLI3ngehENHWh3SYN1QQO6hEf3/6qQobwdfSBS8lukodSOp6ZAi\u002BgTv7FyrOD/38dZY1yCsAYYuoG9w/3xuyoM06iv55pcevlf40D5HvTbHZ5Z\u002BY/\u002BIfDNdewkg8fqIgOGZdk3T/cs/OliI8zGHpyN4aVfl8KbDbG34nGtOPcxdME8c7gbo86mLPylm/4kBlZQl6Ehi4pB6lcogG2GfsTyMa4Liqvjcj3XuGvF9XGyk9saXaFVEOg2\u002Bohg8yNgH604s2pPGHurbCRjSdMfe/TldeyRbCEinCDF1A=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-88f3cec7-00a7-079a-e2e7-7dea1707a836?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5b5cce3d76eaa5f64cd5f7b3ee55ae1e-780441e41ac3ac1f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "522b5db7-ea9f-0c6f-7dfb-15f9968ecab1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "522b5db7-ea9f-0c6f-7dfb-15f9968ecab1",
+        "x-ms-request-id": "69fcace6-201e-0029-42b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "374340266",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,0,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,0,30).json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0d584a96-23e2-80ac-2d5c-9a13136871cd?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5c758f4fc7dae5b9429bc247755f71e5-beacd09bb7f3f276-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b924c784-7d42-73aa-db23-e93915e7c746",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:40 GMT",
+        "ETag": "\u00220x8DB71C7E8886BDE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b924c784-7d42-73aa-db23-e93915e7c746",
+        "x-ms-request-id": "69fcad16-201e-0029-6db0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0d584a96-23e2-80ac-2d5c-9a13136871cd/test-blob-5e4b3216-dbb2-b01c-c95f-58b93214a97d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-8f619acdde84db1f2b63d2f9583600b6-615d03d489b2c3f5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "f84a6b79-7b59-5e02-a802-b0c9ea88b482",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "ETag": "\u00220x8DB71C7E8A1461F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f84a6b79-7b59-5e02-a802-b0c9ea88b482",
+        "x-ms-request-id": "69fcadc4-201e-0029-07b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0d584a96-23e2-80ac-2d5c-9a13136871cd/test-blob-4b8e1cef-b844-498a-ade9-f094fc47e3cd",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-e24f77e3ac83e2aff83398679c5ba889-3e6769b348963d5f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "901a29a8-eafd-e674-a722-fb615d01bf23",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "ETag": "\u00220x8DB71C7E8A3DDC6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "901a29a8-eafd-e674-a722-fb615d01bf23",
+        "x-ms-request-id": "68287923-501e-009a-27b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-0d584a96-23e2-80ac-2d5c-9a13136871cd?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a96a7cc9cdac6a5a5a5ffe59fa7f5b80-ad1fae1450ad3a6a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c020f4de-236d-9185-1570-e17009b7834f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c020f4de-236d-9185-1570-e17009b7834f",
+        "x-ms-request-id": "68287ada-501e-009a-23b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1870997611",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,0,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,0,30)Async.json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89158a30-c3c4-2f1a-52bc-517dd803b99f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b9ff5fd4ac5a071e0dfec8b118e9782c-2d92278c95cfe6c4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "51e7e567-42ae-e1c9-bb0d-74836bedef2c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F2B6FAC9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "51e7e567-42ae-e1c9-bb0d-74836bedef2c",
+        "x-ms-request-id": "69fceebe-201e-0029-18b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89158a30-c3c4-2f1a-52bc-517dd803b99f/test-blob-06b2c5ec-5d18-78f1-3ba3-4c6e996c1baf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-b171dc303116c350c8fd14a75fdf4e78-dfff6487b98fbe21-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "2c35c5f1-fcd8-8411-d42c-a787b933356f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F2BFF44F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2c35c5f1-fcd8-8411-d42c-a787b933356f",
+        "x-ms-request-id": "69fceeed-201e-0029-40b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89158a30-c3c4-2f1a-52bc-517dd803b99f/test-blob-f2153e4e-671b-86f0-5e90-a3be43cb064f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-b14169cf44fd01b1473cdd8a06d4caab-9dff5273a909bd7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "7dcc5448-d996-6a77-ec3c-79c4c0734fc0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F2C23DE8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7dcc5448-d996-6a77-ec3c-79c4c0734fc0",
+        "x-ms-request-id": "16e8e5c6-e01e-007b-24b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89158a30-c3c4-2f1a-52bc-517dd803b99f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-332b02edf1922eb912f5e77e261fe854-fb2163382c09d2df-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "653fa39c-b767-c4d9-859d-ae6e53f926cf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "653fa39c-b767-c4d9-859d-ae6e53f926cf",
+        "x-ms-request-id": "16e8e6d0-e01e-007b-09b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1421447238",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,1024,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,1024,30).json
@@ -1,0 +1,289 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4579b863bd22878ef76d825a805fea72-7af24265790afe5e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3e31654e-8c39-c679-71fa-a79351e8c977",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E97845F5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3e31654e-8c39-c679-71fa-a79351e8c977",
+        "x-ms-request-id": "146c0536-a01e-0055-56b0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932/test-blob-5cfaf565-ce3f-dc24-f4f8-4fa467347fcf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-ebf4b3bc386a41f1fa56312a87666f65-508b0efa76b9c972-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "74fed1e3-de54-aacf-2bee-88bc3fd153b8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E98088F1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "74fed1e3-de54-aacf-2bee-88bc3fd153b8",
+        "x-ms-request-id": "146c055a-a01e-0055-74b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932/test-blob-44f9261a-fba3-ecf8-3d46-cf4320ba82af",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7bc56a9566d64c30c0160cbcfbdc73f1-29e01fd752ac6e47-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "83edc914-2064-b367-7537-afbedd26103d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E982F989\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "83edc914-2064-b367-7537-afbedd26103d",
+        "x-ms-request-id": "69fcb441-201e-0029-44b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932/test-blob-5cfaf565-ce3f-dc24-f4f8-4fa467347fcf?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-c0ec029715432113d8c04afdbe897a30-ba66c3f92a4a5f51-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76a78f36-d0e3-5254-7dbe-beb7b2078043",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Tqk7puIvbIBAVUlAPdVfPXvYeSruhNRq/A0e\u002Bf7guzp1oFW9\u002Bdjt6rp4A06xt65n5pLISEBYwMnV0KrUEHKCX5kPyp1/oUSi6o9wdYGGuURftxNsGHL6Hd\u002BL6CguGdpH9qS0ouwR6EVNJV2x50pITxdldVlfFkcmFK2987gcdNG0KH/c0RZXTc7NHvIVSTWVQpkRyKSB6N9cjY0/U/SMMbGM/L/La30ADieKkfhUEct3KLAeC6wtM0CfgESJF/naQexBiUx2ytccELl89lbnB3zBxytDbSYFXsh\u002BK\u002Bs4d/Ytr08LE4h\u002BAV3ZAvrysDzpt3jIx0/Ol9PFPCqE957r45jDT0cG3PTzQ8bNaWsrEq2MlHNzcLCmXhh8Rddd\u002Bgm\u002B7h5iL2H149uE1IOJAC1omil992Mrd3LoHPAuipYclki9DntMyeNLl7GX75wsHV7qE6uu4AKmk3areRJxxlhFZz07y/GyG9BFMWCxk4jWu/6SQ3bqbbZFF3sEoFDQ2tBYUode8VFsOPjbaK6i9ADu1b0T34LhWvmH9bR2rnqAdVePWEAAd8qtJQt\u002BDwUHoyN6FcqSvPpOd/iN1/ud9Yp9W/NXEpu/7V7zZrl2Y0r0f1KR\u002B5iw7bhcQeFIc6DODy\u002BBAbQSsJCHuydsn1ZA1xStmVepC/rxzG06\u002BtG6d3q\u002BJFaJ9WGW4c/BCUBwRE5hG2nNm9pIJAQ1jzRG17a/zUOtrXv/tuKyFreI6AG5gIgf2d5n7Nufdf9SVGUsTwoYAjz8wpbSYWSHGoQjwDwCfA\u002BrJ/7XV\u002BBoDjd7rWJ8hcesb\u002BXFvb3xTHd54NFXfLXCUNhWgScMQapblLRfV7QCC5W8dlFWPb5RutqGXncOEJGCuV2KJQSfoC47aSgJkvXDd9U8mgZjbBMZBcZNheIzTYMj3J5Xd\u002BWQHdUjG9OWSCflw\u002Bai0nWLHkxKcSA9UhtLBxyk5rVXa//wq30xQFA/g72fZ8H7kXoOl75RDQbEU8q52BS38WFxjVfnsib4Wt78Cu1jnupaT3Whlk73Bl75K1izd2c8iJJbLdppFN9UFT3fVAIYYLXfXoieFloTeof57YbNReJ2wIJbCHAQ8TqWTIEQGLFc4Mqj0xjfnXE3R7NScCdZh9BbaJSAvFhEzm1NCMnZAmHVnAy7KXHJlyIQJMC8vYETPMWwtbAd3CNyXwSrkZWoXkVSfdManV1ekdByb5iYiBHsOssEKE2xuMDpScptHgaMaMZ7akCu\u002BZ9nUiTfqmyL2dfzv1fJpDX4oMQSMVOT8HLK5QfSHR3QPUAsnNYo0Q1UXW/zel\u002Bvw8SRgsl8m8hL02GxFcVluLy5I4EWnQdez8\u002B2vtPjoHYTGyJCQZpTUw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E9873EAF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "76a78f36-d0e3-5254-7dbe-beb7b2078043",
+        "x-ms-content-crc64": "NT8Gi8Hx0ns=",
+        "x-ms-request-id": "146c056e-a01e-0055-05b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932/test-blob-44f9261a-fba3-ecf8-3d46-cf4320ba82af?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-100a0c949aaeebe0f5e86f60f309a67d-58de619f375942b7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d87c644-997f-5859-d25d-d9c296c4ce04",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "oXjgyHV3u0jupbM5Vt2ZJb0ys/rF3fVnM\u002Bqd\u002BqMidyFlz9\u002BdvT7oVxNuzy0wZh81gfyFDudZjsSDeJWL2sGlyy6R04f\u002B\u002B2h\u002BSVvmVw3HN8zKZ3imnGg6DEEbGkSpXX1SyAP/npKYN4aUB8SLcja2vEHIwHJI/i/FVsdG4uEj1ezdlI4Jx5g6Mi/yEZWjr5kKZF0C4JwLCcrUOUfKUVSkcDHYrd6nrPSpjo5CVuyZIqcuPH2DIPRP0ovENY1Qb\u002BDaTqFkygG7YrhpWVINyLPdOxegnBXXIE88iNtS4ndmWB6uZwdLNVelc9nFGseiQgnY5/l2r9PLAy1RJ0ImaH9BAwEzX2GrkQa/\u002Bik8EQaImkbRevt976hL42Pa\u002Bg0VfgpZhBbGbuKoLVbztrWpjvInyI37Ve6EwxNY6Hz90Jb4qnwe4o3vwixjKEylijjzoVRxszKAGSkc1MADbYZmq1y/\u002Bgw5i6xkNwVhmCyh3znaZEYnix1keJBSAg3M7FSl/H3w5Y8suhanDHssH4H8evWHKAk/Px8\u002BWoJ85oiel0qxu5uvsfmprqkwf36iN1kOVogYRcRLZr1dsYoNr9SNCXUwe2PlTcj73XlfD7\u002BgnCIobZAAhVGGZVXeUf9vnP/VonYJcbz1KAm/HWhL61b\u002BvRVn5EJEjIMjqhUOB/vJjEF6iW1IlipmM0SHQWjpO3n\u002B35TqB7e9kRXy5sem5iEN9ZAn0GLptSbqAbH9vEsaOW\u002BcDyhn34WJvfhXVq9jv0wjeUvYwmoXFSpt/wYGv9TK161YCtb5phYLnRNqkl92h0Fk2UP/QncEhPr9\u002Bt9\u002Bgv0jjH4CC7R1KtM0zCRWrYPK9njEouWRy5U1U4bc\u002B6w2jBoWRgbhc3uM7q9wynZTrdd3MgNnuuAXksHozbgumS4n/T8JQGZ96YP8N7M2IQAf4qWvZcioztI6/rRF\u002BKbDXVWASMw2SWxw\u002BkmAa4It4XHAyesSfzRmfi5tz0KyOPDcONpdtdgz6Zg5P2p\u002BKGNPDBxDhC\u002B6sd4hGsmeyHoqvcJYozKozyyYjeBS2UDJ51bLHsIlb7PBIYf7PJoOlSAdDoGoJYQwpjzwqvdPaNidVzJz0qm4BU4Ol4GrrJORife/Ncq/IcHRm3eFNMS8crmuXuRom8J3ZAgzmY4DhPqpXiH/kDIN3jZxojcyM9CJUiXH/U6vKe40SNDCi4gzzRZ93NWjveKHoICt9viLRDE3qkZpO4er\u002BTUyykdhS1KuPdQgtFf65ZVDQFzOAjL1qQOfiuFBypKP0eKgcfKaJVUt/rkka5DaPcSxJfsq3fYCPCFEwsFxbXNCkOJ0WnSiqRsHoQN50T1zxE0cj6SXZfTrnjTRVWKUuw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E9893A2F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "4d87c644-997f-5859-d25d-d9c296c4ce04",
+        "x-ms-content-crc64": "ml\u002B9L1cJRAg=",
+        "x-ms-request-id": "69fcb469-201e-0029-68b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932/test-blob-5cfaf565-ce3f-dc24-f4f8-4fa467347fcf",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c766211bf851abe0a36551a6de654735-87be8e4d6024e3bc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ec72f068-327f-23c3-e9a5-be3387b42888",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E9873EAF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "ec72f068-327f-23c3-e9a5-be3387b42888",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcb4f5-201e-0029-69b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Tqk7puIvbIBAVUlAPdVfPXvYeSruhNRq/A0e\u002Bf7guzp1oFW9\u002Bdjt6rp4A06xt65n5pLISEBYwMnV0KrUEHKCX5kPyp1/oUSi6o9wdYGGuURftxNsGHL6Hd\u002BL6CguGdpH9qS0ouwR6EVNJV2x50pITxdldVlfFkcmFK2987gcdNG0KH/c0RZXTc7NHvIVSTWVQpkRyKSB6N9cjY0/U/SMMbGM/L/La30ADieKkfhUEct3KLAeC6wtM0CfgESJF/naQexBiUx2ytccELl89lbnB3zBxytDbSYFXsh\u002BK\u002Bs4d/Ytr08LE4h\u002BAV3ZAvrysDzpt3jIx0/Ol9PFPCqE957r45jDT0cG3PTzQ8bNaWsrEq2MlHNzcLCmXhh8Rddd\u002Bgm\u002B7h5iL2H149uE1IOJAC1omil992Mrd3LoHPAuipYclki9DntMyeNLl7GX75wsHV7qE6uu4AKmk3areRJxxlhFZz07y/GyG9BFMWCxk4jWu/6SQ3bqbbZFF3sEoFDQ2tBYUode8VFsOPjbaK6i9ADu1b0T34LhWvmH9bR2rnqAdVePWEAAd8qtJQt\u002BDwUHoyN6FcqSvPpOd/iN1/ud9Yp9W/NXEpu/7V7zZrl2Y0r0f1KR\u002B5iw7bhcQeFIc6DODy\u002BBAbQSsJCHuydsn1ZA1xStmVepC/rxzG06\u002BtG6d3q\u002BJFaJ9WGW4c/BCUBwRE5hG2nNm9pIJAQ1jzRG17a/zUOtrXv/tuKyFreI6AG5gIgf2d5n7Nufdf9SVGUsTwoYAjz8wpbSYWSHGoQjwDwCfA\u002BrJ/7XV\u002BBoDjd7rWJ8hcesb\u002BXFvb3xTHd54NFXfLXCUNhWgScMQapblLRfV7QCC5W8dlFWPb5RutqGXncOEJGCuV2KJQSfoC47aSgJkvXDd9U8mgZjbBMZBcZNheIzTYMj3J5Xd\u002BWQHdUjG9OWSCflw\u002Bai0nWLHkxKcSA9UhtLBxyk5rVXa//wq30xQFA/g72fZ8H7kXoOl75RDQbEU8q52BS38WFxjVfnsib4Wt78Cu1jnupaT3Whlk73Bl75K1izd2c8iJJbLdppFN9UFT3fVAIYYLXfXoieFloTeof57YbNReJ2wIJbCHAQ8TqWTIEQGLFc4Mqj0xjfnXE3R7NScCdZh9BbaJSAvFhEzm1NCMnZAmHVnAy7KXHJlyIQJMC8vYETPMWwtbAd3CNyXwSrkZWoXkVSfdManV1ekdByb5iYiBHsOssEKE2xuMDpScptHgaMaMZ7akCu\u002BZ9nUiTfqmyL2dfzv1fJpDX4oMQSMVOT8HLK5QfSHR3QPUAsnNYo0Q1UXW/zel\u002Bvw8SRgsl8m8hL02GxFcVluLy5I4EWnQdez8\u002B2vtPjoHYTGyJCQZpTUw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932/test-blob-44f9261a-fba3-ecf8-3d46-cf4320ba82af",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-61fdabf8be6c7176a127115e34b53b50-bd9148304c098e3d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a6593a20-e251-ec84-02a7-3103a4244e64",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E9893A2F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a6593a20-e251-ec84-02a7-3103a4244e64",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcb5bd-201e-0029-28b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "oXjgyHV3u0jupbM5Vt2ZJb0ys/rF3fVnM\u002Bqd\u002BqMidyFlz9\u002BdvT7oVxNuzy0wZh81gfyFDudZjsSDeJWL2sGlyy6R04f\u002B\u002B2h\u002BSVvmVw3HN8zKZ3imnGg6DEEbGkSpXX1SyAP/npKYN4aUB8SLcja2vEHIwHJI/i/FVsdG4uEj1ezdlI4Jx5g6Mi/yEZWjr5kKZF0C4JwLCcrUOUfKUVSkcDHYrd6nrPSpjo5CVuyZIqcuPH2DIPRP0ovENY1Qb\u002BDaTqFkygG7YrhpWVINyLPdOxegnBXXIE88iNtS4ndmWB6uZwdLNVelc9nFGseiQgnY5/l2r9PLAy1RJ0ImaH9BAwEzX2GrkQa/\u002Bik8EQaImkbRevt976hL42Pa\u002Bg0VfgpZhBbGbuKoLVbztrWpjvInyI37Ve6EwxNY6Hz90Jb4qnwe4o3vwixjKEylijjzoVRxszKAGSkc1MADbYZmq1y/\u002Bgw5i6xkNwVhmCyh3znaZEYnix1keJBSAg3M7FSl/H3w5Y8suhanDHssH4H8evWHKAk/Px8\u002BWoJ85oiel0qxu5uvsfmprqkwf36iN1kOVogYRcRLZr1dsYoNr9SNCXUwe2PlTcj73XlfD7\u002BgnCIobZAAhVGGZVXeUf9vnP/VonYJcbz1KAm/HWhL61b\u002BvRVn5EJEjIMjqhUOB/vJjEF6iW1IlipmM0SHQWjpO3n\u002B35TqB7e9kRXy5sem5iEN9ZAn0GLptSbqAbH9vEsaOW\u002BcDyhn34WJvfhXVq9jv0wjeUvYwmoXFSpt/wYGv9TK161YCtb5phYLnRNqkl92h0Fk2UP/QncEhPr9\u002Bt9\u002Bgv0jjH4CC7R1KtM0zCRWrYPK9njEouWRy5U1U4bc\u002B6w2jBoWRgbhc3uM7q9wynZTrdd3MgNnuuAXksHozbgumS4n/T8JQGZ96YP8N7M2IQAf4qWvZcioztI6/rRF\u002BKbDXVWASMw2SWxw\u002BkmAa4It4XHAyesSfzRmfi5tz0KyOPDcONpdtdgz6Zg5P2p\u002BKGNPDBxDhC\u002B6sd4hGsmeyHoqvcJYozKozyyYjeBS2UDJ51bLHsIlb7PBIYf7PJoOlSAdDoGoJYQwpjzwqvdPaNidVzJz0qm4BU4Ol4GrrJORife/Ncq/IcHRm3eFNMS8crmuXuRom8J3ZAgzmY4DhPqpXiH/kDIN3jZxojcyM9CJUiXH/U6vKe40SNDCi4gzzRZ93NWjveKHoICt9viLRDE3qkZpO4er\u002BTUyykdhS1KuPdQgtFf65ZVDQFzOAjL1qQOfiuFBypKP0eKgcfKaJVUt/rkka5DaPcSxJfsq3fYCPCFEwsFxbXNCkOJ0WnSiqRsHoQN50T1zxE0cj6SXZfTrnjTRVWKUuw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-e6cc42a4-88bc-1bd5-aba5-d248aad43932?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-61e3ded5668e4261bf9bc414a8f490ea-8ee4b7f7f947fc65-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4c127ba5-825a-bb36-eeb9-4c6d09203d49",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4c127ba5-825a-bb36-eeb9-4c6d09203d49",
+        "x-ms-request-id": "69fcb5eb-201e-0029-55b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "229516936",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,1024,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,1024,30)Async.json
@@ -1,0 +1,289 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-23ac646d1118a6fc434b1180ff04dc29-d1c59865b326b606-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8ec0fa2-a473-c43a-b572-f09f8680c25a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F378E85A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a8ec0fa2-a473-c43a-b572-f09f8680c25a",
+        "x-ms-request-id": "146c2805-a01e-0055-4fb0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc/test-blob-da8a6910-6eb0-0bf5-f0f3-cfff416a0752",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-fd6270563bd4d6b47c8d50de67eac76a-3d2972becb36317c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1d1645f8-4722-e547-5c17-a38254ad6010",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F3857152\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1d1645f8-4722-e547-5c17-a38254ad6010",
+        "x-ms-request-id": "146c2840-a01e-0055-7eb0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc/test-blob-67f46b19-d874-0888-ea5f-eab1efa190d9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-cc4901c997c4f2868f67e7e7afe846c1-7bb9b7c3fb1cc565-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e2449e37-47f5-1155-4e00-f7c5d0405890",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F386D0AF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e2449e37-47f5-1155-4e00-f7c5d0405890",
+        "x-ms-request-id": "69fcf346-201e-0029-3eb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc/test-blob-da8a6910-6eb0-0bf5-f0f3-cfff416a0752?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ba881310a7f1a58c88e0633d781d3652-e7103f6d595ee511-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b54aca63-7d69-a91a-3151-7216964eebbb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3ORFfS8\u002BgDQZ4beA1DuDSmqehRqLW\u002BY34IHwUIRDG09i9iJcJYoj2\u002BvATZMgCDSu3J9HURt2TYH\u002BDZ2tTTCv1sVoHd4ZJyXfeqovyw1TF9dNQXTk\u002B8kz7KigXRfsdY26EHfNt\u002BtVlbR5Z9ZxR4J0q/bGXwy7y9r8NDE1eMkO8wQcdLqVhV/s\u002BKy/a5PywqQmLLIhJhWB/0Wc0YO5IB3ra3TRVdLH3iWW2mdg\u002B2BHCXKMDksX7MzvmnV1\u002BbTcMteO1P8eIG3RXk2Ni0yuIQPlVcgRLBHR03\u002Bo4rpdUuVwuqeQ0SdgKOgEurD\u002BiWGAQHhxkKTsywXGvQCAdj2ydAxnHNGkHlDchCzfDHFh0kkeJ6FB7MJBhO6iyRQm37GqUUajl22Q2yIolQt3DL6TZeq2Yk\u002BbcYhKJZjiAlQ7tqV6NbsrvTvcjkx/GVa2yncwDmQqb31iDuC\u002BWXHVrdjO7d9m/NcDaKeu2tQCHFcxk1sgsfTvEUYnGCbabGPKB\u002BBzsCt3UM2fLKa8e5SoX/GIjcYVtPvk3tuYPuSxKPxE49P0jmwrukKNgYVNM5Wxf7g0Ut6dtVPkj9FQ3hLp7gOpeJjBtNGFXNODiDJ2lqtG5r8rfNYdpi6AEP\u002Ba29svo5OBpLv98Mrnr/ULGS0gbfkmCvhTvnItjNFqQaTR6oH3VOSf9fLvSPb0RMzhEo0BX6IGc9Hj2\u002BUgVBfpk64lFcV0E8VIgHgGNsEBX3mlS3pEaOEBy3avFHj\u002BfqDaBrVHzi8HbP7HuN8q/z0P4XxregidpSrNJElOxP5MSgHXLDALupBKnt97fLAC18w5oDP7kgSYPGCLeqrluKgAem7dU9MMBCbsIdwpIih6ykx9FSTKULf9Pu/QgEDmZeY3egFBJIP4LZsMD3Enbhk4EK9daKKDNSq23xTjO4TmBrz18qgmOKXJhOiIvkFF1dDVmG\u002BQiPxDs0XXi0RvFPEXJgm1MnxxEdgJlOO6\u002BnfocApEDqMVVX2/sT5jT61gWW/2cZc3kKNTY4aWh/QZibnN7ho6KwZNAtGL9oA9DsIqqDpzw4jfseBm8Kodfs2JpiiFlWCTJi1pqW7Gq5oiFlXEbN65pcUw7T050ztbMIQDAlBYuHlil4IMChoaGQVGRNpVWBLv0ABiVKciWVLyDnnqwqlKyl3bYtRbrJqrFtQ4849hBddyEzJP9WPRQD0wGvygL1Zc/Hp8efY9kyRmtz7T6WbCkQiheK92\u002B9T6CiKXK5GeCuZ93PcU5IvhNIAO6D4l/lbWbYjz/7en5QGmgm/UpmiSx61XVQ1vrax9wEMuaBKW1AvLwL0Jqwsv1vf1bmIbDI4YfCGQzalJZ7/bdj5zeHzvD61kCeWqiA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F38C2721\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "b54aca63-7d69-a91a-3151-7216964eebbb",
+        "x-ms-content-crc64": "iEHtCDxqEys=",
+        "x-ms-request-id": "146c2851-a01e-0055-0bb0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc/test-blob-67f46b19-d874-0888-ea5f-eab1efa190d9?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-0ab29c0456abbe61a288397214bef3b6-98abee1af0b791ee-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "06616556-a3f6-2d26-98eb-46359d78d3e2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "HKIofxV5P0phs7UW7PAFB2KBWf4tNMy7XXoGX7W3A6lt8wXupCkz7YCRFYq\u002BYpD\u002BCqUBh4usWufVbSKbct\u002BUqbALqPjrFmI4Tmx9mx9B/PvqCFQPtXwdwZgdGTcHmHqg/WvasrmXE/NDyTgfLr/Ik3AmsWqKhPQ07uZfzf0qMLXx3J6zZ0pBUvRhzOxD/pPZVYXH4OcPFXh3psTSOEb2GJiDLVEgFCwm5V52KbgH8PBThnd4Y1DO4sYmPMCFbxqua7RUwNBBuUBYofuImey/b7XTf7HOfrRItEqK\u002BdhroHZEx74EszAfEcw3H8JURUnaZswLsu9o4Oz/CwuFt79o7ACFRNEuu7yFs23lll7y824BsJIMYO6G2\u002BfRBackmloMzzLBzwB3rKsPhf6Cg0mNDBicgwYsW4sS/mnqXLUUYBkS2McsMSNuigPn/NrwA1idQ/iPiBZT4HOmrtGXjFD1\u002ByXkcKqBYdv0LvgCRV\u002BxIvoQTRi9hNcCvvhUhYJS1v6z8QG1C5OtG\u002BIdm1kdUZoU9YvWhz43OHZN4bGyLdxYoVj6TlRe\u002BxdnYjE2n\u002Bl95W1dQI/2fE/AfLiKZyni\u002B\u002B4FxfoBIwJGtfl0biQMAZmNz/xDVOxMYSQJOdKb1JTthGdCMNrufMFrF4qVgg0qs3of/JctnqYCuGPV\u002BOkvquFlh\u002Bq8ydG\u002Bn1M72D1ht98W3oZXfNf9v\u002BbBQHd2GYPXO2ypMPojbumpYF1D8sZooAGEvhpj1y4KZ8cE\u002B4lZSIXPY5zRuIfk83Cdrht6uc0fWKB28lppc2M9n8gyH3JfUBjXdI4pl\u002Bh5n8uqxSkSj6765KLp41YrZfA5kxm/sdT9PV0DokU/9sC4/FKPv645Kw8ZODrPdm3CrA6e7wTOuu72rIjMD\u002Bxou\u002B3iMecDnKVC/2cKpXmZLcbwQfY3oAa86UFkmBIlbRwisX1M7UWFvg9oXPCcxBV0XX/B2832MRrnJUelnwOSHJJL5/T8TD\u002BBaoLnz0QWHyUs7zuTY5FOLIBiZcf94B4L1T9eUNwheBBAQHBKD2LV0AYiebDI/7gA/btzmed3g4pk2/kFuM5JC3YqUyMhAx0ejJTB22duQ9WHXlMgrd4pyL3m5jNo0Bg32W45nqyV3/qeVQ1Stqcj9pgjfVp7KF2YAIpmOhzptbx8igL4NKQp8X9YgljR1xEVw/CbRFK\u002Bu7AQoZ0iL6TdtZ9Q1SylKsHz\u002BozbIqYFxil4UHYsTXBpvs5R6JIHB8Lae8y4gAHlcJkuqErG45gKC9tzqd4tsGcu5xddU0Iv7PPJAKfZTEUnkuDd/qUmoto2R9y3k13jrMpliZjqhxxX/7tW/OLxML6VSxb\u002BULLCB0Q8Jwxldw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F38D385F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "06616556-a3f6-2d26-98eb-46359d78d3e2",
+        "x-ms-content-crc64": "CiTIsGZXZvE=",
+        "x-ms-request-id": "69fcf35f-201e-0029-55b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc/test-blob-da8a6910-6eb0-0bf5-f0f3-cfff416a0752",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ec1a00a42eaf626ae9400a52761791f7-6328d608d4c8fd02-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "31bf5f78-e5ec-ebc5-5733-ef49f61c8b97",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F38C2721\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "31bf5f78-e5ec-ebc5-5733-ef49f61c8b97",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcf3f5-201e-0029-54b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3ORFfS8\u002BgDQZ4beA1DuDSmqehRqLW\u002BY34IHwUIRDG09i9iJcJYoj2\u002BvATZMgCDSu3J9HURt2TYH\u002BDZ2tTTCv1sVoHd4ZJyXfeqovyw1TF9dNQXTk\u002B8kz7KigXRfsdY26EHfNt\u002BtVlbR5Z9ZxR4J0q/bGXwy7y9r8NDE1eMkO8wQcdLqVhV/s\u002BKy/a5PywqQmLLIhJhWB/0Wc0YO5IB3ra3TRVdLH3iWW2mdg\u002B2BHCXKMDksX7MzvmnV1\u002BbTcMteO1P8eIG3RXk2Ni0yuIQPlVcgRLBHR03\u002Bo4rpdUuVwuqeQ0SdgKOgEurD\u002BiWGAQHhxkKTsywXGvQCAdj2ydAxnHNGkHlDchCzfDHFh0kkeJ6FB7MJBhO6iyRQm37GqUUajl22Q2yIolQt3DL6TZeq2Yk\u002BbcYhKJZjiAlQ7tqV6NbsrvTvcjkx/GVa2yncwDmQqb31iDuC\u002BWXHVrdjO7d9m/NcDaKeu2tQCHFcxk1sgsfTvEUYnGCbabGPKB\u002BBzsCt3UM2fLKa8e5SoX/GIjcYVtPvk3tuYPuSxKPxE49P0jmwrukKNgYVNM5Wxf7g0Ut6dtVPkj9FQ3hLp7gOpeJjBtNGFXNODiDJ2lqtG5r8rfNYdpi6AEP\u002Ba29svo5OBpLv98Mrnr/ULGS0gbfkmCvhTvnItjNFqQaTR6oH3VOSf9fLvSPb0RMzhEo0BX6IGc9Hj2\u002BUgVBfpk64lFcV0E8VIgHgGNsEBX3mlS3pEaOEBy3avFHj\u002BfqDaBrVHzi8HbP7HuN8q/z0P4XxregidpSrNJElOxP5MSgHXLDALupBKnt97fLAC18w5oDP7kgSYPGCLeqrluKgAem7dU9MMBCbsIdwpIih6ykx9FSTKULf9Pu/QgEDmZeY3egFBJIP4LZsMD3Enbhk4EK9daKKDNSq23xTjO4TmBrz18qgmOKXJhOiIvkFF1dDVmG\u002BQiPxDs0XXi0RvFPEXJgm1MnxxEdgJlOO6\u002BnfocApEDqMVVX2/sT5jT61gWW/2cZc3kKNTY4aWh/QZibnN7ho6KwZNAtGL9oA9DsIqqDpzw4jfseBm8Kodfs2JpiiFlWCTJi1pqW7Gq5oiFlXEbN65pcUw7T050ztbMIQDAlBYuHlil4IMChoaGQVGRNpVWBLv0ABiVKciWVLyDnnqwqlKyl3bYtRbrJqrFtQ4849hBddyEzJP9WPRQD0wGvygL1Zc/Hp8efY9kyRmtz7T6WbCkQiheK92\u002B9T6CiKXK5GeCuZ93PcU5IvhNIAO6D4l/lbWbYjz/7en5QGmgm/UpmiSx61XVQ1vrax9wEMuaBKW1AvLwL0Jqwsv1vf1bmIbDI4YfCGQzalJZ7/bdj5zeHzvD61kCeWqiA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc/test-blob-67f46b19-d874-0888-ea5f-eab1efa190d9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c525f715d1a270515ba65dd3bf1dc989-52f6c210b56cd5f2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3dbc3067-a1b9-89f5-a0be-64a83313305c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F38D385F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3dbc3067-a1b9-89f5-a0be-64a83313305c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcf481-201e-0029-53b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "HKIofxV5P0phs7UW7PAFB2KBWf4tNMy7XXoGX7W3A6lt8wXupCkz7YCRFYq\u002BYpD\u002BCqUBh4usWufVbSKbct\u002BUqbALqPjrFmI4Tmx9mx9B/PvqCFQPtXwdwZgdGTcHmHqg/WvasrmXE/NDyTgfLr/Ik3AmsWqKhPQ07uZfzf0qMLXx3J6zZ0pBUvRhzOxD/pPZVYXH4OcPFXh3psTSOEb2GJiDLVEgFCwm5V52KbgH8PBThnd4Y1DO4sYmPMCFbxqua7RUwNBBuUBYofuImey/b7XTf7HOfrRItEqK\u002BdhroHZEx74EszAfEcw3H8JURUnaZswLsu9o4Oz/CwuFt79o7ACFRNEuu7yFs23lll7y824BsJIMYO6G2\u002BfRBackmloMzzLBzwB3rKsPhf6Cg0mNDBicgwYsW4sS/mnqXLUUYBkS2McsMSNuigPn/NrwA1idQ/iPiBZT4HOmrtGXjFD1\u002ByXkcKqBYdv0LvgCRV\u002BxIvoQTRi9hNcCvvhUhYJS1v6z8QG1C5OtG\u002BIdm1kdUZoU9YvWhz43OHZN4bGyLdxYoVj6TlRe\u002BxdnYjE2n\u002Bl95W1dQI/2fE/AfLiKZyni\u002B\u002B4FxfoBIwJGtfl0biQMAZmNz/xDVOxMYSQJOdKb1JTthGdCMNrufMFrF4qVgg0qs3of/JctnqYCuGPV\u002BOkvquFlh\u002Bq8ydG\u002Bn1M72D1ht98W3oZXfNf9v\u002BbBQHd2GYPXO2ypMPojbumpYF1D8sZooAGEvhpj1y4KZ8cE\u002B4lZSIXPY5zRuIfk83Cdrht6uc0fWKB28lppc2M9n8gyH3JfUBjXdI4pl\u002Bh5n8uqxSkSj6765KLp41YrZfA5kxm/sdT9PV0DokU/9sC4/FKPv645Kw8ZODrPdm3CrA6e7wTOuu72rIjMD\u002Bxou\u002B3iMecDnKVC/2cKpXmZLcbwQfY3oAa86UFkmBIlbRwisX1M7UWFvg9oXPCcxBV0XX/B2832MRrnJUelnwOSHJJL5/T8TD\u002BBaoLnz0QWHyUs7zuTY5FOLIBiZcf94B4L1T9eUNwheBBAQHBKD2LV0AYiebDI/7gA/btzmed3g4pk2/kFuM5JC3YqUyMhAx0ejJTB22duQ9WHXlMgrd4pyL3m5jNo0Bg32W45nqyV3/qeVQ1Stqcj9pgjfVp7KF2YAIpmOhzptbx8igL4NKQp8X9YgljR1xEVw/CbRFK\u002Bu7AQoZ0iL6TdtZ9Q1SylKsHz\u002BozbIqYFxil4UHYsTXBpvs5R6JIHB8Lae8y4gAHlcJkuqErG45gKC9tzqd4tsGcu5xddU0Iv7PPJAKfZTEUnkuDd/qUmoto2R9y3k13jrMpliZjqhxxX/7tW/OLxML6VSxb\u002BULLCB0Q8Jwxldw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-290a30eb-809e-eec0-0c32-9d97776080fc?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8908218c0a3b6071b9f3c131b695fc89-c18edab3a348e9bb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c5e1d6d1-4d5f-65dd-d9a2-1fb3b88f01f4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c5e1d6d1-4d5f-65dd-d9a2-1fb3b88f01f4",
+        "x-ms-request-id": "69fcf4b5-201e-0029-05b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1110912548",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,2048,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,2048,30).json
@@ -1,0 +1,289 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-ad58a5da0d97dca88b8e650573acee0a-0a2712ffc12ba536-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "72ab2184-69b3-dea5-b0b3-c8df90c9a089",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EA7400D6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "72ab2184-69b3-dea5-b0b3-c8df90c9a089",
+        "x-ms-request-id": "16e8b3e5-e01e-007b-06b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2/test-blob-3345d0ba-1b3f-a1fe-23de-9ed737898fe9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9af89fe06e7dbfe1f57df8ce061c3ec7-e9efb9e336bb74df-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1c7ebc18-2f94-88f1-091f-612519d9c06d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EA7C9E44\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1c7ebc18-2f94-88f1-091f-612519d9c06d",
+        "x-ms-request-id": "16e8b433-e01e-007b-4ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2/test-blob-fa8a5fc2-5b80-3f2f-7793-f9077d2c38cf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-b80783e0f1d9985f05e70dffc8fcb3a6-98362c83facf018c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "2444b87d-e0db-7040-e236-aefffba57ff1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EA7FAB19\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2444b87d-e0db-7040-e236-aefffba57ff1",
+        "x-ms-request-id": "69fcbb04-201e-0029-63b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2/test-blob-3345d0ba-1b3f-a1fe-23de-9ed737898fe9?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-93f65297f88ec8b65d76c8437bd3a235-4d84c15716864354-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "60a84ffd-9c94-7e91-d877-26fe54e77610",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "cp50jR3A7GkiCk7Uy86nJyTfHDE\u002BpgleoQW8qyH3I/emz2SYFAHLAXMh13UMW3So7NHing8HkMyVFuwYBEBHK\u002BdXLvxqDhIiExq9Hc6TUUWRE79PFITnnj6XA/0Vs/0y2auOtS14Pt2/wIr1SXP9AsWmh/GB\u002BBZib4\u002B90wsVDWAdi0QiBJsYGNTikFT68lTLmQE4biwLseGVLEWdumvRqrMq2L4u2/0pjm4cn2fCaH068jkK3J40EdpjjdhWe11pEOagzxqWnL4EDuC97hJ50sPIYsgxx80U9cbky00k0xMQs46AIphipFV6Bc2\u002BdyLI6bsUjRiUN0gZi9pTstBx3zvNrDuD\u002BLArZr5ztsH/Vn6kG\u002BKRD0b6fHtGZ5a\u002BDvGFCSaS8crmRfAL6SdaIYCGGTVbr5bu38/10jDAPJAZbVfM7a2bbWWzvdbxhiUen1r6v05gYl9alypWnR6aJghg8XzQjjPT66zPqPK//Fiq1jPWxX1CuQr3cVaCRM9HGZbOkZWpThEmJ9ShkLlsm5rRrMfqxGGKHThy2BzdUKbciI5c8GrDAYchsJ6ooChQi9a8sZgIXFU1Q3RdNnb1SdYtxQgrEKovDqs/yRTC4XwPIU1GIZ8N1Cw5J632ZcoRLGbHe9sgJXorjKLtyZNBcmH3TRUoric3IPHb8ej9OanhLpyt\u002Bmah7/vSGpT9IAuY\u002BLRL/xi06H0\u002BkFrqRDSRLlL5C5r2lHf7Vl4aVpSTOv/mQ/g0sjmRLEUebmoMtqvHQOxCBBRwomQ8UKm5mpLpq1ZbBAE7XXwYZ99V2CUN75\u002BzUhWoUDXqdaCU92KQ15KzNMITsLKpi\u002BJvKZw1Gsk\u002BL2EJBkd8QVogcI5gpmYaiJBMoqNj\u002BT7tCcYyOCeZtFrXVcgBhtBKNvNn8z8jSeV8VaAL6Xgm2zUiHP2ASQkzhrsziFCeGAG/AWuw/Ab\u002Byb/htuKGjcvisXqS3mrTyuzqNGyE78CU3jyfS\u002BcNdd4vJFI9npMmrPnwUdfWCzqX7Dd\u002BxseZetr/Tdel50Hk1DubY7oXlStZw4dzk53ovtICCF\u002Bvjq8Xlal4PlG8gMW3C3ycOqiAf1cMJQNAJuY8Fo8Eo97iNEaMhM0QnlbanULCvIchTIMqgYgHo2is12/CPCfBt93m1Nc2D7Xbb\u002BEAMojAfWpeGskL2iFW25Hd4K1eTWIuGOVk3Oew6z3OTxKnBnDg61kFZCFetd28j/lFWC8HfCJ\u002B0RmjW6CCri\u002BMPYoPr9Qg/fRTWelB0GMHqEzuapMNxtLwKDVXPI\u002B4grbx0XdSreAkJVo6tCM4PQG2m7NUk0Ocf3e3HoaeycBlmtYzT//rtftryUU40xKvt\u002Bs0oaHcZO9yVFIAmo5ahlyZ1RlMBe4Byua36Mn9ZKtkCGebaicfiDbnwPqs6xptEUPpn/35YrL9Mta7JXwldfCmm5Imvxs0ek3iZUTzVN/MSdeGFMWua6W1nThQY2K6wUsJBk\u002BHRlEotSSwFv1tCd3379uln2Ar9zDscSHj4xbqKKT56U6QRAOFXV\u002Bg/lWoR5RaWXSHFCLq3g4fmtQwRNEOxe1Ycx\u002BPZ6rYIEEBi/naRCmNiYqhYhOBDgs/cKkuVBmNkjhnT9R0yvHJr/Tg6VIURFarortHbGLZ12QUT/YAqssoc/nBc/RVGb6Y17MeoSW5KixTg7JdRiXVjXhvX3r6yQUpuHVZU9FhVYn9rpSvujU/WyXKrScZyizT7OV85rlDng6u9eiwYNdb8i0oX5iRJtJCLwRVMBzeEO1IhWfr5W/PuhCFAMVMj/tNbrr58GqUQsUSOba07W3y0OX7Z9pwbw2\u002BWKWICyYN9aAJCMFh5B\u002BCtEOh2au4G8yiki/gUScg3f6tO5fFDDafBUMWq\u002BWrkezFeLOXzpZhBj3Y5Xn2LKN46SrCs6mIvacMAdRnom/n9gFDG9l0iA5oTDVZ7Ca9qdifncG66N1CPLoLis3C\u002BmPN8e53shHKBGAcWmd0LtGBT1j8xwWuLA4jAN4eaP5BpVLRjPo3RfbG1Zhhno52zg7piTp1xjJeH8TgVLIzrJxi2rQVoqLWSgphNfJsTI6ArDLPNN7DzN8fcmw2VvFEkyj7/8PZYStsEz8wE5BA8tI2YKd/Y3e\u002Bng7U9TA1oPMYHaLJcU3KpksGYiGfkrhP34CZAPZKxC\u002BxPWC0BGv6N3JLGPXtdoCFa7lbeQBVHwxWhRawm6D9zllzGDPtFqLgCyuuU3rCYWj/FJQ87ksuWx5TXn5VSpvSTUmcel5Nl1QXe23Vp8uSkyStsIcLwd8ORLwVmbcjisGQ3AUwJecKsnxAJHPdWbRSwctaqJoTx4xpjjWhN/6d8/CsRMrFYW09ov4Ky5xsMOsIwtfsyeImfBV5x5exaHt\u002BojGCMBTpjGBdHQWcCPvv/F5JmXQmsCoNhci1TJnWizqDjChr6f/XHjV3j6vdinMZiso5Z88GWPIGdatMNEDHh5LLGXzTgxNecno\u002BryF\u002BMPpUnMLOnSNqfDQ1ZHRUiur1rwgZEnH3RQa32vVUx6jRh0Ww\u002BJh\u002B\u002BOluYJxInh6eCeiQSf8ZZR2IXVa7F8IuFrWLY90vpJJSdrceqrLVrqfnGNAMxH6puCInJ5pBwuEnQErnvTpBb2VVPdJH\u002Brprs66v1P7xIVE24au6B3z3ELTV9mpo7vFtpalrtoarYb1ovHTsku7jNR/4sNuOh2fpXi0ecgNQA8S8Qi5UhmrKi4DtUks=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EA832CFF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "60a84ffd-9c94-7e91-d877-26fe54e77610",
+        "x-ms-content-crc64": "20rFIiXE5Jo=",
+        "x-ms-request-id": "16e8b466-e01e-007b-7cb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2/test-blob-fa8a5fc2-5b80-3f2f-7793-f9077d2c38cf?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-55bd3ef2d88ac0aece7903fce310664f-121293fb061322af-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ab027aca-1efc-b05c-c281-33e0aadcc1ed",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CAt\u002BxfLBSm8\u002BFt4eQYFYWY3vuRe4ry9Qv46vtC4lW6E0HOFTrlh/QgWThqZjEBIEEnD9kDM6klnbLgVjEpZBGbs86SWgBKs0b3cSJSiI7K98qqK9J8pt\u002BomId4BTHDBvUm3rJybtZA3FySG8KG0wU0JV52jzg/Lwz\u002B\u002BbGI0q4FNGotK6ncWJjkWU912psdEcVyQ\u002B/TTIe857\u002Blg3UUuAmujNdYWadbV9zFgiX4uURx0df8Bo7OMeficEP6JsUj35FFx02ztLgeFuwTDcpRxC5rM6GdGLF64Fr/deljYSEHobKUovIGvi0f7f\u002BSuyQtgKwVjvMjhrbv2ubyxD7eurXLG1wHzRE8ZHV0fTrB2DUmweU9XdI91Cr7pMgLA\u002BnuQTM515/YFcOK2Sp9vxmMLgKh3AJZkVzjjUcxHBhZMVCbhiwHh/CVXqwhonSnsBURf4bFWTfnlL/WRlpYlwmrMafJ4ijtdJYSHI1WN\u002B7oS80iL5yRg9goo/F8MUGWTLeSdnDc7d38I/rgs0y6gWzQ7gqNNmd9Cb3fkT4ncUNEe8/Fs7F\u002BC23/JfuhsNCLfiKUq0NHGQZQJXzDDUyfxLKnnEd85M2rYuKcjgBr21jdRCMbktYADVLJdZ40qw4RX2FI\u002BhSZHolU6UhgqosF5FoT5ckphDHsp57ks38/ZrfUiz6vItE0RDWZxqmdr1LHs4E0EMVE99svXEKFpFsaFXKQjC9cVsF476GDj82YXwg8HP/9\u002B0Xin4Njf8aevq/af6EnDRMze1y/yzEjsXgNlw1KSYdbHCosrfyr6OcK6iDxuQAsYVHlCKGTPjAUzt4bVejJVHUYf2OG\u002Bl8mh4J1tNEQIghn4SWrVTDlx\u002B3qF\u002B8ekJL\u002BQZWr6TmslWbyzoEfLXle9JzVo3SzHg80Mrd1nOJwB/b/d3NLZDjOu0vOqIa/xqpkmyNCSO0eSyOWd7aCNwiEgsaKH6YGA5BUFvgo9GV4dGwdEPHPLc8J0TxPtPyCPIQzOiXAJbb0bpeC/iHk9VbOHfNadRYWxWT3cD5ptk6T0epz5bpPuE6lGLJqPD\u002BdJOvlgab5N8duLHSwyLV4mqhI7xxHcQ\u002BcjmWkpVxjvJklWltSdCSnmqoTFclFju\u002BZPI4KEU0TVbPcWQNBVIJrCm/bm25aFhZzoURyJGs2Vv92C3jeWZtMEgSndishZkYXuAtZafNxTxZnln/4oSFYlgIDy1kZjLDEj4lpop/rUksOamxf7O0MBLxSZsMrU2DTXuApHZr9DjtahNpqB5x2jEQ06jbE\u002BLkU98acxxX9qTwYllO/sjSgEVww9VgCkf0f2\u002Bp\u002B9mk6HlYnFCXEUEcVbOuuUXFItsofhNjqg/NhAmXZfOsrfrLC7of9mK4O28EVK5hsZEB71xUgb2GQT5pStgHP\u002BtNb6e4463L5Sy4cAKkHxVhrBK4VXaXGCw9BIp7tqtKsTuDtuTGqM3jNgov3FG64mIox97FTqp09he7u98jkC6BLb7HIKgwmsME1R9sZ3uagiJoEu6MRWKRDsCNSyzu/6Xbrq6S88G6OGzbgLlLCE7b4Tm8u30/9OhcNhHnY0/WFdW5UPjNB85grhqBsISpRcZx8WozcgRom7nGNr2v0pTdBWqj0beWDtlrXA0ivkQj8vALdXHlouORELV/BtEQsNtFpKsaBXROm\u002BJQx9Y3Bh11okONpF0jN2KG0oDCVsfIGutxnNnYye17/JmPVNsNmgpXyWSNQwx\u002BYq0IkzLzTETaiK0qxWlDnNiWUaeDk6KHeXh2ak2jOpee83oskDa6iHBUtMwt4tThFGxMNzFkuo7KgVm6fSI3d04VS9HvFszh24l3bt7WWZajlVXhFwNmOjirIg7dAAtOXX1\u002BGFbC8f2fqhun7UuwNCfDFqeMFiAKr1GZA/T9xNt\u002BKRGhWEE/oONYQa0n/gztOy3nGiljggcdM2kFKa3I4aVAKcR6Dpvmg3XEM9SzIrEE7AjG1uryGqbKRGTX\u002Bnc1j5/Hp9RIsyxSAFazn05yqdC4AH1lAcr6jc8db4p3Dsj\u002BjqQ0q3rcvDkcdNaUPntYl9pUH7o5kI2VDRnFK0NiGvFN9NCqPj5V24QESI00Jk\u002BTxNfv4u8OxP4Wn15g11D1uhnlBklqrlmb/gQ19UfAoOaKcWarsngCPvASk56gNQQzTo5zDyAGKVZ\u002BFCTrGM\u002B2Ff63lqYqSgfh4sdZV9r6\u002B4k/wqb5jVGGhAgQLV4TVyYgnL2gKF6eCMRGkWxYrNF7Qxhbq1YovIis8NJeGhypjouhePtdWtNqYfnicvwlbhd21KoF96vP9\u002BA1M3dMQC6nnMKgt3QV3ihFMUlcRkmMR0L650Vyo9cf0UDbaCdb3iHLOpY5RLbjYPaBwIYic3FWqKv0kVipNTjrgOXzOrXA6RMnkUvzUsKMF0ZO8KMQ/Z3PhL97p0yJIcVdDcPQ8GYAgNezOqIloxXpKHoSGkRV2sMH43X2RUHGXq9GVkU\u002B\u002B2cgTm/LncL76iGpkn7StseAx3MAiMzwCjuVrJwynwyQ6m0S8cwUij0ATDlUDPMC8\u002BenxY7SPjJaMAQ0djEmiQrVGOfR/4U7rD11wHzTXD1IUrj0itm9vqx6uMGH4FQL2YLuvzPLMTQirBlRnD21htQGq\u002BN4cj5xV1o7lwbDc4vpKia55NzJvWGEkd6AK\u002BKuhTItgXSw02dEvSfZj1ntXziNqLHW\u002B6H3PS5Bs\u002BBfsWt3jRIU1bJXOFa/dQ=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EA86D608\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "ab027aca-1efc-b05c-c281-33e0aadcc1ed",
+        "x-ms-content-crc64": "VWz5s6GdeGE=",
+        "x-ms-request-id": "69fcbb31-201e-0029-0eb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2/test-blob-3345d0ba-1b3f-a1fe-23de-9ed737898fe9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8c9108930dc605ff6afff45d402bc345-2863c0e3cba9a38f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d934953c-cae5-4814-aca2-0455e1d90201",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EA832CFF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d934953c-cae5-4814-aca2-0455e1d90201",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcbbdc-201e-0029-24b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "cp50jR3A7GkiCk7Uy86nJyTfHDE\u002BpgleoQW8qyH3I/emz2SYFAHLAXMh13UMW3So7NHing8HkMyVFuwYBEBHK\u002BdXLvxqDhIiExq9Hc6TUUWRE79PFITnnj6XA/0Vs/0y2auOtS14Pt2/wIr1SXP9AsWmh/GB\u002BBZib4\u002B90wsVDWAdi0QiBJsYGNTikFT68lTLmQE4biwLseGVLEWdumvRqrMq2L4u2/0pjm4cn2fCaH068jkK3J40EdpjjdhWe11pEOagzxqWnL4EDuC97hJ50sPIYsgxx80U9cbky00k0xMQs46AIphipFV6Bc2\u002BdyLI6bsUjRiUN0gZi9pTstBx3zvNrDuD\u002BLArZr5ztsH/Vn6kG\u002BKRD0b6fHtGZ5a\u002BDvGFCSaS8crmRfAL6SdaIYCGGTVbr5bu38/10jDAPJAZbVfM7a2bbWWzvdbxhiUen1r6v05gYl9alypWnR6aJghg8XzQjjPT66zPqPK//Fiq1jPWxX1CuQr3cVaCRM9HGZbOkZWpThEmJ9ShkLlsm5rRrMfqxGGKHThy2BzdUKbciI5c8GrDAYchsJ6ooChQi9a8sZgIXFU1Q3RdNnb1SdYtxQgrEKovDqs/yRTC4XwPIU1GIZ8N1Cw5J632ZcoRLGbHe9sgJXorjKLtyZNBcmH3TRUoric3IPHb8ej9OanhLpyt\u002Bmah7/vSGpT9IAuY\u002BLRL/xi06H0\u002BkFrqRDSRLlL5C5r2lHf7Vl4aVpSTOv/mQ/g0sjmRLEUebmoMtqvHQOxCBBRwomQ8UKm5mpLpq1ZbBAE7XXwYZ99V2CUN75\u002BzUhWoUDXqdaCU92KQ15KzNMITsLKpi\u002BJvKZw1Gsk\u002BL2EJBkd8QVogcI5gpmYaiJBMoqNj\u002BT7tCcYyOCeZtFrXVcgBhtBKNvNn8z8jSeV8VaAL6Xgm2zUiHP2ASQkzhrsziFCeGAG/AWuw/Ab\u002Byb/htuKGjcvisXqS3mrTyuzqNGyE78CU3jyfS\u002BcNdd4vJFI9npMmrPnwUdfWCzqX7Dd\u002BxseZetr/Tdel50Hk1DubY7oXlStZw4dzk53ovtICCF\u002Bvjq8Xlal4PlG8gMW3C3ycOqiAf1cMJQNAJuY8Fo8Eo97iNEaMhM0QnlbanULCvIchTIMqgYgHo2is12/CPCfBt93m1Nc2D7Xbb\u002BEAMojAfWpeGskL2iFW25Hd4K1eTWIuGOVk3Oew6z3OTxKnBnDg61kFZCFetd28j/lFWC8HfCJ\u002B0RmjW6CCri\u002BMPYoPr9Qg/fRTWelB0GMHqEzuapMNxtLwKDVXPI\u002B4grbx0XdSreAkJVo6tCM4PQG2m7NUk0Ocf3e3HoaeycBlmtYzT//rtftryUU40xKvt\u002Bs0oaHcZO9yVFIAmo5ahlyZ1RlMBe4Byua36Mn9ZKtkCGebaicfiDbnwPqs6xptEUPpn/35YrL9Mta7JXwldfCmm5Imvxs0ek3iZUTzVN/MSdeGFMWua6W1nThQY2K6wUsJBk\u002BHRlEotSSwFv1tCd3379uln2Ar9zDscSHj4xbqKKT56U6QRAOFXV\u002Bg/lWoR5RaWXSHFCLq3g4fmtQwRNEOxe1Ycx\u002BPZ6rYIEEBi/naRCmNiYqhYhOBDgs/cKkuVBmNkjhnT9R0yvHJr/Tg6VIURFarortHbGLZ12QUT/YAqssoc/nBc/RVGb6Y17MeoSW5KixTg7JdRiXVjXhvX3r6yQUpuHVZU9FhVYn9rpSvujU/WyXKrScZyizT7OV85rlDng6u9eiwYNdb8i0oX5iRJtJCLwRVMBzeEO1IhWfr5W/PuhCFAMVMj/tNbrr58GqUQsUSOba07W3y0OX7Z9pwbw2\u002BWKWICyYN9aAJCMFh5B\u002BCtEOh2au4G8yiki/gUScg3f6tO5fFDDafBUMWq\u002BWrkezFeLOXzpZhBj3Y5Xn2LKN46SrCs6mIvacMAdRnom/n9gFDG9l0iA5oTDVZ7Ca9qdifncG66N1CPLoLis3C\u002BmPN8e53shHKBGAcWmd0LtGBT1j8xwWuLA4jAN4eaP5BpVLRjPo3RfbG1Zhhno52zg7piTp1xjJeH8TgVLIzrJxi2rQVoqLWSgphNfJsTI6ArDLPNN7DzN8fcmw2VvFEkyj7/8PZYStsEz8wE5BA8tI2YKd/Y3e\u002Bng7U9TA1oPMYHaLJcU3KpksGYiGfkrhP34CZAPZKxC\u002BxPWC0BGv6N3JLGPXtdoCFa7lbeQBVHwxWhRawm6D9zllzGDPtFqLgCyuuU3rCYWj/FJQ87ksuWx5TXn5VSpvSTUmcel5Nl1QXe23Vp8uSkyStsIcLwd8ORLwVmbcjisGQ3AUwJecKsnxAJHPdWbRSwctaqJoTx4xpjjWhN/6d8/CsRMrFYW09ov4Ky5xsMOsIwtfsyeImfBV5x5exaHt\u002BojGCMBTpjGBdHQWcCPvv/F5JmXQmsCoNhci1TJnWizqDjChr6f/XHjV3j6vdinMZiso5Z88GWPIGdatMNEDHh5LLGXzTgxNecno\u002BryF\u002BMPpUnMLOnSNqfDQ1ZHRUiur1rwgZEnH3RQa32vVUx6jRh0Ww\u002BJh\u002B\u002BOluYJxInh6eCeiQSf8ZZR2IXVa7F8IuFrWLY90vpJJSdrceqrLVrqfnGNAMxH6puCInJ5pBwuEnQErnvTpBb2VVPdJH\u002Brprs66v1P7xIVE24au6B3z3ELTV9mpo7vFtpalrtoarYb1ovHTsku7jNR/4sNuOh2fpXi0ecgNQA8S8Qi5UhmrKi4DtUks="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2/test-blob-fa8a5fc2-5b80-3f2f-7793-f9077d2c38cf",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-396d184f179cd008583fd14ae5646433-745f39b2264b0682-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "15a4ed7d-e7a7-ca07-41fe-7f5ca10706bb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EA86D608\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "15a4ed7d-e7a7-ca07-41fe-7f5ca10706bb",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcbc67-201e-0029-22b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "CAt\u002BxfLBSm8\u002BFt4eQYFYWY3vuRe4ry9Qv46vtC4lW6E0HOFTrlh/QgWThqZjEBIEEnD9kDM6klnbLgVjEpZBGbs86SWgBKs0b3cSJSiI7K98qqK9J8pt\u002BomId4BTHDBvUm3rJybtZA3FySG8KG0wU0JV52jzg/Lwz\u002B\u002BbGI0q4FNGotK6ncWJjkWU912psdEcVyQ\u002B/TTIe857\u002Blg3UUuAmujNdYWadbV9zFgiX4uURx0df8Bo7OMeficEP6JsUj35FFx02ztLgeFuwTDcpRxC5rM6GdGLF64Fr/deljYSEHobKUovIGvi0f7f\u002BSuyQtgKwVjvMjhrbv2ubyxD7eurXLG1wHzRE8ZHV0fTrB2DUmweU9XdI91Cr7pMgLA\u002BnuQTM515/YFcOK2Sp9vxmMLgKh3AJZkVzjjUcxHBhZMVCbhiwHh/CVXqwhonSnsBURf4bFWTfnlL/WRlpYlwmrMafJ4ijtdJYSHI1WN\u002B7oS80iL5yRg9goo/F8MUGWTLeSdnDc7d38I/rgs0y6gWzQ7gqNNmd9Cb3fkT4ncUNEe8/Fs7F\u002BC23/JfuhsNCLfiKUq0NHGQZQJXzDDUyfxLKnnEd85M2rYuKcjgBr21jdRCMbktYADVLJdZ40qw4RX2FI\u002BhSZHolU6UhgqosF5FoT5ckphDHsp57ks38/ZrfUiz6vItE0RDWZxqmdr1LHs4E0EMVE99svXEKFpFsaFXKQjC9cVsF476GDj82YXwg8HP/9\u002B0Xin4Njf8aevq/af6EnDRMze1y/yzEjsXgNlw1KSYdbHCosrfyr6OcK6iDxuQAsYVHlCKGTPjAUzt4bVejJVHUYf2OG\u002Bl8mh4J1tNEQIghn4SWrVTDlx\u002B3qF\u002B8ekJL\u002BQZWr6TmslWbyzoEfLXle9JzVo3SzHg80Mrd1nOJwB/b/d3NLZDjOu0vOqIa/xqpkmyNCSO0eSyOWd7aCNwiEgsaKH6YGA5BUFvgo9GV4dGwdEPHPLc8J0TxPtPyCPIQzOiXAJbb0bpeC/iHk9VbOHfNadRYWxWT3cD5ptk6T0epz5bpPuE6lGLJqPD\u002BdJOvlgab5N8duLHSwyLV4mqhI7xxHcQ\u002BcjmWkpVxjvJklWltSdCSnmqoTFclFju\u002BZPI4KEU0TVbPcWQNBVIJrCm/bm25aFhZzoURyJGs2Vv92C3jeWZtMEgSndishZkYXuAtZafNxTxZnln/4oSFYlgIDy1kZjLDEj4lpop/rUksOamxf7O0MBLxSZsMrU2DTXuApHZr9DjtahNpqB5x2jEQ06jbE\u002BLkU98acxxX9qTwYllO/sjSgEVww9VgCkf0f2\u002Bp\u002B9mk6HlYnFCXEUEcVbOuuUXFItsofhNjqg/NhAmXZfOsrfrLC7of9mK4O28EVK5hsZEB71xUgb2GQT5pStgHP\u002BtNb6e4463L5Sy4cAKkHxVhrBK4VXaXGCw9BIp7tqtKsTuDtuTGqM3jNgov3FG64mIox97FTqp09he7u98jkC6BLb7HIKgwmsME1R9sZ3uagiJoEu6MRWKRDsCNSyzu/6Xbrq6S88G6OGzbgLlLCE7b4Tm8u30/9OhcNhHnY0/WFdW5UPjNB85grhqBsISpRcZx8WozcgRom7nGNr2v0pTdBWqj0beWDtlrXA0ivkQj8vALdXHlouORELV/BtEQsNtFpKsaBXROm\u002BJQx9Y3Bh11okONpF0jN2KG0oDCVsfIGutxnNnYye17/JmPVNsNmgpXyWSNQwx\u002BYq0IkzLzTETaiK0qxWlDnNiWUaeDk6KHeXh2ak2jOpee83oskDa6iHBUtMwt4tThFGxMNzFkuo7KgVm6fSI3d04VS9HvFszh24l3bt7WWZajlVXhFwNmOjirIg7dAAtOXX1\u002BGFbC8f2fqhun7UuwNCfDFqeMFiAKr1GZA/T9xNt\u002BKRGhWEE/oONYQa0n/gztOy3nGiljggcdM2kFKa3I4aVAKcR6Dpvmg3XEM9SzIrEE7AjG1uryGqbKRGTX\u002Bnc1j5/Hp9RIsyxSAFazn05yqdC4AH1lAcr6jc8db4p3Dsj\u002BjqQ0q3rcvDkcdNaUPntYl9pUH7o5kI2VDRnFK0NiGvFN9NCqPj5V24QESI00Jk\u002BTxNfv4u8OxP4Wn15g11D1uhnlBklqrlmb/gQ19UfAoOaKcWarsngCPvASk56gNQQzTo5zDyAGKVZ\u002BFCTrGM\u002B2Ff63lqYqSgfh4sdZV9r6\u002B4k/wqb5jVGGhAgQLV4TVyYgnL2gKF6eCMRGkWxYrNF7Qxhbq1YovIis8NJeGhypjouhePtdWtNqYfnicvwlbhd21KoF96vP9\u002BA1M3dMQC6nnMKgt3QV3ihFMUlcRkmMR0L650Vyo9cf0UDbaCdb3iHLOpY5RLbjYPaBwIYic3FWqKv0kVipNTjrgOXzOrXA6RMnkUvzUsKMF0ZO8KMQ/Z3PhL97p0yJIcVdDcPQ8GYAgNezOqIloxXpKHoSGkRV2sMH43X2RUHGXq9GVkU\u002B\u002B2cgTm/LncL76iGpkn7StseAx3MAiMzwCjuVrJwynwyQ6m0S8cwUij0ATDlUDPMC8\u002BenxY7SPjJaMAQ0djEmiQrVGOfR/4U7rD11wHzTXD1IUrj0itm9vqx6uMGH4FQL2YLuvzPLMTQirBlRnD21htQGq\u002BN4cj5xV1o7lwbDc4vpKia55NzJvWGEkd6AK\u002BKuhTItgXSw02dEvSfZj1ntXziNqLHW\u002B6H3PS5Bs\u002BBfsWt3jRIU1bJXOFa/dQ="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37a82fe7-5eea-edb8-4cb7-8a0f1b2bcee2?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c4f721ebb7b4ea1d3683eb27d9455d11-5a306e66d3828c1a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f4d7043d-ed35-8559-5b6e-e34b90348217",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f4d7043d-ed35-8559-5b6e-e34b90348217",
+        "x-ms-request-id": "69fcbc8d-201e-0029-42b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1631923295",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,2048,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(2,2048,30)Async.json
@@ -1,0 +1,289 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-cc40d3de3319960de7f45264d80fc17d-15008597920dd5ba-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e02196f0-aa5e-e3cf-005b-7cf010cda75b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F46FC5AF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e02196f0-aa5e-e3cf-005b-7cf010cda75b",
+        "x-ms-request-id": "16e8f0f1-e01e-007b-1fb0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9/test-blob-7b460952-b3e9-4920-cfcf-2ef6762e80fe",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-6092199154e4c2f4abf5af30e2d2a7fd-ea5d626349819a49-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d2724971-b9fc-bbcb-9205-18be303ec501",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F478875A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2724971-b9fc-bbcb-9205-18be303ec501",
+        "x-ms-request-id": "16e8f131-e01e-007b-57b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9/test-blob-2a4ec568-310d-367b-b361-c760cbb379fa",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-65f5625e0808ecea24b57300082ba49c-fd985dc066c698b1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "546948e7-b258-b2bc-93e2-2423d864bd28",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F47A5BD2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "546948e7-b258-b2bc-93e2-2423d864bd28",
+        "x-ms-request-id": "993dc98a-d01e-0002-7db0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9/test-blob-7b460952-b3e9-4920-cfcf-2ef6762e80fe?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-d0b6bab4deed58c64dc1af46c0d68ebf-7d1d22f5c2fa7cea-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e8d71e37-70d4-71a8-7227-a0565934c217",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "rNZl2g0aqzx21xGOfNhs0tt\u002Bh0t/fE4hjhDIh\u002By/fRtWNEmgyKbxThoRtDUg7Lna9fWFTSstezCIQ0v8UiNQtln1N0iPzAk1jDkxbsgYAaFW7ZH2OS/vKLkZGIRa9Pz2wP3bKrRxSynsUMHy/Axnb0KppmSRWnwqBg6PdbOE2pc9O63KPdfs5KJoCelu/SyssalCsE6XZGWAsSSl4tV1aHUptMBfnDFrvMHBKVGTuwji48MKQSlJpdZISouyRgLM86F0RUhsTRR31/OM1jsU7fYbw/8SaiZL3w/pFlKluHa/9DWvHnXAdZWuk2o1vc\u002BbM1yVl4MDuol6KGY4gjbC0R59zOEFZM6AWk5pY9a8FSFATuL1ECDzvDqsNfUPh/Nf68JLuPDtls\u002BOFTw0mVayvhNE\u002BDRTzcH\u002BihCmWC7ZcNNaCXcUcF0xUrcTZ/rkviLk\u002Bnfiy4\u002B/DB4ATS3fRj2gtKRp2o/enU21E6V8QGXGGcztwl639qVDm/1ZEyMwUQt6crJWe\u002BOSBVwqLbjpQsu5OjNg8oTe6b7/JT6ShYkqhcGZAc2zcJ7oW7wCjMnsWVgxn9nvz1\u002BHm4nzVlWlAIDSAKj2UED\u002BBsqVd5bH3Fz1EsvlYOWwOrViEmVEvxlIQ1o8L4wh9gkXM5kOWVjIv78s/kOJv6CaIcXylD7bukawTDM8i6zQ1BzCzS1LoeBcmVKmF8DVv4S6oQ3HLmHLPHlSXQ0kizQSXConx/FyTn/klfrrNKKG242vguqeCKW695G0\u002BUPTOA0ek7uWrveTR1KN4phn3wjWzIKAdQlJdFOEbNBgvlU7EV3szaHn7y2VGzqXECYNUxeI3SzBUsIE1B9nEkEnM4n8UtE7exFm79xV6lnPsmMtdxm41\u002BAoer6a6PmCf93rbuixm75V0tgFIu5Qa2dpNCK7Oponbluo1NcSoJIY5G/\u002BaXxwHRak16RBsrXy2A9WMbPXxkRCwwCMCcfnQjFF7T5/UQHr\u002BBcLF2L15rumtvvIu2/fQR0qu6Z85BRPvZVz/MV3c4YNazicy6/iTN1E5lPLH4fCZasgVJVbbxQCu1nNgur1L0J1ulA2Q3VtSG7IN/7BhJ0OsJYaVh7xsfskmRBVFMryTrYQVmQ2jCI1sgwmkzcWQTa8v9JU29kkgwlUEallFzOk1ehHsC451yRz5KMRyh7DDljZmVX4nnPd69Ja4nt50JrYgb1PzpAIguiu4PY1ErnqkAJRi37erDd1asVc3vSo\u002BhQIOUhhdEDH0RZsSb18qNkZcFF4KEQc\u002BtWG2mTLq6TzBebiLNlwiRvCiblncWJ5\u002BMLrQ26jMNLQ7D5z2prb\u002ByZyeUTWmnv/qOY1tZ6KtYhyDOGi32g1UNQUEkCa/K6B5o2T9Pceol5G7JqIbXozRTe2Ac65ORy9PClvwYc7Zas3tM4Q9sCQU2mCW/PNreNZ4MwJ5PvgyK1x1rfOruHWC4buUbirI052Ja1kNt0o749GFuC6MoCwVuwhniAIwqWIq1Bs31wqrb19kr9Oe5LPSeYoiJgAG9kGPvrMioQubmMH3IqNuxAyG2gjPZ/BYttaUVU54DkNiJB2ZqBiXiM4TiRcRp4HQo3W9Www3N45RNwecjgv9Y0p\u002BlT6FlVv0L1E6u57ZRs8Ug7HYurM3auxPSLEQ\u002BvqCVmWMkxKDSw4ZiSv6/Lwvt7A4iApZ5OjXB2oSNkzq4zSWuGU5DPP8UTij/vFHfG5wH5DA2HLwKHG89UuocRTBbuY3JEQW9mr8fDbR9eX3T8r74ha76grBpk/zvFdoE9/j4pALUBgqGSklxFx73nKLhaWA7I8\u002BBUTbdb30I3oTlCgXLhMV6/\u002BykcjtViWuRcfdaDbx52dQ5Z1LMBqaNfXvEnB0ZPBfddmlzhqGEO8fbO/2FvtDIezAhgh1yrulGJvS/kP1eiDXvjIdC9kMipTua8Nq5B86q/CDc56n6WseAPW\u002B8xJrafLO3liJJhXT8/uzh564ejR82FJTccZCL9SG/wrjTddCQsIQm8XGcYXar7/jNCHMZcaBQhrAF/fsTO6DwicLMGYkMUScp95utmbMuIJGnzuy\u002BplEIgv8girKJA8XAq9ej38Z/sLdb74oUsu0M191pe3zEQeNxw5aJ68ZkoOPV3P3belDLOA4lUrbG49ACI7LlH4hZDFn0Mhw/5dTw506WTtX/IW18nkNunu88qt\u002B2d8gTf5FbjMCT5zg0m0IpNGtoMKT6AvJFaHFE6n16t5dMeW4c3XetOsIVa0olSALxRVpzxGoqzGTFzgcQFpJDGS\u002Bg\u002BBHkDGbzywXi5Ke4ECBuU5Ui9vMtEbz5Vw9wjSQvwkIahE/xDTjzgAlkN9fNDa3WobMNICIsc9Zk6rVXgz3hwyJVrZvQfUZsL3b5yOnVLElRmdthEpIv/hB5jBJzrAzLgnS1Z2AR9jRskQC7Mqr8j85r9flScKCQNb\u002BLZvEz6IN6LkZlL8TpT5Om9IGBZLtlfQxUF6YDeQHEFSGwlp9DOLh9QQRUh2/5gqZVq3wvDtD0Fen039DdZrVEoQqTOLkEY8vJBCO3APWcapT/vc2FlRZQzHClTmjXr\u002BpPH\u002BZVZkn9UTewVfq9PQT0WHVL3aj3vwv0QnxIXxVS4WQ5d\u002BEfRwRLAmyFxU8bo59roPXzm8IxR2DaURPdtPIibWSWc7Uj5QFw8MtMYenM2K7s3L4vb1WR\u002BCCANPXgbV16Y2fahS/aR8v0cqr29OV3HXh08=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F47E79E4\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "e8d71e37-70d4-71a8-7227-a0565934c217",
+        "x-ms-content-crc64": "QmMDGP3h1gA=",
+        "x-ms-request-id": "16e8f15a-e01e-007b-7eb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9/test-blob-2a4ec568-310d-367b-b361-c760cbb379fa?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-99c45b07c99388c31b43162fb29e3255-d5642ac27e4b67af-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "baeb1c47-d48c-2153-3461-31d1701a9abd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "DYQ/L\u002BHvR7hJOgG4CTfdIOgeJTfwKU4irsqpsDSxknfWt8dSZgebuQpEWkK\u002BjiF4ki1vUrJQX\u002BQ1HYAWRZeEmKeJ4lFvirnhg2wsq84MZB\u002BpMR4GQkDFhlfjHUmGhHNzwMKaNKzPCAd0jc5GI7MVKbhgbBR5fVZnw1v6jG1wW/74uesMcS9y2igWkrRxf2OkzvORJRhf\u002BkJrM3FR1HyaAzLQTWrICLeI7ZLrY\u002Bui9UT4Vb153zXmmL6ooT6\u002BIQWse46BoDH428U7CDeGdJZXyT0sWH\u002B\u002BICT96rWrIGd5ycyMP\u002BdcIFUSAHr4Ptb\u002BYCQnUNcBkcmG7VpqhLZ8TLtdwj9r\u002BTWv\u002B6joGlgFxuJN/oqQg8\u002BQdzcCBVGN8ZyelbO\u002BmnuXkmbueFQuGXdwgSd3HIUr68nrzUsHaPTjIQkMSYWlRitmtmwkoQp6YV7AkoMpFdUWc6np0s0wjypxC1dLIdDyyzv8EGUZB0m\u002BcWzsR9Vwugw09dXbu3ReNiZBspazLz\u002BNzsdILQRv/WtfK2FhQ0hUAVBKFyv6Fg/Hnto\u002B11WzCkEsX3gOJ4wHxPhpe5AS/PLe7LBFaBgTk7e3gY8pMSUWrCAfNOTPRdnEQlMzkJt\u002BtKHoYOukbaEpGcvBV6b93pPTUs5w8sgNDqfXgSbE4AIcOM3tQdA6cj9\u002B9hsYDu4zxmTAXz3MDsLY2lFDzOt7ZDjIpB7YD5zCmeCP8fut9P\u002B4o7vBBIDFUCkLFWd\u002B9qVUApLiUGrQWrbH/cZdPR3GK\u002BVSiykwuV\u002B4A1P0zfo1Q6I6Ou5pyqSV50kE\u002BQa5aBMMROmBLGp8JEkyKU0W3Iy8krojIwIuXGBAvKPgLL9Y/ppA54kRsxY3vRalN6BXfwu8R2dMlUUR3eiIQW/HnPeJ2Suy1fQDq96j62XriSS/6D2YI\u002BRYDGhVLwqgiHKmcCAeHF11pakWuJyIqKnfJVTEyFgyLnkTMc3CXKbqYyJs/HtEzG3HSkOUgWpHz2O\u002Bdgm23L8ZdEKnC\u002BuPskkCLFV5G6wumlnm/H4Vna0Oy2FqA\u002BadNIdjU4g5ncCCN5f6kVQVzrO3j9uwz99BBNaUmUCJJK9iZfjOFsgj9f2YZMXmGgtY\u002Bf2us3QK7WSnIk6xpAOA\u002BBLolyxcRrfqk5neF2saWunLO6BC23E7WHiTJvR5clH5F2uy/oPf\u002B7JFwyDaLNX5jchk5WhjPh2hrT60yR/DcCBI5P//Z1tm60Du/BdQYCyimZkrFYzoltlNEVBEKzKSglIAkUfV\u002BiZs/voodUEGUEwSES\u002BGl1uTX00mslYKIsANW3rFUM/kzZ9zvxaSwCGXR8AEMRkCC\u002Br2bDH5rkfPYds5GhnHQAB9LkOQE9dFAJ8sjmqWBvGmC0\u002BPzuOd6h5Xo147WaUH0Aa/hwLVcfgTsWySzSDdOVrqkg/KOHId30QlOW95Caf5Jb5k1n/u0ZlXfB13Cx3\u002BemoDUcaWPZiUoqe\u002BsDiImafEmadieGLb\u002B8F2c7tVptQnJ74FdrjgY\u002Bcl0DTXLyBgzuJ1snJ1mwEHJ1UFH8rcPvzTl4h5gyPv5DXAPKguBMygFqXZ3/Nisou9/U5j2kMdSJE4A5iY5kq/hc08tV5Z2SOIZAklA14IceX9vIXUiwnxovQW9gAzCC9aGlkmJfwsZCQr2nU6\u002BEUyL5KzmirE6vrEShJqQuIjVVzZyugE4kvo0FhhqbGTt6mu5MZugG0Fli9fYdvqwSJBCIUZYC1cLU1GysrSY0FJMJJpvF4ctNTu1DS5pYBw/g41H6ErelZ7UbZ5J7WjMzLuFjBIgAXDJVOwKoz5o4jM1sy7nEOfHbY87Wqno40eS6ABy45PKH0JcvpOek/Kgq4urFHp55fvTvh6DJOaHILFkt7r99j5fK5OsipJUaNncWq8efY8NWQJEnyV1RvpblV4iOhw3orWNC\u002BimjRtpf1VE5oo3qOLiV164uRbY6eSZETU0cm69pPg5UTGmZovm2x/QMKBwZCy7P6L9vuletCIEDXwmNQ0mhwGSPhexPDCSkZ43CPlEKO0IeXKL/\u002BYOmp0PohkPwOYS6WleniXVCcOyKu0LZ6so/\u002BSPHfvaWscbg2N6YZnXgtD35B\u002BP5YrHM29u2dU4w3Lx5uJ0gOLqeE5iAxqCWqhpmmgcU4OLmNpZh\u002BqMa4EyIoAwSHq3owHtzavRLeJwBJiHBT9s3K\u002BvZk4H2vj4XczNb\u002BBakdItsjdmLkYX\u002Bmr4KYMRxSZBxQYQQSIsr8hI9a\u002BfA/3B1XLGWZMIBq5pl6wjD/E15limS6qaChDwAMJu3XiWuPZs9hQQS6uTOb5X5ul1yZ/XEw8W\u002BLhTZ8th1ljQ2Sl1kx719hnc5ZrtE1HsAmNnejciV8opv4A92Y4I7nVSwiCVIlOKgBOGOi20KaUmpyVoOpwh7oFfC9Net9xLlDclmlExVx/PnLnjnF2ctVYbF3Ko4POZMNOfNdZALAh3OmY2Tk9UNU/FWF3iPhJjwpZ9Q6Cp4vNDTKl9kiFJj7CxrGH3pmcGhyIio0hV9zLBe3N/wqhnzRdyssHl1mMuu8jtMFHwbFwvdvy\u002BR3\u002BrLZV2vBbuCYzISd9KRPOlIPC\u002B8\u002Bd/qIahEQ8XEEvr6UWXx4Usb1oMQHI75OayZedoSlYL/5NYK0TO1asHlvkBHGBZsr1ueLFWcnO1A4Pf7qsnroY13\u002Bmyf5wAHZnuxKm5OsiGGLNqOdGktY0f4ueBLybAICgyyzx2p3LhLk=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F480C381\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "baeb1c47-d48c-2153-3461-31d1701a9abd",
+        "x-ms-content-crc64": "OGDlLywFWXg=",
+        "x-ms-request-id": "993dc9b5-d01e-0002-24b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9/test-blob-7b460952-b3e9-4920-cfcf-2ef6762e80fe",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c291a9bee2be867d130d4710fb98416b-262aab9dcb3f25d5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3c0f95d8-0848-858a-d98e-0d55f73066bd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F47E79E4\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3c0f95d8-0848-858a-d98e-0d55f73066bd",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dca1e-d01e-0002-06b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "rNZl2g0aqzx21xGOfNhs0tt\u002Bh0t/fE4hjhDIh\u002By/fRtWNEmgyKbxThoRtDUg7Lna9fWFTSstezCIQ0v8UiNQtln1N0iPzAk1jDkxbsgYAaFW7ZH2OS/vKLkZGIRa9Pz2wP3bKrRxSynsUMHy/Axnb0KppmSRWnwqBg6PdbOE2pc9O63KPdfs5KJoCelu/SyssalCsE6XZGWAsSSl4tV1aHUptMBfnDFrvMHBKVGTuwji48MKQSlJpdZISouyRgLM86F0RUhsTRR31/OM1jsU7fYbw/8SaiZL3w/pFlKluHa/9DWvHnXAdZWuk2o1vc\u002BbM1yVl4MDuol6KGY4gjbC0R59zOEFZM6AWk5pY9a8FSFATuL1ECDzvDqsNfUPh/Nf68JLuPDtls\u002BOFTw0mVayvhNE\u002BDRTzcH\u002BihCmWC7ZcNNaCXcUcF0xUrcTZ/rkviLk\u002Bnfiy4\u002B/DB4ATS3fRj2gtKRp2o/enU21E6V8QGXGGcztwl639qVDm/1ZEyMwUQt6crJWe\u002BOSBVwqLbjpQsu5OjNg8oTe6b7/JT6ShYkqhcGZAc2zcJ7oW7wCjMnsWVgxn9nvz1\u002BHm4nzVlWlAIDSAKj2UED\u002BBsqVd5bH3Fz1EsvlYOWwOrViEmVEvxlIQ1o8L4wh9gkXM5kOWVjIv78s/kOJv6CaIcXylD7bukawTDM8i6zQ1BzCzS1LoeBcmVKmF8DVv4S6oQ3HLmHLPHlSXQ0kizQSXConx/FyTn/klfrrNKKG242vguqeCKW695G0\u002BUPTOA0ek7uWrveTR1KN4phn3wjWzIKAdQlJdFOEbNBgvlU7EV3szaHn7y2VGzqXECYNUxeI3SzBUsIE1B9nEkEnM4n8UtE7exFm79xV6lnPsmMtdxm41\u002BAoer6a6PmCf93rbuixm75V0tgFIu5Qa2dpNCK7Oponbluo1NcSoJIY5G/\u002BaXxwHRak16RBsrXy2A9WMbPXxkRCwwCMCcfnQjFF7T5/UQHr\u002BBcLF2L15rumtvvIu2/fQR0qu6Z85BRPvZVz/MV3c4YNazicy6/iTN1E5lPLH4fCZasgVJVbbxQCu1nNgur1L0J1ulA2Q3VtSG7IN/7BhJ0OsJYaVh7xsfskmRBVFMryTrYQVmQ2jCI1sgwmkzcWQTa8v9JU29kkgwlUEallFzOk1ehHsC451yRz5KMRyh7DDljZmVX4nnPd69Ja4nt50JrYgb1PzpAIguiu4PY1ErnqkAJRi37erDd1asVc3vSo\u002BhQIOUhhdEDH0RZsSb18qNkZcFF4KEQc\u002BtWG2mTLq6TzBebiLNlwiRvCiblncWJ5\u002BMLrQ26jMNLQ7D5z2prb\u002ByZyeUTWmnv/qOY1tZ6KtYhyDOGi32g1UNQUEkCa/K6B5o2T9Pceol5G7JqIbXozRTe2Ac65ORy9PClvwYc7Zas3tM4Q9sCQU2mCW/PNreNZ4MwJ5PvgyK1x1rfOruHWC4buUbirI052Ja1kNt0o749GFuC6MoCwVuwhniAIwqWIq1Bs31wqrb19kr9Oe5LPSeYoiJgAG9kGPvrMioQubmMH3IqNuxAyG2gjPZ/BYttaUVU54DkNiJB2ZqBiXiM4TiRcRp4HQo3W9Www3N45RNwecjgv9Y0p\u002BlT6FlVv0L1E6u57ZRs8Ug7HYurM3auxPSLEQ\u002BvqCVmWMkxKDSw4ZiSv6/Lwvt7A4iApZ5OjXB2oSNkzq4zSWuGU5DPP8UTij/vFHfG5wH5DA2HLwKHG89UuocRTBbuY3JEQW9mr8fDbR9eX3T8r74ha76grBpk/zvFdoE9/j4pALUBgqGSklxFx73nKLhaWA7I8\u002BBUTbdb30I3oTlCgXLhMV6/\u002BykcjtViWuRcfdaDbx52dQ5Z1LMBqaNfXvEnB0ZPBfddmlzhqGEO8fbO/2FvtDIezAhgh1yrulGJvS/kP1eiDXvjIdC9kMipTua8Nq5B86q/CDc56n6WseAPW\u002B8xJrafLO3liJJhXT8/uzh564ejR82FJTccZCL9SG/wrjTddCQsIQm8XGcYXar7/jNCHMZcaBQhrAF/fsTO6DwicLMGYkMUScp95utmbMuIJGnzuy\u002BplEIgv8girKJA8XAq9ej38Z/sLdb74oUsu0M191pe3zEQeNxw5aJ68ZkoOPV3P3belDLOA4lUrbG49ACI7LlH4hZDFn0Mhw/5dTw506WTtX/IW18nkNunu88qt\u002B2d8gTf5FbjMCT5zg0m0IpNGtoMKT6AvJFaHFE6n16t5dMeW4c3XetOsIVa0olSALxRVpzxGoqzGTFzgcQFpJDGS\u002Bg\u002BBHkDGbzywXi5Ke4ECBuU5Ui9vMtEbz5Vw9wjSQvwkIahE/xDTjzgAlkN9fNDa3WobMNICIsc9Zk6rVXgz3hwyJVrZvQfUZsL3b5yOnVLElRmdthEpIv/hB5jBJzrAzLgnS1Z2AR9jRskQC7Mqr8j85r9flScKCQNb\u002BLZvEz6IN6LkZlL8TpT5Om9IGBZLtlfQxUF6YDeQHEFSGwlp9DOLh9QQRUh2/5gqZVq3wvDtD0Fen039DdZrVEoQqTOLkEY8vJBCO3APWcapT/vc2FlRZQzHClTmjXr\u002BpPH\u002BZVZkn9UTewVfq9PQT0WHVL3aj3vwv0QnxIXxVS4WQ5d\u002BEfRwRLAmyFxU8bo59roPXzm8IxR2DaURPdtPIibWSWc7Uj5QFw8MtMYenM2K7s3L4vb1WR\u002BCCANPXgbV16Y2fahS/aR8v0cqr29OV3HXh08="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9/test-blob-2a4ec568-310d-367b-b361-c760cbb379fa",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8a6afb9899170a7fdfd390afce859f39-64bbcd6f56c62747-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dbf8964b-5d0a-0c75-b506-5d474afc15ec",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F480C381\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "dbf8964b-5d0a-0c75-b506-5d474afc15ec",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dca63-d01e-0002-42b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "DYQ/L\u002BHvR7hJOgG4CTfdIOgeJTfwKU4irsqpsDSxknfWt8dSZgebuQpEWkK\u002BjiF4ki1vUrJQX\u002BQ1HYAWRZeEmKeJ4lFvirnhg2wsq84MZB\u002BpMR4GQkDFhlfjHUmGhHNzwMKaNKzPCAd0jc5GI7MVKbhgbBR5fVZnw1v6jG1wW/74uesMcS9y2igWkrRxf2OkzvORJRhf\u002BkJrM3FR1HyaAzLQTWrICLeI7ZLrY\u002Bui9UT4Vb153zXmmL6ooT6\u002BIQWse46BoDH428U7CDeGdJZXyT0sWH\u002B\u002BICT96rWrIGd5ycyMP\u002BdcIFUSAHr4Ptb\u002BYCQnUNcBkcmG7VpqhLZ8TLtdwj9r\u002BTWv\u002B6joGlgFxuJN/oqQg8\u002BQdzcCBVGN8ZyelbO\u002BmnuXkmbueFQuGXdwgSd3HIUr68nrzUsHaPTjIQkMSYWlRitmtmwkoQp6YV7AkoMpFdUWc6np0s0wjypxC1dLIdDyyzv8EGUZB0m\u002BcWzsR9Vwugw09dXbu3ReNiZBspazLz\u002BNzsdILQRv/WtfK2FhQ0hUAVBKFyv6Fg/Hnto\u002B11WzCkEsX3gOJ4wHxPhpe5AS/PLe7LBFaBgTk7e3gY8pMSUWrCAfNOTPRdnEQlMzkJt\u002BtKHoYOukbaEpGcvBV6b93pPTUs5w8sgNDqfXgSbE4AIcOM3tQdA6cj9\u002B9hsYDu4zxmTAXz3MDsLY2lFDzOt7ZDjIpB7YD5zCmeCP8fut9P\u002B4o7vBBIDFUCkLFWd\u002B9qVUApLiUGrQWrbH/cZdPR3GK\u002BVSiykwuV\u002B4A1P0zfo1Q6I6Ou5pyqSV50kE\u002BQa5aBMMROmBLGp8JEkyKU0W3Iy8krojIwIuXGBAvKPgLL9Y/ppA54kRsxY3vRalN6BXfwu8R2dMlUUR3eiIQW/HnPeJ2Suy1fQDq96j62XriSS/6D2YI\u002BRYDGhVLwqgiHKmcCAeHF11pakWuJyIqKnfJVTEyFgyLnkTMc3CXKbqYyJs/HtEzG3HSkOUgWpHz2O\u002Bdgm23L8ZdEKnC\u002BuPskkCLFV5G6wumlnm/H4Vna0Oy2FqA\u002BadNIdjU4g5ncCCN5f6kVQVzrO3j9uwz99BBNaUmUCJJK9iZfjOFsgj9f2YZMXmGgtY\u002Bf2us3QK7WSnIk6xpAOA\u002BBLolyxcRrfqk5neF2saWunLO6BC23E7WHiTJvR5clH5F2uy/oPf\u002B7JFwyDaLNX5jchk5WhjPh2hrT60yR/DcCBI5P//Z1tm60Du/BdQYCyimZkrFYzoltlNEVBEKzKSglIAkUfV\u002BiZs/voodUEGUEwSES\u002BGl1uTX00mslYKIsANW3rFUM/kzZ9zvxaSwCGXR8AEMRkCC\u002Br2bDH5rkfPYds5GhnHQAB9LkOQE9dFAJ8sjmqWBvGmC0\u002BPzuOd6h5Xo147WaUH0Aa/hwLVcfgTsWySzSDdOVrqkg/KOHId30QlOW95Caf5Jb5k1n/u0ZlXfB13Cx3\u002BemoDUcaWPZiUoqe\u002BsDiImafEmadieGLb\u002B8F2c7tVptQnJ74FdrjgY\u002Bcl0DTXLyBgzuJ1snJ1mwEHJ1UFH8rcPvzTl4h5gyPv5DXAPKguBMygFqXZ3/Nisou9/U5j2kMdSJE4A5iY5kq/hc08tV5Z2SOIZAklA14IceX9vIXUiwnxovQW9gAzCC9aGlkmJfwsZCQr2nU6\u002BEUyL5KzmirE6vrEShJqQuIjVVzZyugE4kvo0FhhqbGTt6mu5MZugG0Fli9fYdvqwSJBCIUZYC1cLU1GysrSY0FJMJJpvF4ctNTu1DS5pYBw/g41H6ErelZ7UbZ5J7WjMzLuFjBIgAXDJVOwKoz5o4jM1sy7nEOfHbY87Wqno40eS6ABy45PKH0JcvpOek/Kgq4urFHp55fvTvh6DJOaHILFkt7r99j5fK5OsipJUaNncWq8efY8NWQJEnyV1RvpblV4iOhw3orWNC\u002BimjRtpf1VE5oo3qOLiV164uRbY6eSZETU0cm69pPg5UTGmZovm2x/QMKBwZCy7P6L9vuletCIEDXwmNQ0mhwGSPhexPDCSkZ43CPlEKO0IeXKL/\u002BYOmp0PohkPwOYS6WleniXVCcOyKu0LZ6so/\u002BSPHfvaWscbg2N6YZnXgtD35B\u002BP5YrHM29u2dU4w3Lx5uJ0gOLqeE5iAxqCWqhpmmgcU4OLmNpZh\u002BqMa4EyIoAwSHq3owHtzavRLeJwBJiHBT9s3K\u002BvZk4H2vj4XczNb\u002BBakdItsjdmLkYX\u002Bmr4KYMRxSZBxQYQQSIsr8hI9a\u002BfA/3B1XLGWZMIBq5pl6wjD/E15limS6qaChDwAMJu3XiWuPZs9hQQS6uTOb5X5ul1yZ/XEw8W\u002BLhTZ8th1ljQ2Sl1kx719hnc5ZrtE1HsAmNnejciV8opv4A92Y4I7nVSwiCVIlOKgBOGOi20KaUmpyVoOpwh7oFfC9Net9xLlDclmlExVx/PnLnjnF2ctVYbF3Ko4POZMNOfNdZALAh3OmY2Tk9UNU/FWF3iPhJjwpZ9Q6Cp4vNDTKl9kiFJj7CxrGH3pmcGhyIio0hV9zLBe3N/wqhnzRdyssHl1mMuu8jtMFHwbFwvdvy\u002BR3\u002BrLZV2vBbuCYzISd9KRPOlIPC\u002B8\u002Bd/qIahEQ8XEEvr6UWXx4Usb1oMQHI75OayZedoSlYL/5NYK0TO1asHlvkBHGBZsr1ueLFWcnO1A4Pf7qsnroY13\u002Bmyf5wAHZnuxKm5OsiGGLNqOdGktY0f4ueBLybAICgyyzx2p3LhLk="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f6597392-a94a-64e7-52fe-593ec02e11d9?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-393d9fd8d805cd6bda66c2df77a76110-d39f348479cef345-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "610a007b-8a37-7cb2-2e5f-6543baeca5ce",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "610a007b-8a37-7cb2-2e5f-6543baeca5ce",
+        "x-ms-request-id": "993dca8d-d01e-0002-68b0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2074962803",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,0,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,0,30).json
@@ -1,0 +1,271 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-533f171a526531faec8f07e7ced7f05d-c43b2d5ca7c4287c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "26c6190f-3207-7a35-b6db-fa8a961087e3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "ETag": "\u00220x8DB71C7E8F8B7F6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "26c6190f-3207-7a35-b6db-fa8a961087e3",
+        "x-ms-request-id": "68287c12-501e-009a-46b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232/test-blob-c26fbbfc-0f3f-9fef-6f58-4225e667eb5e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-550faa94b633e4c40c3ba7891964787c-6d25dbfd3712ebf6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1cdf4259-949a-f3b2-4d9d-e3e2fdf22872",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "ETag": "\u00220x8DB71C7E900BD47\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1cdf4259-949a-f3b2-4d9d-e3e2fdf22872",
+        "x-ms-request-id": "68287c4c-501e-009a-78b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232/test-blob-f8eefadb-1c97-032a-c77a-2122d3b5008b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-27247d32fe6b6ca396ae0188dd86a9f4-9de5f5de762bc1d8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "19a69a58-f481-c6c2-4a64-eb58f1b847b7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "ETag": "\u00220x8DB71C7E903CA05\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "19a69a58-f481-c6c2-4a64-eb58f1b847b7",
+        "x-ms-request-id": "69fcb072-201e-0029-69b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232/test-blob-3fb2270b-566c-ff26-2927-b6afef10944f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7045131aab28c9f750e956481579ea86-cbc286ff4138340b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "6389e2e2-0e4c-eaf0-af4f-1dbfef691f7e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E90688BF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6389e2e2-0e4c-eaf0-af4f-1dbfef691f7e",
+        "x-ms-request-id": "993d8d2a-d01e-0002-30b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232/test-blob-9cae9cf0-8f21-df4b-906c-fac5eeccccb9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-77a5778600cdad07db195e4b3b00ef00-f6c958e2ea1c3691-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0f76d40b-e42e-f16a-666a-9e74f3308f18",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "ETag": "\u00220x8DB71C7E9085D3E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0f76d40b-e42e-f16a-666a-9e74f3308f18",
+        "x-ms-request-id": "68287c96-501e-009a-37b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232/test-blob-bf19b757-abb4-85f2-d3ef-cf70657b13b7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-50f1d2b759ef81ea314980df117f08ec-2b6eacdbc6cc6e38-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1ab3a790-10f2-c34f-6beb-dd78d0c85478",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:41 GMT",
+        "ETag": "\u00220x8DB71C7E90A31BB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ab3a790-10f2-c34f-6beb-dd78d0c85478",
+        "x-ms-request-id": "69fcb0d3-201e-0029-33b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232/test-blob-3732d1e5-6407-7b69-dbd2-aeff5c61115c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-5712a9a8c3d4b3f489cbe0b96f4cabf7-3c03cf83187e4a69-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4be4058e-747d-9e25-1741-c40a37baa3dc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "ETag": "\u00220x8DB71C7E90CA270\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4be4058e-747d-9e25-1741-c40a37baa3dc",
+        "x-ms-request-id": "146c03e5-a01e-0055-40b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-deefaf6e-f0b7-e515-3af4-60fe115e4232?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d7314142f2d65b40614697fa3a91d349-f4be1016f2d892ff-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "caeab470-08e3-23fb-5b65-8fd0ca75bee6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "caeab470-08e3-23fb-5b65-8fd0ca75bee6",
+        "x-ms-request-id": "146c0524-a01e-0055-45b0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "775632971",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,0,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,0,30)Async.json
@@ -1,0 +1,271 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-322ebbb2ed78ba8372d2e50a8590cea4-331cfd6ad85aa079-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "058047e6-a205-d508-62fe-e0d75faabfe9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F2F91399\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "058047e6-a205-d508-62fe-e0d75faabfe9",
+        "x-ms-request-id": "16e8e739-e01e-007b-69b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1/test-blob-d0f6ab77-50ac-f811-724c-aba9c23fa9a9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f12d6bf436908a30a9438471240dafa7-776c785bfb3f4695-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1a861f82-bb19-9c6a-a2ae-dcfb4bf7fcdc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F30271D2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1a861f82-bb19-9c6a-a2ae-dcfb4bf7fcdc",
+        "x-ms-request-id": "16e8e76c-e01e-007b-15b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1/test-blob-bd0955c1-a588-35dc-079c-2c26398e5cd4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-c3c983cfabb31b631956f11a4ea8f626-45c41e4d4e1b3108-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "5e759b79-562d-0d30-442c-7d0517f3774f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F3057E9F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5e759b79-562d-0d30-442c-7d0517f3774f",
+        "x-ms-request-id": "69fcf0ad-201e-0029-5bb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1/test-blob-160aa3fe-47b9-95c5-3587-93b8f75e1223",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-531695023f31fafd117249e1a12cca96-b4f40502b2bdd767-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b081f82c-9d82-abae-0b29-1e2ea0f07d27",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F308164C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b081f82c-9d82-abae-0b29-1e2ea0f07d27",
+        "x-ms-request-id": "993dc030-d01e-0002-5db0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1/test-blob-09153755-02a1-d160-cfc1-c81024eabee3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-0d3decb9f7134be8f028051402829aac-a5bc9a7fa4d8582c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1ed8e069-c671-01cd-ee7f-32fe3c23c439",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F3099CC1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ed8e069-c671-01cd-ee7f-32fe3c23c439",
+        "x-ms-request-id": "16e8e798-e01e-007b-40b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1/test-blob-1faad6ef-9234-7aef-9073-870012233ea9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-cccb312b1736a45a349c5123b46b89f3-06e19182213552d4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "bfc4651c-5f18-cfb5-9f3e-4f5b0fbce126",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F30BE650\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bfc4651c-5f18-cfb5-9f3e-4f5b0fbce126",
+        "x-ms-request-id": "69fcf0cc-201e-0029-7ab0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1/test-blob-02d00989-5279-fc33-4338-47f87eb4714a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9af9a08e8234b5b85f0f2f9f64d81446-cee35f2e9915e42e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d6e14c2a-055e-1421-23a5-f50c3465da80",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "ETag": "\u00220x8DB71C7F30DE1D0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d6e14c2a-055e-1421-23a5-f50c3465da80",
+        "x-ms-request-id": "146c2667-a01e-0055-63b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a07d812-4f68-6bc1-59da-c7ef0408abe1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e4bdaf350af4aa001a2739fec4ddb7a4-1f89392f2c92551d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c331d3a5-0ada-46c7-dab4-5a0a8360b0b9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c331d3a5-0ada-46c7-dab4-5a0a8360b0b9",
+        "x-ms-request-id": "146c27e2-a01e-0055-35b0-a38109000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "417864201",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,1024,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,1024,30).json
@@ -1,0 +1,733 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-da6cbcae736827ef338c07c3161c7dda-1b4295c1d2227f8a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0a9b5cef-3746-c25b-8e66-4c6a75c3474a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9CAA84C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a9b5cef-3746-c25b-8e66-4c6a75c3474a",
+        "x-ms-request-id": "69fcb634-201e-0029-17b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-0e489c0e-a58d-6ef4-30bd-7ed451f3d6b0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9f0c668ebfb6b24c3386818755354298-f4eb83e931ac042d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "12357f58-29dc-d1e9-7a7e-f07f6870a3aa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9D8870A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "12357f58-29dc-d1e9-7a7e-f07f6870a3aa",
+        "x-ms-request-id": "146c0650-a01e-0055-40b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-aa60564a-0ba8-4361-9103-ad5eeb4e080d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-ed7c2a181cbe456595cb37aea29c1cc2-856bc0c2beb4a569-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "5874a296-a29d-a3bf-365c-1f62d9063d9c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9D6166F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5874a296-a29d-a3bf-365c-1f62d9063d9c",
+        "x-ms-request-id": "69fcb660-201e-0029-42b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-22d41bd3-6ba7-e4ad-fa58-78438afdd640",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-a0a32b79afe28d44a0fa733f1fb9bb2d-2d07c96ad450c0ac-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "590982ad-2ad1-0cc0-6b69-87f5ee759a07",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9DAF7B0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "590982ad-2ad1-0cc0-6b69-87f5ee759a07",
+        "x-ms-request-id": "6828832c-501e-009a-5ab0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-d85c3f5e-387b-a4bc-62f2-79ea8c8df19e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-8b3f77ea8c33d7f11e759805c87b9da8-d54e366dd4ff8465-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e6d25744-4a66-20d9-b860-cd3b8b6fc837",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9DDDD78\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e6d25744-4a66-20d9-b860-cd3b8b6fc837",
+        "x-ms-request-id": "993d90fc-d01e-0002-19b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-0e489c0e-a58d-6ef4-30bd-7ed451f3d6b0?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-cc3b1e43e459bf428ac651dd8d43425c-cfadc7fad771c8f9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "96b1b6cf-b3a3-e2a1-e7aa-36d0a8bdbaab",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "KAX0\u002BlRwqOMT6qXwWCjEcSvudkSun1awGSAbgfFiRYJ4r5ga4Tsp0R7j4TXsweYqMPrXRGf2zImvQ\u002BA0VCbysKQieKiPqY/wxKUlyr0gxFc68VH2iwEbgeIPap1a9X338TCQyUk9m4Zr53/B0QLLj3\u002BJ\u002BmPV\u002ByWjB/fGfz7xlc4oLdiNj/sO/FXKi6SBWbDfRNse0fsZIvYL7cFSdxtIeVGxmaMqPf\u002BDev0NCm\u002BAIa1H5jpj08PTDgvhgaE5vIU5ghJS0MAMtQbbmlb\u002BDBeHissTC5Hh5aWN3YqXSbtdSr5304hcLlHtOjE0hzht1QLzWffWJbD0WJ1sxPI1dGtKfVCYhjiPKlx6JdBgrF1tIAiIpPDEhyQNg3rq72leuMXF6Qnn1U7JZC6aWwDflKs//6PprdB7hvUsigO9pDrzG20LmsNThUu6vj/BKiwkLe/Oq/DFdQv0SmMUu0pLC7/zp0CS1Pno63lYL\u002B6QulvJCFwU7/lKLaZiF1BgP8oBb7KAzYPskVn15r92bUUcY48HSrLtNhzGqXmZL72ph6yvVsA7EOzY3XYDHgg608BgRbPAWfQXEziVuiMKUmGbS18SxxaF4FOjL2086hcUjNW4OekJ6C64mEOIplbIzosUZ9KpJwyp22VgHSmG2ygggS5OURl3kmMwWi7S/Tr82mDiJ4NEa2TJDl2EqcsEMb0bZyQoen1ynNVveM3d1t4qY0PIpLOl2xXJhEK78\u002BiXLChxt5UV1F/jcIqu1fOX6zh/WUWIO40JdYwOXvU6tqns2Eykax5IFI/j5DMp9wYiMZkKPJmiD/CbaEIJB3Vpqbngwfyn838ZNkW2pFZZ336G7C1cMHoQSchbCAPcPw0ZeTt5SDUJez4Z8AVU7GqZQYjDgxpIDHg/0Hc0S\u002Bp8PPY3nSob4JdIfHDuQj90u11ewsd6Gbzy0W3DOXe\u002B1S9TnbQPHE8/fmHxewaqWck4yxQZ1YkjASM5RMy9V6YfiadAm6WLZZ8OH0NliZ22SHejim5jpf\u002BmMJyQ1diCgSa70fFeab4krWV1CrZFvXeFg/tUGs03vOSnmmoJ\u002BpDGi50dqrisV965ft0I7ZpJYXMkC1HcLmZYgxQMts9TG7LVr34YJxK/2Ssdm5zvLs9KXjn35O8\u002B6l02xCajn6EOZWMqMz4bMDlgZTIlv5PKaVVFwleWWzbDl8Uh4mPrGzmKDjU5xfuQLi7/ln\u002B9GCrJbFvRXtxJeAosZ5t5\u002Bk3VdEr4m7BekKRatJQolsW3BX6aV3UHGr1cQZYrDV1fFzTgKiE1xH15a9u3d6lIIOFEdGEd3qLYzVqNnFkaM4NG\u002BpxgSGyjgkEAIOyZUKMTEyC05pj7QjiSCFzHpw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9DF15CD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "96b1b6cf-b3a3-e2a1-e7aa-36d0a8bdbaab",
+        "x-ms-content-crc64": "CDJOvhOBmKE=",
+        "x-ms-request-id": "146c066d-a01e-0055-57b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-d08afc2d-e57a-a365-ef63-13352cb1e332",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-76adaca49b2b671bb64210fce547c35d-5bc33bcceb474256-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d56b7f9d-31bd-2494-36bc-8e3313978ecb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9DFD8F8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d56b7f9d-31bd-2494-36bc-8e3313978ecb",
+        "x-ms-request-id": "69fcb69c-201e-0029-78b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-aa60564a-0ba8-4361-9103-ad5eeb4e080d?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-fd2817b2ef41c89a927f296bed1dbe89-1d631723632a7264-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2933d34f-e552-83ee-9a6f-3ac095bee558",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ZtoVjXIGxXnauOkXJIZ3sQ5GBE4X4AcwyO9xSiSvsi0Mps9Sm1XA33f8N94THXbYtw\u002Bmqr0JVobT5cWDlXtUKga8C363JRa5hiTWGqgoHKp4mZMVCQdvAk9IfrWPPEr8qA3YVxL4IJL47SSZMjzdqskbC/zoPiD/TAgvbqZgKUnZ2nGaUMSXf3gBHBvj1dATa9PsdDFOFGrs2AoKybHrmMTav1jKQloEg4uD5yEEG3c3HAPSc7QYi8UHrne6jbbHFYRXCBZ4SCh56PCmyy1I572T0q2tGCUPwjOSwpTiSvXUu9GdrRJgvtPbWYrDccCXv8a6JroIGv1eR0bi5oaTlp770Q9cqzqqMxTa0b\u002BaS1Bz\u002BgPOKCM6zKHUPmXMfdhNSMLsyKCwOxOLEPOmLkg9w/z2buuCxG56wAVuiGzU3bU7jIn8roOww7/vQhgwlJ1Zlntp1g7tyoRUcQiaQrOntjI9a6G/QRV4RqsrkoFVSixoFPLxawenTcIEqD16FYAMSIzm8ij7mVRm8I9jwTgC/ibcMi3Atksqlh3fupnX/jEqH0r1b1gDbHqdi3t3Q4yKAqkWnuJTS5FBu1sLG9\u002B7jvJeOKLtDY7O2cayIyvPslKRVbfvwF9O19S4tLT891Gb4fyJGQvpnPUbSMUcoCdmcQgJesYnzM2SD2HONVja0uF0F0EuRplHp7nC1HiaMjasUUKr832LcxUv9gmqG2ecQHbkp4nlNytvwtIMZfdV\u002BN0qIeMVL99j6aMs/0\u002BQnItSJZMBtYutxhoXOzCrfg4d2f4rgPmDhhGXgb3luTjc3iVGuj9kU0JSfFvJ/vOut2uUDiVQZBySzp\u002BCajTNxwzhO10LZMTPuYa82QOeuoge6clRUKsSi3kJtOug4ukOhLRO58OWolOnxVSflIsZ9BMWY4Bqe3dhzq/jAq/YL9ecrVROT9LFiEZ2qotWc/bu78DXiX5oowg97RgTs6CjzpZ9AuY2yqVBUds69NHsC1u49BLvAKZYNApMEGG5sdSl09v02HAQtyUbljeiLq42UeK9Wr6Os87wJM7b6rpDh6AGlSH19zLqqDzt1GputgZbFb9//FcWFh8NBLSiNM1r2A\u002BXnJiNQVqv0rGBod9kgW7IgNT6w4tI8H4B6PJ9SHRvgvxa1xptztRlzymllHVAqYJF2bT5cBSETqsai1hnMoo9Eh/jCalUW7H/lfNho1sJwT9vOG6/dRHn1oluUkN8/Z2fZ4JVXZ/Z8X4C\u002BdohIqpPEckY9/kbfpwN\u002BzIg5Qhug5dVwjzZs2SflkbwvHw3xbTeHkF5Ywajg\u002BnlR2FsuAt1lHZCy19udl1leGCzKsEg1jV\u002BQcfH9SCRsj9S9GwCMt47eg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9E09C2C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "2933d34f-e552-83ee-9a6f-3ac095bee558",
+        "x-ms-content-crc64": "OfivfPI12Kg=",
+        "x-ms-request-id": "64d692a0-401e-00a9-3ab0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-11753de6-fd97-9b34-5e2f-c0b5f1c2576d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7cffb3becd7500b64f52cca0efd2761e-2081ced34200397d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "68db02a1-a5da-a7f4-1875-d2cdca4e349f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9E297B5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "68db02a1-a5da-a7f4-1875-d2cdca4e349f",
+        "x-ms-request-id": "16e8af67-e01e-007b-74b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-d85c3f5e-387b-a4bc-62f2-79ea8c8df19e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ade416757d6ec1d8d68701c163b626af-f1e86aa003c4a502-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "14b1ec22-ad33-2c2a-5954-abf08dacbee4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "quNwStRso4/JTTOVH/MCtxIjF9QeZe2WtsJefd5gSY3gW1Y0HSztRv548MThxve5Se62KKFgnkX22ZQRDiWwaAOltcSdzZnlNdHVpnQote/LpDTwqiHsgLwQPUOY2zfZx4fAOxAyG3tU0fLPivfQzSSkRWnxwL7iuTUHjY9VTFqZ/N7taHrfmIm4m9kuHPXEQHAf9JXO5wfI3oLbK47r/oSYNo0Z4mWqxK3gOSXls5w/QkwfNljEyxXXJIn3BG36zJxUluVoq10KdC/o7a7h4yrlm\u002BhCzMgs1Gt4Qr7bssBA5myIkBy215fuFcEo291m9UFfEmiEtwDUKMJ672mfLsJvqAdBWFINLsRRU7YGA/iOEUx9fKBYuy5stGdaPOcuT\u002Bb/uTPVJZ3uUeOkM2RJziTK7N4cIbIhF\u002B3Z1KTqs/LdIgPQB0rEuOyujiu9tIfJI\u002BZDkFAJES003aJG/FD4A53xxhFgecfaBTPxbZKGZGJlD7G\u002BpyOh0xHVmymofrubtouNzO12aaoeaYocF6Oarng/4e2fOlx6T/P/it2dMYZ4VrcH\u002BJh17qYGnz6YhbxtO\u002B2waZ3O/HsvE3z6dt7MgTcDpMHrk7XgyfJGmJsd4sk2kk/w7cjpqVo82OUbe3jHOh4GlOH7gac40J\u002BriGPfETCzw\u002BOO3JRvGvtmr7vPxE16fl59Fk3oOxGotxwoPiH2XMa0aLiUOF2Kl3nmlNLsaQtSMQkFYvrjyojS5iR3R9zZcFL0GluV5UYA83/TAqY\u002Bu04R1Q0Y8frM0Z4wwVI4ElCdDCR/906wvUvDBG96D8fhlCrWZnHOwX5YKEm9ZSTzx\u002BAvNvaBv8MAYRjBVeyKUcLWTi0nYqzfzkqlJ88F8lcmzz2PS9nRX9Rn1gVYDGyRzdaG5xb3zGUzUGer3Jf0\u002B27Am4Wv\u002BwXpBO5YwIynhsHdFFn5fgtBLwLXXPtxJoM9ctqWl3Hm4tLQneIongzYi8mlzsc9\u002B3xjf2uD154Kd95qG02xEe9Q9jKHKOEoGZD1/9AxzFe7/3deMxcFYwozxiUEvYO/J3raVdeVttKaOmbbjdjO2KuGrxvVUt3XSpMoU2G7JFwMNthWV3eAJkikw/mxKtUxZe16fQ5o6tSdAgpDbWNx3hUKzlcAeIE0BYjTMI/kJiC99u1zQadNpEwDuFRsPLjlM\u002BTjp1t\u002BMO1sRneFlLlFudzqhnZ1/Z1uvCkL/L8sx8nP7vyqAH7EP8UAB/svyA\u002BSvv94grZBbzZHdeoycjMtQH6utaa8m7hdJkaxdfahPvMaeT6/s0USjn7GYouUksyS0sZ8gBNo1SNHGltwkPo/pTb3GPn1bow5nCco9jgtyZR6HqIvJb3gsaMbeA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9E4BA44\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "14b1ec22-ad33-2c2a-5954-abf08dacbee4",
+        "x-ms-content-crc64": "v4ex2KBbS3A=",
+        "x-ms-request-id": "993d9117-d01e-0002-31b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-22d41bd3-6ba7-e4ad-fa58-78438afdd640?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-8a11f6803c06f421a69ee07e991dfb38-5fbef48ddb032496-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3fe42ce4-6564-2479-a51a-fb52170f1504",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "KCNeOFdwfA3o2HSh8SAcvrY\u002BfbZ5iDhmTOtLuGTOPxDb2hjdwbNB3ycFK0g/RKbbJXrbyd8RLaDr\u002BOtsJcOoGphkxRYHP/wC/J2PdFzwJgdEcJLp8nUxyqx48sjI1LpjXBGw23\u002BQ0\u002BZ92c1BgblD\u002BtLjKLUxvygiM/pqj00zOifjKxdLQEuItJysbBmo70jyNff25KwEMp3ojaeEJUSZSZ6lXlWi97qHW3QYhVIPekSyd1lWPVZ73vl5YrKjBI5YEiJ6A5HyTz08bok3661K2RNj0q7qQwxIKX9cKZQH41bmwHIwlHayvyccGc7MQ/JMLoifQDHfbs8WMdkRliaoNIoyUSs6GkWcsBOHzik9fOaMEPsLZ6MlB1GjGmOdoSgAc\u002BREmvLHERNDA5AeV6Cl2LXzhYYqnMznDUrZl//h/w/qhlpF\u002BeHzxf/nyGQTBq\u002Bx/kGtqRyi1dYYXI2o7XkTYQOANNFFYN/T/7\u002BHQ9Ro1AaaKJm\u002BNFXzR7CELJxUS9iF02ZgktLda51h2alcG5IBr4iGDcTgVS2ujewgwDNDf7TnAW9uB0E0vbz7XFqsliweg30TzT0TpH04sgTmvatqHlr0dRkik6hGUlAH5PnTAve/Aj22L7F2013yNVU9Tf8RkT3/tyES\u002B\u002B/VzXvtC7\u002BEZbANJrpttO\u002BofqG8MF5SCQVQ9lO700rVrQZO4GE2icidbc\u002BkMCdEpNxNVzmAVsuRgsN1nRVryJJlN3i0H9ONcfTYHsKOrdndC1J3bXsRVVc7vF6ewOyzMqQ9P/iukIUJwOVEpzcIAtTqmJHD9FoWU\u002BIheWJ177AIJewdUW7gL3vMbq2Wza0fMrqJsyha7z1KJusWjBcjlNA1PIFL67BmCWgW9oasgIY0AUen6zuHrTWu0yuCyqJkqdrdYZAs1EcKI6rARPm3naZl4ovQe6iVrY9LnReE4z/Fskyszx/1Byz/nMeRx2g89jaEHecXky4xSLMB4DcvhT9q\u002BpKtC82Hb9pe0N7hA\u002BUmD6bgAMZXrh4eeodr8yf1zxeIJszVjupo/a4NuMNPUETO29CRToV5E0x0jpBFHHuyaQDHWN0ZUIC7dwIXSfZazypDnRhWZICRDhKAYf9aI\u002BEyWk/Dh/dmtIpP1daCYclVGb9mAn9iWwV/NUrKmO\u002BBYVQh5e6nl0cz3eiOB46qD6xJKkdA9CFhz/9KRFKsmxubznSCYXzaroJ4MiWW1FR21SadgW6nQWwzvxXvXFP1hkHM8jgZJ60wbnvEyMH8yvqq024rDxqt9I0HTqFm6lIvgqzjyuIcXK14bRLz4nirN/QaRYnkyncmH/6rEtkLyYMplUUVGAAYjnfBsqIHuhEUXBatS6XIS7g1vQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9E1AD79\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "3fe42ce4-6564-2479-a51a-fb52170f1504",
+        "x-ms-content-crc64": "P1\u002BLg6w8pYs=",
+        "x-ms-request-id": "68288363-501e-009a-0fb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-d08afc2d-e57a-a365-ef63-13352cb1e332?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-bb7c54e301f684f78e4ed83029f8a185-6bfdb630d7c480ae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "deaa1625-1f9c-fd6c-e105-e43c5de2f707",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "memi/YSHvFWdetKcZDpD5OtA3\u002BoaUMf1cVcQgHgWZlba9vJP\u002Biqjb3vXLBqngj714tn1cMQwXUgirIssdjzchhN8wm5H8\u002BrBnHBuQiStTu8ZG52eIfaRqZiqLU6edvg/\u002BqUGK7/Qre/vM9NUwRsjdF2bE1uePWUd6hjVnMWcIiV3L0d\u002BpiIvSW2ur\u002B0iPeh9hrjwA2OcoLw/6UGn\u002BhApUhGt3JHTpc47bMnt8I54\u002B6wwWBYMrB/C24\u002BKPr3hiE5dhV3cdGFWqeHqtJeZrrAux\u002B6Ud6L6HKby6wACSWYQWeN7kGoxm4ZL2q41IfeIKCzeW3bOTRGsYmi26ohgU2B72luzHh1F/SxnSJz0xfuvasPUI\u002B3vQQzSzy4CerH\u002B64ZNuUeb1AkOmV5KZwR0uJ1sBoDFiy9zi5hP4E/vQoJ6aV0WpguzE5W5xYqPpNoHXhaQlXQxOV9W2i2vTPS6Hlbb0P6nXRGSufPqC8Wl5Oe9R4I4X60OSS/9v8zdBMah/6cztNTcXwAF/tyARi2ZsfZG8QRxgb\u002BpzIbOqp5FtLQsSQsecS8T4eiBM2HQjQMCYw7VlhLCL37niudNDrViv0knVPwiej/GMxAc8E5d2D6DzEaPbx6iahqNN\u002BZIxdMyH3MYqTkG4OjPD2MCpT8vibKpykFu0lArherhlENYfm486dDaRS4FfOxdwF\u002B7n8TbXa00nvqRxEwi7SNOJUuldpH0xbtuVUSDpE5VEBLwcOYlBjaWI99zqyWEt1gLtleguEnOxtkJbQhpsfqsO7M6Mnw9KB4UDlKxgRmW6Z3reO32tVjIIakMHJkuLXLlxm9xSoXbzY44jKn3HEXAcoNrfTgNtYZbchDTMQuF5uHfzLqpJJ8XD6tevimu0AVkS6kVw6862BDpFdh0CJuDs6XIF1CKFk7jU26NrvddraELbuVhcCMypfSpwA7HowcP2wqD5rm02TVbMW9BrCkZi2g2aZq1IUKClnJc4VU/HLBnftLs2sfnVpSvBj6z8PnKkDSmkDptWbrIAE9HWPjgGxW/2i5XLLGhThIFBRsEz6V5kVEgmYt1\u002BiQYJNl3oP2cz\u002Bop8xbKcmSDBUEnZ1OewzGqzsanv4KJSeAJPgfYKa0VaDYw29uPrh7tnZRJTpLQeWGnzNI29RBnn6k2wDRcq9uTEv4dbuhWGx\u002BnuiHuQPtNOcWlMFzb3nMlyTwxWO3qkPK4tTyTsgt5UbGyjjvueV6u6Idvt3p\u002BuDOK96SsJMIyvSovNYq\u002BuYa5LN6rKE84N0/dg29le9h3OvwICLpmzC3ugNERv0TT7y4AtYqc05DjUsBVzqFSzEJRt/qNtrHLUl\u002BxvKd\u002BJ3gKCZNAZcVO22dsJbb6EA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9E5F299\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "deaa1625-1f9c-fd6c-e105-e43c5de2f707",
+        "x-ms-content-crc64": "sgiEAiIsKAY=",
+        "x-ms-request-id": "69fcb6cf-201e-0029-26b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-11753de6-fd97-9b34-5e2f-c0b5f1c2576d?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-bbd27662bbed0b2fa43217be0656a218-ecd4e44d0d3d60a8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "76cb7b98-e001-9347-6ee9-e5b1d540394c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/oubs4\u002B/CElGOX01YyrqFuhlKkdLxQ0RZ3wC25MhkPrQQWElIPPvZ3DAw1rDL2Ik8VCDwIuzxTh\u002BikwSvSy2JKiDZCHIxfb1dcPXigKzTjca3upCntBvHXwoppan3KpDCp6xQMtBWytajkrI2zs2yzsU\u002BN9Cc4bYE0alnx5fTZkZk4BjAQ5s2YK\u002B6A\u002BGp0JA8dtbkuTKAZYX2SyFnLsN\u002B0Cwrke708ksqB9chIt2UWwEZK5CBLu1TpLpSyjh5z3GsO3P1fj6hR4SLurFbn0LoYe/gDcNyvaF\u002B2C10YehSsHhldOep3t0Cd6PMNbQ8OAV3qqgIWYFueX2StqYRLOWceMp49iqbfkMS3ZYfZogtAt/oPPdACha3Nztp12h3MUr\u002Bb/ypwwHanGwlNbvrDtL1ZXPGKPAuXC6zgb8vMWcam\u002BxLYTbLg3\u002BeDWBLGxSay\u002BgotHH0sQhaj9OONgFC66rFClmPn\u002B2b6eI0J9uPowEZ2PXWxrz1ZirkMNEjfU0\u002BGyH1hhD7C2w6jMqPgEksyuzStF1LrCUtz6Ruq28ceKyVNcz5mhzwHo2JnHnyZaWh92XkUIkvsq78x7ZsjJ/9HhQeOoq8MzDQIlWPgc/rO6o\u002BjLQJOCfjZUNd/NJmQ5ItzL4llGsbJcR01G5zoDDfEYvMbf/rs\u002BYsepUHXjYeaZ6DYfURhad/I6bv1GP5r8VSfusGWhXSQhjYORmV04eOFqqPsD47jUwkjUoY\u002B5\u002BCcsrP9N9K18\u002BIsR\u002BceYxNqQ/fIf25Kf\u002BHFvFfIcyLuUZ5FYZOxh7oQz6bBv8enxP/1yQ6OdnhyQjLCN3t6/YC/TeZI2PF/uMxNp6/HiLAqHedn0rokX9sl0x9Q71A\u002BpdIWAnHRXvv\u002BdgBCQM7YuslyqBmEExrWmu4bIvXSHtl8HwHNoXZOSM77aWyp4h8MTShF3jdGqoK3T3eTxjv2HFc2xjHNCwlTNF9amKm\u002BLKjPDuXdjECSNWR/BmH\u002BuoKC9U0FcxvtTzIe8qnX7BHZCRLexMdWGIAWlJDNTgSnZInMx5NsqLmc0b\u002BjzpmWuklClg1PL\u002BXLPNy8/t57H/E9d44gGyR\u002BfFBpMeMHolnmf9pXerf3WESUAYrGr7nbIbG\u002Bdkcbdq8U1Bm81e3yw5qC1n8EE6VJNh85jAmZt9yWnhAhSSwC2wk7MqaeOnJmkU3wM8k61w4cdTA30eqVexw9Fkfd0Xpuf/t1yOD\u002Buwuc0vrLqXQDa7cSBNP72vkulbeKUSQ6iM/DgcPdxQ4dLco0mw7v2dGoKbqAy8ymcpUCRzMpdFnXYko6\u002BBewNaa49OcJt0/6Prvl4id5qc0DLR8u233a86lwXSi0tNG55/QD19bVnLtVCBhw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9EA37B8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "76cb7b98-e001-9347-6ee9-e5b1d540394c",
+        "x-ms-content-crc64": "9MZdZJJkdEU=",
+        "x-ms-request-id": "16e8afad-e01e-007b-32b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-aa60564a-0ba8-4361-9103-ad5eeb4e080d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c0249c31a26931db809f8cd8506644e6-b928221bd0516991-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e2a40370-8017-bb05-e035-a316a352922e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9E09C2C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e2a40370-8017-bb05-e035-a316a352922e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8b039-e01e-007b-2eb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "ZtoVjXIGxXnauOkXJIZ3sQ5GBE4X4AcwyO9xSiSvsi0Mps9Sm1XA33f8N94THXbYtw\u002Bmqr0JVobT5cWDlXtUKga8C363JRa5hiTWGqgoHKp4mZMVCQdvAk9IfrWPPEr8qA3YVxL4IJL47SSZMjzdqskbC/zoPiD/TAgvbqZgKUnZ2nGaUMSXf3gBHBvj1dATa9PsdDFOFGrs2AoKybHrmMTav1jKQloEg4uD5yEEG3c3HAPSc7QYi8UHrne6jbbHFYRXCBZ4SCh56PCmyy1I572T0q2tGCUPwjOSwpTiSvXUu9GdrRJgvtPbWYrDccCXv8a6JroIGv1eR0bi5oaTlp770Q9cqzqqMxTa0b\u002BaS1Bz\u002BgPOKCM6zKHUPmXMfdhNSMLsyKCwOxOLEPOmLkg9w/z2buuCxG56wAVuiGzU3bU7jIn8roOww7/vQhgwlJ1Zlntp1g7tyoRUcQiaQrOntjI9a6G/QRV4RqsrkoFVSixoFPLxawenTcIEqD16FYAMSIzm8ij7mVRm8I9jwTgC/ibcMi3Atksqlh3fupnX/jEqH0r1b1gDbHqdi3t3Q4yKAqkWnuJTS5FBu1sLG9\u002B7jvJeOKLtDY7O2cayIyvPslKRVbfvwF9O19S4tLT891Gb4fyJGQvpnPUbSMUcoCdmcQgJesYnzM2SD2HONVja0uF0F0EuRplHp7nC1HiaMjasUUKr832LcxUv9gmqG2ecQHbkp4nlNytvwtIMZfdV\u002BN0qIeMVL99j6aMs/0\u002BQnItSJZMBtYutxhoXOzCrfg4d2f4rgPmDhhGXgb3luTjc3iVGuj9kU0JSfFvJ/vOut2uUDiVQZBySzp\u002BCajTNxwzhO10LZMTPuYa82QOeuoge6clRUKsSi3kJtOug4ukOhLRO58OWolOnxVSflIsZ9BMWY4Bqe3dhzq/jAq/YL9ecrVROT9LFiEZ2qotWc/bu78DXiX5oowg97RgTs6CjzpZ9AuY2yqVBUds69NHsC1u49BLvAKZYNApMEGG5sdSl09v02HAQtyUbljeiLq42UeK9Wr6Os87wJM7b6rpDh6AGlSH19zLqqDzt1GputgZbFb9//FcWFh8NBLSiNM1r2A\u002BXnJiNQVqv0rGBod9kgW7IgNT6w4tI8H4B6PJ9SHRvgvxa1xptztRlzymllHVAqYJF2bT5cBSETqsai1hnMoo9Eh/jCalUW7H/lfNho1sJwT9vOG6/dRHn1oluUkN8/Z2fZ4JVXZ/Z8X4C\u002BdohIqpPEckY9/kbfpwN\u002BzIg5Qhug5dVwjzZs2SflkbwvHw3xbTeHkF5Ywajg\u002BnlR2FsuAt1lHZCy19udl1leGCzKsEg1jV\u002BQcfH9SCRsj9S9GwCMt47eg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-0e489c0e-a58d-6ef4-30bd-7ed451f3d6b0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-243d232cdc0142b57d0b8afada161b60-2ca0f45d1ac76855-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d241afe5-579c-de35-a827-8f790618f9bf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9DF15CD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d241afe5-579c-de35-a827-8f790618f9bf",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8b0de-e01e-007b-44b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "KAX0\u002BlRwqOMT6qXwWCjEcSvudkSun1awGSAbgfFiRYJ4r5ga4Tsp0R7j4TXsweYqMPrXRGf2zImvQ\u002BA0VCbysKQieKiPqY/wxKUlyr0gxFc68VH2iwEbgeIPap1a9X338TCQyUk9m4Zr53/B0QLLj3\u002BJ\u002BmPV\u002ByWjB/fGfz7xlc4oLdiNj/sO/FXKi6SBWbDfRNse0fsZIvYL7cFSdxtIeVGxmaMqPf\u002BDev0NCm\u002BAIa1H5jpj08PTDgvhgaE5vIU5ghJS0MAMtQbbmlb\u002BDBeHissTC5Hh5aWN3YqXSbtdSr5304hcLlHtOjE0hzht1QLzWffWJbD0WJ1sxPI1dGtKfVCYhjiPKlx6JdBgrF1tIAiIpPDEhyQNg3rq72leuMXF6Qnn1U7JZC6aWwDflKs//6PprdB7hvUsigO9pDrzG20LmsNThUu6vj/BKiwkLe/Oq/DFdQv0SmMUu0pLC7/zp0CS1Pno63lYL\u002B6QulvJCFwU7/lKLaZiF1BgP8oBb7KAzYPskVn15r92bUUcY48HSrLtNhzGqXmZL72ph6yvVsA7EOzY3XYDHgg608BgRbPAWfQXEziVuiMKUmGbS18SxxaF4FOjL2086hcUjNW4OekJ6C64mEOIplbIzosUZ9KpJwyp22VgHSmG2ygggS5OURl3kmMwWi7S/Tr82mDiJ4NEa2TJDl2EqcsEMb0bZyQoen1ynNVveM3d1t4qY0PIpLOl2xXJhEK78\u002BiXLChxt5UV1F/jcIqu1fOX6zh/WUWIO40JdYwOXvU6tqns2Eykax5IFI/j5DMp9wYiMZkKPJmiD/CbaEIJB3Vpqbngwfyn838ZNkW2pFZZ336G7C1cMHoQSchbCAPcPw0ZeTt5SDUJez4Z8AVU7GqZQYjDgxpIDHg/0Hc0S\u002Bp8PPY3nSob4JdIfHDuQj90u11ewsd6Gbzy0W3DOXe\u002B1S9TnbQPHE8/fmHxewaqWck4yxQZ1YkjASM5RMy9V6YfiadAm6WLZZ8OH0NliZ22SHejim5jpf\u002BmMJyQ1diCgSa70fFeab4krWV1CrZFvXeFg/tUGs03vOSnmmoJ\u002BpDGi50dqrisV965ft0I7ZpJYXMkC1HcLmZYgxQMts9TG7LVr34YJxK/2Ssdm5zvLs9KXjn35O8\u002B6l02xCajn6EOZWMqMz4bMDlgZTIlv5PKaVVFwleWWzbDl8Uh4mPrGzmKDjU5xfuQLi7/ln\u002B9GCrJbFvRXtxJeAosZ5t5\u002Bk3VdEr4m7BekKRatJQolsW3BX6aV3UHGr1cQZYrDV1fFzTgKiE1xH15a9u3d6lIIOFEdGEd3qLYzVqNnFkaM4NG\u002BpxgSGyjgkEAIOyZUKMTEyC05pj7QjiSCFzHpw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-22d41bd3-6ba7-e4ad-fa58-78438afdd640",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ab5c2565e6c28ce8e4a7b723190edf68-3bf6618ca85db4bc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f431c4dc-bf11-8891-629e-a1a195b9e733",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "ETag": "\u00220x8DB71C7E9E1AD79\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "f431c4dc-bf11-8891-629e-a1a195b9e733",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8b1bd-e01e-007b-15b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "KCNeOFdwfA3o2HSh8SAcvrY\u002BfbZ5iDhmTOtLuGTOPxDb2hjdwbNB3ycFK0g/RKbbJXrbyd8RLaDr\u002BOtsJcOoGphkxRYHP/wC/J2PdFzwJgdEcJLp8nUxyqx48sjI1LpjXBGw23\u002BQ0\u002BZ92c1BgblD\u002BtLjKLUxvygiM/pqj00zOifjKxdLQEuItJysbBmo70jyNff25KwEMp3ojaeEJUSZSZ6lXlWi97qHW3QYhVIPekSyd1lWPVZ73vl5YrKjBI5YEiJ6A5HyTz08bok3661K2RNj0q7qQwxIKX9cKZQH41bmwHIwlHayvyccGc7MQ/JMLoifQDHfbs8WMdkRliaoNIoyUSs6GkWcsBOHzik9fOaMEPsLZ6MlB1GjGmOdoSgAc\u002BREmvLHERNDA5AeV6Cl2LXzhYYqnMznDUrZl//h/w/qhlpF\u002BeHzxf/nyGQTBq\u002Bx/kGtqRyi1dYYXI2o7XkTYQOANNFFYN/T/7\u002BHQ9Ro1AaaKJm\u002BNFXzR7CELJxUS9iF02ZgktLda51h2alcG5IBr4iGDcTgVS2ujewgwDNDf7TnAW9uB0E0vbz7XFqsliweg30TzT0TpH04sgTmvatqHlr0dRkik6hGUlAH5PnTAve/Aj22L7F2013yNVU9Tf8RkT3/tyES\u002B\u002B/VzXvtC7\u002BEZbANJrpttO\u002BofqG8MF5SCQVQ9lO700rVrQZO4GE2icidbc\u002BkMCdEpNxNVzmAVsuRgsN1nRVryJJlN3i0H9ONcfTYHsKOrdndC1J3bXsRVVc7vF6ewOyzMqQ9P/iukIUJwOVEpzcIAtTqmJHD9FoWU\u002BIheWJ177AIJewdUW7gL3vMbq2Wza0fMrqJsyha7z1KJusWjBcjlNA1PIFL67BmCWgW9oasgIY0AUen6zuHrTWu0yuCyqJkqdrdYZAs1EcKI6rARPm3naZl4ovQe6iVrY9LnReE4z/Fskyszx/1Byz/nMeRx2g89jaEHecXky4xSLMB4DcvhT9q\u002BpKtC82Hb9pe0N7hA\u002BUmD6bgAMZXrh4eeodr8yf1zxeIJszVjupo/a4NuMNPUETO29CRToV5E0x0jpBFHHuyaQDHWN0ZUIC7dwIXSfZazypDnRhWZICRDhKAYf9aI\u002BEyWk/Dh/dmtIpP1daCYclVGb9mAn9iWwV/NUrKmO\u002BBYVQh5e6nl0cz3eiOB46qD6xJKkdA9CFhz/9KRFKsmxubznSCYXzaroJ4MiWW1FR21SadgW6nQWwzvxXvXFP1hkHM8jgZJ60wbnvEyMH8yvqq024rDxqt9I0HTqFm6lIvgqzjyuIcXK14bRLz4nirN/QaRYnkyncmH/6rEtkLyYMplUUVGAAYjnfBsqIHuhEUXBatS6XIS7g1vQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-d85c3f5e-387b-a4bc-62f2-79ea8c8df19e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e4a779863f97b67600399d067071a542-93856468471fd1a9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "429c72dd-04e6-efad-af1a-407318ccb717",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7E9E4BA44\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "429c72dd-04e6-efad-af1a-407318ccb717",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8b244-e01e-007b-14b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "quNwStRso4/JTTOVH/MCtxIjF9QeZe2WtsJefd5gSY3gW1Y0HSztRv548MThxve5Se62KKFgnkX22ZQRDiWwaAOltcSdzZnlNdHVpnQote/LpDTwqiHsgLwQPUOY2zfZx4fAOxAyG3tU0fLPivfQzSSkRWnxwL7iuTUHjY9VTFqZ/N7taHrfmIm4m9kuHPXEQHAf9JXO5wfI3oLbK47r/oSYNo0Z4mWqxK3gOSXls5w/QkwfNljEyxXXJIn3BG36zJxUluVoq10KdC/o7a7h4yrlm\u002BhCzMgs1Gt4Qr7bssBA5myIkBy215fuFcEo291m9UFfEmiEtwDUKMJ672mfLsJvqAdBWFINLsRRU7YGA/iOEUx9fKBYuy5stGdaPOcuT\u002Bb/uTPVJZ3uUeOkM2RJziTK7N4cIbIhF\u002B3Z1KTqs/LdIgPQB0rEuOyujiu9tIfJI\u002BZDkFAJES003aJG/FD4A53xxhFgecfaBTPxbZKGZGJlD7G\u002BpyOh0xHVmymofrubtouNzO12aaoeaYocF6Oarng/4e2fOlx6T/P/it2dMYZ4VrcH\u002BJh17qYGnz6YhbxtO\u002B2waZ3O/HsvE3z6dt7MgTcDpMHrk7XgyfJGmJsd4sk2kk/w7cjpqVo82OUbe3jHOh4GlOH7gac40J\u002BriGPfETCzw\u002BOO3JRvGvtmr7vPxE16fl59Fk3oOxGotxwoPiH2XMa0aLiUOF2Kl3nmlNLsaQtSMQkFYvrjyojS5iR3R9zZcFL0GluV5UYA83/TAqY\u002Bu04R1Q0Y8frM0Z4wwVI4ElCdDCR/906wvUvDBG96D8fhlCrWZnHOwX5YKEm9ZSTzx\u002BAvNvaBv8MAYRjBVeyKUcLWTi0nYqzfzkqlJ88F8lcmzz2PS9nRX9Rn1gVYDGyRzdaG5xb3zGUzUGer3Jf0\u002B27Am4Wv\u002BwXpBO5YwIynhsHdFFn5fgtBLwLXXPtxJoM9ctqWl3Hm4tLQneIongzYi8mlzsc9\u002B3xjf2uD154Kd95qG02xEe9Q9jKHKOEoGZD1/9AxzFe7/3deMxcFYwozxiUEvYO/J3raVdeVttKaOmbbjdjO2KuGrxvVUt3XSpMoU2G7JFwMNthWV3eAJkikw/mxKtUxZe16fQ5o6tSdAgpDbWNx3hUKzlcAeIE0BYjTMI/kJiC99u1zQadNpEwDuFRsPLjlM\u002BTjp1t\u002BMO1sRneFlLlFudzqhnZ1/Z1uvCkL/L8sx8nP7vyqAH7EP8UAB/svyA\u002BSvv94grZBbzZHdeoycjMtQH6utaa8m7hdJkaxdfahPvMaeT6/s0USjn7GYouUksyS0sZ8gBNo1SNHGltwkPo/pTb3GPn1bow5nCco9jgtyZR6HqIvJb3gsaMbeA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-d08afc2d-e57a-a365-ef63-13352cb1e332",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5a0fc7c9186f81945452d8fdcc9cd8be-f6f5af7c0304c72d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "22c33edb-a51c-304d-f820-810674581174",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7E9E5F299\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "22c33edb-a51c-304d-f820-810674581174",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8b2f3-e01e-007b-2ab0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "memi/YSHvFWdetKcZDpD5OtA3\u002BoaUMf1cVcQgHgWZlba9vJP\u002Biqjb3vXLBqngj714tn1cMQwXUgirIssdjzchhN8wm5H8\u002BrBnHBuQiStTu8ZG52eIfaRqZiqLU6edvg/\u002BqUGK7/Qre/vM9NUwRsjdF2bE1uePWUd6hjVnMWcIiV3L0d\u002BpiIvSW2ur\u002B0iPeh9hrjwA2OcoLw/6UGn\u002BhApUhGt3JHTpc47bMnt8I54\u002B6wwWBYMrB/C24\u002BKPr3hiE5dhV3cdGFWqeHqtJeZrrAux\u002B6Ud6L6HKby6wACSWYQWeN7kGoxm4ZL2q41IfeIKCzeW3bOTRGsYmi26ohgU2B72luzHh1F/SxnSJz0xfuvasPUI\u002B3vQQzSzy4CerH\u002B64ZNuUeb1AkOmV5KZwR0uJ1sBoDFiy9zi5hP4E/vQoJ6aV0WpguzE5W5xYqPpNoHXhaQlXQxOV9W2i2vTPS6Hlbb0P6nXRGSufPqC8Wl5Oe9R4I4X60OSS/9v8zdBMah/6cztNTcXwAF/tyARi2ZsfZG8QRxgb\u002BpzIbOqp5FtLQsSQsecS8T4eiBM2HQjQMCYw7VlhLCL37niudNDrViv0knVPwiej/GMxAc8E5d2D6DzEaPbx6iahqNN\u002BZIxdMyH3MYqTkG4OjPD2MCpT8vibKpykFu0lArherhlENYfm486dDaRS4FfOxdwF\u002B7n8TbXa00nvqRxEwi7SNOJUuldpH0xbtuVUSDpE5VEBLwcOYlBjaWI99zqyWEt1gLtleguEnOxtkJbQhpsfqsO7M6Mnw9KB4UDlKxgRmW6Z3reO32tVjIIakMHJkuLXLlxm9xSoXbzY44jKn3HEXAcoNrfTgNtYZbchDTMQuF5uHfzLqpJJ8XD6tevimu0AVkS6kVw6862BDpFdh0CJuDs6XIF1CKFk7jU26NrvddraELbuVhcCMypfSpwA7HowcP2wqD5rm02TVbMW9BrCkZi2g2aZq1IUKClnJc4VU/HLBnftLs2sfnVpSvBj6z8PnKkDSmkDptWbrIAE9HWPjgGxW/2i5XLLGhThIFBRsEz6V5kVEgmYt1\u002BiQYJNl3oP2cz\u002Bop8xbKcmSDBUEnZ1OewzGqzsanv4KJSeAJPgfYKa0VaDYw29uPrh7tnZRJTpLQeWGnzNI29RBnn6k2wDRcq9uTEv4dbuhWGx\u002BnuiHuQPtNOcWlMFzb3nMlyTwxWO3qkPK4tTyTsgt5UbGyjjvueV6u6Idvt3p\u002BuDOK96SsJMIyvSovNYq\u002BuYa5LN6rKE84N0/dg29le9h3OvwICLpmzC3ugNERv0TT7y4AtYqc05DjUsBVzqFSzEJRt/qNtrHLUl\u002BxvKd\u002BJ3gKCZNAZcVO22dsJbb6EA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a/test-blob-11753de6-fd97-9b34-5e2f-c0b5f1c2576d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-91bdfbd8e6b5675d44c8d829901d5fcd-0da132c2e4a8a9c9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "da982954-9409-27fa-1482-7d1497f4b2a0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7E9EA37B8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "da982954-9409-27fa-1482-7d1497f4b2a0",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:43 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8b383-e01e-007b-2cb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "/oubs4\u002B/CElGOX01YyrqFuhlKkdLxQ0RZ3wC25MhkPrQQWElIPPvZ3DAw1rDL2Ik8VCDwIuzxTh\u002BikwSvSy2JKiDZCHIxfb1dcPXigKzTjca3upCntBvHXwoppan3KpDCp6xQMtBWytajkrI2zs2yzsU\u002BN9Cc4bYE0alnx5fTZkZk4BjAQ5s2YK\u002B6A\u002BGp0JA8dtbkuTKAZYX2SyFnLsN\u002B0Cwrke708ksqB9chIt2UWwEZK5CBLu1TpLpSyjh5z3GsO3P1fj6hR4SLurFbn0LoYe/gDcNyvaF\u002B2C10YehSsHhldOep3t0Cd6PMNbQ8OAV3qqgIWYFueX2StqYRLOWceMp49iqbfkMS3ZYfZogtAt/oPPdACha3Nztp12h3MUr\u002Bb/ypwwHanGwlNbvrDtL1ZXPGKPAuXC6zgb8vMWcam\u002BxLYTbLg3\u002BeDWBLGxSay\u002BgotHH0sQhaj9OONgFC66rFClmPn\u002B2b6eI0J9uPowEZ2PXWxrz1ZirkMNEjfU0\u002BGyH1hhD7C2w6jMqPgEksyuzStF1LrCUtz6Ruq28ceKyVNcz5mhzwHo2JnHnyZaWh92XkUIkvsq78x7ZsjJ/9HhQeOoq8MzDQIlWPgc/rO6o\u002BjLQJOCfjZUNd/NJmQ5ItzL4llGsbJcR01G5zoDDfEYvMbf/rs\u002BYsepUHXjYeaZ6DYfURhad/I6bv1GP5r8VSfusGWhXSQhjYORmV04eOFqqPsD47jUwkjUoY\u002B5\u002BCcsrP9N9K18\u002BIsR\u002BceYxNqQ/fIf25Kf\u002BHFvFfIcyLuUZ5FYZOxh7oQz6bBv8enxP/1yQ6OdnhyQjLCN3t6/YC/TeZI2PF/uMxNp6/HiLAqHedn0rokX9sl0x9Q71A\u002BpdIWAnHRXvv\u002BdgBCQM7YuslyqBmEExrWmu4bIvXSHtl8HwHNoXZOSM77aWyp4h8MTShF3jdGqoK3T3eTxjv2HFc2xjHNCwlTNF9amKm\u002BLKjPDuXdjECSNWR/BmH\u002BuoKC9U0FcxvtTzIe8qnX7BHZCRLexMdWGIAWlJDNTgSnZInMx5NsqLmc0b\u002BjzpmWuklClg1PL\u002BXLPNy8/t57H/E9d44gGyR\u002BfFBpMeMHolnmf9pXerf3WESUAYrGr7nbIbG\u002Bdkcbdq8U1Bm81e3yw5qC1n8EE6VJNh85jAmZt9yWnhAhSSwC2wk7MqaeOnJmkU3wM8k61w4cdTA30eqVexw9Fkfd0Xpuf/t1yOD\u002Buwuc0vrLqXQDa7cSBNP72vkulbeKUSQ6iM/DgcPdxQ4dLco0mw7v2dGoKbqAy8ymcpUCRzMpdFnXYko6\u002BBewNaa49OcJt0/6Prvl4id5qc0DLR8u233a86lwXSi0tNG55/QD19bVnLtVCBhw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-214fefe1-5079-816d-1523-f2386b29b03a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4f543564cb16a8cc684455e8e73c64ae-3ec51ab3e3bc235a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4bb27def-37bf-a76b-f0f1-4b15cf192d82",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4bb27def-37bf-a76b-f0f1-4b15cf192d82",
+        "x-ms-request-id": "16e8b3ad-e01e-007b-54b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "860917862",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,1024,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,1024,30)Async.json
@@ -1,0 +1,733 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-f6452fa07426ed209ddf6fb34a8abcda-4bd40e345db80a90-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "23fc0b5f-fb08-e219-8623-798df417d6be",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F3C92D71\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "23fc0b5f-fb08-e219-8623-798df417d6be",
+        "x-ms-request-id": "69fcf4f8-201e-0029-42b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-c5dd46de-28d6-ef0f-1421-c3fd3335bd0a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-70bd4413a87f6cf173c8c0b00aefc1a6-aab9fbd7f9f46ae1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "62184294-10a9-09f9-4d57-d92a7c6f7d2b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F3D5334E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "62184294-10a9-09f9-4d57-d92a7c6f7d2b",
+        "x-ms-request-id": "69fcf542-201e-0029-7fb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-197faa47-ae4f-a803-ffb4-e9bf20b6da37",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-d52d2b3ac343c2ce96c41fe04fcd5c73-90b02067562c59e2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a82aa3cb-468a-9daa-338e-71821710d206",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3D81916\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a82aa3cb-468a-9daa-338e-71821710d206",
+        "x-ms-request-id": "146c296f-a01e-0055-01b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-61af93e8-1df9-374c-fb0d-0fe7381caf51",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-df239d6b1d637a19e36fa83e4c2c4707-df7dae60fe351e1c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "d85ec9f8-d544-9ea0-58f3-ddc95700dacb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3DA62AA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d85ec9f8-d544-9ea0-58f3-ddc95700dacb",
+        "x-ms-request-id": "16e8ecd1-e01e-007b-70b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-c5dd46de-28d6-ef0f-1421-c3fd3335bd0a?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-a0ff43fadcbe9108ccfd5d145456139e-3c3434a444bdbd36-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4d8a5117-fab1-43c1-6adf-94cb98b074bf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "PrCgqwcQywleG\u002BtOoCuQJ8TjHab2He627ep6Bj5L0jNQcQTue8Tb9MxQUlSlUIr57vYAdAxStSDC6r4clcXKEkm3/i4moqv/BynapcuaEJxfgRdIS14n/bvkLJEGv14GhUAK7VFb0kxLAGzidxBUKNkhvBSugsbqkAByQXYZ\u002BEjL1B\u002BLjyNKA6/L/EvxRIarkAO35QJKVwN5IF1Q6ZDVMQckF6PwyZi21rhl44V7\u002BUt6x7FyYRNFgXwcEm/G\u002BRoe9cpDzC3iu8ZrAQ5J5XR9/SYR1iHeY8/035Yn07cp79ydRu26OCwemAvqB2AE\u002B5wHnxVItSP4P5H7T\u002B2Xu\u002BcPQRIxq56GwsT68j4V9Fxv7\u002BP5IDSh4Tq5pQZcv\u002Bk/h9wk2sVO00/9gNxQTsLl4ks1i18JnZuzbWDXeAaXKgLau2th8RmWIRyT/J9XUZN408K7JjSJNelBcWxldlpIZlXZdZJXhPEyn2pDdqH7WxzNX6RE3ATOUYWBH4CsMKrBSpVKftwAIU7QiIbJRr9IRhZQmBe1BIpQCyQN1WVwhW6/gSsLsN1AzD5Wc1N9BArGONhqXJiTDEYK\u002BXK38kvpXwMYCsWUPJY5D8vZX5A30gYaR52NBinVK3XkALZqiNnzbBNPZflFMftCMEzNuqy20ydsnautXFnZQt9Qrzvfz4fx5vJ8520M1BWhS9bdCHHILS2P/esuRRC6diMa9YG/YmHE29O5Ouu5X8iWDBGC\u002Bzlth4IOT9Gbw6HiwXFK8d\u002BT4eh0GC2dDvNB1Z4ilzj/N3rprW3/sRKQKBgy13h6b23pAysoDuMMz3mOzXkzeSto44n2YERxkzDV4\u002B8Vazd6x2YwOZQN1imX3d30ceSYXa/syfPvgw4pd2/6Uivz9mRCEwYTAkCWWwxgX4NnfSJMPYVAKKFDi0NYB8ElEoT\u002Bo\u002BZ4sV3ehVpuVW7njiSKwflMrhWls87D/4jCu/t\u002BcUiIYryc7szFbrgr0dIzW/0fzUXI2GRvWPAYtbLVG8pf7\u002BQlXixn7tMth0BdeuH7kKOKo\u002B22tpnkGQnMhDgZ71Lty\u002BHuDfzRt99xmlAjEd4OHSUOSnjcqThKQEUim2mbE5jtb67/DIKmuesORBtIwAcqvWcSCqXaESKoo8y3rht11oe4NaIwDhCjaJCMzWQcAn8\u002B994CiAjzE12MV2i17wrQmW6UkIpk\u002Bq9Wb6IUTkS9i6FMebc9c05\u002BxSJFo7eo7XiGuzT2iHH12fwuqxll3sQYzsvGaHVTkiUgFstoH1f3rYEpjZIQxwMvV5\u002B6Dsc1GOZeLNTs4YQCMigO1nKmjbqlNv2XO1AxCAfHlhHWmIRd6/3kCfKCC8z8J1tpAvCRicrlFdfKnQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F3DB4CEB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "4d8a5117-fab1-43c1-6adf-94cb98b074bf",
+        "x-ms-content-crc64": "6Na5ZUFPR84=",
+        "x-ms-request-id": "69fcf55a-201e-0029-17b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-9f158c46-5c85-2a10-5e48-1d429f1c70e3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-7ecce6d66168715aee452ba62b5073fd-4c533be22f227d67-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b471d501-6eff-bf49-a17c-ba2ed19da8f3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3DEF5E9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b471d501-6eff-bf49-a17c-ba2ed19da8f3",
+        "x-ms-request-id": "146c298a-a01e-0055-1ab0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-197faa47-ae4f-a803-ffb4-e9bf20b6da37?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ecff520c929756831a692bbd59325e63-867d0c3d2ca7aa73-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "08cff00c-0913-7c79-df58-63d3e0395646",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3JUsI8wkSnMsmaSw63TBg8cjKzGaFPXIBhc1DUbwg6yTTSBP3c615oGJ\u002BsHFUQUdx0ce8qyYA8efZB217j0sPBb4HJ1TcqX4bUSwEBo0ArQRGEb/0ZH/\u002BklYr3mx//dDXL6rzTRnyVSiJoRo6PKta2Foo9b2LWqE\u002BCFU\u002BsIrRm1MbLNciDWAqk/xXasMlhJXq0MYSFshTS9TJtQSE86Rdt8WHHs\u002BUeIr6PmGBNC/eGEP/E9/E/4RKh\u002BECGJhbZaAYObM9nqWGFlh7GBimkhflK5yAxZ/EmPhBPJcukh/ynpiBqTp84LneOT1HSadr4/WJXS07mqAAU2D6vGIOl4R4SLl/5SjdaEsi4oyifQ8Q1VihZTUy9sQ4gRWZgiQXz6F5DwEt6/7M7DTiGPfTXhYRqebJbTJPRZG1R2QTQ6YmytMrKS4OIumZ1LkAEJ4MZSM/SBh9TmKu6cmveKRauahOu03k6DToA0b9b5h5TzTzqSIBE/uN6XywfD9knupFPxsQ8ZVQJ70uF0SRgB7KNZqUu4\u002BCGaWsgNHRdGv1g6SceDB9aJ2fo4GlEvx3PGldpkakj\u002BMawuV1ZDCDfrMROFPgNQfuTM09NRgN3QapdYRoc83lUTOBQbVLB8Rs3CTOVBqolschr1m5Z1rKzOXejC5sWsrla6dgHrOSYwTIkBjzf4jsAJ69BsR0a\u002BmYtnTPbHvWAIFaKShzCHhTj0wUsJcCF40c8kuP7xQGcP/9h6g\u002BwvbJMo\u002BXWRaguTgmabe4H7sSVp7nsrnwRlGtU7gotUDQFMxVS74Hqr52vHlTaUWcjhEEq3EJVxB82Kx\u002BKgWet8O3VhSrItQ9CuvgcTYAXRzMEMVm5AoPxv372HLRyYB418S129Nw8Wt9B2BFKOYafHuPsdlAN5P5Z09W7wphK0FrZ1kxioEJmx9aKZypyp3XoZw3AlenOOBwvHSD2gIhHBwfGcFM6PH6hhb6Jg43D5zxvw1uKejpxG64wM4MRYDdOM2ASrDcSvjqfHwArRKSeWyXkls0svIzNRVS1CfjrgBV3O0AdsTr1TQUg\u002B1s6Rdb5kdhtPMl6IYbTRWbSXaQxs576tBlkcKnq/0m4C7Exkw\u002BNy2ggjlNMDRnJSmvUEu9g70fMP5HNlSEuck1/shXFobJnRJI8ETU7rqb/myZOFtxqVxx5ZVNtwDY3AgwVzErz86i5fM5NJN4SkJDqzfn60FthFWsJXDxe\u002BYRsBQ8pFdJsC6eNlJoOHSJOVtTCcwI8PCGwpLbf\u002BqdsanNJ4S/O\u002BXrOjrJCfUuxYwg4uvVXjIZyL8jteHErjBEAETomtDwCf21qA/Rf\u002Bc7V/zGulz\u002BiBN38x7Fm4YD5kvKRQlwRmr7Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:59 GMT",
+        "ETag": "\u00220x8DB71C7F3DFE02A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "08cff00c-0913-7c79-df58-63d3e0395646",
+        "x-ms-content-crc64": "s\u002BV88No4bFE=",
+        "x-ms-request-id": "64d6cace-401e-00a9-50b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-49466f66-bd97-2f6e-4334-c6223e4fcf5e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f22b1b97fd0e62c8f55d24d4df7f064c-f4d408bfd33fdef9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "05b1e35a-8c75-cc19-4363-1dd1dd85bd78",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3DCAC4C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "05b1e35a-8c75-cc19-4363-1dd1dd85bd78",
+        "x-ms-request-id": "993dc5dd-d01e-0002-19b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-61af93e8-1df9-374c-fb0d-0fe7381caf51?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-64d63725281ce217822600e2f675445d-5c0215410e796971-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8ed83250-7517-bb79-021d-5661af3cb2cb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "w2S5f9iJIiNfoHeT985OFuDFw57HqrnexgYPG\u002Bp2LEVILSYOQaF0ValXts2gfKJg2/5E/FYMJRir2rnSeQc46HQySsqoP9U/UG31b/PsPklkrj/sMjDvPAcNY2bootuiHs1YbjLXuJwpBavpF7Ylv5xvbsvITLZEQg7DmttuV62RUlAlk88XjPaiwyyEBSVR6KTJeTQQ2dIXEysjFB3Auq39WMRl/yvMV\u002BHVJYiJwDzpcbI3pN55gHh\u002BDoCk83fY4gl/h61g7Oh4/SFSO7RJjVPuOqJriRXPhNdL5/GrKGNp/UN/CjiOiIXJvqe8JkXENIAstbnVbFjzrwLWFQT3zdS\u002B6T5xyoMaX7IcocpuEl2Sh7Jwf3KqlJDqjFs2uHOA0fHS/j0GUmr9ElYGuMqNhJykQ41Sh05iE1Suhz0n5Kc/m9DZmxQgizRIc2wco9zFXAe\u002BkXTlLkqjcOrpWMss1S2uxxz6tOmIhLhZCRPhRXB36Co1aVMyWm2FNSspNzNpHJ0/bdzAy6ceNgy8jCU3wip6cXCg9mzae2yvdX69XkyE7\u002B12odiUtx2DFzJGds5HTnMBrsXDyCUxZPFvEVUoYNjAN5w4wCBS5rpTHd85lAWeZycLvK\u002BGwSbHRT3mJKbHWrZahj4xD41TrsgLb6tG99Ds0KkuHaQoOXZ1cHvjbMEUi8Mo3w7GbFeauA3ne1F7gE1t\u002BVT8mTwSMkzIvJ8Rb0IG9\u002BPnHhfCJWNSk2WWQL0k\u002Bu8udnJtGPKHFq3B/bC4iEjL4YRtk2I2qtTwqQXWe/GPpMGv4/nQmN7xYAdqACezmQocy185tmeN98uefW7tsJq8MlnuCaVO\u002BkilfDJazKqsPA/6urCSVe1aIesuMhpwA7Btrc7OxJBlztAWkzk0Mish8UBe8/bqKtxrlOe6IMguNXmB7R7b3nh/lOvfe8K0Je\u002B/DUDZEQ\u002B6goPyYjCpq64H6F7As0QNRRPI314KC64Zt274\u002BhKIVCNpxmua6XxI1ek915Nk9HKqssgtETKxsHfU2KrBsbCbf5Q6VuzZclyXgAl0zDMbtcP8TUdKW0PxuBbzxRDShiQ4olj\u002BKZ2F0EBrlZAoPONEuSLmxGNpUCRRSZ3W5axLxfnlOyraHIwld30H3sWyyHwyrwzt68LBz1Ezrd8Ar\u002BqTH9CWQwC4aZyWwE3lYXFenoAhozWgXtk3I2vZp2\u002BsJciSdL/0G4V8ekZvVyp1227f1A9f3wy088H3Xx\u002BU3sIt6ZuFUu2yaoL6pSnvMAauwkf9\u002BtJfTUa83YD9/bxl55uEQm6P8IiBLGqMZDrixcK7SJ3XluTvzZxUyHRstW3Flb2Nau2YHtG/fM5n0\u002BgM2Ri\u002BQrQfjlC2lA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3E16686\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "8ed83250-7517-bb79-021d-5661af3cb2cb",
+        "x-ms-content-crc64": "9PGPaWVK84o=",
+        "x-ms-request-id": "69fcf589-201e-0029-3db0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-b1599804-9070-2a9f-247f-1dc4572af8ab",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f6ccdf61576511a7bb34ccbce7cfddbd-9aa376f06710075b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e12152fb-a0cd-41df-bd7e-e4cc759bde42",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3E16685\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e12152fb-a0cd-41df-bd7e-e4cc759bde42",
+        "x-ms-request-id": "16e8ed03-e01e-007b-18b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-9f158c46-5c85-2a10-5e48-1d429f1c70e3?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b0cd116c03aea973839f03002a73b955-646e973f6bb29dcd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "437bdc4e-50c2-bd2b-625a-d3f41726caab",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vRAQWzF7ZXokaBwIgRy0ReHds59YD/zY6Ex3vokXg1VK9xluxa7vaxEozhTEz3aTJ\u002B5PSAbV1q0TN3PlA6fwDeXHvokDRYAy7keOL0HnFBnV5JabxzpOdCFrWo07CWdpOMAv/RDtkOFuHVq/RqZsLCNZEB8RVUWqeElnmOrz9\u002BTfJfeAuBcI51S0LKrgjy17/i5p4flIWOJ7hITHhfj3eyV23yGu7HMMUSjLXCibyugb7Jm7iRXql8wUBDOSQGFcvbGEarAMzBG7XI/RfPu64Lqbq5leO/EPi0hVmedAeRHGb592FmA4Dx\u002BHACyGGRrRWiR59pTI/YLAdN5otzIqeuJ\u002BCg1bQ8lZY5x51zrEiXEtgz/Cx4N8/nEdtqGB0FjsXYVKBw8MdRdbH5P4TiZH\u002B\u002BptOjPzZ7NfAgubPYwn15NDjXm0eoJhIA4oZ6fvg7BL1bq3FJUl\u002BPXS6gUEcDeKNEcAtMGsk4FoCxklywAMcH5aUGjScML\u002BHpSE4pB8Xa/WnTJf78/vnkI5Tgl7/y30xXqGqiDPuMOFAZUtKLDw661qTi3NrICvarIlmCK5gh5mjxwW9rOPBuVv2u05wnaRSGJbEbH/Jxn51j9tqh\u002Bhy392xpiU2vX62khIXtGSdqg7k0\u002B/XXFtZ2gDHB9zIVzGzQ5uwvzd/W1tYTZpt8hHZmCWMRbP4W4NCV4wkb7VhrjrgZDDJLOrXpbiUvs6BLCfu7W\u002B3O9G9uygYLmerWuvl9p\u002BfTU4hEKt69N/7Y5z0gStkdUIFqnIpIqkI8P6DbAqMrsgvIZ7ZjdyEfEcxgldLY608ByWpoExtdiqlGF/st0iVLrTUhZ\u002BMiqdlQS3rN6BRvU1RRyUlIw67wat0NLW814U\u002BXJPitp3Nr7x\u002BBB8eQn6KU5rSWzAjsAumWMQ0GFYx6Klo7NrMbsbvQ9eopx7vXX8s6eEa6nxVGqyIPF3Z2VdmTBu1tZWjveST4tdYusjs9vtEx261Fz4tE9IuRHKo1aqAAhrDOeepiSv8RselPJ\u002Bjm0WiVNIo8XUdiKHDtXmyKw1s2HjuKbzTm34CuJB2h9dySujsxkDYV1ClpbFF5dPyShu6OGQm9XHIjvmUJnjk5wCKkSpQhSSMlEDoCEPLjfVqUC50vE9zC1V3JHeHBHEXwP6wu1SpYcT3LaQjfu0t/MDEKZYKcCrxF4XU2aDsxVAPkAdFWxKggO5pvU6rT4yoSSd2wxqbDZDT/2OO1EgkCmhT066lqKHuY2inoPKcBcf5bJC5dgJ1dIK2sZuu0eymBXMmF7wdwuBFiF\u002Bx82zeN7mb1af3qpQmHl7sLvcGP5G8AVt/te4L22mwM\u002B3ig0EV2LoiEvwErprewDkdMdPpQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3E4C16E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "437bdc4e-50c2-bd2b-625a-d3f41726caab",
+        "x-ms-content-crc64": "tQ/PxT23VOE=",
+        "x-ms-request-id": "146c29aa-a01e-0055-38b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-49466f66-bd97-2f6e-4334-c6223e4fcf5e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-dcf742ba41af55519b50a9f1ac9d55b7-584f11f84358b04c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d2129cac-6ec1-8208-ca85-0d685f2a75a4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "dNE7JxMUd/zGz3xVWtUiKcsYGhaI\u002BrNI71yucrimB2zW1XnG46qrZ1dqDBmPg73oH4tUdTagDHoe8je3ZgREIMgQfoVcXEUgbbK\u002BHe6ZuWuexVMtUZE2Nsn\u002Bp/Fz9AFSJutRfwU4jMNFNAiD4e6LhDnLGKGxFs822Ue7XbRUrXmxbPYDSDpmZjiQ6B2JslTacyO4p9tfoRAcGqW9fS8O8IaO0XX3iDv/ZbJoIC6xrSfz4OqRnAadUcrm5y6UqOkJgfeW\u002BuDe4urnuEEp94Diam19ypxFfFSA8YCrEaENar3IX582GrJGFP3/quPEc1pJBHzAFt1MwwSiFglgM9FJ2U6EYJfhq0\u002B7N7WeRtJxvH0lYQwkTFPfe5yalASp5uAsttCUPxLDZ1ktBd8nrn0xMVqLO9HFJIz7pOX7RxdLEVHUcpAC3HxqYvqz90dzt80eaGKqHaoOZpFDmZstxyBB4vOOUzztL1TdINnXEi1Fh\u002BwX3N\u002B0oPSmxQv\u002Bv0PgPJrZcRVT5WSQMTgOzPzRN1Rk/RKuFupBjUH/540x7nAR/eQ\u002B/qAX8qKIh6umptT31I62msExMiawmOTTU/3XX0LI/c8YkzizTApwJo4/m\u002BdsCBP\u002BelSv4Mq9jmW8RJ\u002BksCdo3agF30FWAk22wAyXcf38Z0vq2eTuGR0EWgTT9whry3Vn1r0\u002BZinRp3gG\u002BB\u002B\u002BJR1ov9xTutdDesSLAYQ8gwtFSvWWMJpAvgAiGDFs5yD9RTTnajcrFxGeI1z4smWklCRswa0pKPWCJwHcMaGl15KkjbtPVRjUGTLk9w09SAuafYQM/yZy1B0/ZEI2T\u002BZv\u002BEzKVCWpVT8MmKd6RTDoRN/1QbQdmNhrMbmeD/DVnspMdP7Bc/Pm8CdEAGZ\u002B947sVyBiQA0xUmBzXiJrC0VPNvrcLtExJtHrDlGM2Jhx7DkqsbjQcl29GiKeTRXReuXh9clsocm9ujBPdzG8pXnHAnHpQFmNf8ScHxOuktm7GpNrquPPBUpvbfaHgPsrAXWo10uj5zqLU3UFz4K2DihXk1ydUPqV\u002BP0medNiBv7IcB6dBruOFzNZ4FZuyjXIuV/OMO2fjrF6Et5OfW1mKE13PF9jGAdsyHsoRG\u002BkJy7HXcB0lNYRKeJtIvPcQJrF8rcJ943WZKBXYWdydkpB1uqwhh\u002Bt8pR3ZRJ89vYUkIjgY1G4mjCg8fkgHTJunrKYK0sIK7p7GAAikpF7Wm6qQtHfkRP4iDy6EJUmjNViCMdf5MqqC2TNZUtRlQifJZaKdtpgjg2fn6IPThskVYsqv4nKG3aj/zdtESzIp/IzGur\u002Bmxb7Anm5wEQnmr1IqQ\u002B/JtZ\u002B1Qkg53ai833h1/iw3DMwJrp1Lg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3E7CE3A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "d2129cac-6ec1-8208-ca85-0d685f2a75a4",
+        "x-ms-content-crc64": "qkz6H/DO6dQ=",
+        "x-ms-request-id": "993dc646-d01e-0002-7fb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-b1599804-9070-2a9f-247f-1dc4572af8ab?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-a5f973e88acfd5791039f40ba46f04f0-923672549d01dda4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7a484f9e-f813-87e9-cd0a-103bb2dcbee8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/SI418hFeQYtP\u002Bj4HtuZDmt2WFn0kLJV3UsBgtfUu6VXG9GUUjY8EejhWgwHGZyQ4vJ4/W/1sW1w4vl8RPcuWYRDoQIJBbs1OkdxEjWmTcOvcaDkW742YWpkJG88v83wswGHxHiZht02Q8Iog543yZQ1zdJXSf7GDD\u002BYpeBM\u002BHp5gV80H4lLFerCrhf7Dt7LLFvaBvH6mWkCwLg5AOH86kpIrgI/AqoL6rjnlJvmy/1hzXiFcfKIfuf1MV7QEhQJxsTMsmDbiymwzxs5EgTNHPW72DNod3hYvy8aStBLO9ij3s7XGRichUFO1KLWT2zjJxVpFTrhoE5LdPMxwEFYZZNDljQ29gLcHlLyGqLWgnDDNyK74iWewT5/i6Ula8UA9W8Okrg4rTASjPbn74asdfGCbogfnYJtpNT2tmtdtrKN8iQzx\u002B\u002B3i4rxqVYvttK30xWzo/084FjsoO7kQfbFtdZEWv1ieK4Cy\u002BP\u002BLfQsPu0BPuNVqRO0UBHLRiYB0kmTLPOA6lzVVVtnsdcaPbNkwGEA4wMTbwvCjwnrljGHAPiZagEArFSRK\u002BmI7vg7mhJeZ4bFAO9FgLzovVtS6b8p4LDfgNOxYxMNb7cai4EThvX2jS6rwgAIVOlEF\u002B75PkEqXg1HWxk/rANyt5E4K/Q71TZlXFyQfh6w1yzpbEwlFDB18Cxzyyrbt\u002BErOApuzyn0CUK3k\u002BLlmeDvl4TsVT\u002B3TaJgwjrIyAoMiaR6ZEUTQQcD9GMKbYFOj1ZMgzSm72Ghc\u002BtnDQzuLEA4qwk9ajSa21V96WHcreAhEjPke0TVZZpD2fFaqzP6Fccj0cF3ESQhsafeKAUAxcYKRvvZCbD7YkZu\u002BpFDQDAhgtSZuNsfqgEOwsqd9zyVQxMqT2U4IAsWJ297CBeS3XF3vaYxZwzr65v6y0fmXmoJ2bd\u002BGfDK6WHJgpFro6Hqe\u002BRZJTqWZNsGP2PJPlXEMMkEci5gFMSArNREZ\u002BR7f0f5EFBijTgwcnXbd9qMAKsMBFLHZzFzimYg2HhmUfz3i78c0C0FYaKR0/\u002B5hJ3q86wpOGKStBgWhobpQrS/yiB54\u002BwacDB9B6OvNZMyugXJNeXMPRmZZNanBUmnGx/u0gneP6Gw0IN7qzG/436F48yAIAzP8o0H4H4Vcmrn1euDwGOJU3pkGGVhUJHo2YFYIiF8JvoTH997118im10YlNZFPCIa\u002B5BSHAembaL8Hgb8vVBIaq7xcKGEDXsaQX0ISbu6o51fPSaRKQnybLE9f7hYJd0MzyknVMuAlu0UN9uKniPmQXtpnYApt0Gk/gPwR47DwRyf\u002B3qSk0/R3qY5fPIuaM6NVj4974dd4hfoglXIkE9fUXW/6qOpUw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3ECAF87\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "7a484f9e-f813-87e9-cd0a-103bb2dcbee8",
+        "x-ms-content-crc64": "0dAd5KNzsCk=",
+        "x-ms-request-id": "16e8ed2a-e01e-007b-3ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-c5dd46de-28d6-ef0f-1421-c3fd3335bd0a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fb3a68d4e1cd569a59c25ff6315314df-8173e344368de247-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0fc9fe43-fae2-e491-64a8-5be685bcdcbb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3DB4CEB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0fc9fe43-fae2-e491-64a8-5be685bcdcbb",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8ed5f-e01e-007b-6cb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "PrCgqwcQywleG\u002BtOoCuQJ8TjHab2He627ep6Bj5L0jNQcQTue8Tb9MxQUlSlUIr57vYAdAxStSDC6r4clcXKEkm3/i4moqv/BynapcuaEJxfgRdIS14n/bvkLJEGv14GhUAK7VFb0kxLAGzidxBUKNkhvBSugsbqkAByQXYZ\u002BEjL1B\u002BLjyNKA6/L/EvxRIarkAO35QJKVwN5IF1Q6ZDVMQckF6PwyZi21rhl44V7\u002BUt6x7FyYRNFgXwcEm/G\u002BRoe9cpDzC3iu8ZrAQ5J5XR9/SYR1iHeY8/035Yn07cp79ydRu26OCwemAvqB2AE\u002B5wHnxVItSP4P5H7T\u002B2Xu\u002BcPQRIxq56GwsT68j4V9Fxv7\u002BP5IDSh4Tq5pQZcv\u002Bk/h9wk2sVO00/9gNxQTsLl4ks1i18JnZuzbWDXeAaXKgLau2th8RmWIRyT/J9XUZN408K7JjSJNelBcWxldlpIZlXZdZJXhPEyn2pDdqH7WxzNX6RE3ATOUYWBH4CsMKrBSpVKftwAIU7QiIbJRr9IRhZQmBe1BIpQCyQN1WVwhW6/gSsLsN1AzD5Wc1N9BArGONhqXJiTDEYK\u002BXK38kvpXwMYCsWUPJY5D8vZX5A30gYaR52NBinVK3XkALZqiNnzbBNPZflFMftCMEzNuqy20ydsnautXFnZQt9Qrzvfz4fx5vJ8520M1BWhS9bdCHHILS2P/esuRRC6diMa9YG/YmHE29O5Ouu5X8iWDBGC\u002Bzlth4IOT9Gbw6HiwXFK8d\u002BT4eh0GC2dDvNB1Z4ilzj/N3rprW3/sRKQKBgy13h6b23pAysoDuMMz3mOzXkzeSto44n2YERxkzDV4\u002B8Vazd6x2YwOZQN1imX3d30ceSYXa/syfPvgw4pd2/6Uivz9mRCEwYTAkCWWwxgX4NnfSJMPYVAKKFDi0NYB8ElEoT\u002Bo\u002BZ4sV3ehVpuVW7njiSKwflMrhWls87D/4jCu/t\u002BcUiIYryc7szFbrgr0dIzW/0fzUXI2GRvWPAYtbLVG8pf7\u002BQlXixn7tMth0BdeuH7kKOKo\u002B22tpnkGQnMhDgZ71Lty\u002BHuDfzRt99xmlAjEd4OHSUOSnjcqThKQEUim2mbE5jtb67/DIKmuesORBtIwAcqvWcSCqXaESKoo8y3rht11oe4NaIwDhCjaJCMzWQcAn8\u002B994CiAjzE12MV2i17wrQmW6UkIpk\u002Bq9Wb6IUTkS9i6FMebc9c05\u002BxSJFo7eo7XiGuzT2iHH12fwuqxll3sQYzsvGaHVTkiUgFstoH1f3rYEpjZIQxwMvV5\u002B6Dsc1GOZeLNTs4YQCMigO1nKmjbqlNv2XO1AxCAfHlhHWmIRd6/3kCfKCC8z8J1tpAvCRicrlFdfKnQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-197faa47-ae4f-a803-ffb4-e9bf20b6da37",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b8268237beb71c095156ca447967947a-3dbb1ac835e8e6b4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b4f80115-af13-da06-8dad-c87b38ab90e7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3DFE02A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b4f80115-af13-da06-8dad-c87b38ab90e7",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8edff-e01e-007b-80b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3JUsI8wkSnMsmaSw63TBg8cjKzGaFPXIBhc1DUbwg6yTTSBP3c615oGJ\u002BsHFUQUdx0ce8qyYA8efZB217j0sPBb4HJ1TcqX4bUSwEBo0ArQRGEb/0ZH/\u002BklYr3mx//dDXL6rzTRnyVSiJoRo6PKta2Foo9b2LWqE\u002BCFU\u002BsIrRm1MbLNciDWAqk/xXasMlhJXq0MYSFshTS9TJtQSE86Rdt8WHHs\u002BUeIr6PmGBNC/eGEP/E9/E/4RKh\u002BECGJhbZaAYObM9nqWGFlh7GBimkhflK5yAxZ/EmPhBPJcukh/ynpiBqTp84LneOT1HSadr4/WJXS07mqAAU2D6vGIOl4R4SLl/5SjdaEsi4oyifQ8Q1VihZTUy9sQ4gRWZgiQXz6F5DwEt6/7M7DTiGPfTXhYRqebJbTJPRZG1R2QTQ6YmytMrKS4OIumZ1LkAEJ4MZSM/SBh9TmKu6cmveKRauahOu03k6DToA0b9b5h5TzTzqSIBE/uN6XywfD9knupFPxsQ8ZVQJ70uF0SRgB7KNZqUu4\u002BCGaWsgNHRdGv1g6SceDB9aJ2fo4GlEvx3PGldpkakj\u002BMawuV1ZDCDfrMROFPgNQfuTM09NRgN3QapdYRoc83lUTOBQbVLB8Rs3CTOVBqolschr1m5Z1rKzOXejC5sWsrla6dgHrOSYwTIkBjzf4jsAJ69BsR0a\u002BmYtnTPbHvWAIFaKShzCHhTj0wUsJcCF40c8kuP7xQGcP/9h6g\u002BwvbJMo\u002BXWRaguTgmabe4H7sSVp7nsrnwRlGtU7gotUDQFMxVS74Hqr52vHlTaUWcjhEEq3EJVxB82Kx\u002BKgWet8O3VhSrItQ9CuvgcTYAXRzMEMVm5AoPxv372HLRyYB418S129Nw8Wt9B2BFKOYafHuPsdlAN5P5Z09W7wphK0FrZ1kxioEJmx9aKZypyp3XoZw3AlenOOBwvHSD2gIhHBwfGcFM6PH6hhb6Jg43D5zxvw1uKejpxG64wM4MRYDdOM2ASrDcSvjqfHwArRKSeWyXkls0svIzNRVS1CfjrgBV3O0AdsTr1TQUg\u002B1s6Rdb5kdhtPMl6IYbTRWbSXaQxs576tBlkcKnq/0m4C7Exkw\u002BNy2ggjlNMDRnJSmvUEu9g70fMP5HNlSEuck1/shXFobJnRJI8ETU7rqb/myZOFtxqVxx5ZVNtwDY3AgwVzErz86i5fM5NJN4SkJDqzfn60FthFWsJXDxe\u002BYRsBQ8pFdJsC6eNlJoOHSJOVtTCcwI8PCGwpLbf\u002BqdsanNJ4S/O\u002BXrOjrJCfUuxYwg4uvVXjIZyL8jteHErjBEAETomtDwCf21qA/Rf\u002Bc7V/zGulz\u002BiBN38x7Fm4YD5kvKRQlwRmr7Q=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-61af93e8-1df9-374c-fb0d-0fe7381caf51",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ec7ac40d1b39a680c3bd7f37b3eb7464-85a17743a585670b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "84d11e5f-28c4-eea7-41c7-e17a4b70d312",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3E16686\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "84d11e5f-28c4-eea7-41c7-e17a4b70d312",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8eeb1-e01e-007b-1db0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "w2S5f9iJIiNfoHeT985OFuDFw57HqrnexgYPG\u002Bp2LEVILSYOQaF0ValXts2gfKJg2/5E/FYMJRir2rnSeQc46HQySsqoP9U/UG31b/PsPklkrj/sMjDvPAcNY2bootuiHs1YbjLXuJwpBavpF7Ylv5xvbsvITLZEQg7DmttuV62RUlAlk88XjPaiwyyEBSVR6KTJeTQQ2dIXEysjFB3Auq39WMRl/yvMV\u002BHVJYiJwDzpcbI3pN55gHh\u002BDoCk83fY4gl/h61g7Oh4/SFSO7RJjVPuOqJriRXPhNdL5/GrKGNp/UN/CjiOiIXJvqe8JkXENIAstbnVbFjzrwLWFQT3zdS\u002B6T5xyoMaX7IcocpuEl2Sh7Jwf3KqlJDqjFs2uHOA0fHS/j0GUmr9ElYGuMqNhJykQ41Sh05iE1Suhz0n5Kc/m9DZmxQgizRIc2wco9zFXAe\u002BkXTlLkqjcOrpWMss1S2uxxz6tOmIhLhZCRPhRXB36Co1aVMyWm2FNSspNzNpHJ0/bdzAy6ceNgy8jCU3wip6cXCg9mzae2yvdX69XkyE7\u002B12odiUtx2DFzJGds5HTnMBrsXDyCUxZPFvEVUoYNjAN5w4wCBS5rpTHd85lAWeZycLvK\u002BGwSbHRT3mJKbHWrZahj4xD41TrsgLb6tG99Ds0KkuHaQoOXZ1cHvjbMEUi8Mo3w7GbFeauA3ne1F7gE1t\u002BVT8mTwSMkzIvJ8Rb0IG9\u002BPnHhfCJWNSk2WWQL0k\u002Bu8udnJtGPKHFq3B/bC4iEjL4YRtk2I2qtTwqQXWe/GPpMGv4/nQmN7xYAdqACezmQocy185tmeN98uefW7tsJq8MlnuCaVO\u002BkilfDJazKqsPA/6urCSVe1aIesuMhpwA7Btrc7OxJBlztAWkzk0Mish8UBe8/bqKtxrlOe6IMguNXmB7R7b3nh/lOvfe8K0Je\u002B/DUDZEQ\u002B6goPyYjCpq64H6F7As0QNRRPI314KC64Zt274\u002BhKIVCNpxmua6XxI1ek915Nk9HKqssgtETKxsHfU2KrBsbCbf5Q6VuzZclyXgAl0zDMbtcP8TUdKW0PxuBbzxRDShiQ4olj\u002BKZ2F0EBrlZAoPONEuSLmxGNpUCRRSZ3W5axLxfnlOyraHIwld30H3sWyyHwyrwzt68LBz1Ezrd8Ar\u002BqTH9CWQwC4aZyWwE3lYXFenoAhozWgXtk3I2vZp2\u002BsJciSdL/0G4V8ekZvVyp1227f1A9f3wy088H3Xx\u002BU3sIt6ZuFUu2yaoL6pSnvMAauwkf9\u002BtJfTUa83YD9/bxl55uEQm6P8IiBLGqMZDrixcK7SJ3XluTvzZxUyHRstW3Flb2Nau2YHtG/fM5n0\u002BgM2Ri\u002BQrQfjlC2lA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-49466f66-bd97-2f6e-4334-c6223e4fcf5e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c803b8f44fc017a124b5cc8daa901568-0aace532af1e05e5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "191be986-0bda-7f22-d7d7-b427a46be3a3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3E7CE3A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "191be986-0bda-7f22-d7d7-b427a46be3a3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8ef49-e01e-007b-24b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "dNE7JxMUd/zGz3xVWtUiKcsYGhaI\u002BrNI71yucrimB2zW1XnG46qrZ1dqDBmPg73oH4tUdTagDHoe8je3ZgREIMgQfoVcXEUgbbK\u002BHe6ZuWuexVMtUZE2Nsn\u002Bp/Fz9AFSJutRfwU4jMNFNAiD4e6LhDnLGKGxFs822Ue7XbRUrXmxbPYDSDpmZjiQ6B2JslTacyO4p9tfoRAcGqW9fS8O8IaO0XX3iDv/ZbJoIC6xrSfz4OqRnAadUcrm5y6UqOkJgfeW\u002BuDe4urnuEEp94Diam19ypxFfFSA8YCrEaENar3IX582GrJGFP3/quPEc1pJBHzAFt1MwwSiFglgM9FJ2U6EYJfhq0\u002B7N7WeRtJxvH0lYQwkTFPfe5yalASp5uAsttCUPxLDZ1ktBd8nrn0xMVqLO9HFJIz7pOX7RxdLEVHUcpAC3HxqYvqz90dzt80eaGKqHaoOZpFDmZstxyBB4vOOUzztL1TdINnXEi1Fh\u002BwX3N\u002B0oPSmxQv\u002Bv0PgPJrZcRVT5WSQMTgOzPzRN1Rk/RKuFupBjUH/540x7nAR/eQ\u002B/qAX8qKIh6umptT31I62msExMiawmOTTU/3XX0LI/c8YkzizTApwJo4/m\u002BdsCBP\u002BelSv4Mq9jmW8RJ\u002BksCdo3agF30FWAk22wAyXcf38Z0vq2eTuGR0EWgTT9whry3Vn1r0\u002BZinRp3gG\u002BB\u002B\u002BJR1ov9xTutdDesSLAYQ8gwtFSvWWMJpAvgAiGDFs5yD9RTTnajcrFxGeI1z4smWklCRswa0pKPWCJwHcMaGl15KkjbtPVRjUGTLk9w09SAuafYQM/yZy1B0/ZEI2T\u002BZv\u002BEzKVCWpVT8MmKd6RTDoRN/1QbQdmNhrMbmeD/DVnspMdP7Bc/Pm8CdEAGZ\u002B947sVyBiQA0xUmBzXiJrC0VPNvrcLtExJtHrDlGM2Jhx7DkqsbjQcl29GiKeTRXReuXh9clsocm9ujBPdzG8pXnHAnHpQFmNf8ScHxOuktm7GpNrquPPBUpvbfaHgPsrAXWo10uj5zqLU3UFz4K2DihXk1ydUPqV\u002BP0medNiBv7IcB6dBruOFzNZ4FZuyjXIuV/OMO2fjrF6Et5OfW1mKE13PF9jGAdsyHsoRG\u002BkJy7HXcB0lNYRKeJtIvPcQJrF8rcJ943WZKBXYWdydkpB1uqwhh\u002Bt8pR3ZRJ89vYUkIjgY1G4mjCg8fkgHTJunrKYK0sIK7p7GAAikpF7Wm6qQtHfkRP4iDy6EJUmjNViCMdf5MqqC2TNZUtRlQifJZaKdtpgjg2fn6IPThskVYsqv4nKG3aj/zdtESzIp/IzGur\u002Bmxb7Anm5wEQnmr1IqQ\u002B/JtZ\u002B1Qkg53ai833h1/iw3DMwJrp1Lg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-9f158c46-5c85-2a10-5e48-1d429f1c70e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e3bce9fa31c4659698048d692682058a-c27435f4434eaad6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "61f45510-b954-9538-cd68-66e79f25eaaf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "ETag": "\u00220x8DB71C7F3E4C16E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "61f45510-b954-9538-cd68-66e79f25eaaf",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8efec-e01e-007b-31b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "vRAQWzF7ZXokaBwIgRy0ReHds59YD/zY6Ex3vokXg1VK9xluxa7vaxEozhTEz3aTJ\u002B5PSAbV1q0TN3PlA6fwDeXHvokDRYAy7keOL0HnFBnV5JabxzpOdCFrWo07CWdpOMAv/RDtkOFuHVq/RqZsLCNZEB8RVUWqeElnmOrz9\u002BTfJfeAuBcI51S0LKrgjy17/i5p4flIWOJ7hITHhfj3eyV23yGu7HMMUSjLXCibyugb7Jm7iRXql8wUBDOSQGFcvbGEarAMzBG7XI/RfPu64Lqbq5leO/EPi0hVmedAeRHGb592FmA4Dx\u002BHACyGGRrRWiR59pTI/YLAdN5otzIqeuJ\u002BCg1bQ8lZY5x51zrEiXEtgz/Cx4N8/nEdtqGB0FjsXYVKBw8MdRdbH5P4TiZH\u002B\u002BptOjPzZ7NfAgubPYwn15NDjXm0eoJhIA4oZ6fvg7BL1bq3FJUl\u002BPXS6gUEcDeKNEcAtMGsk4FoCxklywAMcH5aUGjScML\u002BHpSE4pB8Xa/WnTJf78/vnkI5Tgl7/y30xXqGqiDPuMOFAZUtKLDw661qTi3NrICvarIlmCK5gh5mjxwW9rOPBuVv2u05wnaRSGJbEbH/Jxn51j9tqh\u002Bhy392xpiU2vX62khIXtGSdqg7k0\u002B/XXFtZ2gDHB9zIVzGzQ5uwvzd/W1tYTZpt8hHZmCWMRbP4W4NCV4wkb7VhrjrgZDDJLOrXpbiUvs6BLCfu7W\u002B3O9G9uygYLmerWuvl9p\u002BfTU4hEKt69N/7Y5z0gStkdUIFqnIpIqkI8P6DbAqMrsgvIZ7ZjdyEfEcxgldLY608ByWpoExtdiqlGF/st0iVLrTUhZ\u002BMiqdlQS3rN6BRvU1RRyUlIw67wat0NLW814U\u002BXJPitp3Nr7x\u002BBB8eQn6KU5rSWzAjsAumWMQ0GFYx6Klo7NrMbsbvQ9eopx7vXX8s6eEa6nxVGqyIPF3Z2VdmTBu1tZWjveST4tdYusjs9vtEx261Fz4tE9IuRHKo1aqAAhrDOeepiSv8RselPJ\u002Bjm0WiVNIo8XUdiKHDtXmyKw1s2HjuKbzTm34CuJB2h9dySujsxkDYV1ClpbFF5dPyShu6OGQm9XHIjvmUJnjk5wCKkSpQhSSMlEDoCEPLjfVqUC50vE9zC1V3JHeHBHEXwP6wu1SpYcT3LaQjfu0t/MDEKZYKcCrxF4XU2aDsxVAPkAdFWxKggO5pvU6rT4yoSSd2wxqbDZDT/2OO1EgkCmhT066lqKHuY2inoPKcBcf5bJC5dgJ1dIK2sZuu0eymBXMmF7wdwuBFiF\u002Bx82zeN7mb1af3qpQmHl7sLvcGP5G8AVt/te4L22mwM\u002B3ig0EV2LoiEvwErprewDkdMdPpQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b/test-blob-b1599804-9070-2a9f-247f-1dc4572af8ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3c44479c51de6036c4e20f1c6b1bcd15-4c4859ca819b7ef1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4e16c847-8177-314e-0579-66b083376dab",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F3ECAF87\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4e16c847-8177-314e-0579-66b083376dab",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:00 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8f08a-e01e-007b-44b0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "/SI418hFeQYtP\u002Bj4HtuZDmt2WFn0kLJV3UsBgtfUu6VXG9GUUjY8EejhWgwHGZyQ4vJ4/W/1sW1w4vl8RPcuWYRDoQIJBbs1OkdxEjWmTcOvcaDkW742YWpkJG88v83wswGHxHiZht02Q8Iog543yZQ1zdJXSf7GDD\u002BYpeBM\u002BHp5gV80H4lLFerCrhf7Dt7LLFvaBvH6mWkCwLg5AOH86kpIrgI/AqoL6rjnlJvmy/1hzXiFcfKIfuf1MV7QEhQJxsTMsmDbiymwzxs5EgTNHPW72DNod3hYvy8aStBLO9ij3s7XGRichUFO1KLWT2zjJxVpFTrhoE5LdPMxwEFYZZNDljQ29gLcHlLyGqLWgnDDNyK74iWewT5/i6Ula8UA9W8Okrg4rTASjPbn74asdfGCbogfnYJtpNT2tmtdtrKN8iQzx\u002B\u002B3i4rxqVYvttK30xWzo/084FjsoO7kQfbFtdZEWv1ieK4Cy\u002BP\u002BLfQsPu0BPuNVqRO0UBHLRiYB0kmTLPOA6lzVVVtnsdcaPbNkwGEA4wMTbwvCjwnrljGHAPiZagEArFSRK\u002BmI7vg7mhJeZ4bFAO9FgLzovVtS6b8p4LDfgNOxYxMNb7cai4EThvX2jS6rwgAIVOlEF\u002B75PkEqXg1HWxk/rANyt5E4K/Q71TZlXFyQfh6w1yzpbEwlFDB18Cxzyyrbt\u002BErOApuzyn0CUK3k\u002BLlmeDvl4TsVT\u002B3TaJgwjrIyAoMiaR6ZEUTQQcD9GMKbYFOj1ZMgzSm72Ghc\u002BtnDQzuLEA4qwk9ajSa21V96WHcreAhEjPke0TVZZpD2fFaqzP6Fccj0cF3ESQhsafeKAUAxcYKRvvZCbD7YkZu\u002BpFDQDAhgtSZuNsfqgEOwsqd9zyVQxMqT2U4IAsWJ297CBeS3XF3vaYxZwzr65v6y0fmXmoJ2bd\u002BGfDK6WHJgpFro6Hqe\u002BRZJTqWZNsGP2PJPlXEMMkEci5gFMSArNREZ\u002BR7f0f5EFBijTgwcnXbd9qMAKsMBFLHZzFzimYg2HhmUfz3i78c0C0FYaKR0/\u002B5hJ3q86wpOGKStBgWhobpQrS/yiB54\u002BwacDB9B6OvNZMyugXJNeXMPRmZZNanBUmnGx/u0gneP6Gw0IN7qzG/436F48yAIAzP8o0H4H4Vcmrn1euDwGOJU3pkGGVhUJHo2YFYIiF8JvoTH997118im10YlNZFPCIa\u002B5BSHAembaL8Hgb8vVBIaq7xcKGEDXsaQX0ISbu6o51fPSaRKQnybLE9f7hYJd0MzyknVMuAlu0UN9uKniPmQXtpnYApt0Gk/gPwR47DwRyf\u002B3qSk0/R3qY5fPIuaM6NVj4974dd4hfoglXIkE9fUXW/6qOpUw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-12f05888-85bc-65c2-e02a-cedf244cd10b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-100bd286eb57748e85f59ddd10db76a0-b9934ab9195b1c94-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d7a0e070-9c0e-6537-af39-19cc1bc11a92",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d7a0e070-9c0e-6537-af39-19cc1bc11a92",
+        "x-ms-request-id": "16e8f0b0-e01e-007b-66b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "859298062",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,2048,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,2048,30).json
@@ -1,0 +1,733 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-d73c6433e247554912f5746de626c008-d40a3e6dd3ee960c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1576e9e7-5eb8-5843-beba-122c76043899",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EAC22AF3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1576e9e7-5eb8-5843-beba-122c76043899",
+        "x-ms-request-id": "69fcbcc7-201e-0029-73b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-4a3b3858-ccf8-3a2b-9246-2b1ef3df1d24",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-d33d08a7cef88d3c2fe7d3945888655c-93917944aa7954c2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "a572da2e-2a1a-9af7-69f4-10fa051e7a47",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EACB9D12\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a572da2e-2a1a-9af7-69f4-10fa051e7a47",
+        "x-ms-request-id": "69fcbcf1-201e-0029-1bb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-646cab4a-d76c-5915-c353-ce0a0a0684c6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f1f730cd493350394ef146b5a290fd05-ac8f634177d008e0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "504ee995-b274-b9c9-1339-e414cfb4b403",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EACE34BF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "504ee995-b274-b9c9-1339-e414cfb4b403",
+        "x-ms-request-id": "16e8b687-e01e-007b-6db0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-b048770b-6b12-1a2f-bd3c-8271332464df",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-1ef9617752d207d962ffd36dbf99951f-7c331fdf66440a8d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1c6527a1-29d0-78d3-7704-4affb584df39",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EAD279E1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1c6527a1-29d0-78d3-7704-4affb584df39",
+        "x-ms-request-id": "69fcbd19-201e-0029-3eb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-4a3b3858-ccf8-3a2b-9246-2b1ef3df1d24?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-8088124e2461b3bc7645f0cf3f0dd8d1-e9ae3b33ef48cb42-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8729372-974f-1333-b0fc-7fc3f638dfbd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "DPWvzRDnSC/dA05FLPsrfrvotg6zE2gJNd0xzt/g\u002BvM2CyRf9FiNB6c\u002BPyBq6glPnA50\u002B9MN6PmNppgztXlP/AhbDiHWy4pjW65nddRInkvT4jHQa/8gKCIr0k3AWVEt7kIXD9voeNCEEaAkpnMkRAhMYNNHfpEJO\u002BX/q/k8owFdOYaRMI5w6mlgTFpe\u002B4KvBo1Fc/l\u002B5W\u002BxDtT16czXR22fx2zskhR623Vp5jE2qz9jT6Vs9y8I3lQW4CK5egGdiQXsvzQWwnN4y5iDFf49emOVkpknak89l\u002BkY1rLywGF0zF0sSesKTI0y8yyXhMhV2Ga/I\u002BdodR\u002B1ridL/uvBhgo3DkmhETB3i0UM9XYjphIgwv1LM5x5DFY\u002BdpvDv06hcG0hYHZ\u002BtMc2R5ihXH\u002BokggVKjvudVNtvQLzY5qVs8z2aoQJAUacog02FesE17DWleOSrpQTs/sZtKJzi1EsoJTMq/H7npHCeYgtt19naeVSHM22AgQ347eJ702jKBa8CXRWNyy\u002B2/dS0DUL5fubsUu9IG6DdZ6PlMc6ca5EH1Bxca3qETG5lEDWZDLPLP677T0C5genOZTWx6Nlg2lIDrDkmXRNsKAZA4wurRFrv2jIfoRxQTlIyjgZE0mOUxDXjVWB65KKbjyc6OJ7eYuCawc6nAXl18x3m888NJxXi698Vh\u002B86dTVPhBH1FlXzVCslqhCU7cL8baICk/DTjmfRV0y/iJsxoIyZV30nQNzIM5\u002Bj530FTf4cWVpNN6FEfDWqI77JM8tQNAmD\u002B1aFlSyFOqBRL6cqjAlOoy9ApKjrVRtHfV0d/v\u002BUU/NzgVJnVoQth/0BMwyOv1e1upCbz09gmKZ7fhfPpzugvNuz9wr25wxrUtyrqiHOuP3FaEQvOERj0uisLBisXiCBYHZw2sgM/pOEMLyytS5ErIVZyj73cYRXT\u002BQiCvrz/vT8KknrXd41\u002BKnwqseH8R36Z3\u002BTElPhye7x2Yrj6vOYkDGHtorkmU6nZBGUxsa8j17GZ6O7IKyhGmBa\u002BURTEc32F9rWAHpTFY4xK\u002B5CTMModUor3YMQHa9FJpxqSd/KVBJDnu7rpo8kc1IVSjT\u002BHs1dMoQ6J3QKpjprUNmeKIvuJtfcPq4UfI67B6oxOpN6hweOzVdbkCyeOTi0QBX1RkrGJ2Nc4iBfSPX1vt/KGatnMMnSD1t0klarPcV1YDx4xcFfatNwHaTnb4ShZhEM1B9NDQ9L43bvkZTMsaQa6ei5fLkeqq6YNtMk6p\u002BWkyxFXmnmKBLtLOKKb9l\u002BY2wAzIWb6ClYLmlwtNZ8JvjXGP5ohxN6NIGVzE/WlDqVWdOnJB3aOusC7W/AdXM8sMYp8xcbFdwYhpgDxduZgVoum1sC1QLa/R3TJdnjef9OWVuJ7OEjukP3Tl2F1jUPaSvVkZoYOduDDvX5B/ACdQzY9WyAD9S5CyEXC0blFSbow/ytzeglNl\u002B/xp3ranJT9NkQ7SCIj1kXHIa4wO5U3jnO0EQzVGdks78MwEl2zeCugxatlGfGYDSjVvEhbHVxauikHFouYKBx7Dmhu47P4E7mCn2Xp0mRyLBPT/22A0dJm5Vg0rFGgGK2O6guZKSlk7Zie2I32YOe0hPpntCiu6jyGB/5rs2dX4nbIWuho2PL6fwHU8glUcIRggCdnOFR04A/fAyEq\u002BSohNuYHPgX/S6v3fUUW2fgzMYd5\u002BzNP8KoiQ3romdXB33Xno8sTXTJ\u002BcTR7b7sfbgYXq8GZoQ324TZL1OqbFrHWJa3PPzYtH\u002BRE\u002B4n\u002BxIDvEuVk0P4EKC5n4LKE13hX41pypUodQC7f6ovtRKWD\u002BCy1XMIFJjXD0f1/V15zqEh7/RgvjC9G0cK2lPZiJuN44\u002BiVz4q2Qr0UrtNMnfjQbDJDYVedVHwNfnsPXpFPUasaBmNl3di9xbpbCt1L\u002BkPZ1ii0LrWb6498mFEPtvQr1U0oIpeFao5phaudMlmesXQ3JXhomzL1jhrj6UV3vh7GLzWAI9esVHuqWqkJ/qk13ebs2IF7wzoaIpR8oYE44dec1wMkHo2citEMvkCZ\u002B59hrhtumtWNSmv7ZgEzP6LqYWjRfRemAc9ZQE2gfwT5gDcFGvNl2lbyD4yXOKh8aVsuElzXyI53y5xcBUqX7Ntm8eXaLhS/hJcB322bDtkW3ObygmyoEce4nU9XGcUcaiKxMDayojs2bo21xekQ7LyzNShTlWpuvuAuIZDFaHrB9XVK2d6iVDqrvBPe4kvul7CCk9SsuMTIQnFWlICqYQYS89Bj1hLuEOD9t\u002BlWn8yUT4nQQsSWJUyggodtW8\u002Bp8VsNu/57esGtpILzrvDrYbKkslUGyi5BjM6Tw1ObgLUhU7aOSOPeGNTIMp5BknZLxRDEuJlqozcszC8v56duAhPN0ltKXSjOxpmAPoeP/\u002BpIR/5CxsgrtrCPYYy0rjEtWjCKc8ArAWf4BfH/6mSvnMxE15\u002B5K0tboiuquvucCihoYuRXBXwqLUaGWrDWK9xL38Swf8aRZD7lPtGkgEZ8W/vJl4eASJdAGrpZItCKdXZfXtsm24pRxv6lcdaqdZ0ACf7FDJREy5c9YFUcSEFeWrlbVSFrVXBhd8CY2tawpaUdSRjhxWjiCpND\u002BWslRY6tVycdTyBrlLR\u002BU5TDu\u002BCwfMq//v8ofIVAeVqeF2wFPDJB63O/k2Z0obRkY3HUHk6ik3ygdUaPhOqR3MXV3Y1YeRdigdBtANlkQ=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EAD2EF0B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "a8729372-974f-1333-b0fc-7fc3f638dfbd",
+        "x-ms-content-crc64": "\u002BoJhAxFYwq8=",
+        "x-ms-request-id": "68288afc-501e-009a-2db0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-cae2ee9c-d497-802c-22e1-87a5fe212f8c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-19894945e0f379382a8d4049f18eb865-d9f7370602fbb420-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "218cdc53-3711-b9e9-eaff-9fa8dc5d5d78",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EAD4C37D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "218cdc53-3711-b9e9-eaff-9fa8dc5d5d78",
+        "x-ms-request-id": "16e8b6a7-e01e-007b-07b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-646cab4a-d76c-5915-c353-ce0a0a0684c6?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b21e899a245eaf4d4f89b7d60ececce7-2e5f55cd579d3050-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "196fbd7d-bdab-acac-9508-0093d70369a8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "tNSsQJA2xrC\u002Btz72TG68JmmR3GkJ7UJwv6anGMfjWSo0wqCTSw0Z5gasniCXkUQHbPedPjAsOseSPIHpj63p214UwYrOKNtcePZiXU8h2S5in6zPRhv5B4jZAQ6LL1dZw8PCg8\u002B6OUQcQcU6yt13cGJTh\u002B8BGZRDGrkB9CbM0EmeCZmLX1ZeqGVnswVVvj2qYZCsN6dnV6kufmgVuEQdUHB7m8BD6xEM9d6JmWWO7Vx8V5OVH5ihN7HwXODtSPAgSmOV2SJ8Z3V/n0LI3b5DoJEMmWGxhzDX2mQOU48xHqzuaU4C\u002BRM5/\u002B8eFoBW2FrzrLxO4a\u002BOb8Izvf\u002B9bRPmToGV2nRvQaZ90plxk3GwgQEKG6bS4jz9YPmMzjwUe5HcN8j\u002BwP7lhGsW0Q8VHdxRgzz\u002Bs1JsE2tEmHl643JpaVYHlFuoscACJJc7uxAs50IdOkv/Fcg/byNcuSiEaqD4rGi5DoiAqNF8/I67MVhbF7E2XagnaVONyCQ3TPeXfbn2Qg\u002Boc9m6nJJ5gxk5gz7LAaF3Tg340UIUK0VjSVza5H7UxO5IsqTXfMAVruY6U0Tma0pVIC\u002Bs/XHMk0eTVlM2np\u002BaZb5Qgk/9n9FN4iNc2tcAfd0RhMNPKMd9fB5cQyVs3w9Gn\u002B6Fluj7WIFdXhtOcLlwk9l2JBrbSzz30wYwoFus4AITFTroeuf0FixB8cmrLgxk7LBL9rv0a1SxjsLiyrcmsX4YOlp/hxjygQ3umVlzS6T6y7SqYOlHHqrmN\u002BwkEkt0G0BLk/Ox5WSYWXWuBtH6PkIe6P8Ce1GU0BuwmFArzm/BeX4ZKLiwSOZQEgZ0mRjZ7PiqBSlMcp/utsLYAUwUbIsG7I1S4BaJbaAZsmlKIDcD1qxXgchFdQfeKnH12EaZPKV7bq2KhgviIJiJMsA2pJaK1CqfvOvDwHaGdLWklJVZgHbDz7KKeFCgdWAvu0JGqIbbagQc\u002BYC6t602BBJWPYwCMLJKctTjAFva/0aLkwQzP8svyCmRPYb2CBcEU3Q\u002BSjfTLYuQ/DWx\u002BGqoQfo5LySoA8VGJnVicfMsVGm93qznnLQOt2Z5o0KWfdC/6PuMvNnzXFCv9yPCcbuXZKjL9Bm9waVFKni9L2CCr6iko4n3n5eQyYJbOKSQS0aq4T\u002BZyom3ASZWRpFhNSzwLEd6Hs4yoMQROyqWYokAtd8yE04g6OUf7aFioVkGL5RVawtcFS14eEF6iI9fIJ\u002BdVZGyLyLez0NiWzAsz/5rCgyVQfZ9o5\u002BxuZoMpV9Wv80BxEzHU/9xd5vI\u002Brr9S6lDD36Cyd6oILLyAXWI0SnjDJtiKwqyo7YMI8lbtanltG7wyZbh0/buWKSa1FKK6aVx5O4emh\u002BekWvHdqUVTWsIDUwGlweTATmldNNmF85jgToj6tC7xhlPUjgqGlxR2Qs5kccFhFKe3uO0eSVMOHmcY/Rr8WOaTUYztkXOaObcVJvHLIYHXv3ohQvtBk3zAxm/jbdo5ueon0OB0s0Mz3X82CWKhAzylQX2gmxXrUf4P7MrDtsvdG2zH41DhYsw27WW8S0oaX4NzfiycWN6UfH7iJMZ4cCazGS31mV\u002Brg95xqe3wLwZ0NY1HUHifAIKOM6bSP34F/r0/CTJcZIZjh/oOKq8w5A14bi95MN/t09hrJ2X42YSga\u002BswsSXUF9DG48i\u002BkRXTnQ9ZmdFOzM3dEXUaMT0gqu41rf7DwHMnZFYecgzXbwLCV4oWn3/zEZ8dU1/w\u002BeaTpnjaSSMXD5zcMjV7MFqAxeIyF9lzCguuQlxf5qzTdmpvisuT/OYf6wgtem0Kd\u002BEEXI29vuINYJxta8aG92kwCLuLC6WPLMj70iyRRY\u002BeZAp7G0nfVfeIYiovZpEfmTPe/THxvyx7tW\u002BEgey1fBrMjwf8C5vfEPLDwql7X8Z33Dk4skhdrKTeP2YaWpPLEyYPYpdJY41YP\u002Bx/LbyDAFVpTOWzfImSbyJi3cx1hPYe\u002BO\u002BDLD1u7nir4LKcHr8oWz8Q8Q2uF9ZcvPN05kWA4rr2YDTM/9RYOl5tB1wXNlBjekLNJNPocODZJq8J\u002Bcfy6v43pb5KG1sq\u002BLavARB6RYajEawCs72nDe9T89llTkBWehxd31CR2R8n4mwdOS/QnqEoZuhb8HcAUFfPNmeBxWp2GMbz3GY10TiM2tFRShS/g1U4fOeYOonlHY84wuL3ZdzB5uBo3II68lWvztVl7sZDT7MSiYiCnh59Dv7W/Q5VlbT0T6M0FqaS/UpR6Gu0fy7ItbNvpNxUfwjCK83DY/VHWjlgcZ9jTzjMf4w\u002BcPXyiI\u002BQDkebJjDYn9BaMerYj1lUyo5yE82PZWZ6Y2UQFg5TD2M\u002Bc1Wt7HQIh9HPCR0N87Ay6WYngLTCAKjhIIKLiEnBxyKH2lwD5x5aaYw7wFwJbK\u002B03Wyoa47ufHKsjIvxfP\u002BHzQI6hhlULsIHzRbohkBM1/PTFqrdGZuTmZ4plxqSqOyMs/NaDqaWIO5qoJ53xbYyX/TX3iYUqrOmZuy7alfndSRqXBJM8okNfTX8cnk9W5PoN3dl\u002BorGd8k/86f6GvaWgyt6DaljpW0riqEwWDg6aQtYk3MggbqZY\u002BQJDT8hU2I/Ze9Nww3qRFIKOjAp1h/QxUpcYUeDdgGwoKmFWlguCnd\u002B8TII7KX9bk7g1kdKb03EeEf0hPHau\u002B/tnSKkZSn53C/46uUth9iknzM4op\u002B6JnEbwSIQOYVFZHUCWw=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EAD649DF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "196fbd7d-bdab-acac-9508-0093d70369a8",
+        "x-ms-content-crc64": "RHACaezaiCY=",
+        "x-ms-request-id": "993d9630-d01e-0002-69b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-7c1365c2-6d96-de11-7c52-a73055a3269e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9d79b43425b20a4573fc09e53cfb4d01-30a2d09c793f3b71-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1e2a1207-43ed-1dcc-a320-e6e9c54623e4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EAD73420\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1e2a1207-43ed-1dcc-a320-e6e9c54623e4",
+        "x-ms-request-id": "64d69863-401e-00a9-7fb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-b048770b-6b12-1a2f-bd3c-8271332464df?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4c8c0f2508c2bf51acc4229520c2a83e-b73e60da2b8f32db-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c58b337b-4ad8-6fba-261e-27361ce6c8bb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Pg1kJZSc6V5GEqNawbxAl/uHZUHO2sUijx6niqnNGr\u002BtsiSEGKdO7ZWJUrLLqseDpn4aCm/InmNIQpV19V\u002B1effjrA6Yu35TOHerRIgSVuVWI\u002BQqsg9Q5RTAO9YR2fg21Nm65/256\u002BoAx9L3HFnbNeuvHtF6isbok8f513\u002BoQV5\u002BdW\u002BvV27onTj5Kus9WMi65QbqYromu0oS0lM1vxNqV4VzeKbqK958xoGZgV/bqzr\u002BP/J5vd\u002BkWLolnIUas90lj9NmyeAi0LknbZs4jTrqNiYZNoAg8JmlzyDsxI9YYhOkdPGMdeJa3G44UU9Da8uAOmVeAXxcBJ45wPm/NQsqzwuHlBhIXsFEvloS6J5JYWRVbIop\u002BWCXSHBSU7Tom6djDYJEvNeyN9ujGkMhShsA716VasmAAdWr70un9QsNWyOzr9scBaWNojSvhd8cdf5VUmNWUzDd4gysmcyLC0HQlr4gbppA5Oq4B8iU0Xz2jnlNUqOntgjy1c3Pb2zYAZfy3\u002B4h/AdjFG55nUxnSRCPtgpTPbieKOC2LZnNcXR94AUxofKN1JJy6T01Lhm8ioy8P7lhhcTeVLcNa85ulaP6\u002B7xGNqceAeF44FN6afnH\u002BqMMETG6HFtBUk07gGnDBFOaOjJcdVTlnj3Y6KRwZOq9RnErYYRxP99hBONZ4oF3tNwA4C7Ga4ROJ3L04TO30e5ifjn4mKLPKPpT\u002BnFxi7u7YDTHcIS89tvt3DoRfV6rqjP09mRIfxs6MLczc3AS3Zu3OID/72FqpoddC7xovaucp1A\u002BfJVXc\u002BEYjT/MiINr2v\u002BeWkXdq7rRilDd6nRf0XMLlssg1GAGYMSf52EhnR0E8jC8yWJmv/uVbPJEeoltuLvLwfK3SgWemPqAPcRYr\u002Bwz2PdDogcQpdfPimhuwuY7Mi6mVtwrTagrHjFo5oE3PLwFEKGRKRW0uxsa57\u002BcL9YURQuVslkQCItPGITWqL9WmE6sabFEqQgZ8ZrAEGXoju5aU6B1ooli9QgWQhGR3RJcxE9x8MYlz5sDfMC/T/clZ4mVe1Qe4PbESXSoLmb2hxSIZEwWdp0oNYMFciXIo6UQ8NuI/GG9PuNYrKZRfKE0DPWsNuurD/DrbEbRGW7Q/KbOmD2LboqzyiZovcr31rni0GYwHGy6ZOHqnI8b7CR1iLAAg\u002BNjqZ1q\u002BWvFQlIl9JWM7kgIoN85FDNcoNL6l94B8zUa9lPVfibIxiMA9SKPxKf6jv3cbejQxm6wBwjKb2GNxE8dC/1Ct3AiP9m8OB8RzdsrAAngJYZMSjDkJXYe/VbBczHScrmpt9eNui0OE41Pnzktn25YrZ/J0MHNXZL5A0GC\u002BsXuPlsigUgxU2pYPjailYY88V7oacaSCaH33FpFk7bsixjIYGDeCh4mJlo0cJGKKsgLvBLjmpH/XDS5KqXu7L\u002B0bLId2jQlXuZAwkNrXZkPbLGSOdajCfGHyAQsJN94NzmafwTfbFCT5l4so9hOk/6bqb3zW7PoEWPBlhEv\u002BTkGx4oJ0N6VMABh/lJ4dmYYOTUGkXsihduGsm6hHdY\u002BY\u002B0kJdtORcIgBXm9kl1gb5r8qF3cKWi\u002B5EKugh5w8xIpIptlVFGKyvNy5osCZPJ\u002BJkLTpHV4YjmFZkCZoMKjrxFmk2/B\u002BhtJct5paUPcvIBPL1vbnE\u002BdscBh4O4Q8CowzjZ5m9CCvSsnijGWDvj2qKnASnBmyBLCyOKvYBotOIK0OJoNYyCvzHIwtBIeB6LIazdET6a5yQYjt9Lt010Q\u002BlGv4dVd6UWJEX3\u002BNhMAo8FA5/Tj6ejb\u002B26U6axNwfkVILrAbybMaoHyuj4pu5PyIxMRrexoLBFo0\u002BZnyQCYPE\u002BD6BZZQDSbdHxy8S6qsj/bocWZPBQNrfOoV5tAZaCBWX7vpdJ9mOPedjlv9TviviCmiyc6/wA7djsjseiZWw7c8Jevuw1tXQjiusXanbe3xZh6mdl4R1p\u002Bsy6XWuf6RRsqkwSkMwMTOC0fV0Q6YNmDa\u002BtPHsE1Y6g9MQfe1gMh6HSqsAqzEpKVZ2CrWfAVRFNVE\u002B78qidZ9S9bZwH8NWIq/W7Qj7DO0FhYurdgiQq4J\u002ByziMIUJD1NULrbWKuRmTH\u002BgVuBRbWjh0OVpPBw\u002BWsloz8VSKyfFdkxgj718nitxyCFYgiuNuI3EAF/foBN3VdPtbVsfFGFXmuCUMJ2rZTL6N3P6pdjd2xc3TeqH5dZ46TnpjzCQUvP/wOdLOUfwWNttJWifvK/6z5ID54Z2z7UKW0ejwZXCKeS/\u002BuUxkqHPRvTPWsBtmWxKLr9ejGstSTFyQJ3ATJcFazuEH4HKyX0wNKCRZ3T0nIIbGZLWY115UnGzv1HDzvpdye\u002BEqXmqfyVCbpfKXCG8vaQb5TLELwfeCo1QFworLGWmc52FL/MIcJqtk/TFbzZQNwGt5\u002BmHmZrnpp7sWmfbV0JyZChEN02w03SYFpsTGJuWwCAIfQR73poCnUlUXBZyknxyUwsODD\u002B0PRR1L0L/lI3DVVoH0tp99kVOAVnEXLdeJYRe4IWQSPQgVEAvxq9XAwj7UQb8Kv9iNJyFv8ql7\u002BBdFsm\u002BoPPIcsxmJ36aTi\u002BWNz5QyMuwofrE/OwoyskpeqSfkq\u002BlmGIU8x46VgNAx6ZtL4jMVObU7LUO\u002BeQH36fDfOzZ\u002Bru/8F6cPBWtdgv3hDUF\u002B9tAXOW9iuY6lp6\u002BDRO2NtkWZs0q7T8qMFjRZ7ZpF3XvAg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EAD84569\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "c58b337b-4ad8-6fba-261e-27361ce6c8bb",
+        "x-ms-content-crc64": "bBA8Z8ttN1A=",
+        "x-ms-request-id": "69fcbd3d-201e-0029-60b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-1c6defef-b923-362f-4ac8-8d30e4891c9c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-472be0b9252a143cb4579c844005aec2-7f10716e42479cfd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "916efb08-5dbb-790c-3e1d-12c305005e07",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EAD92FA5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "916efb08-5dbb-790c-3e1d-12c305005e07",
+        "x-ms-request-id": "68288b22-501e-009a-50b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-cae2ee9c-d497-802c-22e1-87a5fe212f8c?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-d143d8cee2db3b8d722c886efa95117e-6e998256e6eb5bde-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "202d4c85-3678-1000-48a5-5e004027d4da",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "jjIMfxxxv1UUZwB4vAjc/cqEdJ9rOnBYsjOxjL5G/aM8K7\u002BlzuU8KnVVn5WoSac9wdva2GIcnFTCtM3pwDKWzmlcO5BINy7lR0oqFpvbsGmMdMviayRAH49r4xoXU2lCvtArSw0W9Iqt9JEY8oa45gNkXUxms2NFGxwB3VMUzfTg6FfKr2RbdX9BNXeTKC0JsvwWs/Yd2wpt5i/wFRY2mCacNwku7jefCOfMJX7rsfPu\u002BCtW/Rr\u002BwgxNXcg0amBoCpxQ9vAj2sTFd6oOUbaMgTQ8Ah3r4JsMnXX94ZBuap2GYxrhm7sDyx1mkYVv73FVwNuU\u002BGhDfCoBQ1l7JvkzVg0Nh\u002B2cq\u002BV5OTb/hU4VnK0DpyC02nE0Q\u002Bbv4Fdhh6UjMzp4YmiDuRX1Gr8yQ/fb66ard37Yfnyc2EMHrMqNF7GR3FIUnDpFgO0Lvr\u002BxAgDuE/SxthAmSrS93IkkfA1KaAMOoGelx05sZfaQzb\u002B96tVDGJjW3GGgapGdVsCwIQTgwFa8o2KZSUylRVAZlX30APK04WN0dIuhbTXVCHCOu0TysA1oAEZzqc9MMJcQhtUUqFXO/ECgbEzLGjYsxEDbF4kMJ\u002BVvjP\u002BrQDeUJ0P0keZgwV8awL8EUkPAneYQRuWOcRkNBF/vpBxWIrsIDEQJ14hPywLhwFfKB9Whr\u002B4Zm/lRBbYp5o2GcRxDxJ0D\u002B0X/t8ZdwXrirbDCQ/yKTfUtPIfBtwaN3/D7yFrmnfu5xwuPovcovNl/blgGZ6OQ/CMnFYgVQkQ/ctfVYfgg/A\u002B0CHvx\u002B6v9BYCtQkiuh3hNa8s2v4hzo4THTy8fU1rhXnJIUV4nnwF4KRAHaP/8kepfh/Ys6T2HQWT2Kat73bEmzOPVZTYZJszKvpV4azuFy75FwMxjtHU0wQ/5MHVW/Exe4ZscJiu0RWEqYiqoD9UpcV7sNh3lwhdtoKQmIPVWdMFJGYmfaaSSkHpqOVJKjLI50L4WacYueR\u002BDroWHjSVr0\u002B1oXvVMiQi5WqWieojFIhTy7E83Pwv7Gp9qHLofCwNV/2Zk4i287Ue2XA4gjP6XvotxlaDVNJPibURW4W1Omk6iTHsiYEDmNf8IgOL82o2g0l4urnVif8rSgnXpZgvaZ8LAfj\u002BDdF1Lil\u002BhzLOw5ZK3tQ8OH\u002BvYP82xUN3L/c/zLhkgPFxNHV0A4yMWwbIXIZ3iMbD8y0jX5z9y0iR/f42QrZ6akKk2aZexDjzHwn4amS5A6Mse9mPQSFUc20s5gWOWhRMUfJD0rMgZS7wMECTBWDj2P5fBcbc6yUhTGY5Md43YMDxqBR2dTDwDBaumxDgwW4MTQkHM1BRc2rJIoJI6zNMvM9/oVlMaWPNavmsMkwUPI74KOTVLDFwoDipqVKupyDnXd5BYSAQw\u002BOlOcRWoUEetOH3UL5Oe5CeCv0gosARHsPUyNBx0t9u52kBL/JpGf77jvBsu1ZmlOJJo1oi8B0jlB8AgdRsqOIGiGlRSU\u002BeNPECJRPPoGdtcjfuJC\u002BBS/dP4ZfXZJgmiuYSajLtFUuWq25lIMsJU/e3lw\u002BgfoCygTx2AWe3ytBU25otvTowgFjoW3zBHCsoQpGgH9GIhgxhX\u002BT2dxPn4uCeDEUs35a5hxa2uCcH7WURTcLWE6sCzFGNzF1VPglJBHiYJw/h\u002B2b66pi61c3pWW5/4SlNDc85m0P3oxM5ZEUJbbeqb8pZM1Jf3ykOR/aHpHLy1Vzj\u002B/atXovL7lRTwYJXsWgaPu2kJq3W8TKiK1dNb/6gRo7kKXG8/Q0\u002BkUD\u002BCBmmupKObWWBSrKvCQrECzcwfoJZs3r3b4v2WT3gZZVo2OUU\u002B3DEvv6VHv/cORxq9PXaChLCoFSis08GmBAnoOUdRiwhsw/Cb7\u002BDwJR/FzZri2RICl\u002BCpjSMdkQlvibubX4avvbsSUXmF55TQuPAI5wUmwyv35qFmp/3kTzHnK2YlVMWZFRDf0IeYfLBL2dUzFKoDSMaPpHnkSRW\u002BLQJHnrsuq2Mqb9H1R/KjXmnxG80nsTqH4\u002BOglbBMtcz6IKOFUd31HS1yCKTZDQDT60YP8i1IlnvHwLrXjhWz3roE\u002ByZOHg2L/P2gtamWrdXizKlqPMOfsYonvpEjHY8Yvinq1RHahM04hPUwp\u002BDRMRLl9cFrSaL3ZUmcJ2B8aN9uh/eAq9jECEfcMbjNbwmqVYx\u002BPSfNrHWH83DHPV1tvBsVwSDpUYU6IO15jxjqKfY/8dHT/Sq4oNuB\u002BLho/Mrpb3ScuK3pwQQHRB06Uxxcncl6iEyMmb/xXSBEZ1jN0SQijyCjTXFIVTDNzLkNfUy\u002BJVvu7nN\u002BXdW1q1qMpVmrOnL4F8T8uU9YMTIbv80G49/ThUL83uOwpDJK7qIWu7DWIZJGFWWIwWwMlrxBYp0Hr8h7uB8XrluPR3ORscqtQnWBRJ07v815S8PW8Egmb0GUQz/ZmwKQv3M2ts7y9xChXlNGvx7/zO/6AW1cQb0TaNcy/G6L06dz8YUqBAj/h1SzNJL04K8jlXZP35qVM321Ik72wPqhFous086Y1cjm\u002BnkZqAwrH4goDmf4O/MN3r0IdOG6CcZZER4HRwzhi8CtaOUge4twigPGzbGTqdqXn/UQkGDmLPGywJbuJNd7R4OnStIO7GIyl\u002Bre9DsVxWhDb6gX0Ppfxzzzbbv0gmUrSoYu7F4IiLKS3vh1CDi2nfouq7QvY3aIR4OWGn\u002BnPhWEsqm05tkKO\u002Bf1hPI=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EADB2B27\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "202d4c85-3678-1000-48a5-5e004027d4da",
+        "x-ms-content-crc64": "k0YWyYBVnvE=",
+        "x-ms-request-id": "16e8b6cf-e01e-007b-2fb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-7c1365c2-6d96-de11-7c52-a73055a3269e?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-3e5f0760317854809d66ef193f54fee2-fe78cd28fb04afe8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b93d9eda-3ed3-e38f-5b9b-e6041ccce721",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Aum/BD3PwMbXsfznD6Wl23JtM\u002Bqg4/FVjwG2ISNwzTnehIZdw5Hdr\u002Bd3PdO2wqVBNC7IecKaUh74aXQ7GJ\u002BiZ\u002BTCCIofRxfgj4MDKKUens1bdez1p1N3RDJnZFocoZZH1dbu9LkaIuwW6Ok/lip52sun4KOyrL\u002BQS8NYt\u002BO9w\u002B7svFLOL6oTQVL/3r5pOK4I7oqPdcHzlCgWXan2wmsJWST7UtnXqqsglJ5Qss0BJxIUUMhZLk4s\u002BScqt9EAHH/n9oWabuXVMETebuAiouFaFTaW4nGisCrWz1mxrPLZIHgfabxIZ7ktPx\u002BEer9tCVZG0KKaajkNRUVaw56LI4RRBE5oAzkkEq59aaNRHTZraMUDa9xQP7Y\u002BEiR37aMaoRubM3VxBAYdIb3zHAGWvCcP71rZiLenAcWYKvAUrSQLY8eHtenA\u002BWS/5UkeXCK0p1X8Z/1IQBhj9DKw2doVCHOZ6Lk5DgY\u002BTvb2GqNtiKSi44KbGEUmwiKuJMG3ECCJqdzWhXRpe5lPvhkHUiZ19WuNDfZXeu8uciaWi\u002BpFhj3VbHDGlwIvOWjpS1osHm/8OC5VKQMpMS/sqBNO0\u002B\u002BuCjfbMeW1rl1pXdSObi6VAVO2mlK871w6rDpB2e/u4WV4O0EiUOyKRonQ7Msum8MAV6bAlzmc8RrboYWqc9VuenxuFTLtcrFmLFPI6wOQCxB2QYJJLkks20knR65n39K0YnFPwIaRE\u002BX0WWvl0wUWSpZ1MzJSJEsyQTnpxSoD/0yBFImSQUuK5S6dVdXdRwdDEP0Y8aygYj4lHH5Mp0268VofZL98hAlL600Etc52VfoxprUt6g2g4bJLbCTMPT7h4mR7vuJIxozzzQZem6xvr8eDGwGXjQZMf4MNMBjkfq0PI9Jq\u002B5YY6d8pOR0HQUUF3LxcSCI8SVVdLj9fOpZ0Dk5YTnjZBLMwazEiblPoRD0\u002BCFRbhzWL0tl9DcxXuK5JtSrPrvLMK9gILN3wGtoBdOkBITJBGYcYzHyeW/fn2bKD2bkpGZZKcdx8UltYm7f/fJjiVpd8B5yjtuF2Ls/gIVMrbUEh11pTt69VxcYrwDHEn99eBIIaBtEdhWO000MMmzAILS123qQ9j5/nJkHVePWvso7wghzQEGZwA1L3n\u002BNsSSqWIpMETsA6IXXjM\u002BCPSA1uBCG0HBkTOB3HBtpSRu\u002B7et0XPlVhq2PNtmCm7NyF4LtEiJrBuCwRgul2PUjm59qFKLgDeAm3DFi95mW4bExAQSUfDr1V\u002BsKwBrxs624b58\u002BGIcQkgWixjXxBA9HHWBWdNvsixtkdMC31U3FNSyHqov6VMkuIG7\u002B9boBBE/bw6K2mzrRy\u002BSD2afCWLi72Y0FbV2HSMSbJFRo8ZFhY2xw2BGrDp3xseKjen8hb8e2Qxwo/5ryVHreH3LmaNpXIno3TXynDMrzF7t649JFdbiMtq5xOGfVgoeazPMrC0kETFQE7h5HDzZRNeffd3CklKW2WbIr4eYSXc75DEPXyAhydpd6QIueRat4HAZ/\u002BgsS8jRNcLGW3Gpx8oxPTf7yfW3faQDZKlQaFBAKs8HjlmfH6hoLildW35otCE37UvuohaKYnI0GOcfgM1ydjCikjlgoh2fg6vMWhI1qrCIGIsUYXi4fSvnavaxSJ1b6uU9thHnx0suXy56vghf/n4ml3hCXhTH\u002BiUdiUcW3ksOcH889/SekEE/5gJaTb8Th2yImrElCYzAdbv8yj4EB4DTbE2JEwZ5h/cnAmgCfbxl\u002BgHqnjOJ6WbyfII4odYTO\u002B6BdtFxmmRmDwK6DgcUvggPhtA8KXlNWYLWlqZ0QOYhE9aJgPba5G\u002BddI8wz9tv3b6KKRr11xJlNC1emwPN4c4smPogmz0BJJJgnqT6HImnZrj3\u002BhfLKzzEFFzZjFlb35LBBDbhPzKBeQSIlUhtexejpzRK1eemYW29bIbQN6hJFL8CKRhCxieGZoETMpXkVpk1NdUVEQmrGqLJI9K7oUFsP3CJa0IPUOEMxG9mky7XyRXtmvHDI/OlVx51eZJUysU/twMVavtHNdT0GFyqRIdz8Vq83gZPmQuM1AQzmedeqAmaJtwbsm4qlmUc3xunCxKG8Xg3p/y\u002B4B4HmIbnA6v9lXBDAB2rWE78kjehIsn/1djhvJhvJvAc60bOFCnnM4K5LzmbU/sE25k5SxW1Hb1UF7Kt9VcDjn5wNiTW7UQVBV606AOAVIHd7ND/JevqV82Jafx3OT4rtZDLKx3WLe5VJDXG8CW5w8Mw0Ah2BFiSle5XXXNHrcwQiTJitTlj987yqgGmI1enz6Y5Nmk1taE4OIU/jtBrDXZppnbjRw6JzNhJg2pW7GKGr43dDmdi6tORKoykJHjuh5ybTHzgtHiXv2mA7CI24VwiuN9Cjg8O9sujUiyB5ZhfWwvNu5/lpfsVRV790g6xakkwcXupq/mdjEWxPWJcBcnBMYEWaSW8PQLUPUigESTM8ffjUWQspb8SID9aNGiYuU\u002BFLKB9mvETdERo1X6w/Xsg9Et6eLRlpIvSBEjmYgiqS3P5GuR0T1cGz90vs9AwUTLEKTAdLkCLL4gkm4a4LRI7zooKt9KWvKTkY6jXNfCrkaMGIjjYnS0jfetsT6PATqLK4/VGNalgPXyLKLqXs/mHeQnjogrZYyFs10nnOmzxFCUGHEILVVwJpfS8TWRii8nx1Map7JyX4YDD6W5veQMfigSVkZenfCOt6gwGI=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:44 GMT",
+        "ETag": "\u00220x8DB71C7EADD26B0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "b93d9eda-3ed3-e38f-5b9b-e6041ccce721",
+        "x-ms-content-crc64": "sM7xU6vzFnY=",
+        "x-ms-request-id": "64d69891-401e-00a9-2ab0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-1c6defef-b923-362f-4ac8-8d30e4891c9c?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b4e8cdb53aca5e2ab2f11853ad2fba0a-34ab846d377b4d08-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a226cf45-1bea-1207-9a0e-766a832b7162",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0VzQpLj/VVllc3iG4qwUd7/Zos4azDX9z6IlpoovwCkJHEavbfEu\u002BDvXky3Q0jbNY0p7BP3yRwUn0tUV2a/ONbJOfcZlZAnOq6qTQjgILP1rV0I/tLwrFtRAiJsbGB6LCF16gVRwZ/5BrFhTXgTMH6XYqoJsj4D2I2byJdxuspOMBznbjaqo\u002B\u002B9E/ghj2LjQdGn1Q26cH3nchF7tfUIh0/rFxlbK8ZH6L66SJ5B4kkquIrFzeG8l8OjA/ghMun2tIisNnhFhBYLX\u002BhO/CffoY/ETP1uRrlqKn9ZuCvKIrnQx5QVlavM5TBwum31bZebw15oWOHshG3TQgv468/qPTkuejSTyg/n\u002B2vI/YxPcLznwfjNXcXb4D8qQlOf0/lkhnkwxvNjC/VOhGF2J4rdg9FPESnXHN9zVpn5aYe8RCdyZHcTGqnNhLoDftlkYby0SL6CUMLPjWWZwXBZZaJtkkA\u002BB8MXzmkngYhz06IGDvDZRRzFOfNkptcNdVU5cCMXkeyVJl39oHpVWs82W73Hk7KDfCCBpFRM2VzoBlUX7g1pWEG1cOSS26Smc98gLksZReWitfP\u002BlemUREz9EZolQWzByQN8EiLN7KB/3zR1LKsV0rxzcTQZasJUHSybkcoKfTJyYmFHmTfC1MlPgrq1Ixuh6z7Ztcw4pGI9J/D2Ml7acV4CBspFzjWIrJhuzeQLnv4Q\u002BaqLLMtiNb4DCnFCzKJudRFYtxhNWBkFUQk3ydp6NYj24TiwU0CWn80MRsfERd/2AFTWruvhx52RgdvCLm/nhNToS\u002B9puiXMxhdPQRFVQQ8pPcmBo4adFR2fIs1o1G1hKL3u2/nwjEYzCejUkoKIOEDMlPCiYeVOSzbNzptUZ\u002B2l6hRXZmkRNLGDTpmdyIKbEuaMmD98wsbYoIzHIr2u2qX7LqRqNNXXu2A/HxNLsIK0Nruwy8uyJStRfsXYThHz0Hf3pp3aLN4QtNzfQaO3jOwOEuwB/g7aSQV9GLoT/21OS0qfVA3k2gXdoBbq1ueLne3Vzj8h7dZlGV2UXRAn/LlzjPZVFDjiKTTqJFn773Ih8X7IOi0yKFl0NjqwTHzxuaNde0XtNoWw96EGO8l4bSnrcm\u002BVW8aIQWSY4OH\u002BLdi79Gq6nnQsML75F0aIK\u002ByT\u002B8kMyN4RXF3c0TndVFGntsXITkdewc6xuz2smEB//BV0COkU7WT\u002BppQM2ck\u002BTtxpVWCAw92pMTX6WxGcYMQZYNEgaU9ojsVcyaevUeQFd2hhR0bj/zw7ytezHpZXYkXT83j4GeWRAMafI/Y1\u002BeNR9OelOx19OWWU6J53uXAzBWth215vCVmGzEJ8QNtGAcz0XSWurickVrYXZzFHHUtWbBqO1CKA4uuOIm7a/PSKTurNg1hKgFdAPYSoV6YoP7L7KdS8uy2ud34\u002BII\u002B4SVXBiRRGdZ3vD\u002BvDSpaZ2I9BYeK749cjzZe5HwveDGPLi/Ay5s6N4cYVDB3o\u002BWyXFJru\u002BL6s/Gl\u002Bob\u002BAiVqSEP\u002BL\u002B8KmZvG8t3wYpte5NtAnJgps7xOhHouGsEUPDVRvhvseYP2t7K2pMkVCkFmVxW7rXWdMISXv5t03H7asraYnqSPYmtHSeTVYx7zOYoox8OraJ6/xH2HVMnogdtD6/ICfGuc1uS6ZFOQt91llHYRXAS7L0on6Nom\u002BA2hXsgJkYcs8M0ui/De8PQ7LwygIbBDxzXWiLyn2pOBZe7XCQWbhyZGSKO48sAT7D5F/LnNhtZdbYeCMwjKdRYpnRYB9/f\u002Br6fmWdkcitR1sqyOYe3Zw\u002B8YiZt\u002BCVQdi9ONn2WqAeQ2V00R5yz9QOKzHHBsTBM4T9k2\u002BW5ccJZD2N4Fjvt\u002By7DISAqQx\u002ByyG0i4yuzTsT\u002BwVU\u002Bccwh16da2zh5e57H3NFDPpAQIp4fsdN4lk7W5YBeeVTm74lioQl4z6fnOYzOWwYacFA07t623r/4qUEYhDW32sJJ4O1IIJ2Gl1M2OHgGqjtIvLVwaYp2L9EJafeIYAtyb17KhHoYkk/yrldLgKYH8j9Fz8eAR7E30/Ecfral/jcHg8kZfCXBcColfbszKm9qwbf4QpBD8iftkrCI/FOZDLAgBDyc7nXZRF/dWsn2BOlB8X0\u002B7bumw5HhK6l1eHOWjHDLEuZyjdMB3v4wZpcd943HBwsWmh80uUCq\u002B8KMpAwsBo5ZKzHDD2Np/Q79tlz6g3QbbjEov/JR1lllh5IQdXqxxF/IhIycBDfnrN0QNsLjsDhOsTXbA0bcB1SYXUeRGUfUC7I88j6nv2o5QRMVAZ\u002BWgheZgcRElsDZLL14A6awFlNVPCsQ5r455vGL4cJzhsX1AdtwN1dDj3TxI8VBL7vDSSq/gAV0RZtZX9rSuPT\u002BpaW3gsGLQB870az2X8L4uLd1iJiX88bAQPxAFpe8cNaAMr5fyay6eAjLg65YviWYYOcjnTAcZrGetwIFCymHf6DWNi1EmK7Ku1BPjHBYp8LW57WwmNOmY4vMgRKqdSzfRAQNQkf4U4g4GOHfzJpBRg9/bmNz1uaNb9Khd9dcYAYjsEgsC2V63lQteH/xxpcxS3sDKwaJa61dQBK1Vtuwm7jbvBwSVTqpxFAPRl5m26k7cCycGTU/WgTajotShYe4fNyHFgp7HzZAmWa2uiUO9qSpeebvFIKDnCIXd4ZvVz6IVwmB38VewFD2W7/OiKAfi9gm6UugiSgaA3noI6dv0QIn7iLbjRafCrmV\u002BM=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EAE22F05\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "a226cf45-1bea-1207-9a0e-766a832b7162",
+        "x-ms-content-crc64": "fcsJP3l8Mxo=",
+        "x-ms-request-id": "68288b4f-501e-009a-7bb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-4a3b3858-ccf8-3a2b-9246-2b1ef3df1d24",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-82709c92483258f202d6c06bffa93e17-86ce82f56171987b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4dbf82fd-45a5-c036-07c5-55affb0397f1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EAD2EF0B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4dbf82fd-45a5-c036-07c5-55affb0397f1",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68288ba9-501e-009a-4cb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "DPWvzRDnSC/dA05FLPsrfrvotg6zE2gJNd0xzt/g\u002BvM2CyRf9FiNB6c\u002BPyBq6glPnA50\u002B9MN6PmNppgztXlP/AhbDiHWy4pjW65nddRInkvT4jHQa/8gKCIr0k3AWVEt7kIXD9voeNCEEaAkpnMkRAhMYNNHfpEJO\u002BX/q/k8owFdOYaRMI5w6mlgTFpe\u002B4KvBo1Fc/l\u002B5W\u002BxDtT16czXR22fx2zskhR623Vp5jE2qz9jT6Vs9y8I3lQW4CK5egGdiQXsvzQWwnN4y5iDFf49emOVkpknak89l\u002BkY1rLywGF0zF0sSesKTI0y8yyXhMhV2Ga/I\u002BdodR\u002B1ridL/uvBhgo3DkmhETB3i0UM9XYjphIgwv1LM5x5DFY\u002BdpvDv06hcG0hYHZ\u002BtMc2R5ihXH\u002BokggVKjvudVNtvQLzY5qVs8z2aoQJAUacog02FesE17DWleOSrpQTs/sZtKJzi1EsoJTMq/H7npHCeYgtt19naeVSHM22AgQ347eJ702jKBa8CXRWNyy\u002B2/dS0DUL5fubsUu9IG6DdZ6PlMc6ca5EH1Bxca3qETG5lEDWZDLPLP677T0C5genOZTWx6Nlg2lIDrDkmXRNsKAZA4wurRFrv2jIfoRxQTlIyjgZE0mOUxDXjVWB65KKbjyc6OJ7eYuCawc6nAXl18x3m888NJxXi698Vh\u002B86dTVPhBH1FlXzVCslqhCU7cL8baICk/DTjmfRV0y/iJsxoIyZV30nQNzIM5\u002Bj530FTf4cWVpNN6FEfDWqI77JM8tQNAmD\u002B1aFlSyFOqBRL6cqjAlOoy9ApKjrVRtHfV0d/v\u002BUU/NzgVJnVoQth/0BMwyOv1e1upCbz09gmKZ7fhfPpzugvNuz9wr25wxrUtyrqiHOuP3FaEQvOERj0uisLBisXiCBYHZw2sgM/pOEMLyytS5ErIVZyj73cYRXT\u002BQiCvrz/vT8KknrXd41\u002BKnwqseH8R36Z3\u002BTElPhye7x2Yrj6vOYkDGHtorkmU6nZBGUxsa8j17GZ6O7IKyhGmBa\u002BURTEc32F9rWAHpTFY4xK\u002B5CTMModUor3YMQHa9FJpxqSd/KVBJDnu7rpo8kc1IVSjT\u002BHs1dMoQ6J3QKpjprUNmeKIvuJtfcPq4UfI67B6oxOpN6hweOzVdbkCyeOTi0QBX1RkrGJ2Nc4iBfSPX1vt/KGatnMMnSD1t0klarPcV1YDx4xcFfatNwHaTnb4ShZhEM1B9NDQ9L43bvkZTMsaQa6ei5fLkeqq6YNtMk6p\u002BWkyxFXmnmKBLtLOKKb9l\u002BY2wAzIWb6ClYLmlwtNZ8JvjXGP5ohxN6NIGVzE/WlDqVWdOnJB3aOusC7W/AdXM8sMYp8xcbFdwYhpgDxduZgVoum1sC1QLa/R3TJdnjef9OWVuJ7OEjukP3Tl2F1jUPaSvVkZoYOduDDvX5B/ACdQzY9WyAD9S5CyEXC0blFSbow/ytzeglNl\u002B/xp3ranJT9NkQ7SCIj1kXHIa4wO5U3jnO0EQzVGdks78MwEl2zeCugxatlGfGYDSjVvEhbHVxauikHFouYKBx7Dmhu47P4E7mCn2Xp0mRyLBPT/22A0dJm5Vg0rFGgGK2O6guZKSlk7Zie2I32YOe0hPpntCiu6jyGB/5rs2dX4nbIWuho2PL6fwHU8glUcIRggCdnOFR04A/fAyEq\u002BSohNuYHPgX/S6v3fUUW2fgzMYd5\u002BzNP8KoiQ3romdXB33Xno8sTXTJ\u002BcTR7b7sfbgYXq8GZoQ324TZL1OqbFrHWJa3PPzYtH\u002BRE\u002B4n\u002BxIDvEuVk0P4EKC5n4LKE13hX41pypUodQC7f6ovtRKWD\u002BCy1XMIFJjXD0f1/V15zqEh7/RgvjC9G0cK2lPZiJuN44\u002BiVz4q2Qr0UrtNMnfjQbDJDYVedVHwNfnsPXpFPUasaBmNl3di9xbpbCt1L\u002BkPZ1ii0LrWb6498mFEPtvQr1U0oIpeFao5phaudMlmesXQ3JXhomzL1jhrj6UV3vh7GLzWAI9esVHuqWqkJ/qk13ebs2IF7wzoaIpR8oYE44dec1wMkHo2citEMvkCZ\u002B59hrhtumtWNSmv7ZgEzP6LqYWjRfRemAc9ZQE2gfwT5gDcFGvNl2lbyD4yXOKh8aVsuElzXyI53y5xcBUqX7Ntm8eXaLhS/hJcB322bDtkW3ObygmyoEce4nU9XGcUcaiKxMDayojs2bo21xekQ7LyzNShTlWpuvuAuIZDFaHrB9XVK2d6iVDqrvBPe4kvul7CCk9SsuMTIQnFWlICqYQYS89Bj1hLuEOD9t\u002BlWn8yUT4nQQsSWJUyggodtW8\u002Bp8VsNu/57esGtpILzrvDrYbKkslUGyi5BjM6Tw1ObgLUhU7aOSOPeGNTIMp5BknZLxRDEuJlqozcszC8v56duAhPN0ltKXSjOxpmAPoeP/\u002BpIR/5CxsgrtrCPYYy0rjEtWjCKc8ArAWf4BfH/6mSvnMxE15\u002B5K0tboiuquvucCihoYuRXBXwqLUaGWrDWK9xL38Swf8aRZD7lPtGkgEZ8W/vJl4eASJdAGrpZItCKdXZfXtsm24pRxv6lcdaqdZ0ACf7FDJREy5c9YFUcSEFeWrlbVSFrVXBhd8CY2tawpaUdSRjhxWjiCpND\u002BWslRY6tVycdTyBrlLR\u002BU5TDu\u002BCwfMq//v8ofIVAeVqeF2wFPDJB63O/k2Z0obRkY3HUHk6ik3ygdUaPhOqR3MXV3Y1YeRdigdBtANlkQ="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-646cab4a-d76c-5915-c353-ce0a0a0684c6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c6fa3e834dec3567bacf7d69368664e0-42b73748095be2fe-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "016d1018-236b-19bd-f06f-5b461a226d2c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EAD649DF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "016d1018-236b-19bd-f06f-5b461a226d2c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68288c6b-501e-009a-7fb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "tNSsQJA2xrC\u002Btz72TG68JmmR3GkJ7UJwv6anGMfjWSo0wqCTSw0Z5gasniCXkUQHbPedPjAsOseSPIHpj63p214UwYrOKNtcePZiXU8h2S5in6zPRhv5B4jZAQ6LL1dZw8PCg8\u002B6OUQcQcU6yt13cGJTh\u002B8BGZRDGrkB9CbM0EmeCZmLX1ZeqGVnswVVvj2qYZCsN6dnV6kufmgVuEQdUHB7m8BD6xEM9d6JmWWO7Vx8V5OVH5ihN7HwXODtSPAgSmOV2SJ8Z3V/n0LI3b5DoJEMmWGxhzDX2mQOU48xHqzuaU4C\u002BRM5/\u002B8eFoBW2FrzrLxO4a\u002BOb8Izvf\u002B9bRPmToGV2nRvQaZ90plxk3GwgQEKG6bS4jz9YPmMzjwUe5HcN8j\u002BwP7lhGsW0Q8VHdxRgzz\u002Bs1JsE2tEmHl643JpaVYHlFuoscACJJc7uxAs50IdOkv/Fcg/byNcuSiEaqD4rGi5DoiAqNF8/I67MVhbF7E2XagnaVONyCQ3TPeXfbn2Qg\u002Boc9m6nJJ5gxk5gz7LAaF3Tg340UIUK0VjSVza5H7UxO5IsqTXfMAVruY6U0Tma0pVIC\u002Bs/XHMk0eTVlM2np\u002BaZb5Qgk/9n9FN4iNc2tcAfd0RhMNPKMd9fB5cQyVs3w9Gn\u002B6Fluj7WIFdXhtOcLlwk9l2JBrbSzz30wYwoFus4AITFTroeuf0FixB8cmrLgxk7LBL9rv0a1SxjsLiyrcmsX4YOlp/hxjygQ3umVlzS6T6y7SqYOlHHqrmN\u002BwkEkt0G0BLk/Ox5WSYWXWuBtH6PkIe6P8Ce1GU0BuwmFArzm/BeX4ZKLiwSOZQEgZ0mRjZ7PiqBSlMcp/utsLYAUwUbIsG7I1S4BaJbaAZsmlKIDcD1qxXgchFdQfeKnH12EaZPKV7bq2KhgviIJiJMsA2pJaK1CqfvOvDwHaGdLWklJVZgHbDz7KKeFCgdWAvu0JGqIbbagQc\u002BYC6t602BBJWPYwCMLJKctTjAFva/0aLkwQzP8svyCmRPYb2CBcEU3Q\u002BSjfTLYuQ/DWx\u002BGqoQfo5LySoA8VGJnVicfMsVGm93qznnLQOt2Z5o0KWfdC/6PuMvNnzXFCv9yPCcbuXZKjL9Bm9waVFKni9L2CCr6iko4n3n5eQyYJbOKSQS0aq4T\u002BZyom3ASZWRpFhNSzwLEd6Hs4yoMQROyqWYokAtd8yE04g6OUf7aFioVkGL5RVawtcFS14eEF6iI9fIJ\u002BdVZGyLyLez0NiWzAsz/5rCgyVQfZ9o5\u002BxuZoMpV9Wv80BxEzHU/9xd5vI\u002Brr9S6lDD36Cyd6oILLyAXWI0SnjDJtiKwqyo7YMI8lbtanltG7wyZbh0/buWKSa1FKK6aVx5O4emh\u002BekWvHdqUVTWsIDUwGlweTATmldNNmF85jgToj6tC7xhlPUjgqGlxR2Qs5kccFhFKe3uO0eSVMOHmcY/Rr8WOaTUYztkXOaObcVJvHLIYHXv3ohQvtBk3zAxm/jbdo5ueon0OB0s0Mz3X82CWKhAzylQX2gmxXrUf4P7MrDtsvdG2zH41DhYsw27WW8S0oaX4NzfiycWN6UfH7iJMZ4cCazGS31mV\u002Brg95xqe3wLwZ0NY1HUHifAIKOM6bSP34F/r0/CTJcZIZjh/oOKq8w5A14bi95MN/t09hrJ2X42YSga\u002BswsSXUF9DG48i\u002BkRXTnQ9ZmdFOzM3dEXUaMT0gqu41rf7DwHMnZFYecgzXbwLCV4oWn3/zEZ8dU1/w\u002BeaTpnjaSSMXD5zcMjV7MFqAxeIyF9lzCguuQlxf5qzTdmpvisuT/OYf6wgtem0Kd\u002BEEXI29vuINYJxta8aG92kwCLuLC6WPLMj70iyRRY\u002BeZAp7G0nfVfeIYiovZpEfmTPe/THxvyx7tW\u002BEgey1fBrMjwf8C5vfEPLDwql7X8Z33Dk4skhdrKTeP2YaWpPLEyYPYpdJY41YP\u002Bx/LbyDAFVpTOWzfImSbyJi3cx1hPYe\u002BO\u002BDLD1u7nir4LKcHr8oWz8Q8Q2uF9ZcvPN05kWA4rr2YDTM/9RYOl5tB1wXNlBjekLNJNPocODZJq8J\u002Bcfy6v43pb5KG1sq\u002BLavARB6RYajEawCs72nDe9T89llTkBWehxd31CR2R8n4mwdOS/QnqEoZuhb8HcAUFfPNmeBxWp2GMbz3GY10TiM2tFRShS/g1U4fOeYOonlHY84wuL3ZdzB5uBo3II68lWvztVl7sZDT7MSiYiCnh59Dv7W/Q5VlbT0T6M0FqaS/UpR6Gu0fy7ItbNvpNxUfwjCK83DY/VHWjlgcZ9jTzjMf4w\u002BcPXyiI\u002BQDkebJjDYn9BaMerYj1lUyo5yE82PZWZ6Y2UQFg5TD2M\u002Bc1Wt7HQIh9HPCR0N87Ay6WYngLTCAKjhIIKLiEnBxyKH2lwD5x5aaYw7wFwJbK\u002B03Wyoa47ufHKsjIvxfP\u002BHzQI6hhlULsIHzRbohkBM1/PTFqrdGZuTmZ4plxqSqOyMs/NaDqaWIO5qoJ53xbYyX/TX3iYUqrOmZuy7alfndSRqXBJM8okNfTX8cnk9W5PoN3dl\u002BorGd8k/86f6GvaWgyt6DaljpW0riqEwWDg6aQtYk3MggbqZY\u002BQJDT8hU2I/Ze9Nww3qRFIKOjAp1h/QxUpcYUeDdgGwoKmFWlguCnd\u002B8TII7KX9bk7g1kdKb03EeEf0hPHau\u002B/tnSKkZSn53C/46uUth9iknzM4op\u002B6JnEbwSIQOYVFZHUCWw="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-b048770b-6b12-1a2f-bd3c-8271332464df",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5ad37a18c6bba7b306cae8901024e540-19f1997f0aa07645-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea971700-9696-0a86-d1ba-d557dd11badb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EAD84569\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "ea971700-9696-0a86-d1ba-d557dd11badb",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68288d0a-501e-009a-14b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Pg1kJZSc6V5GEqNawbxAl/uHZUHO2sUijx6niqnNGr\u002BtsiSEGKdO7ZWJUrLLqseDpn4aCm/InmNIQpV19V\u002B1effjrA6Yu35TOHerRIgSVuVWI\u002BQqsg9Q5RTAO9YR2fg21Nm65/256\u002BoAx9L3HFnbNeuvHtF6isbok8f513\u002BoQV5\u002BdW\u002BvV27onTj5Kus9WMi65QbqYromu0oS0lM1vxNqV4VzeKbqK958xoGZgV/bqzr\u002BP/J5vd\u002BkWLolnIUas90lj9NmyeAi0LknbZs4jTrqNiYZNoAg8JmlzyDsxI9YYhOkdPGMdeJa3G44UU9Da8uAOmVeAXxcBJ45wPm/NQsqzwuHlBhIXsFEvloS6J5JYWRVbIop\u002BWCXSHBSU7Tom6djDYJEvNeyN9ujGkMhShsA716VasmAAdWr70un9QsNWyOzr9scBaWNojSvhd8cdf5VUmNWUzDd4gysmcyLC0HQlr4gbppA5Oq4B8iU0Xz2jnlNUqOntgjy1c3Pb2zYAZfy3\u002B4h/AdjFG55nUxnSRCPtgpTPbieKOC2LZnNcXR94AUxofKN1JJy6T01Lhm8ioy8P7lhhcTeVLcNa85ulaP6\u002B7xGNqceAeF44FN6afnH\u002BqMMETG6HFtBUk07gGnDBFOaOjJcdVTlnj3Y6KRwZOq9RnErYYRxP99hBONZ4oF3tNwA4C7Ga4ROJ3L04TO30e5ifjn4mKLPKPpT\u002BnFxi7u7YDTHcIS89tvt3DoRfV6rqjP09mRIfxs6MLczc3AS3Zu3OID/72FqpoddC7xovaucp1A\u002BfJVXc\u002BEYjT/MiINr2v\u002BeWkXdq7rRilDd6nRf0XMLlssg1GAGYMSf52EhnR0E8jC8yWJmv/uVbPJEeoltuLvLwfK3SgWemPqAPcRYr\u002Bwz2PdDogcQpdfPimhuwuY7Mi6mVtwrTagrHjFo5oE3PLwFEKGRKRW0uxsa57\u002BcL9YURQuVslkQCItPGITWqL9WmE6sabFEqQgZ8ZrAEGXoju5aU6B1ooli9QgWQhGR3RJcxE9x8MYlz5sDfMC/T/clZ4mVe1Qe4PbESXSoLmb2hxSIZEwWdp0oNYMFciXIo6UQ8NuI/GG9PuNYrKZRfKE0DPWsNuurD/DrbEbRGW7Q/KbOmD2LboqzyiZovcr31rni0GYwHGy6ZOHqnI8b7CR1iLAAg\u002BNjqZ1q\u002BWvFQlIl9JWM7kgIoN85FDNcoNL6l94B8zUa9lPVfibIxiMA9SKPxKf6jv3cbejQxm6wBwjKb2GNxE8dC/1Ct3AiP9m8OB8RzdsrAAngJYZMSjDkJXYe/VbBczHScrmpt9eNui0OE41Pnzktn25YrZ/J0MHNXZL5A0GC\u002BsXuPlsigUgxU2pYPjailYY88V7oacaSCaH33FpFk7bsixjIYGDeCh4mJlo0cJGKKsgLvBLjmpH/XDS5KqXu7L\u002B0bLId2jQlXuZAwkNrXZkPbLGSOdajCfGHyAQsJN94NzmafwTfbFCT5l4so9hOk/6bqb3zW7PoEWPBlhEv\u002BTkGx4oJ0N6VMABh/lJ4dmYYOTUGkXsihduGsm6hHdY\u002BY\u002B0kJdtORcIgBXm9kl1gb5r8qF3cKWi\u002B5EKugh5w8xIpIptlVFGKyvNy5osCZPJ\u002BJkLTpHV4YjmFZkCZoMKjrxFmk2/B\u002BhtJct5paUPcvIBPL1vbnE\u002BdscBh4O4Q8CowzjZ5m9CCvSsnijGWDvj2qKnASnBmyBLCyOKvYBotOIK0OJoNYyCvzHIwtBIeB6LIazdET6a5yQYjt9Lt010Q\u002BlGv4dVd6UWJEX3\u002BNhMAo8FA5/Tj6ejb\u002B26U6axNwfkVILrAbybMaoHyuj4pu5PyIxMRrexoLBFo0\u002BZnyQCYPE\u002BD6BZZQDSbdHxy8S6qsj/bocWZPBQNrfOoV5tAZaCBWX7vpdJ9mOPedjlv9TviviCmiyc6/wA7djsjseiZWw7c8Jevuw1tXQjiusXanbe3xZh6mdl4R1p\u002Bsy6XWuf6RRsqkwSkMwMTOC0fV0Q6YNmDa\u002BtPHsE1Y6g9MQfe1gMh6HSqsAqzEpKVZ2CrWfAVRFNVE\u002B78qidZ9S9bZwH8NWIq/W7Qj7DO0FhYurdgiQq4J\u002ByziMIUJD1NULrbWKuRmTH\u002BgVuBRbWjh0OVpPBw\u002BWsloz8VSKyfFdkxgj718nitxyCFYgiuNuI3EAF/foBN3VdPtbVsfFGFXmuCUMJ2rZTL6N3P6pdjd2xc3TeqH5dZ46TnpjzCQUvP/wOdLOUfwWNttJWifvK/6z5ID54Z2z7UKW0ejwZXCKeS/\u002BuUxkqHPRvTPWsBtmWxKLr9ejGstSTFyQJ3ATJcFazuEH4HKyX0wNKCRZ3T0nIIbGZLWY115UnGzv1HDzvpdye\u002BEqXmqfyVCbpfKXCG8vaQb5TLELwfeCo1QFworLGWmc52FL/MIcJqtk/TFbzZQNwGt5\u002BmHmZrnpp7sWmfbV0JyZChEN02w03SYFpsTGJuWwCAIfQR73poCnUlUXBZyknxyUwsODD\u002B0PRR1L0L/lI3DVVoH0tp99kVOAVnEXLdeJYRe4IWQSPQgVEAvxq9XAwj7UQb8Kv9iNJyFv8ql7\u002BBdFsm\u002BoPPIcsxmJ36aTi\u002BWNz5QyMuwofrE/OwoyskpeqSfkq\u002BlmGIU8x46VgNAx6ZtL4jMVObU7LUO\u002BeQH36fDfOzZ\u002Bru/8F6cPBWtdgv3hDUF\u002B9tAXOW9iuY6lp6\u002BDRO2NtkWZs0q7T8qMFjRZ7ZpF3XvAg="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-cae2ee9c-d497-802c-22e1-87a5fe212f8c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-96aca0247390a212e6410a3a02be49f7-9d9fb0260074f679-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0346272e-828b-f395-25fc-eccd5947e618",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EADB2B27\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0346272e-828b-f395-25fc-eccd5947e618",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68288df3-501e-009a-69b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "jjIMfxxxv1UUZwB4vAjc/cqEdJ9rOnBYsjOxjL5G/aM8K7\u002BlzuU8KnVVn5WoSac9wdva2GIcnFTCtM3pwDKWzmlcO5BINy7lR0oqFpvbsGmMdMviayRAH49r4xoXU2lCvtArSw0W9Iqt9JEY8oa45gNkXUxms2NFGxwB3VMUzfTg6FfKr2RbdX9BNXeTKC0JsvwWs/Yd2wpt5i/wFRY2mCacNwku7jefCOfMJX7rsfPu\u002BCtW/Rr\u002BwgxNXcg0amBoCpxQ9vAj2sTFd6oOUbaMgTQ8Ah3r4JsMnXX94ZBuap2GYxrhm7sDyx1mkYVv73FVwNuU\u002BGhDfCoBQ1l7JvkzVg0Nh\u002B2cq\u002BV5OTb/hU4VnK0DpyC02nE0Q\u002Bbv4Fdhh6UjMzp4YmiDuRX1Gr8yQ/fb66ard37Yfnyc2EMHrMqNF7GR3FIUnDpFgO0Lvr\u002BxAgDuE/SxthAmSrS93IkkfA1KaAMOoGelx05sZfaQzb\u002B96tVDGJjW3GGgapGdVsCwIQTgwFa8o2KZSUylRVAZlX30APK04WN0dIuhbTXVCHCOu0TysA1oAEZzqc9MMJcQhtUUqFXO/ECgbEzLGjYsxEDbF4kMJ\u002BVvjP\u002BrQDeUJ0P0keZgwV8awL8EUkPAneYQRuWOcRkNBF/vpBxWIrsIDEQJ14hPywLhwFfKB9Whr\u002B4Zm/lRBbYp5o2GcRxDxJ0D\u002B0X/t8ZdwXrirbDCQ/yKTfUtPIfBtwaN3/D7yFrmnfu5xwuPovcovNl/blgGZ6OQ/CMnFYgVQkQ/ctfVYfgg/A\u002B0CHvx\u002B6v9BYCtQkiuh3hNa8s2v4hzo4THTy8fU1rhXnJIUV4nnwF4KRAHaP/8kepfh/Ys6T2HQWT2Kat73bEmzOPVZTYZJszKvpV4azuFy75FwMxjtHU0wQ/5MHVW/Exe4ZscJiu0RWEqYiqoD9UpcV7sNh3lwhdtoKQmIPVWdMFJGYmfaaSSkHpqOVJKjLI50L4WacYueR\u002BDroWHjSVr0\u002B1oXvVMiQi5WqWieojFIhTy7E83Pwv7Gp9qHLofCwNV/2Zk4i287Ue2XA4gjP6XvotxlaDVNJPibURW4W1Omk6iTHsiYEDmNf8IgOL82o2g0l4urnVif8rSgnXpZgvaZ8LAfj\u002BDdF1Lil\u002BhzLOw5ZK3tQ8OH\u002BvYP82xUN3L/c/zLhkgPFxNHV0A4yMWwbIXIZ3iMbD8y0jX5z9y0iR/f42QrZ6akKk2aZexDjzHwn4amS5A6Mse9mPQSFUc20s5gWOWhRMUfJD0rMgZS7wMECTBWDj2P5fBcbc6yUhTGY5Md43YMDxqBR2dTDwDBaumxDgwW4MTQkHM1BRc2rJIoJI6zNMvM9/oVlMaWPNavmsMkwUPI74KOTVLDFwoDipqVKupyDnXd5BYSAQw\u002BOlOcRWoUEetOH3UL5Oe5CeCv0gosARHsPUyNBx0t9u52kBL/JpGf77jvBsu1ZmlOJJo1oi8B0jlB8AgdRsqOIGiGlRSU\u002BeNPECJRPPoGdtcjfuJC\u002BBS/dP4ZfXZJgmiuYSajLtFUuWq25lIMsJU/e3lw\u002BgfoCygTx2AWe3ytBU25otvTowgFjoW3zBHCsoQpGgH9GIhgxhX\u002BT2dxPn4uCeDEUs35a5hxa2uCcH7WURTcLWE6sCzFGNzF1VPglJBHiYJw/h\u002B2b66pi61c3pWW5/4SlNDc85m0P3oxM5ZEUJbbeqb8pZM1Jf3ykOR/aHpHLy1Vzj\u002B/atXovL7lRTwYJXsWgaPu2kJq3W8TKiK1dNb/6gRo7kKXG8/Q0\u002BkUD\u002BCBmmupKObWWBSrKvCQrECzcwfoJZs3r3b4v2WT3gZZVo2OUU\u002B3DEvv6VHv/cORxq9PXaChLCoFSis08GmBAnoOUdRiwhsw/Cb7\u002BDwJR/FzZri2RICl\u002BCpjSMdkQlvibubX4avvbsSUXmF55TQuPAI5wUmwyv35qFmp/3kTzHnK2YlVMWZFRDf0IeYfLBL2dUzFKoDSMaPpHnkSRW\u002BLQJHnrsuq2Mqb9H1R/KjXmnxG80nsTqH4\u002BOglbBMtcz6IKOFUd31HS1yCKTZDQDT60YP8i1IlnvHwLrXjhWz3roE\u002ByZOHg2L/P2gtamWrdXizKlqPMOfsYonvpEjHY8Yvinq1RHahM04hPUwp\u002BDRMRLl9cFrSaL3ZUmcJ2B8aN9uh/eAq9jECEfcMbjNbwmqVYx\u002BPSfNrHWH83DHPV1tvBsVwSDpUYU6IO15jxjqKfY/8dHT/Sq4oNuB\u002BLho/Mrpb3ScuK3pwQQHRB06Uxxcncl6iEyMmb/xXSBEZ1jN0SQijyCjTXFIVTDNzLkNfUy\u002BJVvu7nN\u002BXdW1q1qMpVmrOnL4F8T8uU9YMTIbv80G49/ThUL83uOwpDJK7qIWu7DWIZJGFWWIwWwMlrxBYp0Hr8h7uB8XrluPR3ORscqtQnWBRJ07v815S8PW8Egmb0GUQz/ZmwKQv3M2ts7y9xChXlNGvx7/zO/6AW1cQb0TaNcy/G6L06dz8YUqBAj/h1SzNJL04K8jlXZP35qVM321Ik72wPqhFous086Y1cjm\u002BnkZqAwrH4goDmf4O/MN3r0IdOG6CcZZER4HRwzhi8CtaOUge4twigPGzbGTqdqXn/UQkGDmLPGywJbuJNd7R4OnStIO7GIyl\u002Bre9DsVxWhDb6gX0Ppfxzzzbbv0gmUrSoYu7F4IiLKS3vh1CDi2nfouq7QvY3aIR4OWGn\u002BnPhWEsqm05tkKO\u002Bf1hPI="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-7c1365c2-6d96-de11-7c52-a73055a3269e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c24a963dc6d28f0f74fe2e8ebd60ac0b-6bc9d4ff18934bc5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b6295374-b6cb-ce50-b04a-aed11ae78e29",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EADD26B0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "b6295374-b6cb-ce50-b04a-aed11ae78e29",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68288e92-501e-009a-80b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Aum/BD3PwMbXsfznD6Wl23JtM\u002Bqg4/FVjwG2ISNwzTnehIZdw5Hdr\u002Bd3PdO2wqVBNC7IecKaUh74aXQ7GJ\u002BiZ\u002BTCCIofRxfgj4MDKKUens1bdez1p1N3RDJnZFocoZZH1dbu9LkaIuwW6Ok/lip52sun4KOyrL\u002BQS8NYt\u002BO9w\u002B7svFLOL6oTQVL/3r5pOK4I7oqPdcHzlCgWXan2wmsJWST7UtnXqqsglJ5Qss0BJxIUUMhZLk4s\u002BScqt9EAHH/n9oWabuXVMETebuAiouFaFTaW4nGisCrWz1mxrPLZIHgfabxIZ7ktPx\u002BEer9tCVZG0KKaajkNRUVaw56LI4RRBE5oAzkkEq59aaNRHTZraMUDa9xQP7Y\u002BEiR37aMaoRubM3VxBAYdIb3zHAGWvCcP71rZiLenAcWYKvAUrSQLY8eHtenA\u002BWS/5UkeXCK0p1X8Z/1IQBhj9DKw2doVCHOZ6Lk5DgY\u002BTvb2GqNtiKSi44KbGEUmwiKuJMG3ECCJqdzWhXRpe5lPvhkHUiZ19WuNDfZXeu8uciaWi\u002BpFhj3VbHDGlwIvOWjpS1osHm/8OC5VKQMpMS/sqBNO0\u002B\u002BuCjfbMeW1rl1pXdSObi6VAVO2mlK871w6rDpB2e/u4WV4O0EiUOyKRonQ7Msum8MAV6bAlzmc8RrboYWqc9VuenxuFTLtcrFmLFPI6wOQCxB2QYJJLkks20knR65n39K0YnFPwIaRE\u002BX0WWvl0wUWSpZ1MzJSJEsyQTnpxSoD/0yBFImSQUuK5S6dVdXdRwdDEP0Y8aygYj4lHH5Mp0268VofZL98hAlL600Etc52VfoxprUt6g2g4bJLbCTMPT7h4mR7vuJIxozzzQZem6xvr8eDGwGXjQZMf4MNMBjkfq0PI9Jq\u002B5YY6d8pOR0HQUUF3LxcSCI8SVVdLj9fOpZ0Dk5YTnjZBLMwazEiblPoRD0\u002BCFRbhzWL0tl9DcxXuK5JtSrPrvLMK9gILN3wGtoBdOkBITJBGYcYzHyeW/fn2bKD2bkpGZZKcdx8UltYm7f/fJjiVpd8B5yjtuF2Ls/gIVMrbUEh11pTt69VxcYrwDHEn99eBIIaBtEdhWO000MMmzAILS123qQ9j5/nJkHVePWvso7wghzQEGZwA1L3n\u002BNsSSqWIpMETsA6IXXjM\u002BCPSA1uBCG0HBkTOB3HBtpSRu\u002B7et0XPlVhq2PNtmCm7NyF4LtEiJrBuCwRgul2PUjm59qFKLgDeAm3DFi95mW4bExAQSUfDr1V\u002BsKwBrxs624b58\u002BGIcQkgWixjXxBA9HHWBWdNvsixtkdMC31U3FNSyHqov6VMkuIG7\u002B9boBBE/bw6K2mzrRy\u002BSD2afCWLi72Y0FbV2HSMSbJFRo8ZFhY2xw2BGrDp3xseKjen8hb8e2Qxwo/5ryVHreH3LmaNpXIno3TXynDMrzF7t649JFdbiMtq5xOGfVgoeazPMrC0kETFQE7h5HDzZRNeffd3CklKW2WbIr4eYSXc75DEPXyAhydpd6QIueRat4HAZ/\u002BgsS8jRNcLGW3Gpx8oxPTf7yfW3faQDZKlQaFBAKs8HjlmfH6hoLildW35otCE37UvuohaKYnI0GOcfgM1ydjCikjlgoh2fg6vMWhI1qrCIGIsUYXi4fSvnavaxSJ1b6uU9thHnx0suXy56vghf/n4ml3hCXhTH\u002BiUdiUcW3ksOcH889/SekEE/5gJaTb8Th2yImrElCYzAdbv8yj4EB4DTbE2JEwZ5h/cnAmgCfbxl\u002BgHqnjOJ6WbyfII4odYTO\u002B6BdtFxmmRmDwK6DgcUvggPhtA8KXlNWYLWlqZ0QOYhE9aJgPba5G\u002BddI8wz9tv3b6KKRr11xJlNC1emwPN4c4smPogmz0BJJJgnqT6HImnZrj3\u002BhfLKzzEFFzZjFlb35LBBDbhPzKBeQSIlUhtexejpzRK1eemYW29bIbQN6hJFL8CKRhCxieGZoETMpXkVpk1NdUVEQmrGqLJI9K7oUFsP3CJa0IPUOEMxG9mky7XyRXtmvHDI/OlVx51eZJUysU/twMVavtHNdT0GFyqRIdz8Vq83gZPmQuM1AQzmedeqAmaJtwbsm4qlmUc3xunCxKG8Xg3p/y\u002B4B4HmIbnA6v9lXBDAB2rWE78kjehIsn/1djhvJhvJvAc60bOFCnnM4K5LzmbU/sE25k5SxW1Hb1UF7Kt9VcDjn5wNiTW7UQVBV606AOAVIHd7ND/JevqV82Jafx3OT4rtZDLKx3WLe5VJDXG8CW5w8Mw0Ah2BFiSle5XXXNHrcwQiTJitTlj987yqgGmI1enz6Y5Nmk1taE4OIU/jtBrDXZppnbjRw6JzNhJg2pW7GKGr43dDmdi6tORKoykJHjuh5ybTHzgtHiXv2mA7CI24VwiuN9Cjg8O9sujUiyB5ZhfWwvNu5/lpfsVRV790g6xakkwcXupq/mdjEWxPWJcBcnBMYEWaSW8PQLUPUigESTM8ffjUWQspb8SID9aNGiYuU\u002BFLKB9mvETdERo1X6w/Xsg9Et6eLRlpIvSBEjmYgiqS3P5GuR0T1cGz90vs9AwUTLEKTAdLkCLL4gkm4a4LRI7zooKt9KWvKTkY6jXNfCrkaMGIjjYnS0jfetsT6PATqLK4/VGNalgPXyLKLqXs/mHeQnjogrZYyFs10nnOmzxFCUGHEILVVwJpfS8TWRii8nx1Map7JyX4YDD6W5veQMfigSVkZenfCOt6gwGI="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce/test-blob-1c6defef-b923-362f-4ac8-8d30e4891c9c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5d85cfff1a3d3c94ff58f5647b646bcb-465d88f24227c666-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0659f0c5-301e-7a4c-24c7-dbe6be95dd7a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EAE22F05\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0659f0c5-301e-7a4c-24c7-dbe6be95dd7a",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68288f33-501e-009a-17b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "0VzQpLj/VVllc3iG4qwUd7/Zos4azDX9z6IlpoovwCkJHEavbfEu\u002BDvXky3Q0jbNY0p7BP3yRwUn0tUV2a/ONbJOfcZlZAnOq6qTQjgILP1rV0I/tLwrFtRAiJsbGB6LCF16gVRwZ/5BrFhTXgTMH6XYqoJsj4D2I2byJdxuspOMBznbjaqo\u002B\u002B9E/ghj2LjQdGn1Q26cH3nchF7tfUIh0/rFxlbK8ZH6L66SJ5B4kkquIrFzeG8l8OjA/ghMun2tIisNnhFhBYLX\u002BhO/CffoY/ETP1uRrlqKn9ZuCvKIrnQx5QVlavM5TBwum31bZebw15oWOHshG3TQgv468/qPTkuejSTyg/n\u002B2vI/YxPcLznwfjNXcXb4D8qQlOf0/lkhnkwxvNjC/VOhGF2J4rdg9FPESnXHN9zVpn5aYe8RCdyZHcTGqnNhLoDftlkYby0SL6CUMLPjWWZwXBZZaJtkkA\u002BB8MXzmkngYhz06IGDvDZRRzFOfNkptcNdVU5cCMXkeyVJl39oHpVWs82W73Hk7KDfCCBpFRM2VzoBlUX7g1pWEG1cOSS26Smc98gLksZReWitfP\u002BlemUREz9EZolQWzByQN8EiLN7KB/3zR1LKsV0rxzcTQZasJUHSybkcoKfTJyYmFHmTfC1MlPgrq1Ixuh6z7Ztcw4pGI9J/D2Ml7acV4CBspFzjWIrJhuzeQLnv4Q\u002BaqLLMtiNb4DCnFCzKJudRFYtxhNWBkFUQk3ydp6NYj24TiwU0CWn80MRsfERd/2AFTWruvhx52RgdvCLm/nhNToS\u002B9puiXMxhdPQRFVQQ8pPcmBo4adFR2fIs1o1G1hKL3u2/nwjEYzCejUkoKIOEDMlPCiYeVOSzbNzptUZ\u002B2l6hRXZmkRNLGDTpmdyIKbEuaMmD98wsbYoIzHIr2u2qX7LqRqNNXXu2A/HxNLsIK0Nruwy8uyJStRfsXYThHz0Hf3pp3aLN4QtNzfQaO3jOwOEuwB/g7aSQV9GLoT/21OS0qfVA3k2gXdoBbq1ueLne3Vzj8h7dZlGV2UXRAn/LlzjPZVFDjiKTTqJFn773Ih8X7IOi0yKFl0NjqwTHzxuaNde0XtNoWw96EGO8l4bSnrcm\u002BVW8aIQWSY4OH\u002BLdi79Gq6nnQsML75F0aIK\u002ByT\u002B8kMyN4RXF3c0TndVFGntsXITkdewc6xuz2smEB//BV0COkU7WT\u002BppQM2ck\u002BTtxpVWCAw92pMTX6WxGcYMQZYNEgaU9ojsVcyaevUeQFd2hhR0bj/zw7ytezHpZXYkXT83j4GeWRAMafI/Y1\u002BeNR9OelOx19OWWU6J53uXAzBWth215vCVmGzEJ8QNtGAcz0XSWurickVrYXZzFHHUtWbBqO1CKA4uuOIm7a/PSKTurNg1hKgFdAPYSoV6YoP7L7KdS8uy2ud34\u002BII\u002B4SVXBiRRGdZ3vD\u002BvDSpaZ2I9BYeK749cjzZe5HwveDGPLi/Ay5s6N4cYVDB3o\u002BWyXFJru\u002BL6s/Gl\u002Bob\u002BAiVqSEP\u002BL\u002B8KmZvG8t3wYpte5NtAnJgps7xOhHouGsEUPDVRvhvseYP2t7K2pMkVCkFmVxW7rXWdMISXv5t03H7asraYnqSPYmtHSeTVYx7zOYoox8OraJ6/xH2HVMnogdtD6/ICfGuc1uS6ZFOQt91llHYRXAS7L0on6Nom\u002BA2hXsgJkYcs8M0ui/De8PQ7LwygIbBDxzXWiLyn2pOBZe7XCQWbhyZGSKO48sAT7D5F/LnNhtZdbYeCMwjKdRYpnRYB9/f\u002Br6fmWdkcitR1sqyOYe3Zw\u002B8YiZt\u002BCVQdi9ONn2WqAeQ2V00R5yz9QOKzHHBsTBM4T9k2\u002BW5ccJZD2N4Fjvt\u002By7DISAqQx\u002ByyG0i4yuzTsT\u002BwVU\u002Bccwh16da2zh5e57H3NFDPpAQIp4fsdN4lk7W5YBeeVTm74lioQl4z6fnOYzOWwYacFA07t623r/4qUEYhDW32sJJ4O1IIJ2Gl1M2OHgGqjtIvLVwaYp2L9EJafeIYAtyb17KhHoYkk/yrldLgKYH8j9Fz8eAR7E30/Ecfral/jcHg8kZfCXBcColfbszKm9qwbf4QpBD8iftkrCI/FOZDLAgBDyc7nXZRF/dWsn2BOlB8X0\u002B7bumw5HhK6l1eHOWjHDLEuZyjdMB3v4wZpcd943HBwsWmh80uUCq\u002B8KMpAwsBo5ZKzHDD2Np/Q79tlz6g3QbbjEov/JR1lllh5IQdXqxxF/IhIycBDfnrN0QNsLjsDhOsTXbA0bcB1SYXUeRGUfUC7I88j6nv2o5QRMVAZ\u002BWgheZgcRElsDZLL14A6awFlNVPCsQ5r455vGL4cJzhsX1AdtwN1dDj3TxI8VBL7vDSSq/gAV0RZtZX9rSuPT\u002BpaW3gsGLQB870az2X8L4uLd1iJiX88bAQPxAFpe8cNaAMr5fyay6eAjLg65YviWYYOcjnTAcZrGetwIFCymHf6DWNi1EmK7Ku1BPjHBYp8LW57WwmNOmY4vMgRKqdSzfRAQNQkf4U4g4GOHfzJpBRg9/bmNz1uaNb9Khd9dcYAYjsEgsC2V63lQteH/xxpcxS3sDKwaJa61dQBK1Vtuwm7jbvBwSVTqpxFAPRl5m26k7cCycGTU/WgTajotShYe4fNyHFgp7HzZAmWa2uiUO9qSpeebvFIKDnCIXd4ZvVz6IVwmB38VewFD2W7/OiKAfi9gm6UugiSgaA3noI6dv0QIn7iLbjRafCrmV\u002BM="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-f641c558-0362-0680-7200-d3534ee3edce?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-686c92eecf68710ce40c1ba733c787aa-07785a21e20c7622-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "290c8f15-888d-920a-72d5-3a77de6b022c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "290c8f15-888d-920a-72d5-3a77de6b022c",
+        "x-ms-request-id": "68288f64-501e-009a-44b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "355157356",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,2048,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToAppendBlob_SmallMultiple(6,2048,30)Async.json
@@ -1,0 +1,733 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-0549f83cf74a0fa3c1042334e4d1f588-4fe27df711ca613d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8f180558-c0a7-ec1b-37ab-3006878f1eb7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4BB9321\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8f180558-c0a7-ec1b-37ab-3006878f1eb7",
+        "x-ms-request-id": "993dcab6-d01e-0002-0eb0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-0824f8d5-e5d0-52a3-6806-0f3087b768b5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-b559d29f8411b06aad2c172c267b1d2d-2021707182bf8e8d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "01ed1c20-0d99-3773-c2a4-e7d0c758c937",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4CC194F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "01ed1c20-0d99-3773-c2a4-e7d0c758c937",
+        "x-ms-request-id": "993dcafe-d01e-0002-51b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-73710fb5-94c2-2d9a-1d90-fd55012dca8b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-0039a93b85965e128745c4bc2a3a2f54-eca9aff1d5f04fa3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "13c88a35-512a-69e8-25b8-da10c10fe645",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4CD2A9B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "13c88a35-512a-69e8-25b8-da10c10fe645",
+        "x-ms-request-id": "16e8f376-e01e-007b-6ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-09d655cd-858d-734e-62c5-26a0b1eb647f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-3498960d8b6e16310849c9cfe97f4819-8a15afa4753c8cef-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3d9b7631-b590-f30c-7517-92d97330e1b2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4CED80C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3d9b7631-b590-f30c-7517-92d97330e1b2",
+        "x-ms-request-id": "146c2c80-a01e-0055-14b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-77517b43-ab1e-40f4-5df6-eb40e74d503a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-35813f843c1e9584aadc9aef84fc9d8c-7640a648136f5249-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "4bdf6304-a974-0db5-da71-814a5a4a5faa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D148B2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4bdf6304-a974-0db5-da71-814a5a4a5faa",
+        "x-ms-request-id": "69fcfb33-201e-0029-54b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-0824f8d5-e5d0-52a3-6806-0f3087b768b5?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-cff5c1ab74271cb7ba91865e979452fd-ef8a35697830f155-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0fd4dcdb-9650-8c3d-e434-c075fbc4ee1c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "dOtkLYcynuRTIbUgmvfSY3m5FGk7yl7oFkHRS7OQlbNy/IiClk\u002Bq\u002BeAuMrueTYdpw0gd4fki2aqNexZGYFIww4sBrZ5uUM0qDxqIDZeiSsm5Z4hrc7S5TyPd9Bo4Y5iN/W8vnJ/p\u002BnJ689HfmcsS6jBNjPjJxFDXSF57kFuy8auC\u002Bw8oc64q0G0V8H/i2rVXywrq69afwzkfWFNAbWkXyAEmXJ676neCIryLtNPQ9G2pI8VQyAXU4jfWCBpa6WID/ih9vH0Wm\u002BCTZ8gaFA9mTmTml0mjxgD8UXpn5eJcJzlZh7arUjjvkojlvWA8uc4nb7m2c1EYYDcngWoDrrX\u002BNj\u002BPwYxZuvwr9gXBvQigv5isP3UoprPnQCd\u002Bg9DO7OPS54YgrfdBzrW9i31MV6Iuh8LRVm8/1ZCMqIFk2zYrXQoh79aCfxGganHAaho2muiFT/wO/JV0khH2lAV23PJ\u002Bki1yK2jMrAiwMez9f2t1VQ2Y34s6HWB0rVzEi\u002BoMKo1\u002BQtjtxG\u002BAuaP0XcupdxOmgD/33f1nRHXN/X4LByAdpAdefj2SiJGeGCboRb\u002BUyzVJHQurFEyQF/1jH8bxdbGC1rnES/jWE/euWcXWf/61ODJIwuoVco\u002B6zWc/L2nKraN0ZW8F0IA9cwkT/LuHuZj/reaTqLLHbWQqCX2RluSO46wiYhmPsGiyCk/gAXXUMxPOP4GCNgTwrfgK2sYCq9wlhRkOZFd/cP1\u002B4Z1j5mzuVtZqwlZjC6ynMrQghNWhsF9yu3tcxc68T8\u002BEBFVmjMaMG4TwmOmFwXpsZjKiXusn3DE\u002B8SvxkpEHrXOH3gZXQaXtlGhQsBh17PkB716cGfHjXCcjJ5ubmonz6ep1/uNzFSWMtcmD1isZyAQx76Iya5SBo4LeMxkKUvnfXccu/\u002B0Wjto5D2QnYIX8Cl6XaavmwH1V9FtglOELgmLPpHlj6sgWG2HI\u002BVswWkL84ii7c\u002BhO\u002BJxK2AuStfn5LYwBV7wMmB\u002BVgE5JHsciJJkYY7G4UA96gavcGRK9hGVnzsvPLwKG8EoIJfKaBNrVKLRxeVFIQN19h9YQL34N2Pzo4k/7UvWXkXJnsCoc33zRB/FdSwoTH47uUacsdcHL\u002Bkz2sSKK2tW\u002B2uff4JCyYKdZPyiNsI3x1MLADAFNaxuxnLXeJS5aRiwcnnAiND7\u002BPPH/0jaZPUq\u002BBdxfyc3TcW/LLUTb1Dp5//n7cBEdzp\u002BEwtAPTZjlF15qHyBR\u002BnxfSC0BVgb5I2i2htI9ncw5oTY92wf9xCPW5hbmcLQZKAV8nCjjHHeZip5oWMfFqHmRMH3pFB90YYQKKnDwE7KznV3NwAGkVYW/o1BolWtbED6cVD82MBTmBzqk2fEHqHfstLtq\u002BOd47dv4KnDOC8wYrhoyVL9yfGxI57nG/3uTt/vZfOCv8RhWJGZkPgWkF/ttiyvX1FS3eTdOIRAuse1fZHJ09Y/saLwB2y9ZDj5npM\u002B9WXRQvOOmIQOoYdAHKHJ4BNmSLyJsgSNv1fgkXmv45nxBcVh5D6ePztOLQwfr\u002BrO94All1XStUNdR4OfqgsKXr3pTxbca//UxAmFO4D0bg9pFZ35ikxEIkyCAKC7ApUwQ9JSMlzT8ouATM9ITX2\u002BaNV0MpRpENRtoSzKWmtfGcV0VPeyoj\u002BulSMWdTmA/9DSw5fPRswAxzL54JEwCZgcJTcJ0/SGD8aZxZ1xVpue7KFb95bXj9b1d43AuMGqfouK9kwGdyvcTLfNMX0yj3CXWvPv1BYBSJVcEFxqwVME70sR5lxLmHV5f6bfBl5ZxuQZKV3Nvqp1ham6pmbPdYtgxEYyIKUUT8J6dlRvIkY7Bk10TZf1OzCgnGCykPISqgoffj4UJ6Y/BN2bU0RSBmNnf6AVWyvzb40VkYBEYbrQa8hOU6QEIt6nNUS6WevoTpX9TxVN\u002BVLiKA6xApIh\u002Bqcmyut4B7a7X1jFbiHnORWlKUbuRxKlhm55bCeZVyBIhTqdk48AbErjQfO4iI8s/vL1D9VPM7OUgUR5ApuPIgg4eOjnRaWKoLz8DwUi6PnjTG0wpEtK/VGLCRJKh22vUCPrgBOiRbVNbmsYUySudZRKmbIqWn288XuXXDyTPB1TTL7lN2TqPQq75zXcLqos3Jd6A\u002Bm7hPWmKpKUDul4ui5NyQZlxT4zXFyrcndH4MLRZn\u002BlFTwzl8vFQwzWVi4hPy0LkmWnxxdZSqONEBKCXknPxqRp06DyGjE\u002BnIYtWQouhjNGPE5dLZ9oT8qYooO1RuDHCpOFu2\u002BIFXQwaSaRK/GZYonfOCH7cpUI/YPWVXexhVmlak52pM7HvibaKMB42yfZA0P12g6\u002Bz5v6fLnrscP8guPM68GjIrm/F33/IUXUjCZf/VI3u69O5pq2fCQU3Ahi2ancq\u002B9iNeCGOsKMv65WJeyTj7RxyMc0ggEm6KaVpjtxnEeb9\u002BQ6\u002BcdxrYDovirsYFo3hVBX8QzmpCnqP0k58JSHHyNmujIIWJHs/BtGS8faOohMXhzrHas2sU\u002B\u002BTL56N7joZaMHiaYkLyy\u002BavD1oFhmEATA7ZZ3mAF4LATiTgvXcsReWeYg1qziJDLwLLa2QRDzVDy5tUYmcMmdj12dRd0g5vQol0Z2QTlX4slnh29Ower38vXPGbmCO\u002BUch0tTQOJR00W\u002Bia3KeRcDYdZ8wu1eUslyqVLrUc06ql9dWb3yBKHrEbQljDQ9KXXiz7vnBXj3wjB93JeM=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D36B49\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "0fd4dcdb-9650-8c3d-e434-c075fbc4ee1c",
+        "x-ms-content-crc64": "RdNmUy9o0as=",
+        "x-ms-request-id": "993dcb17-d01e-0002-68b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-3263833c-5fe1-2f27-c1fe-10fd6efa7c32",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9c4ebbe0f297ed385aa28b72bc49a4ea-a4f1ea029af175a9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "7d6e7790-4f75-d159-4fba-aef95719b8a2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D47C87\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7d6e7790-4f75-d159-4fba-aef95719b8a2",
+        "x-ms-request-id": "16e8f3af-e01e-007b-1ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-73710fb5-94c2-2d9a-1d90-fd55012dca8b?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-90054351954c023b0bbe211728c125c3-4fde68540178fac5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "84e412a4-7055-46a6-35a6-346afa8f95ba",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2p9eIffUmkjWQ1dNJGtOTTGkTGD2QSGEVOk4mmbiXAkClurNq0EVO68UoW\u002BWrJzy76NaeivF7Zh\u002B2cwOmwDi8\u002BZOS46AgKHvjxGw4Z\u002Bx7qhNRarDiOLdPKlRT9J0B6CuMq6JR2AOcm4BausaFAv4zOokwVVVH2sEcA7kLjHPe4dwAq/xKKZHPtM8wR32wyeeWYLnUEZLWBNDhNdSKUM8Mu9jqRJbB6RD3IKBGV1NDa3mRtWu6CpBJamcrqPP9RWQAI8tkhkVQlLeo3PDyT\u002B19XYqbOJujUnEIoRpv1kAdOds8RnOIHuT0QSD0ES2fVtp57gspYgyInJFaXCVq4L53S6MVtgm5tX7lpve6r0FDaQp/9ig1M5eOs\u002BmiLYK/SWCivMVKieDQwDjMA7tVDe1QFvLbKupWAhgLRwIf14e8Jh1XGDJ7\u002BN9pbzYvKPAcOaX8UhaP5F62DHqtfwKesOixT91ePfW61F4Tsbu0Zxln7w2cI4Vw7EH\u002B4Qv3jnmciv5NvdjS/juwQb24vHLiweUhRY/1Ak1jAGObn1zpw0Ykdub9JqlAVTER6\u002BHH\u002BHAPG98mlgjp54hxKn21dx7ehn53lAVL5Zs74PBe4xZrW0gzTIN9g209ek8ejDxrix3SM2WjkCQqgzZEKrVYSwRxxc81giqboMLROlm2LVle0BXSTK/wx4sjyIlM\u002BZj35O9K7IZtNgkzdpJiklWKdFWc5VpfRf6UQP4D0blhDqdqGVVqa0CTMZnM3xYdjjU1mVRzsBQ\u002BWF8w9mvIKWSPkifq\u002BLkAIAkVCbPAUmaodvLJDnglLV6Ta4E2eXUUywh1fQ0uMpV8NXlLXqZgfgX4SH94/xrsaqSJV403yeaTwH6rStUZukQdTNk\u002Bmc74Mu17PjE1m8vtSNKoZJsIRCuS915ntPMw3o47G7IB7dDV0WSfvMu1nmRy/gICsVWpFQjta\u002BJwkH46Sh9i\u002BkBZ61sB0pN2qIcf3Vk59PbxLm14UgZpFEHuZQDmZXKsUqPj2NKnAJ6CMqxBjY6JdpuHSVvyKqh58JcZE21SkANUs4q1VhwkCe2O9l9aJ4bzZO6lXxwWuig7aig7je0xb6Ko7RoD1CB/Yz9uYzQI34kQJe6\u002BrXDnffliuevz6LwAXYa88Tpsr1COJfwcqBcz8kpfK2g\u002BsoIxga9goVp0S7pDLgWti\u002B6Oo7Zd8Ee0ipWibsdhlP1UAarEi2\u002BLDA42WZoB2boRRmZbkEfxoII6vTcZvnJS0vb9Lyya6MC\u002Bw5eoJ1atcvEbkShhBcR1omDoyc44sU2bo4bjROqNtl1l3MzwSblrTQpF/i1KMczyR0yLsh7yRlIJzEPPyi3GjhqLOyk3hVjnvXyD8rMgUbH6MP1dwcR\u002Bc1Z6pn01W4Mcf3ASvvajuoIz4/SiLpPe6bqR1dkwqIwWTIfS/R7bsiH5p7MDDZL7VnY7Kh3PnASCW7zCY4XqK9akPHIukP2jGDHS6Ibgm9vn1n9i9X6uRrCDEGGiGQ6bz3vcXxFgjMW4l9HsPLN94f\u002Bg2o0GR3ZYNfWBq0BcAT7jdtlLBHzKh0m56h1swgn9BW6hwT6BVYfFRGlbnuFFHJbSyMWaMp2C1lMDjJ0ZK3OrhKXR\u002Bj/AYeFRRf/TruioNI2GmflEIxLRHyrrfckq7Bk1r9p7c2JW0qbkSOzdr2dqm1fPkpF6J6GTANsVFOQYZpmm3f8ObMFrL4cSn9omM2\u002BDQOJxGxmHu4h4qDJHAb3CjCITNpGoXG6WZKLKZ4eHbQ1rUdQBpwuAH2I2lYSPI\u002B3JT9P4EvyeGuSz2ra2vRQAsXsk26/pwOTWkxcvcYapx0C0wNezz1pQzXbvTcyUyWJONeRJqgg\u002BH48vIX/lbukdydN2Abw8TOIg1A54\u002BnMYQYn04TuiYF14duFIhO3aq15NkYP5XsemEakCKNX5xWVb1p\u002B2ME2tu2l1/Yra88g0BijwKyivXyLCDs9SoDeHfrG8LK4OJLrQoBYaQ2E8yx3hDiKtCdo8rLe88\u002BF\u002BWttxrr8ZXscaJeGuH0rSVNuBhQPxsZIVGnTXf0A2UXCZUkV66JTiI6xWhygA/upPKhecO27djKlJHJQKQd9HI5SxFIzFl6wG32GXmuqqFFtKSFVoWlYBu8Xb8cwAl\u002BGMz6NTT\u002BodiVKrlVvNRfH\u002Bnsh4v/mKHsl\u002Br1jG6eWgBge/yotHVoRxLL7CvMT6dHXT3RLDyBfoAvDZ1OBRVp\u002Bsy08UDXtmt0gDx5N6x2IERDrjMwyS3H4v18fabUHj39XfVfF1pic6rWXKv8CEbXuO1ZClriOTGi8RJDWzTAoGX\u002Be9W7Gwjp4T6IWmyBx9a2qMC5fxPnHyTDuCJEHxRyFbhGAYxtGKHgbykcVd7FIS07jLJwByVSF1yw917qocImGkSwP8JKRYwi2RPqysVF/pr1CJJl/g6W8\u002BovvCVC\u002Bclm9j\u002BaEOFq8UciUSoVa0ybbvTD8ZkzvBw2GUvUGolm3\u002BNGh9CFq\u002Bm1ihtPR6zkgYidlE0wgwQwNzYjY/eZlta5u3FKzuN4EcMLDmt94HhzUZvDOoY4NlzfFlCeZkf2H/dAkYg7nbalIYaKJXCYslK9sBJf1lhQfYEUb7SS3at7FPJ0OVLwN7flGhT/rhDoQmf93LY1lkWa8BAHJzH\u002BEkfbDwyCJHUDzXhaerxHUM9wKClQlPz1RX6o3Uk\u002B6RCF5wfNJKMAahnu/hM52x\u002BFU59Ekv8ErX1K4cmN1Uss=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D47C88\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "84e412a4-7055-46a6-35a6-346afa8f95ba",
+        "x-ms-content-crc64": "03dU1UGgxNs=",
+        "x-ms-request-id": "64d6d00a-401e-00a9-29b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-09d655cd-858d-734e-62c5-26a0b1eb647f?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-367c0eef199a34943ce848b47eb8cf22-21f609a942e6db29-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4455e300-3334-f34d-14be-b80d297a38c3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "8Tga9STtHYsLG\u002B\u002BE2WW6btqYyOJrfpaFX05ioZC1XKQ0r85MtICi9DdbxQjPPVH5l0mXy6xvX3KilZXWi3z6Vr9KTymXbbpZ9dSrD7iNtSL8aAlGHZH3xFBbqh/ry2m6YW9JhO0oYiqPPtXYxFC5Fd9z2iJzszgtU4rZPMOabipq8K5JQzA10wbft9\u002B8H/8AoZU/d/BGR602HDFiTiZn9M\u002BrbdShb9GvPQcck/xYcTSL2ZotW/Y5JKgBEyb\u002B0oTgeMIQELErXjHDkDnpKrOw3qr913WLOZnYcUkroFyqsGuCPBs5SGCCX3poacq8T/n0UDV8APsPVD4pOJ5nAL7UGN/OZ\u002B6Yd5VJenf6Is/OGyJPNk8nLq9wc\u002BfcEA/BGl\u002B8lFHr7ucLXNmfMoaDFDJvWxx8GMlvreovXvQHu2eGiF8YPo5\u002B4i07Q9l2iPwp7V60bbTzRQKVTeZnu5DyBKFyGaomatak8HjvQdTv\u002BSTtBnGWUk2ykkJdg/CnFyedSD84A29RA4KIEH08AwQupVTCebUfXLJTv4ZoyOfl/NlRUvmVt/W1nALuDkHQdo8\u002BLt2c5Z5yfuuM5EPp6TqbohOj67ALmO5fDNyyME5wg0n2KZoJSBc73tQNCNOxy7LHUmstLIreMpXvPdjBv02cHGH68r\u002BgkVr8aAzc/ZAarUAq697jQla\u002BF/cEGgo\u002Beh\u002BHcOxyt9nyJsAQMcR\u002BAjUF1JCXltRvudkKO9rInHdPvu7sVIyjqPZnN8Qd0hGSPxXB/kV6puNLGLcTZ3v\u002BKopJwXPWka2oYiuZMF8QUebIePvFBp0x1BcLoTzVj0F7aQ050xCeu65oGZwZ4XaEOsbQS\u002B9/OSPsF\u002B1by/Bw09LqHsdR1n7WKbxNXOwBF/Ohh2Z2BERR\u002BzDpTbwjQvC\u002B90bKL8KvMmRI\u002BiEzMtw26//5ukOJ\u002Bs6NmCOWaInBsufLj2WmN\u002Bgw8VQCLQojHshTsmK8KYesNfx4PJafGMrahkg5Z6N2kLMXycnvhs3DanpaQ7UnBYhgHlpoLvpSkNmKJ6fC6bcl3CKupWC\u002Bva4vtNIcRdUVs4DA2UhIDmG5xTjvZF4lAYHDNGaSeWAnoWGrOXooNUsDdXQmAQ9u3c7B9OAnzlhQCbJRWRBugzogmDjnndTnkY/t6\u002B/p//9xVFeX0ISAANIIWy/I19w7lPI6BWnXhj/52mNQOuJpZgqy3wS417K1oJhl30GlH7qysVb9r/mWms4XnfYhL8XwnvQlFffYgr1AhWXRcqb\u002BVLupnoiLa7cQG0U2oTm7k3HSdUBNfwnC2i\u002BZvSmUxSgnGUg7eJA9ZDM8FfmyoeGDhPHz/v1msNSx5sNY8q6Ne1YdDofwfxvglBANEGoPDzhOFTg3oMYqwWl0ipHN5HGEr5mjlZNZkgXWE2nsWKBqodeKCt11VdqQ8k0efPWKE7CfiWHRbHql9IIzYY1cPmjICei6QtmUDlm\u002BEqJGOhYPTP\u002B5Tc8\u002BmDRc5RVaQvRNM7PkVXIM0NDWCnoHE1nXX7psIxWNo/GZiXCzXV3EOctkcd/vYuSjA3wv4kJVNoXahYZb7h/fv5DCSssBWHJyEtGuo6F66P3VyCCYXsCvRFPr2NfXaEushbFOLBcZoaoJvNBxppPjYJ2JhiX\u002BRmHQEwZ4Fn\u002Bbm6mFAR3wK7vlvCd1j6HvPZ2/B3g6TuIlrj9QfhkRoIoqbiEm66R28zTho8r\u002BiLa/4NVouQ8HYE3HYFPdn62h1BucSyGAyFL5SBNDWKoYJyWIkZ1EqOZ7Iw3TX4tRmFSHP86uYT2VPheCb3H8xAeirzguVQ0PXSs1ISgTrGnGp6\u002B\u002BuxjbacXn8lKFwTl0fl8FMbBSI0NGeOKjeEAVgZGuvMfBPQjuxkVzRmK7iZzywKLIDnu5dIRseEM2OPGE0XDB1wVxs0FWFmpq3tzgi\u002B5FsLieTHMV9UdDVcXFuI5U73Xx\u002BrKXgA1gcvcRTpWoi\u002BxU8Ic55YX9q\u002BG9Ll57kV7cFu9n7pE8ri\u002BqPdp8BKaxmsnYcMcGGgnv9E7Q2VKv5eCYNTemQZ1bGEFXjqeqgKc7C5OUoiCW1fzld/lCa9Xd\u002B1j5485vC1ksfViFroxhRXSnlc2\u002BGkLAAl87wMmjGa1sepNPsJ3YywA5aCXIESdvhDGFmtUHHuAWOeFuM0qPiGSrGTP5EpTWz8nNhbIc9/E4yzyYHX7XZFyyOHa7aZi1qd/BHffzdnGdrssMOpku\u002BkLwNmgO92rl1LXXRtoeGmUxGNvSW9r5RFXL\u002Bm6zyinCgz40yzMwprF03EhCGy\u002BXf5Rl2yK9XJ5n9vESQ/z8MQmLFcOb6U8yAXEpXX6RtyglM3vaTe8HBSefzdRBHWO0eKo/tgZs\u002B5VEM9qwlP8g1T/I7Q\u002BAIeQagxCc/Bt68eMNdOTUUgAiuTfmlRoVVnAof/eVeDBTNFfGJTL2z/95ykL2ox8aS4I\u002BpjPXmovJBC2fdHwk5HizuUCNDi3NK\u002Bk4bMvYH7NRDTN1VtH8e5nL/CAFV1uDVeXJQunfjDxVcHpKny7A8eV5TWZIr42ntz2nwRENyNSNtBblD9zKcoD3H\u002BZWstxqCws6iwn1OqZYIourN8srR6imvOoX2uIJr9vlUY\u002BnUARhPLYG0jzKmHpvje1RHjq1y9c9sPXxUzApMdsuEOgXsNGGSfsVJHVs3CRwqE31uJGhMIW3aqAPcOmF3aFgnIiSWNwbytU\u002BoKdi0NPRgKriNHlKjN9iYEY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D566C9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "4455e300-3334-f34d-14be-b80d297a38c3",
+        "x-ms-content-crc64": "PbsUnET\u002Bmok=",
+        "x-ms-request-id": "146c2c98-a01e-0055-28b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-77517b43-ab1e-40f4-5df6-eb40e74d503a?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-a7cbade34ecc9ea4bbc3ee86802ee79a-842845739649db0c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2986b78d-2110-0188-fa71-7d929e5e192c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "MXfYEo9G1Aw/nN5Qcdntu2KP3lSZzD3wPqOpJxUPqC/3lulT/CsRYI7EkzWiWnFajI8qUIQLrGQ56NTsnaz2MPSvWNrvmr82fn3G1DgITeMxTpuG5Veq7OmEGRRXJMLhzmNB8wGWavLQ89EGRdcsMZrwuk4Rb0ucBGzxa4Cq3lm65AbVx1rim\u002BSptvGGo6YRWOh5Z2p00F4Ype6Vpf9xJRR3S2HRVmlADh5qaLlZFWDG3xKXMXfuRhSnvSJrTPblN5HdDldFQAF/OFlMCmekvo\u002BOz8Xs2vOdiAVMKZlH1cEnhDAofAcIgJ8QGPgeojysAv6S3X0w\u002BF2dQIVS\u002BBZoN2OYJIU3fEKIhU4m3MH7f\u002BbIoCeatPhD9ozTijyBtoiIp\u002BCVhX62dYa8ClcvChybosGfiVfvzoJqVS35Y/EGBs/FnjTgZflnESug3aqgE\u002BxvN\u002Bh74iwwmdldKjBQvRGUtgOIaWzouj3HN3csTvDYykFAiSsJiiSilQRagzrIF1QZDCenGKmAh3yrs6q0A0rohWDuDzPliive5dRnjTcC/iAjE0HJMbGXwAKuXdd67pK5cv3Z2gcgM4H7yDLVGflFqLSKkfAJHlOuVk8wNy1UZPdCrRs6KSQZAt\u002B/zml/wqcJabUj71yhsFOpKoO37/xUp2M6k2vdCn\u002BPcY4QSVDqL5SoJ813MHSboPzIkP6hYRPjaycFRC47K141k37OkWcCvvruD8cv3Hbun/NuFXqA7g97LN4p5eplbPxuQZ32zQ6VxdEDslJLtI6wF6U7zRXktaVvUmSJ2dkQiKLLwJrY\u002BNLl2FCofDu9MHhPeM1FKp/miYz4h3qpDOz38yqvf/Pz1x7SVvTFOzlqsSLsOWAMyl0D5DcO4HFYO8xksYgRDbCEW6Gvc9SrIU1TjtVYvNKL6ynMrJq85fetehonYYqwWKNxZ96/XFaJV8Ppu1KbAH752MVfRWEVyHapAfm6g8DCojUx5lX0zI7SQlTX0imkEXqbLojFURNCXJ5nFVtdztQCJhgcahkpBQs2jAIMPfZMBO9\u002BHlU3/VEh7oq2jLczdHSA1asQh6dgcih9jsQRNh6oGhBr3rB\u002ByinH\u002BnuPcnhUAxiOi2dKO3xIHqssum6NELhrDnGmx5XDAQuCSY0s0ACwKIurg6q2Xd\u002BTI8AEUg\u002B6OurCJGQGrjuCyolcyPLvG02rfJLj4Y0NtLGSEqTVvq/7yA6iaaycqXpQKLggWpTsowdzWdV91lhctW\u002Byc5uWrQzZYQDjTbKgD9IXk7jU7FocpW\u002BcYWXafvG2RbQ86TbfuXusR/iUCVZV0kkDZUOgiMgVls0r\u002Bkum/\u002BMPLQf9YyacONo9KKVhiJwYR48b1xiuFb3sJ1Nos74vBUcVhNtOV24jZixoYl8isw0xE7O8iyjKYRdKETzTNIUbDiJeTAPAyu8h\u002BHDrRbJeyXNFNqALcnofSyPDBEUyTzKnTVQ8xGcJcEnDm5K33htl60jIjf3lEJuoPgHg/MWq76g\u002BRPheIQQMO8ZXR9fnZ2wHXhj8acI0wjy5lIVmKXODGazqeZojB8pEvFE2jcjEwNeU2J2srYXmCYG7pIx\u002BpRJT0y4r/e7R5FdOuK1w/TR09dSu0VDV12wmBG8YZ2I9xRY/47qamMLowvRGXfTYdQxMR6\u002B40NTCffzBBPh/uHz1EPOXMRl62lwRxQ5bj3l4To5iyyCyhfVCfGa92JTKaQl4UE0AQUTy0m1TpwrFZ\u002B2DSbVqHO1bQ4v\u002BVLSzvAHHR1wF4j8sdw1JcPmzXt3rfRV4Oo/fX0wcHQzBAuyQPxVrjF\u002BtwISuVtGoIKzzp\u002BSuEtefOoFy6OcQ6MUya3QhuTDkSNJ9PbyRyeS9Nz6gKXUnE\u002B8U8QST\u002BKN4nde\u002BfOtdhmd7D18SMNUaDXGdtbGob75QCliFDMgsUE8uBaDl0k34X7DXJBoWFeIa\u002BeOT9UPyzy0ZbnGT2HqfTr4P4yo0NTskpVUB0EukOvV1ahLlmVoMPDVyy2TbZIc2ONVcBjG35sSnb1Dt8f/idTR8Hm1nubVjA6f1wWnWSEDNyph1RzTEvYROPSoKHko2kFYwX0Yazn4g\u002BAKJwiRa0SYPICZmbC3/t2DpGHyLWOVdvzETpun5s/wZVU4xOvtg9GwD\u002Bv4kzyMpMKfmMbYClaAcLALyRyo9FmwqTRfezn1liSQQh17nOO8N6XVBE4JGF8CuFA74ba1BxuSR\u002BoIMSmIqgKiR8Q1CNfMS5V21\u002BwLq4zVXL7lubBt3z8F5VT5tAZ8TF5LatCWybN8a5YdPi8rhpxZMtBqouxSMGiJMyN\u002B1peO9ouRvEC8QpcPaVIaTJ0P2l64oIE2Ealt9TpoCZaT/ZUCkkunmcZbmPA9XzmeO\u002BPLfVjAwjYSWOTeI8cKUDT8e2u5G75VZECUXQeQ\u002BLZvz71WnIg9zzti7DViyXX/UUi7POPN5SAldhkYKGUugWAublAJs7eswqgwWiuE8prKmQu\u002B1b/SoeqdMSpvIabWMG7VMFsh9aGRDno3nYr0nId\u002BTZNZc6ukX8xpaIKNPZ0FWim8s75DqKNqKcdBmwBjqJSm7NQXfLzDLNSKuI0fB9DZMkNhO\u002BjFPqTz70ngYsDICcPt6kzI8d1o\u002BYbltOwWSyH2aGjA/myr3bIzJ4123soXwrLJMR2EEDxh\u002BD5h34m02aAn7fpUCwtTQgialc5P8h640fY9SRoEblgoXwYyRf4kfkntUuzTv7endfMQ=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D78959\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "2986b78d-2110-0188-fa71-7d929e5e192c",
+        "x-ms-content-crc64": "9uJdf17HDCc=",
+        "x-ms-request-id": "69fcfb5c-201e-0029-7cb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-86127e2b-53dc-216d-6095-ab979a0e8b14",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-824e93ec3e4e99c7aed9fd4c2128e4b3-96ec9f398aabebdb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "166aff87-503a-4085-f3ca-0356e8ec0917",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D89AAA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "166aff87-503a-4085-f3ca-0356e8ec0917",
+        "x-ms-request-id": "6828d7f6-501e-009a-1eb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-3263833c-5fe1-2f27-c1fe-10fd6efa7c32?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-6d1c684bd4a6f0a6b2781591a6edd1b3-f9931d1131fd0797-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "31c9071c-e065-e207-de3a-9a113145c0d1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Ol6chYGH6kNk3eQih9/ni\u002BoBSD4DnIbhGKjLeUWPpXTJvOE4bpI/BKc8JUGtWMzbTGQD6JU9wZ3Xu2zZu3D91TdwWMv\u002Brx1XwUSXxndFM7/b8C3hi73ei/pDYLImZUg2P08JPf8B3ZxHrCZRpvslkoit/stDHEl6kc3Quk9qMVz7YIcoO/a/2RKQmt\u002BWjeX/Hs4qeGd88yIFj6syMSNN3HrKVUZz/VeR7SS5soJq5APo0JyBQLj0f21kIqxKjajvQ71kyzifiyB2mItCw0Cgm6qoSmCGy5zC1dbYD9urR2B7yW/EBRnKSUR7Cqcssrwsw4YBoUJIaHchofVixnxFy1Erx/nR25aR3QEbC8H0liMZq0tUqaUeM2H3o2MjaILINT9WAevDW\u002BfwcMRALF22LAvRSBow8SGrDJOY2TgybXR\u002BUtWCnZQ4VlBjZDnh3QYDQXZXUR9omEQdq/RXKoKvvQJPwtqHNI93mfHKzIzoyi\u002BNlJjB2xtUFrqRZfKf4SvNtKY2khssfAzn4Lguncu3NODFyZbp7eLn\u002Bqsf9c\u002Bc17jG/BjmsjgUYReL2vpjJnjv2jAR2heV48bET5dvDIY9SggAaKGy0YKosGh/XhPnhNMzMBueiv2gMBhSIWKgpFSQTo/yYr7XPAmuaCqvFYWy3cvEPNxrnsAKYDeIYK8fCAsT7g\u002BE9CEUXPMR8CHT8BuTn0SX22h3JbDO5wKHTtxZjmAenCd1Leipr\u002BDpWa2eN28c9cBriC2jnMhftQ0ejQ0XuGLBtVTzHXFc7SuHjssCMLCSa1gb7gYzev9eFXjaiiLS0qFL3IIbKNhOD5oBHA79XYRdjCG1\u002B8pbjjpUlAf5gWMJtLsptlMtdkKAzd5sMl7xYbjzff4AHdbX8E5Hx5TQVI02\u002BGdS06cxLxXfNC3r71zbYjNPBQNlCJblUsYF5a\u002Bur3hRNTr3n40Rwk7oIemp6wHya2RhgU6J0e/QbYHgK0lmMYS1mrki5MOlPkO1fOatPGbFEnlLTC4px2NKJjIMMJYEgvBk9FFH0Iegu0ML1FUJIjAaGxjPG\u002BRWi9JV172RmQ2tsPr2SEgVfULyqpHrHvMOQQQB8hV9NWcMDmh\u002B8fjJDyE1XiNbEtnoBJ3W3HBSa2zfR5a5kKf4L3uT6TrflotKKZtvtcDPsy4qGO13p1j2uaP8n6phD356PS6oxymfCW4Ri7PV4rasD5Roj3e5gYginDCX4/bh6Rkc9XeSJ\u002BsFiw5\u002BZRylIdbtT48W\u002BIAHwLylhiv4ByZ3MKGauO0\u002BGeioYwNoOhtsfXtZqpNmy/CYFTS77KG/DIPoBzV6C2jprjanbZV8noWgOQiwnl2SEGSwAaO4gy1G6FaAfzPm8XIScPtdv15bHHavGrOYD20lVfbQyQnEMCsJYIQ\u002B/B5SukeWnS5hNVEGVeUtCWh5rtnpWio8FShoTT/QVF7ZHSBXXGBrAXE/wx\u002BlynQklybDj7KrVaH0FaQfLlDukeHyLDfF1awIDaxnqZYKlkuzQ7UYDcSsLsd\u002BY0e7TNIhUDI\u002Bs509X8J5uoEFQ6sK6n5ZbOua1YQdRv5vRnFlTMHaRllkzOOtduPynlJDpuocc3nIYeDnhnqtIGyfzRhRFG7AK/1Rph2bq/UHpzYy2p8TU9P4nerg8r/etqt3DqnKoYrkgnvtys1bLbbq4N5De0bMjHlFWXeD3zg9c\u002B9yI51MPAasTlckJYgFnG809RLgmjtkqoEvhUgTYaJCr1fd6AkYnqPYly3vqGbxQLwHTuomXdizDnkbHbe9mO204nYxKLNmHFduBwIOdAIbPUWLDBK4G1J/KtqQ/IDsG/8/O8bwwBcJoDKSuFXVpJl3AN9yMYva\u002B8Yksv7Y1h/WgewDzjk7K30tgmvgJmL9qYVAGfygeulzZT//zA0ZMMoTuzdo0tZfO9ViRa4f\u002BtVjJwh5mL0iNQcCj2n6PF5vE1KhzWorlNev4d0nPjU7U2tpnKUFoJgN8IUvZUJsZf928jFcfixrN5Ixybbf\u002B/fRxzz9kJ\u002B5anK6k93k\u002By6UQnvesUwD3tQ\u002B/mQS09bhLvWOXp4GbtRfvIe\u002BoutPhjtknIc7AUqqzehnv5I7p5ac2WXnVp2QjtOnfvTERTzp73corjdPpSyq45C1nq9BJBTxIsmFZzCd0w20lINV5oisfdAbEvlfTTM5PXIN2vAjZVrf0yJzY4dGitopmhGpVf0HCSDfJhEbkdWVTCq\u002Bj/kdkC8odRJlOBlI1IgfNbIhj\u002Bh0BtHPRD5JxEFN3RdciPrgDArigN/qodAGllKJ\u002B1wjdL1CSoknTUvw37HRGFoC7EyNPimnPg8JiWQAyK7sv8jlKmlaGj1xub6/8qAtGYl2BKoG\u002B70yezWtOcEkJoSdBB/p7O3xqNEOHIVq6Exu22/aisQD5sQKsq8zrOF8TJI6Ie6ARC2chFvY9984yJPoP11RSZu/mR1b3jo\u002Bvfzwkc/yL8Ze7ZdCPgVpK\u002B7k0ukbS2yDKwL3eojQJWbzXsdf6GYPRpjMilHGDguVVm4vdgtQInKPbGXN\u002B7U\u002BjsgxT\u002BA\u002BCUOH1IxQT8AavR33YSQZoK5aojtV0HsBQkvjjvuJlb4rV0wrqKJ//9OxdK9I1pmQJO0a1qyk6DnHhpJAbMDFkShezAnY7vgL2qJopFvLuWyxU2kNb74Rhm4SYyIQP5IS7OOH6QmPuDX1DvwJO0Td/MwljxlXtyFpTEWbxYvW\u002B5sQVrh4RM9iIZo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4DA4816\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "31c9071c-e065-e207-de3a-9a113145c0d1",
+        "x-ms-content-crc64": "sMoxUDe/erk=",
+        "x-ms-request-id": "64d6d02b-401e-00a9-48b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-86127e2b-53dc-216d-6095-ab979a0e8b14?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4a32eed87e625583b964f59db661a8b8-49d6fbfc4c3f43e0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9675bd72-e894-c7c6-d232-ffa1026da7e2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "MxhhwQhKKTRmVeqvebs0wR2dxPTzqh8SYfnljGW4/cJtfiOewKhE\u002BnGQJIAR65abg7YmMp4sp4n4T2AOZZzPrlgnQvqXlgF1WMmDYoWeAXVjSgmvkcokQNeapXBINpXUwXUo6ambA\u002By0sdrUqUQDWk3qqhqTIB2NAwEj/fCQLSI0rqEQdhjMx0cc\u002BuDwUJaSl0sjXYt6QaFYmuWndwX8I4O3n/ui8uM1HePTdiU8nbJqkWakbc\u002BXumwAuNsyJU9BINZcOLGb76Ro7UCopst7G/wyPOafWLW0IOSOoToHAveTklVO4GQBz6HCPICP7xShhZzfAOlpocggqBjMDE1pYOpIFBR1LDuYMGxE3Rs1JDHQ7RyeKAIOKvCNLTdMNcNTWNyVRtoALFhhRs98JMSs64Pn/B8xyzfnOeoj5/4DS/up8YQ/oN1Wz8HEPOEzkgUr4EKzZTikIo2krQ3w3ERZXfrT0zNAbUulkC1dbI5VtKfk\u002BAa8T\u002BbDBM73mvLQZvJ9at7nYL7S63P3DdULRrX\u002BT/llC\u002BQ9nQ0UD85lSdNY1Sk64AKvblPpEgyTxEERuL4Y\u002BEr5a1oNP83R0lHwbaKgnjir0GazTuGlfPnYqtjMAlcPTFCIX2nOLKA03psC\u002BKRq8yUJZudYZKlpU\u002B9hNZX1BM/64CBRGD/P3KTFfnBFooNUbbaywpxvt\u002BemHgt6bfYLP9nMCBiDGdrmOolDkuU5JLFsDMjeQkIyiig5qvo0VG6tuT\u002BWeZpr0FTczIgSLCQBbflaDWEtLPyXmX7vSm7gseUaldimo6sWADt0Ana5H14DNz0A2UcNf41C/t8ce4bl\u002Bxqj95ZLW8pNQwwluSqF3nkf6xMx4NieDRVLY6TL\u002BoW1jwdcFSfHt9xzspY658ZjvSBm/JBysxtBBeqBAPclgkiHcCojKMhRVzM3vi1BYyVO6KaDZP70QtvrGhA9RrfkTTBNsnecQJRYFaRcO/XtAKHEMhhRoR1Kki5ONw24ExF8UnD99LGusqgRK09ZmAbm/hpueBOfk6sSAh9ITQiGnwGS4OmE8AzwFn9vP3bO8fooaDnzSpv93L/E6/GSZmWfi4tNxrcdYQ4OfWKUL1Q1RBEkIOTPk1VmlAMqwAUbXq8a0LTqgCpCCgcq5Mw4aa1rj6bfbUWAz/c25zG08qEI8x\u002Byel6fS8Pn4RXdpK6JLStWvzBePPBpmQG8tJj4jhhmIfGshe9Oy0Pi94swoypIrLoGXTNwqrcuSOBd45cr71P9doO93ac7B/Pte0RlOfXWcwfe8TDk9nc5fTwP8Oestwg4Miyni84Sy1U/gy9yyQ/rh3CPTf0iGYALg2BqLBcMQMM8LQbIL\u002Bg5yybapHJIx7MtI2l3HWoLFRmsmwdup54\u002BM0JrNpwIIleHVYHWSHUNw7ysPQitlCJZMRfsHJPgyiOHnHAw3JAXJAER78foNM2kntdLwmqWkJ4gEQWFGwbEpoteTqsE3eYrlRgHm6RbcfxJSH27lQi48QvREMuLkgn7TUk8iuUhoMDwHy1Sj/T5xaAIO9OICBCDpV2gMs0boAIPC05bHuYWKKe8ynbaZWEW2EsqglY1c0U4uOSIgG3z1X8qQ4Omnaa58hIsyz2aqD/8ilqC8B2s2ZgII2YBjqc5yfX3sCLdbzqkcZBECKgHnQ\u002Bli/YTceRhfmnrnXpAt2Nr8gFIo/gdHhog3X\u002BNZ9DwAYZWXAKwJlcRljG48tLAZLks2Bamv/oXh23c8pRk0xaZ\u002Bpzz6VphusupNg3GZStHYHjFYY\u002B6SkGMP9SV1DTDrMIbH/g1zHtfyx5L/IjtUCJBlJIbnnGH3rBaZ6qGzOaX5olKq0UzEpT9ZpZwb024nu6xUz\u002BhqA1RlEBH22TQ2P84sxb\u002Bo6XcDoL\u002BHjjaFm9ioci71Him9T18\u002BBYF6zYvLI2XOLs3uvtJ1ES9o4nVdn3Q5TmbFQSGkr7YgqqO1yNLzvGqQ960K\u002BfNcf806VG0poGZNQb9kxeIEab8XjdRu/0hcdSXKjOfG7lRzqMFUahtJNso9aIcTjraITE4uMyvfLYBEnh8HHxO\u002BRlMq8Vzg7/9jzpbKMVbBSOavQgBZ2PtoVLtAz4w8Adf2vuIz6J1Z55xOiiRVFPwpg1U4l9zTJK1Xwlzhn\u002BAzZ8y/E3K0jWAJFVpkCw6W03\u002B/F0x2w2o7I5p0m\u002BYAeEf8G2JX1gFJtPY1L0JCbxmewS8dYkhT/GRig\u002B/Yf/F5yJ0Sp\u002B\u002BsPz1\u002BNaKWAdPn\u002BLRAldq3IxX/qF8\u002BNRIRcXTEuyalb8dp8oIxnyzlvbqQest7l6oWwuWHUz9QrgnrbIRt0YbtQojtFqMYhYQpGeqkrfpGldmK7fhBHdyH2US4RnJod\u002BwzozhCjoDG/j1hXjlU7ABPZJbqouPOrCSsJT1eoD8RgKH\u002BcMqCBAdYhC\u002B637/jcu1EaSHbvdUIJTbT1mlDqB4\u002BD92XVnt1jSBPUd70U4xkiPIQGncddcLM9kuTrm3eFRvRvM/iS9yyDpvBTCv2E9Gqrw23M03m4JnaiqAvod7ysXyDIpa8gnzVngubW\u002BmXFqJ56T8gZyHN6pw1x4F8Qmz8ztrvMzE7LezQoVVCC0TwA7P99fifkgpa9Tg6Rrq7mVve3ozO5\u002BOxPvtST4WMi99XRYQNvox0HTyQlD35AKcyFQg5oyz34VuQDPc9TUKEjmkY4sE2bhrPasFQPlPl9/4UIDq9kyjyX6RovXGVdo\u002B6C8XUoE=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4DF2961\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "9675bd72-e894-c7c6-d232-ffa1026da7e2",
+        "x-ms-content-crc64": "n2rEbOM8PUM=",
+        "x-ms-request-id": "6828d823-501e-009a-47b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-0824f8d5-e5d0-52a3-6806-0f3087b768b5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bd7ec8c496882781d1d7c088d540d30b-5f0bcab999781d73-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "739fa35c-29cf-503c-3a12-95ebd07eedca",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D36B49\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "739fa35c-29cf-503c-3a12-95ebd07eedca",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828d870-501e-009a-0db0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "dOtkLYcynuRTIbUgmvfSY3m5FGk7yl7oFkHRS7OQlbNy/IiClk\u002Bq\u002BeAuMrueTYdpw0gd4fki2aqNexZGYFIww4sBrZ5uUM0qDxqIDZeiSsm5Z4hrc7S5TyPd9Bo4Y5iN/W8vnJ/p\u002BnJ689HfmcsS6jBNjPjJxFDXSF57kFuy8auC\u002Bw8oc64q0G0V8H/i2rVXywrq69afwzkfWFNAbWkXyAEmXJ676neCIryLtNPQ9G2pI8VQyAXU4jfWCBpa6WID/ih9vH0Wm\u002BCTZ8gaFA9mTmTml0mjxgD8UXpn5eJcJzlZh7arUjjvkojlvWA8uc4nb7m2c1EYYDcngWoDrrX\u002BNj\u002BPwYxZuvwr9gXBvQigv5isP3UoprPnQCd\u002Bg9DO7OPS54YgrfdBzrW9i31MV6Iuh8LRVm8/1ZCMqIFk2zYrXQoh79aCfxGganHAaho2muiFT/wO/JV0khH2lAV23PJ\u002Bki1yK2jMrAiwMez9f2t1VQ2Y34s6HWB0rVzEi\u002BoMKo1\u002BQtjtxG\u002BAuaP0XcupdxOmgD/33f1nRHXN/X4LByAdpAdefj2SiJGeGCboRb\u002BUyzVJHQurFEyQF/1jH8bxdbGC1rnES/jWE/euWcXWf/61ODJIwuoVco\u002B6zWc/L2nKraN0ZW8F0IA9cwkT/LuHuZj/reaTqLLHbWQqCX2RluSO46wiYhmPsGiyCk/gAXXUMxPOP4GCNgTwrfgK2sYCq9wlhRkOZFd/cP1\u002B4Z1j5mzuVtZqwlZjC6ynMrQghNWhsF9yu3tcxc68T8\u002BEBFVmjMaMG4TwmOmFwXpsZjKiXusn3DE\u002B8SvxkpEHrXOH3gZXQaXtlGhQsBh17PkB716cGfHjXCcjJ5ubmonz6ep1/uNzFSWMtcmD1isZyAQx76Iya5SBo4LeMxkKUvnfXccu/\u002B0Wjto5D2QnYIX8Cl6XaavmwH1V9FtglOELgmLPpHlj6sgWG2HI\u002BVswWkL84ii7c\u002BhO\u002BJxK2AuStfn5LYwBV7wMmB\u002BVgE5JHsciJJkYY7G4UA96gavcGRK9hGVnzsvPLwKG8EoIJfKaBNrVKLRxeVFIQN19h9YQL34N2Pzo4k/7UvWXkXJnsCoc33zRB/FdSwoTH47uUacsdcHL\u002Bkz2sSKK2tW\u002B2uff4JCyYKdZPyiNsI3x1MLADAFNaxuxnLXeJS5aRiwcnnAiND7\u002BPPH/0jaZPUq\u002BBdxfyc3TcW/LLUTb1Dp5//n7cBEdzp\u002BEwtAPTZjlF15qHyBR\u002BnxfSC0BVgb5I2i2htI9ncw5oTY92wf9xCPW5hbmcLQZKAV8nCjjHHeZip5oWMfFqHmRMH3pFB90YYQKKnDwE7KznV3NwAGkVYW/o1BolWtbED6cVD82MBTmBzqk2fEHqHfstLtq\u002BOd47dv4KnDOC8wYrhoyVL9yfGxI57nG/3uTt/vZfOCv8RhWJGZkPgWkF/ttiyvX1FS3eTdOIRAuse1fZHJ09Y/saLwB2y9ZDj5npM\u002B9WXRQvOOmIQOoYdAHKHJ4BNmSLyJsgSNv1fgkXmv45nxBcVh5D6ePztOLQwfr\u002BrO94All1XStUNdR4OfqgsKXr3pTxbca//UxAmFO4D0bg9pFZ35ikxEIkyCAKC7ApUwQ9JSMlzT8ouATM9ITX2\u002BaNV0MpRpENRtoSzKWmtfGcV0VPeyoj\u002BulSMWdTmA/9DSw5fPRswAxzL54JEwCZgcJTcJ0/SGD8aZxZ1xVpue7KFb95bXj9b1d43AuMGqfouK9kwGdyvcTLfNMX0yj3CXWvPv1BYBSJVcEFxqwVME70sR5lxLmHV5f6bfBl5ZxuQZKV3Nvqp1ham6pmbPdYtgxEYyIKUUT8J6dlRvIkY7Bk10TZf1OzCgnGCykPISqgoffj4UJ6Y/BN2bU0RSBmNnf6AVWyvzb40VkYBEYbrQa8hOU6QEIt6nNUS6WevoTpX9TxVN\u002BVLiKA6xApIh\u002Bqcmyut4B7a7X1jFbiHnORWlKUbuRxKlhm55bCeZVyBIhTqdk48AbErjQfO4iI8s/vL1D9VPM7OUgUR5ApuPIgg4eOjnRaWKoLz8DwUi6PnjTG0wpEtK/VGLCRJKh22vUCPrgBOiRbVNbmsYUySudZRKmbIqWn288XuXXDyTPB1TTL7lN2TqPQq75zXcLqos3Jd6A\u002Bm7hPWmKpKUDul4ui5NyQZlxT4zXFyrcndH4MLRZn\u002BlFTwzl8vFQwzWVi4hPy0LkmWnxxdZSqONEBKCXknPxqRp06DyGjE\u002BnIYtWQouhjNGPE5dLZ9oT8qYooO1RuDHCpOFu2\u002BIFXQwaSaRK/GZYonfOCH7cpUI/YPWVXexhVmlak52pM7HvibaKMB42yfZA0P12g6\u002Bz5v6fLnrscP8guPM68GjIrm/F33/IUXUjCZf/VI3u69O5pq2fCQU3Ahi2ancq\u002B9iNeCGOsKMv65WJeyTj7RxyMc0ggEm6KaVpjtxnEeb9\u002BQ6\u002BcdxrYDovirsYFo3hVBX8QzmpCnqP0k58JSHHyNmujIIWJHs/BtGS8faOohMXhzrHas2sU\u002B\u002BTL56N7joZaMHiaYkLyy\u002BavD1oFhmEATA7ZZ3mAF4LATiTgvXcsReWeYg1qziJDLwLLa2QRDzVDy5tUYmcMmdj12dRd0g5vQol0Z2QTlX4slnh29Ower38vXPGbmCO\u002BUch0tTQOJR00W\u002Bia3KeRcDYdZ8wu1eUslyqVLrUc06ql9dWb3yBKHrEbQljDQ9KXXiz7vnBXj3wjB93JeM="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-73710fb5-94c2-2d9a-1d90-fd55012dca8b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7e8a300310e2d723bba131a75cb4fadf-b365de6cbc386eef-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5f45c189-33ce-2213-d95e-e91502b57c68",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:01 GMT",
+        "ETag": "\u00220x8DB71C7F4D47C88\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "5f45c189-33ce-2213-d95e-e91502b57c68",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828d926-501e-009a-2db0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "2p9eIffUmkjWQ1dNJGtOTTGkTGD2QSGEVOk4mmbiXAkClurNq0EVO68UoW\u002BWrJzy76NaeivF7Zh\u002B2cwOmwDi8\u002BZOS46AgKHvjxGw4Z\u002Bx7qhNRarDiOLdPKlRT9J0B6CuMq6JR2AOcm4BausaFAv4zOokwVVVH2sEcA7kLjHPe4dwAq/xKKZHPtM8wR32wyeeWYLnUEZLWBNDhNdSKUM8Mu9jqRJbB6RD3IKBGV1NDa3mRtWu6CpBJamcrqPP9RWQAI8tkhkVQlLeo3PDyT\u002B19XYqbOJujUnEIoRpv1kAdOds8RnOIHuT0QSD0ES2fVtp57gspYgyInJFaXCVq4L53S6MVtgm5tX7lpve6r0FDaQp/9ig1M5eOs\u002BmiLYK/SWCivMVKieDQwDjMA7tVDe1QFvLbKupWAhgLRwIf14e8Jh1XGDJ7\u002BN9pbzYvKPAcOaX8UhaP5F62DHqtfwKesOixT91ePfW61F4Tsbu0Zxln7w2cI4Vw7EH\u002B4Qv3jnmciv5NvdjS/juwQb24vHLiweUhRY/1Ak1jAGObn1zpw0Ykdub9JqlAVTER6\u002BHH\u002BHAPG98mlgjp54hxKn21dx7ehn53lAVL5Zs74PBe4xZrW0gzTIN9g209ek8ejDxrix3SM2WjkCQqgzZEKrVYSwRxxc81giqboMLROlm2LVle0BXSTK/wx4sjyIlM\u002BZj35O9K7IZtNgkzdpJiklWKdFWc5VpfRf6UQP4D0blhDqdqGVVqa0CTMZnM3xYdjjU1mVRzsBQ\u002BWF8w9mvIKWSPkifq\u002BLkAIAkVCbPAUmaodvLJDnglLV6Ta4E2eXUUywh1fQ0uMpV8NXlLXqZgfgX4SH94/xrsaqSJV403yeaTwH6rStUZukQdTNk\u002Bmc74Mu17PjE1m8vtSNKoZJsIRCuS915ntPMw3o47G7IB7dDV0WSfvMu1nmRy/gICsVWpFQjta\u002BJwkH46Sh9i\u002BkBZ61sB0pN2qIcf3Vk59PbxLm14UgZpFEHuZQDmZXKsUqPj2NKnAJ6CMqxBjY6JdpuHSVvyKqh58JcZE21SkANUs4q1VhwkCe2O9l9aJ4bzZO6lXxwWuig7aig7je0xb6Ko7RoD1CB/Yz9uYzQI34kQJe6\u002BrXDnffliuevz6LwAXYa88Tpsr1COJfwcqBcz8kpfK2g\u002BsoIxga9goVp0S7pDLgWti\u002B6Oo7Zd8Ee0ipWibsdhlP1UAarEi2\u002BLDA42WZoB2boRRmZbkEfxoII6vTcZvnJS0vb9Lyya6MC\u002Bw5eoJ1atcvEbkShhBcR1omDoyc44sU2bo4bjROqNtl1l3MzwSblrTQpF/i1KMczyR0yLsh7yRlIJzEPPyi3GjhqLOyk3hVjnvXyD8rMgUbH6MP1dwcR\u002Bc1Z6pn01W4Mcf3ASvvajuoIz4/SiLpPe6bqR1dkwqIwWTIfS/R7bsiH5p7MDDZL7VnY7Kh3PnASCW7zCY4XqK9akPHIukP2jGDHS6Ibgm9vn1n9i9X6uRrCDEGGiGQ6bz3vcXxFgjMW4l9HsPLN94f\u002Bg2o0GR3ZYNfWBq0BcAT7jdtlLBHzKh0m56h1swgn9BW6hwT6BVYfFRGlbnuFFHJbSyMWaMp2C1lMDjJ0ZK3OrhKXR\u002Bj/AYeFRRf/TruioNI2GmflEIxLRHyrrfckq7Bk1r9p7c2JW0qbkSOzdr2dqm1fPkpF6J6GTANsVFOQYZpmm3f8ObMFrL4cSn9omM2\u002BDQOJxGxmHu4h4qDJHAb3CjCITNpGoXG6WZKLKZ4eHbQ1rUdQBpwuAH2I2lYSPI\u002B3JT9P4EvyeGuSz2ra2vRQAsXsk26/pwOTWkxcvcYapx0C0wNezz1pQzXbvTcyUyWJONeRJqgg\u002BH48vIX/lbukdydN2Abw8TOIg1A54\u002BnMYQYn04TuiYF14duFIhO3aq15NkYP5XsemEakCKNX5xWVb1p\u002B2ME2tu2l1/Yra88g0BijwKyivXyLCDs9SoDeHfrG8LK4OJLrQoBYaQ2E8yx3hDiKtCdo8rLe88\u002BF\u002BWttxrr8ZXscaJeGuH0rSVNuBhQPxsZIVGnTXf0A2UXCZUkV66JTiI6xWhygA/upPKhecO27djKlJHJQKQd9HI5SxFIzFl6wG32GXmuqqFFtKSFVoWlYBu8Xb8cwAl\u002BGMz6NTT\u002BodiVKrlVvNRfH\u002Bnsh4v/mKHsl\u002Br1jG6eWgBge/yotHVoRxLL7CvMT6dHXT3RLDyBfoAvDZ1OBRVp\u002Bsy08UDXtmt0gDx5N6x2IERDrjMwyS3H4v18fabUHj39XfVfF1pic6rWXKv8CEbXuO1ZClriOTGi8RJDWzTAoGX\u002Be9W7Gwjp4T6IWmyBx9a2qMC5fxPnHyTDuCJEHxRyFbhGAYxtGKHgbykcVd7FIS07jLJwByVSF1yw917qocImGkSwP8JKRYwi2RPqysVF/pr1CJJl/g6W8\u002BovvCVC\u002Bclm9j\u002BaEOFq8UciUSoVa0ybbvTD8ZkzvBw2GUvUGolm3\u002BNGh9CFq\u002Bm1ihtPR6zkgYidlE0wgwQwNzYjY/eZlta5u3FKzuN4EcMLDmt94HhzUZvDOoY4NlzfFlCeZkf2H/dAkYg7nbalIYaKJXCYslK9sBJf1lhQfYEUb7SS3at7FPJ0OVLwN7flGhT/rhDoQmf93LY1lkWa8BAHJzH\u002BEkfbDwyCJHUDzXhaerxHUM9wKClQlPz1RX6o3Uk\u002B6RCF5wfNJKMAahnu/hM52x\u002BFU59Ekv8ErX1K4cmN1Uss="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-09d655cd-858d-734e-62c5-26a0b1eb647f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0f8456c2bf7572043b86906c6df73ff6-180b3d332c551d55-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0e61c62a-8d39-d1fc-0b95-4993d0b8d866",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "ETag": "\u00220x8DB71C7F4D566C9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "0e61c62a-8d39-d1fc-0b95-4993d0b8d866",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828d9c5-501e-009a-3db0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "8Tga9STtHYsLG\u002B\u002BE2WW6btqYyOJrfpaFX05ioZC1XKQ0r85MtICi9DdbxQjPPVH5l0mXy6xvX3KilZXWi3z6Vr9KTymXbbpZ9dSrD7iNtSL8aAlGHZH3xFBbqh/ry2m6YW9JhO0oYiqPPtXYxFC5Fd9z2iJzszgtU4rZPMOabipq8K5JQzA10wbft9\u002B8H/8AoZU/d/BGR602HDFiTiZn9M\u002BrbdShb9GvPQcck/xYcTSL2ZotW/Y5JKgBEyb\u002B0oTgeMIQELErXjHDkDnpKrOw3qr913WLOZnYcUkroFyqsGuCPBs5SGCCX3poacq8T/n0UDV8APsPVD4pOJ5nAL7UGN/OZ\u002B6Yd5VJenf6Is/OGyJPNk8nLq9wc\u002BfcEA/BGl\u002B8lFHr7ucLXNmfMoaDFDJvWxx8GMlvreovXvQHu2eGiF8YPo5\u002B4i07Q9l2iPwp7V60bbTzRQKVTeZnu5DyBKFyGaomatak8HjvQdTv\u002BSTtBnGWUk2ykkJdg/CnFyedSD84A29RA4KIEH08AwQupVTCebUfXLJTv4ZoyOfl/NlRUvmVt/W1nALuDkHQdo8\u002BLt2c5Z5yfuuM5EPp6TqbohOj67ALmO5fDNyyME5wg0n2KZoJSBc73tQNCNOxy7LHUmstLIreMpXvPdjBv02cHGH68r\u002BgkVr8aAzc/ZAarUAq697jQla\u002BF/cEGgo\u002Beh\u002BHcOxyt9nyJsAQMcR\u002BAjUF1JCXltRvudkKO9rInHdPvu7sVIyjqPZnN8Qd0hGSPxXB/kV6puNLGLcTZ3v\u002BKopJwXPWka2oYiuZMF8QUebIePvFBp0x1BcLoTzVj0F7aQ050xCeu65oGZwZ4XaEOsbQS\u002B9/OSPsF\u002B1by/Bw09LqHsdR1n7WKbxNXOwBF/Ohh2Z2BERR\u002BzDpTbwjQvC\u002B90bKL8KvMmRI\u002BiEzMtw26//5ukOJ\u002Bs6NmCOWaInBsufLj2WmN\u002Bgw8VQCLQojHshTsmK8KYesNfx4PJafGMrahkg5Z6N2kLMXycnvhs3DanpaQ7UnBYhgHlpoLvpSkNmKJ6fC6bcl3CKupWC\u002Bva4vtNIcRdUVs4DA2UhIDmG5xTjvZF4lAYHDNGaSeWAnoWGrOXooNUsDdXQmAQ9u3c7B9OAnzlhQCbJRWRBugzogmDjnndTnkY/t6\u002B/p//9xVFeX0ISAANIIWy/I19w7lPI6BWnXhj/52mNQOuJpZgqy3wS417K1oJhl30GlH7qysVb9r/mWms4XnfYhL8XwnvQlFffYgr1AhWXRcqb\u002BVLupnoiLa7cQG0U2oTm7k3HSdUBNfwnC2i\u002BZvSmUxSgnGUg7eJA9ZDM8FfmyoeGDhPHz/v1msNSx5sNY8q6Ne1YdDofwfxvglBANEGoPDzhOFTg3oMYqwWl0ipHN5HGEr5mjlZNZkgXWE2nsWKBqodeKCt11VdqQ8k0efPWKE7CfiWHRbHql9IIzYY1cPmjICei6QtmUDlm\u002BEqJGOhYPTP\u002B5Tc8\u002BmDRc5RVaQvRNM7PkVXIM0NDWCnoHE1nXX7psIxWNo/GZiXCzXV3EOctkcd/vYuSjA3wv4kJVNoXahYZb7h/fv5DCSssBWHJyEtGuo6F66P3VyCCYXsCvRFPr2NfXaEushbFOLBcZoaoJvNBxppPjYJ2JhiX\u002BRmHQEwZ4Fn\u002Bbm6mFAR3wK7vlvCd1j6HvPZ2/B3g6TuIlrj9QfhkRoIoqbiEm66R28zTho8r\u002BiLa/4NVouQ8HYE3HYFPdn62h1BucSyGAyFL5SBNDWKoYJyWIkZ1EqOZ7Iw3TX4tRmFSHP86uYT2VPheCb3H8xAeirzguVQ0PXSs1ISgTrGnGp6\u002B\u002BuxjbacXn8lKFwTl0fl8FMbBSI0NGeOKjeEAVgZGuvMfBPQjuxkVzRmK7iZzywKLIDnu5dIRseEM2OPGE0XDB1wVxs0FWFmpq3tzgi\u002B5FsLieTHMV9UdDVcXFuI5U73Xx\u002BrKXgA1gcvcRTpWoi\u002BxU8Ic55YX9q\u002BG9Ll57kV7cFu9n7pE8ri\u002BqPdp8BKaxmsnYcMcGGgnv9E7Q2VKv5eCYNTemQZ1bGEFXjqeqgKc7C5OUoiCW1fzld/lCa9Xd\u002B1j5485vC1ksfViFroxhRXSnlc2\u002BGkLAAl87wMmjGa1sepNPsJ3YywA5aCXIESdvhDGFmtUHHuAWOeFuM0qPiGSrGTP5EpTWz8nNhbIc9/E4yzyYHX7XZFyyOHa7aZi1qd/BHffzdnGdrssMOpku\u002BkLwNmgO92rl1LXXRtoeGmUxGNvSW9r5RFXL\u002Bm6zyinCgz40yzMwprF03EhCGy\u002BXf5Rl2yK9XJ5n9vESQ/z8MQmLFcOb6U8yAXEpXX6RtyglM3vaTe8HBSefzdRBHWO0eKo/tgZs\u002B5VEM9qwlP8g1T/I7Q\u002BAIeQagxCc/Bt68eMNdOTUUgAiuTfmlRoVVnAof/eVeDBTNFfGJTL2z/95ykL2ox8aS4I\u002BpjPXmovJBC2fdHwk5HizuUCNDi3NK\u002Bk4bMvYH7NRDTN1VtH8e5nL/CAFV1uDVeXJQunfjDxVcHpKny7A8eV5TWZIr42ntz2nwRENyNSNtBblD9zKcoD3H\u002BZWstxqCws6iwn1OqZYIourN8srR6imvOoX2uIJr9vlUY\u002BnUARhPLYG0jzKmHpvje1RHjq1y9c9sPXxUzApMdsuEOgXsNGGSfsVJHVs3CRwqE31uJGhMIW3aqAPcOmF3aFgnIiSWNwbytU\u002BoKdi0NPRgKriNHlKjN9iYEY="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-77517b43-ab1e-40f4-5df6-eb40e74d503a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ad58e18aaad10dd3ef0e2cf564a8f3d8-6e1efbd7bc608321-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3bebbcfc-6d53-5f2f-32e1-b4b63bb8d31c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "ETag": "\u00220x8DB71C7F4D78959\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3bebbcfc-6d53-5f2f-32e1-b4b63bb8d31c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828da93-501e-009a-7db0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "MXfYEo9G1Aw/nN5Qcdntu2KP3lSZzD3wPqOpJxUPqC/3lulT/CsRYI7EkzWiWnFajI8qUIQLrGQ56NTsnaz2MPSvWNrvmr82fn3G1DgITeMxTpuG5Veq7OmEGRRXJMLhzmNB8wGWavLQ89EGRdcsMZrwuk4Rb0ucBGzxa4Cq3lm65AbVx1rim\u002BSptvGGo6YRWOh5Z2p00F4Ype6Vpf9xJRR3S2HRVmlADh5qaLlZFWDG3xKXMXfuRhSnvSJrTPblN5HdDldFQAF/OFlMCmekvo\u002BOz8Xs2vOdiAVMKZlH1cEnhDAofAcIgJ8QGPgeojysAv6S3X0w\u002BF2dQIVS\u002BBZoN2OYJIU3fEKIhU4m3MH7f\u002BbIoCeatPhD9ozTijyBtoiIp\u002BCVhX62dYa8ClcvChybosGfiVfvzoJqVS35Y/EGBs/FnjTgZflnESug3aqgE\u002BxvN\u002Bh74iwwmdldKjBQvRGUtgOIaWzouj3HN3csTvDYykFAiSsJiiSilQRagzrIF1QZDCenGKmAh3yrs6q0A0rohWDuDzPliive5dRnjTcC/iAjE0HJMbGXwAKuXdd67pK5cv3Z2gcgM4H7yDLVGflFqLSKkfAJHlOuVk8wNy1UZPdCrRs6KSQZAt\u002B/zml/wqcJabUj71yhsFOpKoO37/xUp2M6k2vdCn\u002BPcY4QSVDqL5SoJ813MHSboPzIkP6hYRPjaycFRC47K141k37OkWcCvvruD8cv3Hbun/NuFXqA7g97LN4p5eplbPxuQZ32zQ6VxdEDslJLtI6wF6U7zRXktaVvUmSJ2dkQiKLLwJrY\u002BNLl2FCofDu9MHhPeM1FKp/miYz4h3qpDOz38yqvf/Pz1x7SVvTFOzlqsSLsOWAMyl0D5DcO4HFYO8xksYgRDbCEW6Gvc9SrIU1TjtVYvNKL6ynMrJq85fetehonYYqwWKNxZ96/XFaJV8Ppu1KbAH752MVfRWEVyHapAfm6g8DCojUx5lX0zI7SQlTX0imkEXqbLojFURNCXJ5nFVtdztQCJhgcahkpBQs2jAIMPfZMBO9\u002BHlU3/VEh7oq2jLczdHSA1asQh6dgcih9jsQRNh6oGhBr3rB\u002ByinH\u002BnuPcnhUAxiOi2dKO3xIHqssum6NELhrDnGmx5XDAQuCSY0s0ACwKIurg6q2Xd\u002BTI8AEUg\u002B6OurCJGQGrjuCyolcyPLvG02rfJLj4Y0NtLGSEqTVvq/7yA6iaaycqXpQKLggWpTsowdzWdV91lhctW\u002Byc5uWrQzZYQDjTbKgD9IXk7jU7FocpW\u002BcYWXafvG2RbQ86TbfuXusR/iUCVZV0kkDZUOgiMgVls0r\u002Bkum/\u002BMPLQf9YyacONo9KKVhiJwYR48b1xiuFb3sJ1Nos74vBUcVhNtOV24jZixoYl8isw0xE7O8iyjKYRdKETzTNIUbDiJeTAPAyu8h\u002BHDrRbJeyXNFNqALcnofSyPDBEUyTzKnTVQ8xGcJcEnDm5K33htl60jIjf3lEJuoPgHg/MWq76g\u002BRPheIQQMO8ZXR9fnZ2wHXhj8acI0wjy5lIVmKXODGazqeZojB8pEvFE2jcjEwNeU2J2srYXmCYG7pIx\u002BpRJT0y4r/e7R5FdOuK1w/TR09dSu0VDV12wmBG8YZ2I9xRY/47qamMLowvRGXfTYdQxMR6\u002B40NTCffzBBPh/uHz1EPOXMRl62lwRxQ5bj3l4To5iyyCyhfVCfGa92JTKaQl4UE0AQUTy0m1TpwrFZ\u002B2DSbVqHO1bQ4v\u002BVLSzvAHHR1wF4j8sdw1JcPmzXt3rfRV4Oo/fX0wcHQzBAuyQPxVrjF\u002BtwISuVtGoIKzzp\u002BSuEtefOoFy6OcQ6MUya3QhuTDkSNJ9PbyRyeS9Nz6gKXUnE\u002B8U8QST\u002BKN4nde\u002BfOtdhmd7D18SMNUaDXGdtbGob75QCliFDMgsUE8uBaDl0k34X7DXJBoWFeIa\u002BeOT9UPyzy0ZbnGT2HqfTr4P4yo0NTskpVUB0EukOvV1ahLlmVoMPDVyy2TbZIc2ONVcBjG35sSnb1Dt8f/idTR8Hm1nubVjA6f1wWnWSEDNyph1RzTEvYROPSoKHko2kFYwX0Yazn4g\u002BAKJwiRa0SYPICZmbC3/t2DpGHyLWOVdvzETpun5s/wZVU4xOvtg9GwD\u002Bv4kzyMpMKfmMbYClaAcLALyRyo9FmwqTRfezn1liSQQh17nOO8N6XVBE4JGF8CuFA74ba1BxuSR\u002BoIMSmIqgKiR8Q1CNfMS5V21\u002BwLq4zVXL7lubBt3z8F5VT5tAZ8TF5LatCWybN8a5YdPi8rhpxZMtBqouxSMGiJMyN\u002B1peO9ouRvEC8QpcPaVIaTJ0P2l64oIE2Ealt9TpoCZaT/ZUCkkunmcZbmPA9XzmeO\u002BPLfVjAwjYSWOTeI8cKUDT8e2u5G75VZECUXQeQ\u002BLZvz71WnIg9zzti7DViyXX/UUi7POPN5SAldhkYKGUugWAublAJs7eswqgwWiuE8prKmQu\u002B1b/SoeqdMSpvIabWMG7VMFsh9aGRDno3nYr0nId\u002BTZNZc6ukX8xpaIKNPZ0FWim8s75DqKNqKcdBmwBjqJSm7NQXfLzDLNSKuI0fB9DZMkNhO\u002BjFPqTz70ngYsDICcPt6kzI8d1o\u002BYbltOwWSyH2aGjA/myr3bIzJ4123soXwrLJMR2EEDxh\u002BD5h34m02aAn7fpUCwtTQgialc5P8h640fY9SRoEblgoXwYyRf4kfkntUuzTv7endfMQ="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-3263833c-5fe1-2f27-c1fe-10fd6efa7c32",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bd876aac4b685b4a688dcbcddbdb6c5a-1d137a53fb46bb2c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1396f3ec-9dcc-3e13-176e-8d7873cbc9bc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "ETag": "\u00220x8DB71C7F4DA4816\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1396f3ec-9dcc-3e13-176e-8d7873cbc9bc",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828db43-501e-009a-24b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Ol6chYGH6kNk3eQih9/ni\u002BoBSD4DnIbhGKjLeUWPpXTJvOE4bpI/BKc8JUGtWMzbTGQD6JU9wZ3Xu2zZu3D91TdwWMv\u002Brx1XwUSXxndFM7/b8C3hi73ei/pDYLImZUg2P08JPf8B3ZxHrCZRpvslkoit/stDHEl6kc3Quk9qMVz7YIcoO/a/2RKQmt\u002BWjeX/Hs4qeGd88yIFj6syMSNN3HrKVUZz/VeR7SS5soJq5APo0JyBQLj0f21kIqxKjajvQ71kyzifiyB2mItCw0Cgm6qoSmCGy5zC1dbYD9urR2B7yW/EBRnKSUR7Cqcssrwsw4YBoUJIaHchofVixnxFy1Erx/nR25aR3QEbC8H0liMZq0tUqaUeM2H3o2MjaILINT9WAevDW\u002BfwcMRALF22LAvRSBow8SGrDJOY2TgybXR\u002BUtWCnZQ4VlBjZDnh3QYDQXZXUR9omEQdq/RXKoKvvQJPwtqHNI93mfHKzIzoyi\u002BNlJjB2xtUFrqRZfKf4SvNtKY2khssfAzn4Lguncu3NODFyZbp7eLn\u002Bqsf9c\u002Bc17jG/BjmsjgUYReL2vpjJnjv2jAR2heV48bET5dvDIY9SggAaKGy0YKosGh/XhPnhNMzMBueiv2gMBhSIWKgpFSQTo/yYr7XPAmuaCqvFYWy3cvEPNxrnsAKYDeIYK8fCAsT7g\u002BE9CEUXPMR8CHT8BuTn0SX22h3JbDO5wKHTtxZjmAenCd1Leipr\u002BDpWa2eN28c9cBriC2jnMhftQ0ejQ0XuGLBtVTzHXFc7SuHjssCMLCSa1gb7gYzev9eFXjaiiLS0qFL3IIbKNhOD5oBHA79XYRdjCG1\u002B8pbjjpUlAf5gWMJtLsptlMtdkKAzd5sMl7xYbjzff4AHdbX8E5Hx5TQVI02\u002BGdS06cxLxXfNC3r71zbYjNPBQNlCJblUsYF5a\u002Bur3hRNTr3n40Rwk7oIemp6wHya2RhgU6J0e/QbYHgK0lmMYS1mrki5MOlPkO1fOatPGbFEnlLTC4px2NKJjIMMJYEgvBk9FFH0Iegu0ML1FUJIjAaGxjPG\u002BRWi9JV172RmQ2tsPr2SEgVfULyqpHrHvMOQQQB8hV9NWcMDmh\u002B8fjJDyE1XiNbEtnoBJ3W3HBSa2zfR5a5kKf4L3uT6TrflotKKZtvtcDPsy4qGO13p1j2uaP8n6phD356PS6oxymfCW4Ri7PV4rasD5Roj3e5gYginDCX4/bh6Rkc9XeSJ\u002BsFiw5\u002BZRylIdbtT48W\u002BIAHwLylhiv4ByZ3MKGauO0\u002BGeioYwNoOhtsfXtZqpNmy/CYFTS77KG/DIPoBzV6C2jprjanbZV8noWgOQiwnl2SEGSwAaO4gy1G6FaAfzPm8XIScPtdv15bHHavGrOYD20lVfbQyQnEMCsJYIQ\u002B/B5SukeWnS5hNVEGVeUtCWh5rtnpWio8FShoTT/QVF7ZHSBXXGBrAXE/wx\u002BlynQklybDj7KrVaH0FaQfLlDukeHyLDfF1awIDaxnqZYKlkuzQ7UYDcSsLsd\u002BY0e7TNIhUDI\u002Bs509X8J5uoEFQ6sK6n5ZbOua1YQdRv5vRnFlTMHaRllkzOOtduPynlJDpuocc3nIYeDnhnqtIGyfzRhRFG7AK/1Rph2bq/UHpzYy2p8TU9P4nerg8r/etqt3DqnKoYrkgnvtys1bLbbq4N5De0bMjHlFWXeD3zg9c\u002B9yI51MPAasTlckJYgFnG809RLgmjtkqoEvhUgTYaJCr1fd6AkYnqPYly3vqGbxQLwHTuomXdizDnkbHbe9mO204nYxKLNmHFduBwIOdAIbPUWLDBK4G1J/KtqQ/IDsG/8/O8bwwBcJoDKSuFXVpJl3AN9yMYva\u002B8Yksv7Y1h/WgewDzjk7K30tgmvgJmL9qYVAGfygeulzZT//zA0ZMMoTuzdo0tZfO9ViRa4f\u002BtVjJwh5mL0iNQcCj2n6PF5vE1KhzWorlNev4d0nPjU7U2tpnKUFoJgN8IUvZUJsZf928jFcfixrN5Ixybbf\u002B/fRxzz9kJ\u002B5anK6k93k\u002By6UQnvesUwD3tQ\u002B/mQS09bhLvWOXp4GbtRfvIe\u002BoutPhjtknIc7AUqqzehnv5I7p5ac2WXnVp2QjtOnfvTERTzp73corjdPpSyq45C1nq9BJBTxIsmFZzCd0w20lINV5oisfdAbEvlfTTM5PXIN2vAjZVrf0yJzY4dGitopmhGpVf0HCSDfJhEbkdWVTCq\u002Bj/kdkC8odRJlOBlI1IgfNbIhj\u002Bh0BtHPRD5JxEFN3RdciPrgDArigN/qodAGllKJ\u002B1wjdL1CSoknTUvw37HRGFoC7EyNPimnPg8JiWQAyK7sv8jlKmlaGj1xub6/8qAtGYl2BKoG\u002B70yezWtOcEkJoSdBB/p7O3xqNEOHIVq6Exu22/aisQD5sQKsq8zrOF8TJI6Ie6ARC2chFvY9984yJPoP11RSZu/mR1b3jo\u002Bvfzwkc/yL8Ze7ZdCPgVpK\u002B7k0ukbS2yDKwL3eojQJWbzXsdf6GYPRpjMilHGDguVVm4vdgtQInKPbGXN\u002B7U\u002BjsgxT\u002BA\u002BCUOH1IxQT8AavR33YSQZoK5aojtV0HsBQkvjjvuJlb4rV0wrqKJ//9OxdK9I1pmQJO0a1qyk6DnHhpJAbMDFkShezAnY7vgL2qJopFvLuWyxU2kNb74Rhm4SYyIQP5IS7OOH6QmPuDX1DvwJO0Td/MwljxlXtyFpTEWbxYvW\u002B5sQVrh4RM9iIZo="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441/test-blob-86127e2b-53dc-216d-6095-ab979a0e8b14",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7dfd5819d13c60077a17cf2bbd11dfb2-7c5b30f83098bfd0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "48ca15ec-bf22-4d4f-debc-1a46135a8f78",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:03 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "ETag": "\u00220x8DB71C7F4DF2961\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "48ca15ec-bf22-4d4f-debc-1a46135a8f78",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828dc22-501e-009a-76b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "MxhhwQhKKTRmVeqvebs0wR2dxPTzqh8SYfnljGW4/cJtfiOewKhE\u002BnGQJIAR65abg7YmMp4sp4n4T2AOZZzPrlgnQvqXlgF1WMmDYoWeAXVjSgmvkcokQNeapXBINpXUwXUo6ambA\u002By0sdrUqUQDWk3qqhqTIB2NAwEj/fCQLSI0rqEQdhjMx0cc\u002BuDwUJaSl0sjXYt6QaFYmuWndwX8I4O3n/ui8uM1HePTdiU8nbJqkWakbc\u002BXumwAuNsyJU9BINZcOLGb76Ro7UCopst7G/wyPOafWLW0IOSOoToHAveTklVO4GQBz6HCPICP7xShhZzfAOlpocggqBjMDE1pYOpIFBR1LDuYMGxE3Rs1JDHQ7RyeKAIOKvCNLTdMNcNTWNyVRtoALFhhRs98JMSs64Pn/B8xyzfnOeoj5/4DS/up8YQ/oN1Wz8HEPOEzkgUr4EKzZTikIo2krQ3w3ERZXfrT0zNAbUulkC1dbI5VtKfk\u002BAa8T\u002BbDBM73mvLQZvJ9at7nYL7S63P3DdULRrX\u002BT/llC\u002BQ9nQ0UD85lSdNY1Sk64AKvblPpEgyTxEERuL4Y\u002BEr5a1oNP83R0lHwbaKgnjir0GazTuGlfPnYqtjMAlcPTFCIX2nOLKA03psC\u002BKRq8yUJZudYZKlpU\u002B9hNZX1BM/64CBRGD/P3KTFfnBFooNUbbaywpxvt\u002BemHgt6bfYLP9nMCBiDGdrmOolDkuU5JLFsDMjeQkIyiig5qvo0VG6tuT\u002BWeZpr0FTczIgSLCQBbflaDWEtLPyXmX7vSm7gseUaldimo6sWADt0Ana5H14DNz0A2UcNf41C/t8ce4bl\u002Bxqj95ZLW8pNQwwluSqF3nkf6xMx4NieDRVLY6TL\u002BoW1jwdcFSfHt9xzspY658ZjvSBm/JBysxtBBeqBAPclgkiHcCojKMhRVzM3vi1BYyVO6KaDZP70QtvrGhA9RrfkTTBNsnecQJRYFaRcO/XtAKHEMhhRoR1Kki5ONw24ExF8UnD99LGusqgRK09ZmAbm/hpueBOfk6sSAh9ITQiGnwGS4OmE8AzwFn9vP3bO8fooaDnzSpv93L/E6/GSZmWfi4tNxrcdYQ4OfWKUL1Q1RBEkIOTPk1VmlAMqwAUbXq8a0LTqgCpCCgcq5Mw4aa1rj6bfbUWAz/c25zG08qEI8x\u002Byel6fS8Pn4RXdpK6JLStWvzBePPBpmQG8tJj4jhhmIfGshe9Oy0Pi94swoypIrLoGXTNwqrcuSOBd45cr71P9doO93ac7B/Pte0RlOfXWcwfe8TDk9nc5fTwP8Oestwg4Miyni84Sy1U/gy9yyQ/rh3CPTf0iGYALg2BqLBcMQMM8LQbIL\u002Bg5yybapHJIx7MtI2l3HWoLFRmsmwdup54\u002BM0JrNpwIIleHVYHWSHUNw7ysPQitlCJZMRfsHJPgyiOHnHAw3JAXJAER78foNM2kntdLwmqWkJ4gEQWFGwbEpoteTqsE3eYrlRgHm6RbcfxJSH27lQi48QvREMuLkgn7TUk8iuUhoMDwHy1Sj/T5xaAIO9OICBCDpV2gMs0boAIPC05bHuYWKKe8ynbaZWEW2EsqglY1c0U4uOSIgG3z1X8qQ4Omnaa58hIsyz2aqD/8ilqC8B2s2ZgII2YBjqc5yfX3sCLdbzqkcZBECKgHnQ\u002Bli/YTceRhfmnrnXpAt2Nr8gFIo/gdHhog3X\u002BNZ9DwAYZWXAKwJlcRljG48tLAZLks2Bamv/oXh23c8pRk0xaZ\u002Bpzz6VphusupNg3GZStHYHjFYY\u002B6SkGMP9SV1DTDrMIbH/g1zHtfyx5L/IjtUCJBlJIbnnGH3rBaZ6qGzOaX5olKq0UzEpT9ZpZwb024nu6xUz\u002BhqA1RlEBH22TQ2P84sxb\u002Bo6XcDoL\u002BHjjaFm9ioci71Him9T18\u002BBYF6zYvLI2XOLs3uvtJ1ES9o4nVdn3Q5TmbFQSGkr7YgqqO1yNLzvGqQ960K\u002BfNcf806VG0poGZNQb9kxeIEab8XjdRu/0hcdSXKjOfG7lRzqMFUahtJNso9aIcTjraITE4uMyvfLYBEnh8HHxO\u002BRlMq8Vzg7/9jzpbKMVbBSOavQgBZ2PtoVLtAz4w8Adf2vuIz6J1Z55xOiiRVFPwpg1U4l9zTJK1Xwlzhn\u002BAzZ8y/E3K0jWAJFVpkCw6W03\u002B/F0x2w2o7I5p0m\u002BYAeEf8G2JX1gFJtPY1L0JCbxmewS8dYkhT/GRig\u002B/Yf/F5yJ0Sp\u002B\u002BsPz1\u002BNaKWAdPn\u002BLRAldq3IxX/qF8\u002BNRIRcXTEuyalb8dp8oIxnyzlvbqQest7l6oWwuWHUz9QrgnrbIRt0YbtQojtFqMYhYQpGeqkrfpGldmK7fhBHdyH2US4RnJod\u002BwzozhCjoDG/j1hXjlU7ABPZJbqouPOrCSsJT1eoD8RgKH\u002BcMqCBAdYhC\u002B637/jcu1EaSHbvdUIJTbT1mlDqB4\u002BD92XVnt1jSBPUd70U4xkiPIQGncddcLM9kuTrm3eFRvRvM/iS9yyDpvBTCv2E9Gqrw23M03m4JnaiqAvod7ysXyDIpa8gnzVngubW\u002BmXFqJ56T8gZyHN6pw1x4F8Qmz8ztrvMzE7LezQoVVCC0TwA7P99fifkgpa9Tg6Rrq7mVve3ozO5\u002BOxPvtST4WMi99XRYQNvox0HTyQlD35AKcyFQg5oyz34VuQDPc9TUKEjmkY4sE2bhrPasFQPlPl9/4UIDq9kyjyX6RovXGVdo\u002B6C8XUoE="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-2a589c85-941b-6963-6743-2eca78db2441?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dd45774f2d469181d1210a6a065ae965-c368c4117b38e257-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d8b4c11-8001-0f99-1ed2-0cb55c5b478e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5d8b4c11-8001-0f99-1ed2-0cb55c5b478e",
+        "x-ms-request-id": "6828dc5b-501e-009a-2db0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1794713503",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,0,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,0,30).json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5e735fdb-286c-6701-6c55-f35d2ef5da46?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2d82eb1c66e5be402bb6d0a9a169449f-0ca191c3a5eff5f6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3ae7b347-c5ad-43c9-0856-d0265794bb1c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EB6A6D55\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3ae7b347-c5ad-43c9-0856-d0265794bb1c",
+        "x-ms-request-id": "68288fbb-501e-009a-0fb0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5e735fdb-286c-6701-6c55-f35d2ef5da46/test-blob-5c857691-1741-b9ca-6337-ee3601f1de55",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-202fb4a5e9a768591eccdaf9014e2252-b796d33d73314311-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d7e1163d-5a79-385e-fa8c-3624e2224478",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EB746E8B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d7e1163d-5a79-385e-fa8c-3624e2224478",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "6828900d-501e-009a-58b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5e735fdb-286c-6701-6c55-f35d2ef5da46/test-blob-7a16cdca-a00d-1899-0f7f-2c5a51d5e4dc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-aa8f90f6ed1258ea02a1de8e8bd90926-fb9da26733851e9b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d483cf2c-908f-f814-b383-fde7949eb8c6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "ETag": "\u00220x8DB71C7EB76B81F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d483cf2c-908f-f814-b383-fde7949eb8c6",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "64d69c44-401e-00a9-02b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-5e735fdb-286c-6701-6c55-f35d2ef5da46?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dbad2c7762db9bb1ab34f5d8d3e320e3-a62b28a17df535f0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "12f87d64-6f9f-36e9-342a-11524dbb1817",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "12f87d64-6f9f-36e9-342a-11524dbb1817",
+        "x-ms-request-id": "64d69d0b-401e-00a9-39b0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1066291499",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,0,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,0,30)Async.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7c9fab44-6881-562f-a278-675a2ed94b30?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-24142bb80fde1ca674a528ae72a4f54a-abf3f36ac2db2a01-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "addb1773-6c17-0c23-f23c-0d40582d2310",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "ETag": "\u00220x8DB71C6FFAAB31F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "addb1773-6c17-0c23-f23c-0d40582d2310",
+        "x-ms-request-id": "e3497ad9-701e-0069-75af-a3a8ce000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7c9fab44-6881-562f-a278-675a2ed94b30/test-blob-ccdbd5f6-1621-1dcb-840f-44bfee73cb27",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-fa20bf90fefcd4ef31c258eb98bf94d6-887a2c86508f4ce4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b92b621f-d001-b31c-758e-2f401cd22463",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "ETag": "\u00220x8DB71C6FFC56331\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b92b621f-d001-b31c-758e-2f401cd22463",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "e3497b68-701e-0069-72af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7c9fab44-6881-562f-a278-675a2ed94b30/test-blob-16e747dc-9efd-f219-e709-6d1e19e6360a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-dfc07861d376b646a988ab0c95815a11-98bfb0e86e2f15e7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ed2e8aba-9843-5bd0-5e55-c7ba41d3e3ab",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "Date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "ETag": "\u00220x8DB71C6FFCBF1E9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ed2e8aba-9843-5bd0-5e55-c7ba41d3e3ab",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "e3497b84-701e-0069-0caf-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-7c9fab44-6881-562f-a278-675a2ed94b30?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-55b2f8f05d311a3e0587d48761ee6dcd-732eb1052de8083c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "87954d8a-faba-e99c-6e7a-78b469903f8b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "87954d8a-faba-e99c-6e7a-78b469903f8b",
+        "x-ms-request-id": "d3b7ae36-401e-004d-73af-a35e6e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1051017035",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,1024,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,1024,30).json
@@ -1,0 +1,223 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c930ed7f-00db-f609-a67a-0f47b19cf6c2?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b1c747c8db99406bbe7012753908bec9-2ca1e6f3483cbca8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "deed8fb8-8797-d212-8f3d-4ec4ed238031",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EBAA055A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "deed8fb8-8797-d212-8f3d-4ec4ed238031",
+        "x-ms-request-id": "64d69d66-401e-00a9-06b0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c930ed7f-00db-f609-a67a-0f47b19cf6c2/test-blob-44f83eb0-9e4f-120a-81f6-5a51241f0b50",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-c12395c5cc8be4f2f08d9cf532039569-5064a0c8e21c5cc4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "93bdf965-cae2-e24f-e066-b47c1da49947",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CKo4rF0T7BmF21ygLcGubzH\u002BohqUXoOYEq\u002BqQoUe9NqpDkl551/zDud0nNO7ihvYX6q6IAQyt6onn5muaamUZuaC9h53NIfRCpMyIMGv3YeT0eLbZNTVd1eeUkfFRaU94DXsOZT8YCoi6BVw/5fpd8ISGpfGuQISrH/H2eI/C8Xu9D\u002BLw6PzlnG4uHy\u002BZHfAtdqFsyoOdycz2o0UNYdI4txQggtXXbQeHoQlDgCFVEcHBiMHulia330YV\u002BgW3mDpb9afbeFsaVclZpSl6GgmrYZFDC5jQCeEtaONPgXLBz8jPJ8q5uZlm53L4lPD9PYV8qli0dIyhS6uG7g\u002B3ipRWV9VgqzJ/Mef33GQl17UwMCseExcaTZt8bZwe8suJ7xzeoj0bnJKS/XiwvFhoe3Q2lr3kWbd9fAo55H1WYD8cbe0HR3W31JOYixXeadEDE/Jn6FwNpVWloSXzIbgVfJ05VA6rYTQ\u002BfoHqC85hntJ49tBLLnfizoiXYaZPhPLbQw64pRWCl/L\u002BaWnaI5lHRAITuirnyg5lVkVF0/9NrvmPDsi/6Pn8tl7djMTNyOsvEB2kPArH87kAU06QPIPzsLqwSxSQh5sIVsPMCj1JV02aVoPhqbKuhxsPv5WrLLmbKhwKHb2WXohCm\u002BUHO\u002Bl7tvvBNeY/0ccHwYP5gMfFXSpKMSAhPzmQA/g7Xs2Np0txk8iZ6jaTmxgVAlw5nN2AfX66/MrJWreCMPItxLL5elo4h\u002Bz/a7MztpYHzDzdlmbaeuGPEqqAqDlRF7kEpZalG4gBwRUwgRGLRwZ0wY665JqLE0mRamevuB\u002BzrhQ57xE/orB029VR6fnPw4ukC\u002Baq1jLeuVIM0/FgUgj1fRL9kVg1dV7eRgjFOWmPwWacC2w4yJghG3X\u002B8o7\u002B1EmMXGym0jIzbtaHzJAqGb/ovRJKxAac/LS63LYiNkKQH3G/eJ086O90aJyVsTvH9wH11nV8c9AC75/4K/W8EThT960eqqDi65QjFpuqBwt4syW0bGANE6uhfIj9BPz5uFdkAflOqUxg0yqhGV10mKiUf3jPx\u002BTYRqQBvS4X5abXKV5EBgVR6cmZU1l1a/pObOPgaIVEKbByS7sVTSweCS1Dyi/\u002B8FKjQpVvNrSLoxqpsxBKd7zhUz\u002Bt0bpKPJzduwpr8WHKT3xRPOYv1PL75uigq5nbk5FwYnbwUR6YWUY4kbuqX7G4n2PUOTqW8b4MsirRqZDCwed4\u002B48rGj5duOOgN0N3UYc3J8x2B5qW2bD4o57zxq/1NY\u002BUMWQiTYVltkBW9ro61WCjmoGEjPpM4iHeMnZfabIz6wGz4yAi1JoG0JEaP\u002BL2vc5\u002BUCwuMKjVB09CRFtPBgyOA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "\u002BLas9HfN5DcxEqitugfGdQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EBB3B838\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "93bdf965-cae2-e24f-e066-b47c1da49947",
+        "x-ms-content-crc64": "jUdSp/b7ih4=",
+        "x-ms-request-id": "64d69dae-401e-00a9-49b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c930ed7f-00db-f609-a67a-0f47b19cf6c2/test-blob-228ed322-18ae-492b-990d-19eb1ea74c4b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-1d9ec995ac248822a83b2b270e7c0d32-075096810b145ed9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "27c52ac5-a736-81cb-f0da-38f7556c0eb3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0Z\u002BDZhgX6WJ6b0KCQPvfKREvc13423H3PZgby7KwUrQNc5yclcwgdER/oVm/gNeiF8eSmhWepfUujCiA\u002Bx6vyRyNdc1fQ5RFD/4YeDkYN73BebTrHbifbs6mbgikoHgm0Nc8MgsJQtQzTYsWhSy8FlRrv4JqxKxk7Qb\u002BudWLoG\u002BF8qhh2wWytzbguNAtiemi6Ve0OeH2uwsr2EQECon\u002BqKwbkJODWjpPuAdMiQzbN2QdXM9912eNjzacNQPArays4Q8jEfhVHo8dZIDZqjH/UKDg5626gdFFjQFc5iQ2jwtbn6j8uCVrxz4/X3LmtOUEnOVi4Mb\u002B8l8\u002B3oP3\u002BTdq5tV1fgqJA5d7dR9veiFeXtkbV0o\u002B1K5EXK1Jvdmic80G1HidcTXae5lO52qmjnc934Cp3KLtLBImMCFdP0W92AJSaKaoweyjQNuw8OxEns01C95Z\u002BJYrGahmdkATfTtTkA5oVCbRlB6TBpvGPDsm4pJUKDRnZOBrJk/9QkuskMOfXWDd20mnZHfAxvL7ZN1sP5Stv1UH6ywu/S3X01HT5nXXJt7bSAZJrcO8p53tb8JykAK2/tBumHE0rt4c0JAl7N98Iz3\u002BkfeNZBKRSkSOQY1rZEJPHOilaY5tppooLdwzl7q\u002BcEuEdP4LKJq\u002B3U0tpW1QsGtN1tD317qukOpcZTc1XrOJ0NBC5/BDQ/NO5otBQAEt13xx5cDqx5mQ1eMUr8NiiH\u002BZo9WcDsl6CpPcqPAvbVDpL427xHjynwk2sRENL5Qw614Mp5wskMmy9tstDR6oYWiSKn81p8QGpwPLZVy3bdr/rL2SIsWzvZ7ECM2dxJLrjlCpegUU\u002B0SZBgCYYCts\u002BokALmFgFj6j323hcJ/2aOJx4NcMDvLV6rB5\u002BBzEG1xzWA1DnZUwincRBpuXMouko54eJoBTX\u002ByXK0Ow5x0i3sMRbRiSsstMQFVf\u002BwhXPbcl1FV9pvTbIPggrHFSgKJa7ifXhsVzEvDT0eYq82PkQO6MixPIpTjPNU0fcQVZ\u002BsCzBQ3gf7byssFlqtQOsSyUPGyDxfWOkknvB1F3U6Hqedcld\u002B1WA8A3mdhSYvpjwYQhijSZ1TTLJHPE8Xhke14fejD96Dk\u002BPjisSywcPC9Oi0XNVshsUaOiWlJ6khJI0h56MujJZtlK4kz77YoIr\u002BhEdWUylySVsimMWo7nxKsmY3gNoQlGhCVsg3N8cGQZmqppNhysFjv55H\u002B/PQtLYx6g1YkR\u002Bg3f/fFAxRSxGULEc8DjfY6Pek09FL2Jh0cZISBU25vbCKCcijgra1EnSMo9\u002BspKZ\u002BWQEVo70\u002BVQVXapJqP0XD6m6WogRvJVYw78FszyS419zro6xMlBnzW6TA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "gsLqjq50\u002BnZToIVto1c9QA==",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EBB84B66\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "27c52ac5-a736-81cb-f0da-38f7556c0eb3",
+        "x-ms-content-crc64": "9GVqPcofLYg=",
+        "x-ms-request-id": "68289253-501e-009a-03b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c930ed7f-00db-f609-a67a-0f47b19cf6c2/test-blob-44f83eb0-9e4f-120a-81f6-5a51241f0b50",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b5f84c72c7fc6c270d1778dfc3cb2ac5-0b9e71b2320cf1cb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f3b6814e-72df-e111-5073-6f9d68f7d66c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EBB3B838\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "\u002BLas9HfN5DcxEqitugfGdQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f3b6814e-72df-e111-5073-6f9d68f7d66c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68289327-501e-009a-42b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "CKo4rF0T7BmF21ygLcGubzH\u002BohqUXoOYEq\u002BqQoUe9NqpDkl551/zDud0nNO7ihvYX6q6IAQyt6onn5muaamUZuaC9h53NIfRCpMyIMGv3YeT0eLbZNTVd1eeUkfFRaU94DXsOZT8YCoi6BVw/5fpd8ISGpfGuQISrH/H2eI/C8Xu9D\u002BLw6PzlnG4uHy\u002BZHfAtdqFsyoOdycz2o0UNYdI4txQggtXXbQeHoQlDgCFVEcHBiMHulia330YV\u002BgW3mDpb9afbeFsaVclZpSl6GgmrYZFDC5jQCeEtaONPgXLBz8jPJ8q5uZlm53L4lPD9PYV8qli0dIyhS6uG7g\u002B3ipRWV9VgqzJ/Mef33GQl17UwMCseExcaTZt8bZwe8suJ7xzeoj0bnJKS/XiwvFhoe3Q2lr3kWbd9fAo55H1WYD8cbe0HR3W31JOYixXeadEDE/Jn6FwNpVWloSXzIbgVfJ05VA6rYTQ\u002BfoHqC85hntJ49tBLLnfizoiXYaZPhPLbQw64pRWCl/L\u002BaWnaI5lHRAITuirnyg5lVkVF0/9NrvmPDsi/6Pn8tl7djMTNyOsvEB2kPArH87kAU06QPIPzsLqwSxSQh5sIVsPMCj1JV02aVoPhqbKuhxsPv5WrLLmbKhwKHb2WXohCm\u002BUHO\u002Bl7tvvBNeY/0ccHwYP5gMfFXSpKMSAhPzmQA/g7Xs2Np0txk8iZ6jaTmxgVAlw5nN2AfX66/MrJWreCMPItxLL5elo4h\u002Bz/a7MztpYHzDzdlmbaeuGPEqqAqDlRF7kEpZalG4gBwRUwgRGLRwZ0wY665JqLE0mRamevuB\u002BzrhQ57xE/orB029VR6fnPw4ukC\u002Baq1jLeuVIM0/FgUgj1fRL9kVg1dV7eRgjFOWmPwWacC2w4yJghG3X\u002B8o7\u002B1EmMXGym0jIzbtaHzJAqGb/ovRJKxAac/LS63LYiNkKQH3G/eJ086O90aJyVsTvH9wH11nV8c9AC75/4K/W8EThT960eqqDi65QjFpuqBwt4syW0bGANE6uhfIj9BPz5uFdkAflOqUxg0yqhGV10mKiUf3jPx\u002BTYRqQBvS4X5abXKV5EBgVR6cmZU1l1a/pObOPgaIVEKbByS7sVTSweCS1Dyi/\u002B8FKjQpVvNrSLoxqpsxBKd7zhUz\u002Bt0bpKPJzduwpr8WHKT3xRPOYv1PL75uigq5nbk5FwYnbwUR6YWUY4kbuqX7G4n2PUOTqW8b4MsirRqZDCwed4\u002B48rGj5duOOgN0N3UYc3J8x2B5qW2bD4o57zxq/1NY\u002BUMWQiTYVltkBW9ro61WCjmoGEjPpM4iHeMnZfabIz6wGz4yAi1JoG0JEaP\u002BL2vc5\u002BUCwuMKjVB09CRFtPBgyOA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c930ed7f-00db-f609-a67a-0f47b19cf6c2/test-blob-228ed322-18ae-492b-990d-19eb1ea74c4b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a9b58cfb443e54e03243a7057b18a5b3-eea47e222d0870c3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d3a8aa71-1ab5-ddd4-612d-08fb7a205c13",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EBB84B66\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "gsLqjq50\u002BnZToIVto1c9QA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d3a8aa71-1ab5-ddd4-612d-08fb7a205c13",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "682893ee-501e-009a-7fb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "0Z\u002BDZhgX6WJ6b0KCQPvfKREvc13423H3PZgby7KwUrQNc5yclcwgdER/oVm/gNeiF8eSmhWepfUujCiA\u002Bx6vyRyNdc1fQ5RFD/4YeDkYN73BebTrHbifbs6mbgikoHgm0Nc8MgsJQtQzTYsWhSy8FlRrv4JqxKxk7Qb\u002BudWLoG\u002BF8qhh2wWytzbguNAtiemi6Ve0OeH2uwsr2EQECon\u002BqKwbkJODWjpPuAdMiQzbN2QdXM9912eNjzacNQPArays4Q8jEfhVHo8dZIDZqjH/UKDg5626gdFFjQFc5iQ2jwtbn6j8uCVrxz4/X3LmtOUEnOVi4Mb\u002B8l8\u002B3oP3\u002BTdq5tV1fgqJA5d7dR9veiFeXtkbV0o\u002B1K5EXK1Jvdmic80G1HidcTXae5lO52qmjnc934Cp3KLtLBImMCFdP0W92AJSaKaoweyjQNuw8OxEns01C95Z\u002BJYrGahmdkATfTtTkA5oVCbRlB6TBpvGPDsm4pJUKDRnZOBrJk/9QkuskMOfXWDd20mnZHfAxvL7ZN1sP5Stv1UH6ywu/S3X01HT5nXXJt7bSAZJrcO8p53tb8JykAK2/tBumHE0rt4c0JAl7N98Iz3\u002BkfeNZBKRSkSOQY1rZEJPHOilaY5tppooLdwzl7q\u002BcEuEdP4LKJq\u002B3U0tpW1QsGtN1tD317qukOpcZTc1XrOJ0NBC5/BDQ/NO5otBQAEt13xx5cDqx5mQ1eMUr8NiiH\u002BZo9WcDsl6CpPcqPAvbVDpL427xHjynwk2sRENL5Qw614Mp5wskMmy9tstDR6oYWiSKn81p8QGpwPLZVy3bdr/rL2SIsWzvZ7ECM2dxJLrjlCpegUU\u002B0SZBgCYYCts\u002BokALmFgFj6j323hcJ/2aOJx4NcMDvLV6rB5\u002BBzEG1xzWA1DnZUwincRBpuXMouko54eJoBTX\u002ByXK0Ow5x0i3sMRbRiSsstMQFVf\u002BwhXPbcl1FV9pvTbIPggrHFSgKJa7ifXhsVzEvDT0eYq82PkQO6MixPIpTjPNU0fcQVZ\u002BsCzBQ3gf7byssFlqtQOsSyUPGyDxfWOkknvB1F3U6Hqedcld\u002B1WA8A3mdhSYvpjwYQhijSZ1TTLJHPE8Xhke14fejD96Dk\u002BPjisSywcPC9Oi0XNVshsUaOiWlJ6khJI0h56MujJZtlK4kz77YoIr\u002BhEdWUylySVsimMWo7nxKsmY3gNoQlGhCVsg3N8cGQZmqppNhysFjv55H\u002B/PQtLYx6g1YkR\u002Bg3f/fFAxRSxGULEc8DjfY6Pek09FL2Jh0cZISBU25vbCKCcijgra1EnSMo9\u002BspKZ\u002BWQEVo70\u002BVQVXapJqP0XD6m6WogRvJVYw78FszyS419zro6xMlBnzW6TA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c930ed7f-00db-f609-a67a-0f47b19cf6c2?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-de9134af456dee5af8b4b5f0bbf6d07e-995ef1fe62961827-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd2b0acf-034e-2cb7-6496-a616b6c7604b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bd2b0acf-034e-2cb7-6496-a616b6c7604b",
+        "x-ms-request-id": "6828941f-501e-009a-2fb0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "3252674",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,1024,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,1024,30)Async.json
@@ -1,0 +1,223 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-566f60c8-b61d-8231-5b4a-f2604fc159c4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-10287957a2e5bcdf04e6d7429779c74a-78b0d2407d47c68e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fb11eb08-47b6-aa5d-09be-79f9e3ac5a1d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "ETag": "\u00220x8DB71C70005597A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fb11eb08-47b6-aa5d-09be-79f9e3ac5a1d",
+        "x-ms-request-id": "d3b7ae92-401e-004d-4aaf-a35e6e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-566f60c8-b61d-8231-5b4a-f2604fc159c4/test-blob-a5d9a61e-cf07-d050-9a08-50c6521edf9e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-283a3bb93d6e006df82b22dceff3ec14-e82a0dc60b6a7eac-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "878952b3-a837-3d46-1600-9da5705e6c87",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\u002B0b0/ORPOjmbQWCu9pZX6t7apDJU923BmP3MlXyaUM6E9ssMKuO6BXUeyG/8YOVCGWjXpChQBQTZMmTng6S8AfCSKQDLS7/7IJ69Ni7\u002BxTgXiXsUwqumM/HGM/h\u002B0oLRYcZ\u002Bajbld86o24OJk87V220sz/koqD5E6/YPBRjHfE4b7NVof1sBMhGta\u002BcoHZ8i8FiKUgOIqLiIOX5A1nK14F41baf5bVsRKp3oez1XHM5W7BTAPClLk0Mc4EbcwVyf94uI8q/4KYP8eShloCx7MByw6eld9aM16tpj3I0UNWhBSIOxzykeXsKQw8MB5fIXoa8pK9hyQQHnUgjVlEz250O/JFipyWHykYonzTLfNATnTDvd6wmQzgaBynwhScp2mtuAQcCabddNNppNS3TPBx4D7UcQGPw6L1ZRJ//l0UjAsDJXX/JETN5jj7RvQoORssJdHVyCZYHeRRJqSUbYZ2VSjZpCeKgsv6BorIhIy\u002BzSv3Q9iLPrPUuxeBng2QOXiydPHbXoTzoZMF67Grj4lnoml4nSm9\u002BxZlBPkP\u002BOS\u002Bad0CFg\u002Ba026m85I1dVMCOSuOGeukF6xfBInbZlmb46iuR3HkmXl53M760ZmHeHXDUtvNgd75GkIgsxGFv20VCw/5hy3RLZ\u002ByBE0cqTYC14wEGBON3mHZtT0/s\u002BZn9B1R5caJnfFH4jU8C42R7HEcLeuFcadZlzyuH9HwoWm5WgAvysNviTmKzCXeQcLkN9i8I5YK0oJ2CF6Z234vV0DLgrF9YhGtrKSiCrWBe0V5ydgJRI3TvoeNubJ01a3La2TVEs8BZtW3DobxWNfM5I0JEBGWFhKy59Qp77hvOMb25p9ArGh2aFMCUjYG4lW/sMU1a7WcJVVSEir614cdR9W/\u002BnI4jEgkkre\u002Bk8PcvAWOei7zOd0BarFJ7oo9i4Db5QpgRvfTdzSNAMkN3ZGBdWYlfG1oKh34vo\u002Bw/q299xcm4q65fGUNqvL6ZikD850vuGkkCA8jY8rsZ5h4EoiWzxmx5vriyAjxJ8FqbbP05LrygTY0ie8IA37TzRTclZh6U6cPUhyiTOBgIuA9uPYW93LdhYFCUjU6qdN8Hwr0JII48Aoc5ZKuQERVxFb\u002Bylp4zNWR/xAHKAFh1Kg5Jj3lfA5uBMjr\u002BhHQPzU8/J3eO\u002B\u002BI80IlUiVyIcgIqwD6ZSoWYFhIkMWRjMKzsc/qyjtjg6jIsDLrsBno6\u002BLw408Q5cobJow1hZsZ92Z/caBVh1eMpSdYMbTnOqA\u002Bb6TSkKlzotv136O/Lf4NrrjMbE55k2SLdD4nuKQVI\u002BvcByXmR2bM\u002B87EX7ej3Xc5WpL8Ks5htMxAVyxrW/on4Lu30ybIF2dR/3CA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "W8iSNlGrQGnaOoWsZyPWRg==",
+        "Date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "ETag": "\u00220x8DB71C7000E967F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "878952b3-a837-3d46-1600-9da5705e6c87",
+        "x-ms-content-crc64": "PP6WsCpCa2Q=",
+        "x-ms-request-id": "d3b7aecc-401e-004d-7daf-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-566f60c8-b61d-8231-5b4a-f2604fc159c4/test-blob-6357b055-5db0-dc0e-d971-53b57fcc8359",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-642f3e0316264ae4e11fd5bdcf27f82e-496ece0b8f42dd95-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a9501224-2d0f-0292-2820-0f966ad5d38c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "XwOlGv1Jx/C\u002Bv6QGEzO5o7XdIPiJNvhZRtjBbHwppo1G5xZyet0LsY1KD7rHaNOuWOzd\u002BYQuECgLS9MkiFpzlRgXwCscRyjY0m9qPyc\u002Bkt0FEhOPS60JF9fuZy4J5igy1nmhsKinkhHDBSYUw9AAzLn1HnVH5ElrDahULeD6zuxGOGitnOE1XoACzEaG9FQG7pp0E8ey6vIvNaL/UmQwyDY6zopoUi/Yv8D1RRcD5RhUTj9Ghbokk012fmY\u002BNgsb0QMPSybJnptqnFQHvaXbLFCKqgQl6kJ7Fjo88dTImYi12nQT85nxi7Cj2\u002BlmHNaom1EWtIwG9efBkzXsjKzGoQLLUuMxxzm2mB9UgQ5ZFfljlFaDsuX8ruSNUl9kBf4E3Drmm8rzd9MYYBttsnTYZ347ifhVQ\u002B8dzqP\u002Bo3XZUZMgT6TTc3oubxyDalLJj/twtOrhKHsGrphLyMwn9NNdPg6ITGLPBPQDDRnc0tmcVD\u002Bnju\u002BK\u002BCkXGaELiKquB3tIJSxDQEKYoK/23RtiKty/rnSMf2Xk00XlcDLBw3xJVQaek62sWBP8D\u002B4/kxsNte/FTNk2IYcVZFHmXtAP190zrYcVw5YuE1VgkHB3pD8q17tD/HeiEjR\u002BiC9bxfpD7TgRDOWT9/FZljiE1pEXnr8SvIYVzNtlkJtTlztm001bHaI4Zphalt/J6mU\u002BHjyjZupwSQhzLiFcq3tKQGC28sPrKLnu3zcnuCamS\u002BJ1J3JfrzBR9opE6O6B27scD1V/E/eiU/WDtYaySJHizOI/54MJ65EwZPw4pkDKbAR8CqjRJzjq09R82/qpn635YhsMQvQ3EyTET677aa21uUiCNT3oEKSqVBOvjA\u002BWhsVOP0MkvikQRfeEDNiK7mknxyKxJ2lwEFF3Yu7gh4cULcjorSppkPsfcvBGYwPMH2WqiMTt5F9b3i7xrVs7L71wcN8PoUE/vTcnkrR5KaxNq0KINv/CJ0hpjM/7d\u002BKf40Iy1vMkvH4kasuNxVKq4rSBowIZs/m\u002BrkmWphRyQ0VUiK5yR1O5Ke7EY8szNGH2vqoaetTghTBIdCeqjhVpsSeFOTyjOJpgyHoTVU8tinnnoOdpWMlxcwN\u002BKdIrDprZWrKjrvokUoYPubFZzC/hG\u002Bmuwu0t/1leE8U5JQ7INbnfOvucitt\u002Bw01hWp4XGKfTnA7pfUysq1pYRZo16i14R4T3eZI0RJANL/\u002BgzKW7RvseZoj/3rdtMo\u002BgRERASdgg6BIZIJ4Vnlh9201MDN61nf6fFoSkeGnMiUYClP9LzeYnf\u002BOToSZcCccvggNqISaw66ZGoTJTfHCpTZZXEgpYMQ5mJY36IfzXQg29dPVlYmggUahYBSuz0w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "FgPWB5Ik750L8E2B3spc/Q==",
+        "Date": "Tue, 20 Jun 2023 19:46:10 GMT",
+        "ETag": "\u00220x8DB71C70011CA4D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a9501224-2d0f-0292-2820-0f966ad5d38c",
+        "x-ms-content-crc64": "gPbdutAELEg=",
+        "x-ms-request-id": "e3497d0b-701e-0069-71af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-566f60c8-b61d-8231-5b4a-f2604fc159c4/test-blob-a5d9a61e-cf07-d050-9a08-50c6521edf9e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4df86cf185b08ed2d021978419009958-a251f1f8da0e6e15-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5d80c6a6-c20e-6e78-4bab-6dac7ea69123",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C7000E967F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "W8iSNlGrQGnaOoWsZyPWRg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5d80c6a6-c20e-6e78-4bab-6dac7ea69123",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "e3497e10-701e-0069-5aaf-a3a8ce000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "\u002B0b0/ORPOjmbQWCu9pZX6t7apDJU923BmP3MlXyaUM6E9ssMKuO6BXUeyG/8YOVCGWjXpChQBQTZMmTng6S8AfCSKQDLS7/7IJ69Ni7\u002BxTgXiXsUwqumM/HGM/h\u002B0oLRYcZ\u002Bajbld86o24OJk87V220sz/koqD5E6/YPBRjHfE4b7NVof1sBMhGta\u002BcoHZ8i8FiKUgOIqLiIOX5A1nK14F41baf5bVsRKp3oez1XHM5W7BTAPClLk0Mc4EbcwVyf94uI8q/4KYP8eShloCx7MByw6eld9aM16tpj3I0UNWhBSIOxzykeXsKQw8MB5fIXoa8pK9hyQQHnUgjVlEz250O/JFipyWHykYonzTLfNATnTDvd6wmQzgaBynwhScp2mtuAQcCabddNNppNS3TPBx4D7UcQGPw6L1ZRJ//l0UjAsDJXX/JETN5jj7RvQoORssJdHVyCZYHeRRJqSUbYZ2VSjZpCeKgsv6BorIhIy\u002BzSv3Q9iLPrPUuxeBng2QOXiydPHbXoTzoZMF67Grj4lnoml4nSm9\u002BxZlBPkP\u002BOS\u002Bad0CFg\u002Ba026m85I1dVMCOSuOGeukF6xfBInbZlmb46iuR3HkmXl53M760ZmHeHXDUtvNgd75GkIgsxGFv20VCw/5hy3RLZ\u002ByBE0cqTYC14wEGBON3mHZtT0/s\u002BZn9B1R5caJnfFH4jU8C42R7HEcLeuFcadZlzyuH9HwoWm5WgAvysNviTmKzCXeQcLkN9i8I5YK0oJ2CF6Z234vV0DLgrF9YhGtrKSiCrWBe0V5ydgJRI3TvoeNubJ01a3La2TVEs8BZtW3DobxWNfM5I0JEBGWFhKy59Qp77hvOMb25p9ArGh2aFMCUjYG4lW/sMU1a7WcJVVSEir614cdR9W/\u002BnI4jEgkkre\u002Bk8PcvAWOei7zOd0BarFJ7oo9i4Db5QpgRvfTdzSNAMkN3ZGBdWYlfG1oKh34vo\u002Bw/q299xcm4q65fGUNqvL6ZikD850vuGkkCA8jY8rsZ5h4EoiWzxmx5vriyAjxJ8FqbbP05LrygTY0ie8IA37TzRTclZh6U6cPUhyiTOBgIuA9uPYW93LdhYFCUjU6qdN8Hwr0JII48Aoc5ZKuQERVxFb\u002Bylp4zNWR/xAHKAFh1Kg5Jj3lfA5uBMjr\u002BhHQPzU8/J3eO\u002B\u002BI80IlUiVyIcgIqwD6ZSoWYFhIkMWRjMKzsc/qyjtjg6jIsDLrsBno6\u002BLw408Q5cobJow1hZsZ92Z/caBVh1eMpSdYMbTnOqA\u002Bb6TSkKlzotv136O/Lf4NrrjMbE55k2SLdD4nuKQVI\u002BvcByXmR2bM\u002B87EX7ej3Xc5WpL8Ks5htMxAVyxrW/on4Lu30ybIF2dR/3CA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-566f60c8-b61d-8231-5b4a-f2604fc159c4/test-blob-6357b055-5db0-dc0e-d971-53b57fcc8359",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b6943a85bb1df3e1a06c4b1b41aef8bc-795617eb8596019c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a4ef2fb1-7554-ff7e-36b6-38a62869a66f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C70011CA4D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "FgPWB5Ik750L8E2B3spc/Q==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a4ef2fb1-7554-ff7e-36b6-38a62869a66f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "e3497eab-701e-0069-5faf-a3a8ce000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "XwOlGv1Jx/C\u002Bv6QGEzO5o7XdIPiJNvhZRtjBbHwppo1G5xZyet0LsY1KD7rHaNOuWOzd\u002BYQuECgLS9MkiFpzlRgXwCscRyjY0m9qPyc\u002Bkt0FEhOPS60JF9fuZy4J5igy1nmhsKinkhHDBSYUw9AAzLn1HnVH5ElrDahULeD6zuxGOGitnOE1XoACzEaG9FQG7pp0E8ey6vIvNaL/UmQwyDY6zopoUi/Yv8D1RRcD5RhUTj9Ghbokk012fmY\u002BNgsb0QMPSybJnptqnFQHvaXbLFCKqgQl6kJ7Fjo88dTImYi12nQT85nxi7Cj2\u002BlmHNaom1EWtIwG9efBkzXsjKzGoQLLUuMxxzm2mB9UgQ5ZFfljlFaDsuX8ruSNUl9kBf4E3Drmm8rzd9MYYBttsnTYZ347ifhVQ\u002B8dzqP\u002Bo3XZUZMgT6TTc3oubxyDalLJj/twtOrhKHsGrphLyMwn9NNdPg6ITGLPBPQDDRnc0tmcVD\u002Bnju\u002BK\u002BCkXGaELiKquB3tIJSxDQEKYoK/23RtiKty/rnSMf2Xk00XlcDLBw3xJVQaek62sWBP8D\u002B4/kxsNte/FTNk2IYcVZFHmXtAP190zrYcVw5YuE1VgkHB3pD8q17tD/HeiEjR\u002BiC9bxfpD7TgRDOWT9/FZljiE1pEXnr8SvIYVzNtlkJtTlztm001bHaI4Zphalt/J6mU\u002BHjyjZupwSQhzLiFcq3tKQGC28sPrKLnu3zcnuCamS\u002BJ1J3JfrzBR9opE6O6B27scD1V/E/eiU/WDtYaySJHizOI/54MJ65EwZPw4pkDKbAR8CqjRJzjq09R82/qpn635YhsMQvQ3EyTET677aa21uUiCNT3oEKSqVBOvjA\u002BWhsVOP0MkvikQRfeEDNiK7mknxyKxJ2lwEFF3Yu7gh4cULcjorSppkPsfcvBGYwPMH2WqiMTt5F9b3i7xrVs7L71wcN8PoUE/vTcnkrR5KaxNq0KINv/CJ0hpjM/7d\u002BKf40Iy1vMkvH4kasuNxVKq4rSBowIZs/m\u002BrkmWphRyQ0VUiK5yR1O5Ke7EY8szNGH2vqoaetTghTBIdCeqjhVpsSeFOTyjOJpgyHoTVU8tinnnoOdpWMlxcwN\u002BKdIrDprZWrKjrvokUoYPubFZzC/hG\u002Bmuwu0t/1leE8U5JQ7INbnfOvucitt\u002Bw01hWp4XGKfTnA7pfUysq1pYRZo16i14R4T3eZI0RJANL/\u002BgzKW7RvseZoj/3rdtMo\u002BgRERASdgg6BIZIJ4Vnlh9201MDN61nf6fFoSkeGnMiUYClP9LzeYnf\u002BOToSZcCccvggNqISaw66ZGoTJTfHCpTZZXEgpYMQ5mJY36IfzXQg29dPVlYmggUahYBSuz0w=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-566f60c8-b61d-8231-5b4a-f2604fc159c4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1b3dd65d3c4f8d3098d1508fa0e5c069-0f195b2a963ef900-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4efa28e8-edb7-5dce-5ca1-e95b9ddf6594",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4efa28e8-edb7-5dce-5ca1-e95b9ddf6594",
+        "x-ms-request-id": "e3497efe-701e-0069-28af-a3a8ce000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "948244736",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,2048,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,2048,30).json
@@ -1,0 +1,223 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b8460e84-62a8-8ac0-50ff-36c97cb895c3?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-36c52df7141f2b1f298e808227a87feb-0559010bbe6d1ffe-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ae4045ff-35f8-b3f6-5f86-da10e5016f46",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7EFB6749F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ae4045ff-35f8-b3f6-5f86-da10e5016f46",
+        "x-ms-request-id": "993db03d-d01e-0002-09b0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b8460e84-62a8-8ac0-50ff-36c97cb895c3/test-blob-504565b5-df8c-ee9b-b537-9365f13c1b4b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-9101e1322c928d5289af63c7c9ec754d-77d59bb5d5a69a5f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "efd1b489-02eb-4f37-1fa2-bdb3f1446f12",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0irNCb8pGSCqUvjAopDBImqOilU4Oc/OmlRHx6DzMm4PcJPHbhKMXXapjCXuCk93Axw9Lb3S65ha/25q4VF/th\u002BKsTH9\u002BrNXAS3fj62q35AF0MSEtgWxPIX6bG\u002BjInwkKdUFZFgdegho5SuP8lzrsCDeZRCN\u002BgAa2XWsAo1Es9\u002Bxu2XXpHo36Fa8G9HZIUkoDrtPxbxrly/U64vjcHd6JDFL3jf2Ewylpny50d8vQLgrg/PS9O4jRSQ2A7jvVHffQfafjUISMfuvqh4/ssVPparTt\u002ByDqDBDKJkSwBBUtlIE2o/oj7J1GVH4I0rP45Ne5l0NG52LW5jGXGWo/3HqWvTMOtc1Zxb3XZ2ai4Xlc0UGs9qzRpq1eX/3IjJNzRrgDshWA6i7KH9HFb7/8c8S4OkfokuWNhRZFsFYPkTjqpCDuX29jm\u002BdS4pbbDDctYiv5UFJLirOStez/OzmYuo6Y2stfDdSVFF5glfBOsrkfWE5qVkDmnxltW\u002BlCpKDt\u002BigIAjErjlQXJDvz6zTDQ8Mz3\u002BLrbmRN8nvx8bIrEq/9spuIBnBH88n6EzIE8rQkqhfmTsS9wkvDuk/1eZyiLBFL9nhZez1Sq\u002BvZMRsyCP\u002BHzUeaBMPrf7APhIwgkrotGCbg\u002BTx7iy8ak6LYpNFwkbGQbWxUx\u002BdNYLaICbZxchlx69k0EU/DDAIYv7Eg0pre3zMakCUN2BA/k1hF84G4qSFJpvj4fEBhjSFqPEh2LI4bqSqDVuH0JBOI9L33vRhAoBZPl2uiJmKyuMLD45vHiabKKkpXNRJ/VYKlL4fCag/I6ZwyJlUieYLIEJ3fMEB3wSsW7VLN6asD0AHo/PbasE6y\u002Bvn/laMRp7CHjuR0oGUCbW5c63z9OsAxLhYTebzL7WBPLDVGeCuHxUWiRlqGj2/cpo9IvcTR9cA5zqeM/i4z\u002B\u002BGD5XRv\u002B/UC1OY3WrSlql6mdtLtQ2\u002BbvXY1TKmEOwcXbkq4wuo7rKraRejempsLVCQI5kdbRrhyKGf\u002BOq8LvpnfH\u002BxqLKe0qspn0z2GvOKa6fhFe1S/\u002B\u002BfSBtqCPXH7jocPP7qu4We8lDu9M3N662tFI1D2xgNFH2PEV\u002BXNMm2YbER2d71oK8hQyOcYwoi0VxuvPNohBMhDieBWqolBr2GOJIcvBLOuHTdIZf1cLBybT8DKHfVTdyd8Mq3dEUF/DxmFSt4BhVKoAR/imJ8LJ52Du1qIt1GsOq1f8tHFkMv1yVaj1qF\u002BmcquIhyVsJ6IcQsQGVXmtleH2VBwoZJA4nAT7I8IZ1D8RSGQGlV01knO10HGtXe2D1L\u002B2/1RDfg4LX\u002BsgcPPQAn6U9Q0FpwCUwLGYYpQeiz4Xd18SUtTazdpl\u002B0ViFSF/5d4DGGjgfi2/Ii6iqwt5/NS9CPmkza\u002BZyicyr7u7IruAKIy2C2LVNwkhUyC2KCLO6/5wtQwn2yg\u002BeV4xvc5yA/9jEoKOs\u002BFh18Hwc2p\u002B05IEY7O9Sn2vaF1kh5IUo4lKv18xQwWgQDgdHu1KN1e9v5W8LUoKxMmBw7olGjxPTSRItbQbTZCMVCOLkCuQZSD1tsf8aHZPP/qFr49beyX7zcG5AXGjkmIFL8kWfySd8V6ZP2NkQuS9\u002BXXJhZ4BMOkNn8Jp51O/UhRl9zitKLDF974gwjuyh3rtCwf72gzD8/7gCO9SJAn62e1fDkusANDE843v4H6tWwhXfOxbs3gHkgNJzR/RY8OkNehOY4kvMPonNtZ\u002B5ANwMr3XCrctryZ1R2xIYjOw44\u002B6O7qWXvePKEviJHyhmL4PyYph\u002Bmkchoax2Rwc5s62dkNGtLhY6ePGV\u002BJrS3q5w66\u002BOKi5XvkmraUj5HXbcjF9K74pWtP1pu\u002Bmq6KGoTsb\u002BBVtbq4mDRdaIBcDNPVt6uWg/i\u002B8gHjauJG5ErNWr/x6B\u002BxgbhODRx6W3zrM8nHqSLDM1bMbX2eckqYcfPpkA3AqmS0Y/YzSHbcBFbE\u002BHcYvztnymcpJXqh008ttdtokMtu6kllE0Usz\u002BsgMGjmmboTf7K4gYWm10Tp0lCmxZJbc3OLlg3ts6v2Ovq8CTUR\u002BznVGjZo8A8FiBMEuwE0hgoYhLz1WwNsZcwGwkaLKs5PmBcW0atcMoNkRg466PhqwbTwY0R4XGA2aPRqIi2Iel0EtOLp3bRe/FH5URT1cXzTm8DR2sdJ13v24Kj28hCVm8vw9jQVQOPAUWbyfstLAPd3lkYstp9Vup2nMv0Lp8pBY7UJBLsI/lsdEUlgl1hwa9\u002Bxv1uKqSUsW3uWbg3mtOmcsRsWAjw8Lpgqz6UWNSMFdocdWeiu9vqP3Ol/spANdpyfw\u002BZ9GmmjtVCDX5lAFmYYUPeGiRrBLboghiUS/HwIHZkItjE8yBxdeeSX65chD8aDJ2GYhq1BntZsHJREkLjUuwIAd2A024ibKU82aQHjP3Yej5Uab5brhxda0KuH2OlrgzCVIJhmTgvY/V1eCzWUSR1eJcDj\u002BgtrVPBI2grdExBlyuYRTh6duAFJQbJ5jXvhhkeOafMoR4jlKYvoHbQA\u002B6oNOEBPgvr\u002BgG2/mniZMcd0ZxODDuldfYMdLGRStZqNSEXIbFT7kgOMj6lFaO1QTDfEc7agfezAr7r9MlaWq8rTMhHykIVyuNUQNn9/19SVzOAsTkHkLQqZB7zaPl/s9iOesnabXbtykfrhkAdtQJfmJ2W2al2I7sUHWYkIWHp1IwBb4WVeOq8k\u002BbxHAp0Da4=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "\u002BOp2usKlf0lEig2KSKlVFQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7EFBE96B8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "efd1b489-02eb-4f37-1fa2-bdb3f1446f12",
+        "x-ms-content-crc64": "U7M31qOYi6s=",
+        "x-ms-request-id": "993db065-d01e-0002-2cb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b8460e84-62a8-8ac0-50ff-36c97cb895c3/test-blob-36c98f86-e777-f1cb-08c4-3ea7bb472823",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ae19d8de5837599e3ab6256aafa8e53d-87fe274371dc392f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5bb0f9ab-2a81-a8c6-1a1a-64459cdf92bc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AbGzG0Z9ySCz2kXChQaxoBC3CI2Sjeyy0lcuiLKaq8o9DBtZwPFnnsqvqQ6Ua5JQXCU/WMAbU3PEAUnvTkFuGC57hXjrWN8fUGnD4uTdHWfF3iyMWlMJIrinlL\u002BneFCJQZDgGeYZZANGIAdWV3CO5\u002BTiKm8U4b3bcWPAQ8Qgd9gZOaFU/QOAq3ooRTpLsspIGK3axU3gdF/SBaeCWSA/JakvPR7POungYX717JuDj76YeCoXRbGKOMVCgfhb/VJZ6SCQG3WseN7D\u002BmTO6ojDTnXp6uD2KN/3pARYjbnxhGMsnAJ783NJ7P9MU0tNvE49fjKCchNxY8FAmHdwU\u002Bsk0nUAok6FSFsBn/3hqdSUqui2Gw6GbhJPuzlBO1r82JkTJ4HVTBr/tzbWgdMWj7nsq\u002B2OujfdnmNjseYVQwwBBcZkzYFSv17Ot2PYr\u002B0\u002BOSt/VI9sbR5hNokecZsz6XQp1XsMssI3meyPwAPTBO52JHe7lu59lZeoApf4NE3Cm83vrtpxMoZpR7qj3K0ajTGbp00jd1OFrEDkY68qP2WezCU25FYTBPLxUk4z2bjpjXRlXIwAnyN5aQGajM7XPghVBBCI5Knbh6NaMiUFUdOI\u002BtY6xOLYni0BvHpUeXcjGRNF3tSoYanLitTppWz9dBguEpL4nHkmfWXihigvhw4rNhgSv3P\u002B35ktbzoN7vnAA0diJWblK32ZH2BuxdqAmwPGvm5U67WkMDL4yyw/GI5sIoLgzWGnRQubeJ8Tjxq\u002BrNQ3RzCKbBeSvfU07WBQWgfRAqJXoM6hHnhiuXMWkKAXOR9YB9Fe4bZqTg9sc1irSh2XQY13ZwwFlSi4J7KkeyxUHLNA\u002BFM2cyDs7FG\u002BNaoft25Wfk8ToNITUnKopbkDxtLiF1alalHKYc5si3q6R19\u002BmXBETf3dQHzgLabhjc1m6CV/3B1UeU0djByApxRXWAsSKgxJv3jUBNfaxDyr6NQBBaJUO2tCKh8jJsHgXZlnidSbz2PAHSmtqtdGebQQcaNIfqFyAh2gzwDsJpi386c\u002BcjtnEBlwQeh5p5CT\u002B7BrErQemN739Ya3\u002Bv9j0/eQ9bYwCAd5qGGJ2D25\u002BVuNDNRQgRPjmVvIRn21sBUaDW3w6LHaY/Oo8mlTlMChPvwqKu4rE1LjrFxaZ8KKw/hMbsrPyBGpsqjgp4\u002BpkASbJgeBioYm7/kbDTtVf/sxHi5xBiX10XbqgXdFSmzDOhtXv0G6CThyJX7RtLvVVDKsrohgOIneplWRlgkO4aWNWNMf/cC6dxX1/uGmJBy7FS1EmJvjYgGReBnrKXMvY0PZQ1zotVZy8jdzajmoOIE41YDbykgJqvXRjYSnzk2ixpudzeDA01/W0qZkcPfH6UCXs1PyU5n70JlnFijRyyPp0aSeCmuheAIgBPiipTr9CaRDDxr6r3ICovxHWbw3BQaDep5TKd7V9jtQ0U6hWCtfaQyEjbsI7yExnGhuWR5F6f/xHyqbqeDFbhnfqd4jYEnR6O\u002Bws3dLeot9IY12Z5wcCudPsDkAw78svh\u002BhKUVDDjsenXEvlTaIpqSfHYhSTwd9wp/21LAQ0CQvg/RXqVFFORNSV8kq7XSxxgmUYKY32m8YJGamTTqKDsxN/xJCMP1TWeN0//c9U9UqRA2me29\u002B\u002BKmEPoTqn\u002BzZx0j93O1ibpUMQQfCwtp329GRewgs45NczwdpvfF4aLr3mzivQHbnx9V3mjlouzXODGOzWCPjrOS0oA3m\u002BbCjlNlMyieiyJtaqrMytUla9BPRmrGOxA\u002BWE\u002B5U\u002B59oAc4k0wZgG/ENLETIWa5vsPeaWqz6FF7/Fc/Jtbc4Ts378ajlDuFD\u002BdgixG5sxmtgJ2P3uaDzbu1wJb42l2Y61N53zGcFiqIVV2DT11Dwkk9jaI5TQZQsB4O7dOgjDGJy6O\u002BQ9fkEW5zA4WI/IJacgJJu0i7X5pNJSsTkSha58kr\u002BYe9hX51VXw3yk18y7OfsH/NWtDozmwJbRqs1IBCGBu8YQb6nOyD1GXMh5FIzF13c9ysiYz0QysbtBRnyID78bI1wGaopRePTYJvGEravKC9NWCjlZKOxCHf4uTYHA/k0JXjFw/2zs7JHTgKiSbgPPt3ppccVFgfpvhEzMYyty12ike096WUymaV2nhWgD76/6HtYHV4xHw5w2wTrf4ImmoOlALjK0VR4twsin3fySa5TdEgQVK3/cHLezA5gRhojUASS\u002Bw8G9BYm4GZTDn\u002BWfpJVmAo5FUXVpo9G7ARFF3Hw/05zX02fTYAx6XNHq2HySE17Cq0Q6Tu/vVWAwAcR4cn0Yw8xIx9EtkuJByvRjfotU6S2yQzD4BUTtKL4Ho14HwiqUkhSwSQuN1RihuEP7S9bUmxjWhe8MYL5HW59TJe\u002BEeciJjqx25J/iJK4YFk0A8ZyncwgFMTx7iHFWKO2seu8pHX57cb1qXfZ5NKEA9ApxRqnCq7LnfwiMDgZ64Lvyden/LzkOhUAffRURzDybepQnJOIDqY88Ad417yO27316hv73QYURIoEp426dlbLMMNNyU/uZrowagu0a2NZcaE2X1wV9o/kO1gIhGYYgnqwrab5QBJuBoNgynL7YNgnqzXrgxf5tjkzaY325uJTGOiRA768XzGPyFnZtCwd6Nt/4dgxLP5it/dsxdeEdx\u002BgDLKKaVwaaksEXLu9HwENFoCydgUJIuvpLkzHT5pZClA5OKd6kn9/ZXaNLNBCpJc=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "75UPTRATf86QjpkGqiLPxQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7EFC218A2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5bb0f9ab-2a81-a8c6-1a1a-64459cdf92bc",
+        "x-ms-content-crc64": "2CYYScH///s=",
+        "x-ms-request-id": "69fcdcdf-201e-0029-40b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b8460e84-62a8-8ac0-50ff-36c97cb895c3/test-blob-504565b5-df8c-ee9b-b537-9365f13c1b4b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f4fc60a91a12164b0e3775be67d1a43f-809342bcfa15116e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f707c888-1393-3190-15d9-63bdbb6bffee",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7EFBE96B8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "\u002BOp2usKlf0lEig2KSKlVFQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f707c888-1393-3190-15d9-63bdbb6bffee",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcdd4a-201e-0029-27b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "0irNCb8pGSCqUvjAopDBImqOilU4Oc/OmlRHx6DzMm4PcJPHbhKMXXapjCXuCk93Axw9Lb3S65ha/25q4VF/th\u002BKsTH9\u002BrNXAS3fj62q35AF0MSEtgWxPIX6bG\u002BjInwkKdUFZFgdegho5SuP8lzrsCDeZRCN\u002BgAa2XWsAo1Es9\u002Bxu2XXpHo36Fa8G9HZIUkoDrtPxbxrly/U64vjcHd6JDFL3jf2Ewylpny50d8vQLgrg/PS9O4jRSQ2A7jvVHffQfafjUISMfuvqh4/ssVPparTt\u002ByDqDBDKJkSwBBUtlIE2o/oj7J1GVH4I0rP45Ne5l0NG52LW5jGXGWo/3HqWvTMOtc1Zxb3XZ2ai4Xlc0UGs9qzRpq1eX/3IjJNzRrgDshWA6i7KH9HFb7/8c8S4OkfokuWNhRZFsFYPkTjqpCDuX29jm\u002BdS4pbbDDctYiv5UFJLirOStez/OzmYuo6Y2stfDdSVFF5glfBOsrkfWE5qVkDmnxltW\u002BlCpKDt\u002BigIAjErjlQXJDvz6zTDQ8Mz3\u002BLrbmRN8nvx8bIrEq/9spuIBnBH88n6EzIE8rQkqhfmTsS9wkvDuk/1eZyiLBFL9nhZez1Sq\u002BvZMRsyCP\u002BHzUeaBMPrf7APhIwgkrotGCbg\u002BTx7iy8ak6LYpNFwkbGQbWxUx\u002BdNYLaICbZxchlx69k0EU/DDAIYv7Eg0pre3zMakCUN2BA/k1hF84G4qSFJpvj4fEBhjSFqPEh2LI4bqSqDVuH0JBOI9L33vRhAoBZPl2uiJmKyuMLD45vHiabKKkpXNRJ/VYKlL4fCag/I6ZwyJlUieYLIEJ3fMEB3wSsW7VLN6asD0AHo/PbasE6y\u002Bvn/laMRp7CHjuR0oGUCbW5c63z9OsAxLhYTebzL7WBPLDVGeCuHxUWiRlqGj2/cpo9IvcTR9cA5zqeM/i4z\u002B\u002BGD5XRv\u002B/UC1OY3WrSlql6mdtLtQ2\u002BbvXY1TKmEOwcXbkq4wuo7rKraRejempsLVCQI5kdbRrhyKGf\u002BOq8LvpnfH\u002BxqLKe0qspn0z2GvOKa6fhFe1S/\u002B\u002BfSBtqCPXH7jocPP7qu4We8lDu9M3N662tFI1D2xgNFH2PEV\u002BXNMm2YbER2d71oK8hQyOcYwoi0VxuvPNohBMhDieBWqolBr2GOJIcvBLOuHTdIZf1cLBybT8DKHfVTdyd8Mq3dEUF/DxmFSt4BhVKoAR/imJ8LJ52Du1qIt1GsOq1f8tHFkMv1yVaj1qF\u002BmcquIhyVsJ6IcQsQGVXmtleH2VBwoZJA4nAT7I8IZ1D8RSGQGlV01knO10HGtXe2D1L\u002B2/1RDfg4LX\u002BsgcPPQAn6U9Q0FpwCUwLGYYpQeiz4Xd18SUtTazdpl\u002B0ViFSF/5d4DGGjgfi2/Ii6iqwt5/NS9CPmkza\u002BZyicyr7u7IruAKIy2C2LVNwkhUyC2KCLO6/5wtQwn2yg\u002BeV4xvc5yA/9jEoKOs\u002BFh18Hwc2p\u002B05IEY7O9Sn2vaF1kh5IUo4lKv18xQwWgQDgdHu1KN1e9v5W8LUoKxMmBw7olGjxPTSRItbQbTZCMVCOLkCuQZSD1tsf8aHZPP/qFr49beyX7zcG5AXGjkmIFL8kWfySd8V6ZP2NkQuS9\u002BXXJhZ4BMOkNn8Jp51O/UhRl9zitKLDF974gwjuyh3rtCwf72gzD8/7gCO9SJAn62e1fDkusANDE843v4H6tWwhXfOxbs3gHkgNJzR/RY8OkNehOY4kvMPonNtZ\u002B5ANwMr3XCrctryZ1R2xIYjOw44\u002B6O7qWXvePKEviJHyhmL4PyYph\u002Bmkchoax2Rwc5s62dkNGtLhY6ePGV\u002BJrS3q5w66\u002BOKi5XvkmraUj5HXbcjF9K74pWtP1pu\u002Bmq6KGoTsb\u002BBVtbq4mDRdaIBcDNPVt6uWg/i\u002B8gHjauJG5ErNWr/x6B\u002BxgbhODRx6W3zrM8nHqSLDM1bMbX2eckqYcfPpkA3AqmS0Y/YzSHbcBFbE\u002BHcYvztnymcpJXqh008ttdtokMtu6kllE0Usz\u002BsgMGjmmboTf7K4gYWm10Tp0lCmxZJbc3OLlg3ts6v2Ovq8CTUR\u002BznVGjZo8A8FiBMEuwE0hgoYhLz1WwNsZcwGwkaLKs5PmBcW0atcMoNkRg466PhqwbTwY0R4XGA2aPRqIi2Iel0EtOLp3bRe/FH5URT1cXzTm8DR2sdJ13v24Kj28hCVm8vw9jQVQOPAUWbyfstLAPd3lkYstp9Vup2nMv0Lp8pBY7UJBLsI/lsdEUlgl1hwa9\u002Bxv1uKqSUsW3uWbg3mtOmcsRsWAjw8Lpgqz6UWNSMFdocdWeiu9vqP3Ol/spANdpyfw\u002BZ9GmmjtVCDX5lAFmYYUPeGiRrBLboghiUS/HwIHZkItjE8yBxdeeSX65chD8aDJ2GYhq1BntZsHJREkLjUuwIAd2A024ibKU82aQHjP3Yej5Uab5brhxda0KuH2OlrgzCVIJhmTgvY/V1eCzWUSR1eJcDj\u002BgtrVPBI2grdExBlyuYRTh6duAFJQbJ5jXvhhkeOafMoR4jlKYvoHbQA\u002B6oNOEBPgvr\u002BgG2/mniZMcd0ZxODDuldfYMdLGRStZqNSEXIbFT7kgOMj6lFaO1QTDfEc7agfezAr7r9MlaWq8rTMhHykIVyuNUQNn9/19SVzOAsTkHkLQqZB7zaPl/s9iOesnabXbtykfrhkAdtQJfmJ2W2al2I7sUHWYkIWHp1IwBb4WVeOq8k\u002BbxHAp0Da4="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b8460e84-62a8-8ac0-50ff-36c97cb895c3/test-blob-36c98f86-e777-f1cb-08c4-3ea7bb472823",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cd66b8acd2e39a3ef0be4c98d862ecbd-8f4f2224868c34d0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d4bcd1b9-9ad7-b028-6e01-8c9a3911ad98",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7EFC218A2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "75UPTRATf86QjpkGqiLPxQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d4bcd1b9-9ad7-b028-6e01-8c9a3911ad98",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcdde4-201e-0029-34b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "AbGzG0Z9ySCz2kXChQaxoBC3CI2Sjeyy0lcuiLKaq8o9DBtZwPFnnsqvqQ6Ua5JQXCU/WMAbU3PEAUnvTkFuGC57hXjrWN8fUGnD4uTdHWfF3iyMWlMJIrinlL\u002BneFCJQZDgGeYZZANGIAdWV3CO5\u002BTiKm8U4b3bcWPAQ8Qgd9gZOaFU/QOAq3ooRTpLsspIGK3axU3gdF/SBaeCWSA/JakvPR7POungYX717JuDj76YeCoXRbGKOMVCgfhb/VJZ6SCQG3WseN7D\u002BmTO6ojDTnXp6uD2KN/3pARYjbnxhGMsnAJ783NJ7P9MU0tNvE49fjKCchNxY8FAmHdwU\u002Bsk0nUAok6FSFsBn/3hqdSUqui2Gw6GbhJPuzlBO1r82JkTJ4HVTBr/tzbWgdMWj7nsq\u002B2OujfdnmNjseYVQwwBBcZkzYFSv17Ot2PYr\u002B0\u002BOSt/VI9sbR5hNokecZsz6XQp1XsMssI3meyPwAPTBO52JHe7lu59lZeoApf4NE3Cm83vrtpxMoZpR7qj3K0ajTGbp00jd1OFrEDkY68qP2WezCU25FYTBPLxUk4z2bjpjXRlXIwAnyN5aQGajM7XPghVBBCI5Knbh6NaMiUFUdOI\u002BtY6xOLYni0BvHpUeXcjGRNF3tSoYanLitTppWz9dBguEpL4nHkmfWXihigvhw4rNhgSv3P\u002B35ktbzoN7vnAA0diJWblK32ZH2BuxdqAmwPGvm5U67WkMDL4yyw/GI5sIoLgzWGnRQubeJ8Tjxq\u002BrNQ3RzCKbBeSvfU07WBQWgfRAqJXoM6hHnhiuXMWkKAXOR9YB9Fe4bZqTg9sc1irSh2XQY13ZwwFlSi4J7KkeyxUHLNA\u002BFM2cyDs7FG\u002BNaoft25Wfk8ToNITUnKopbkDxtLiF1alalHKYc5si3q6R19\u002BmXBETf3dQHzgLabhjc1m6CV/3B1UeU0djByApxRXWAsSKgxJv3jUBNfaxDyr6NQBBaJUO2tCKh8jJsHgXZlnidSbz2PAHSmtqtdGebQQcaNIfqFyAh2gzwDsJpi386c\u002BcjtnEBlwQeh5p5CT\u002B7BrErQemN739Ya3\u002Bv9j0/eQ9bYwCAd5qGGJ2D25\u002BVuNDNRQgRPjmVvIRn21sBUaDW3w6LHaY/Oo8mlTlMChPvwqKu4rE1LjrFxaZ8KKw/hMbsrPyBGpsqjgp4\u002BpkASbJgeBioYm7/kbDTtVf/sxHi5xBiX10XbqgXdFSmzDOhtXv0G6CThyJX7RtLvVVDKsrohgOIneplWRlgkO4aWNWNMf/cC6dxX1/uGmJBy7FS1EmJvjYgGReBnrKXMvY0PZQ1zotVZy8jdzajmoOIE41YDbykgJqvXRjYSnzk2ixpudzeDA01/W0qZkcPfH6UCXs1PyU5n70JlnFijRyyPp0aSeCmuheAIgBPiipTr9CaRDDxr6r3ICovxHWbw3BQaDep5TKd7V9jtQ0U6hWCtfaQyEjbsI7yExnGhuWR5F6f/xHyqbqeDFbhnfqd4jYEnR6O\u002Bws3dLeot9IY12Z5wcCudPsDkAw78svh\u002BhKUVDDjsenXEvlTaIpqSfHYhSTwd9wp/21LAQ0CQvg/RXqVFFORNSV8kq7XSxxgmUYKY32m8YJGamTTqKDsxN/xJCMP1TWeN0//c9U9UqRA2me29\u002B\u002BKmEPoTqn\u002BzZx0j93O1ibpUMQQfCwtp329GRewgs45NczwdpvfF4aLr3mzivQHbnx9V3mjlouzXODGOzWCPjrOS0oA3m\u002BbCjlNlMyieiyJtaqrMytUla9BPRmrGOxA\u002BWE\u002B5U\u002B59oAc4k0wZgG/ENLETIWa5vsPeaWqz6FF7/Fc/Jtbc4Ts378ajlDuFD\u002BdgixG5sxmtgJ2P3uaDzbu1wJb42l2Y61N53zGcFiqIVV2DT11Dwkk9jaI5TQZQsB4O7dOgjDGJy6O\u002BQ9fkEW5zA4WI/IJacgJJu0i7X5pNJSsTkSha58kr\u002BYe9hX51VXw3yk18y7OfsH/NWtDozmwJbRqs1IBCGBu8YQb6nOyD1GXMh5FIzF13c9ysiYz0QysbtBRnyID78bI1wGaopRePTYJvGEravKC9NWCjlZKOxCHf4uTYHA/k0JXjFw/2zs7JHTgKiSbgPPt3ppccVFgfpvhEzMYyty12ike096WUymaV2nhWgD76/6HtYHV4xHw5w2wTrf4ImmoOlALjK0VR4twsin3fySa5TdEgQVK3/cHLezA5gRhojUASS\u002Bw8G9BYm4GZTDn\u002BWfpJVmAo5FUXVpo9G7ARFF3Hw/05zX02fTYAx6XNHq2HySE17Cq0Q6Tu/vVWAwAcR4cn0Yw8xIx9EtkuJByvRjfotU6S2yQzD4BUTtKL4Ho14HwiqUkhSwSQuN1RihuEP7S9bUmxjWhe8MYL5HW59TJe\u002BEeciJjqx25J/iJK4YFk0A8ZyncwgFMTx7iHFWKO2seu8pHX57cb1qXfZ5NKEA9ApxRqnCq7LnfwiMDgZ64Lvyden/LzkOhUAffRURzDybepQnJOIDqY88Ad417yO27316hv73QYURIoEp426dlbLMMNNyU/uZrowagu0a2NZcaE2X1wV9o/kO1gIhGYYgnqwrab5QBJuBoNgynL7YNgnqzXrgxf5tjkzaY325uJTGOiRA768XzGPyFnZtCwd6Nt/4dgxLP5it/dsxdeEdx\u002BgDLKKaVwaaksEXLu9HwENFoCydgUJIuvpLkzHT5pZClA5OKd6kn9/ZXaNLNBCpJc="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-b8460e84-62a8-8ac0-50ff-36c97cb895c3?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-603c59d7ef0982daa06a031759187919-ed870162af487c17-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea03e1dd-2bae-fd16-702b-8057ece7d519",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ea03e1dd-2bae-fd16-702b-8057ece7d519",
+        "x-ms-request-id": "69fcde27-201e-0029-70b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1618386353",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,2048,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(2,2048,30)Async.json
@@ -1,0 +1,223 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37359f19-a44d-4052-f350-661302124d7f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-75962b7c986e015e4ee25d7daa1adc8e-f48920587f642aa7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "35d95d6a-f44e-9c1b-c24a-d95fb78b44e4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C70466CCFE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "35d95d6a-f44e-9c1b-c24a-d95fb78b44e4",
+        "x-ms-request-id": "f1de2b61-801e-0020-75af-a3ea25000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37359f19-a44d-4052-f350-661302124d7f/test-blob-c7222130-e90d-1b37-aa2d-1588bf02b9b1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-763e1cb393986ab83ea11dd3b17628c1-82ab274bc67adaf3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "69a89702-15f6-7c71-5cb0-78a61507c8b8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "gAEfZR8jpIElvosg3pPcv5An\u002BgLioKsY8HcaLsRB9xTegAi\u002B4lOSQBAnfnmMEMwaAmVl/JpMs\u002BBVB3WnCXW85MZ2QV6LHtw8lLryuiExi9\u002BqACtf2/p5kc0nadre6jaaa5qzFs9tjuSIKGfgWvi\u002BI3yW/QlJXQnM/LCRY7QBXqmDV0\u002BHfnQQPHFH1rKSmTfUaUZeR\u002B0tUA2R5hoe3Csvhsq\u002BXQOpN6QIhsCYAoZWOWN5vfpuoxa7VgZB9pda8WBFF0/o1DszKjGiVcEtlE6GOq22pR8xweKzAgf8Z0AMrZVfUuo3bmQnRZLIy01VjcG4urvqo0tBFFZtNNEzNsLwlqgszkFjT8xJj2CMaPWUXnRFRK2FIQpJHj6UyTqS8w7P1zWlKL\u002BAVGvvoRTrtKxg2NVc7vIVa3Sd4q8DzoWStptRvJDA7zW1xe9BlYD1XmqSNPFkNQUbumzBCEYPfIblXep5mfcboOmfpygD09Xzp4NFcZqTLYCVNQIk/ubvpkhpXDiWfMVzd5MIxI7cGOaWzWDCyQvrUS9q42P09qECrwHgmXedXSq\u002B0voGimjxuBwcjjGGLdw8fQoJK5lhfoDxBhSN/H9v\u002BXA1A/cR5MbGeCpG2GhwfIIkoxtskzGRXVN5FYRTZLydrJTAUCnkK5lEQrNuGqYYgYqSaFhjAmU\u002Bo6ajmM9CchRuqSvTrytYQHiCKFF\u002BI0KtYZP6wftjOqovgqyDQZPJAc\u002Be/3F6RdFeOSjg4NoUwH9j9TY7SLEZC26Boy1\u002B1f7luSaB3yTQMxvCm4fSglrPG8EsH0tcjbkehfMD\u002BKGj32Qq\u002Bye0kuFbk8IaeawpR4gUsohsUrWziStsY1owzTp6Hrsjp4czG4jg0YyJQRQM9D5r7kYYN42ud3H7Ry\u002BGKsWHoFrxBp8A4Zb/i4ApKUgWYG4cxd/zYectdDAVN9RZWabGAqC6G\u002B6eag2wGasNhE0p5ObAamXmkz5zw5Ju6qrCpjHaYienXEWAfVrRQ0g7IO/j7FLtmO5A4G5iRldbMH9j7XN5MiImgoihQO0LFFD1N6Kii/5X1Q1DmYK5RBXtJE3ablbVwe7NvGnKS1gBNcwdbA\u002B1uaSBCxhlNpmfbT1ytBugMKX6IHW01c6VjYm0QWS2m9gGN2uoWWM9b4pULU8rV5Y8YQUmI0yZAeTV7H6OsPU16dJlbH2w99ZCvLDrX6d/aTXzd\u002BBej3eMbDaG0m3kr76VH0N8xusZjGku42ebrqE8VoJImzkU1lpa2f9GKSRpXQzxVT9kAqNJ2et3MKsQ8L2USXzqmxSFgUnpIezs02JExIVaqVlh2FPf/8JNnKWuSulBst\u002BnfsL4bNP2e\u002BC2XQaIMmsmtUZkMnEpC5xSN\u002BSjOtcDqiGCnUXDYj2Fal1yKKG7xWo5iJSi3X9ufXMlpjTvU0AJs7PlBZUmYlMI3scTt\u002BL6lnJ5abJCYcyhFB/RnrsJlhcdaHXu1r/VEyVAmf63WsaRKg/BdemOxlLmQ/F1VMSX/kiw9k5tDL\u002BzpFWMAsfO6rlZQHOsSCAtj6EiCJPNYL9hqJu2B2R3Ix1PDdGTAcSLF1g3GxNQ67YngmesSgQs5USWKlkrGONV4h1VXDtPmY3dl/A6lkSrEL3kjoT9ytkZIyeN/ddrX/914jn2\u002B4571\u002Bjaz7IU8U//6hmcRoleWBhEOzkTwpy2cjjwxbMLtRUuababIvomBTHYjRO9zhh2Foogsr9VZxVMI116Iyyb9DQEbd3SwjUdHTYHOjWJ\u002BKMgeq4p6gNW2AKhT/6drOEFPJjeuGE7o1NUA5SITizfwyu5Wql\u002BcQoxrZTaMXM2gHFUAf2cq0BC5dda1OZuzYrVwYzT5FE4h8uOrAvMYHLgHoIiM0wvQxjqdnXSI5wjwt8KBW/nYpwfHHoyDv41doRkerZkTJo\u002Bpn5z6G3cZWMuauorwVoC\u002BLzmAxbR/DQatQDwbanmv3ZFzF/wc3kuQrYXA6QTCbQqYYH6fUmDbKlKWTNs7Pi6SKp05fX6EoVCt8BguviQBqtLxQsn7EEtwl\u002B2phlGwVa\u002BXLv5nyS\u002BL0/8t8WII7GwuVOHISbsklxpRyKVRGxr/PVqoV09l2eHjJa8KzR7pJ\u002BuBezGv6Av0cpekFgCKevikLrQHoFTciLs/5SQMGcn7aKD5z6ApT1UO8\u002BT3gcOhWOr2Zp5q4YdWpPK2b8MnqFiNqO1f0GsYut9e\u002BOxv5Ma3Xow5VbMrkEcZY2rtct9SJwuMadkWQYi/nev\u002BzCibJr/r/xE27lKlYhhmBm0AawfADNHgo7stYR0DubfHbIRefjyrAXPOGzi5JsfAsDsbfzKj/v8W\u002BkLE/p30M3SanjWUB8gwVWnT8fGZJ7zzbLDiKDpFY22FB0P55kLV2ifD3oiSLKgy6ynIz80NvdLF0ZHs0cs6VTqIDsBEdm8m/hfJlUj0YQAIr30QvJOgt0mw89TxKMgcyYmOCd2n7nS64dH1RChKEbBRpGKOKZhnJ5d2k0KaddUPrMu/ZhciYMDIVZrBq3NhJuJkX0SlTp/xJyJGMRryIKw85ZccyquZL0NhxZP9pXwkFaygNdZQah4rzj803C/l1jUuhMWcRFw2y2/BQ4jL80GmYhuuUeqV7Lt5MTxsZFNTvC\u002BezuC2R9EQaWqmTuaVH9q9TnnUN4RKWNgKI1NfimccrYeZbSSg79pKXehAL12U49Fh7tXZv0RrFHXIbGS98J8DSeFfO7K2HJ6fSc=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "9KARY/y/QWaswj7JlTEYhQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C7046F9EBD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "69a89702-15f6-7c71-5cb0-78a61507c8b8",
+        "x-ms-content-crc64": "5PPwkbYwVpQ=",
+        "x-ms-request-id": "f1de2b8e-801e-0020-1baf-a3ea25000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37359f19-a44d-4052-f350-661302124d7f/test-blob-a4a9b464-1838-ab31-addf-24f624954f95",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-05e851e644ce8aebb3a7c1d59e8624ef-e18a9e05a4ca6300-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3fcafbfb-4d2c-9311-b134-7540bd23cf4a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "umIO1zG0JfKW8dege65J3OjVqz0nMTfblO/LDskay281Zh4QbKb2sUo2D/n\u002BXIxJJGgk42B8O4grMkJB6RcpeyVnaxSQOXBC3/ry8SE93Tdjgulh9ugPuSqV5DljtccyDJTUl/F3uOv34QRmiUpn7VUL3mctyIQ8V7Hq\u002B1Q23ioyv\u002BWNaUVG68n\u002BaRTkqTDgLffkWNdgBUQPlz9Ajb2WwQLaM8ll2YQQxPKdL19wWK6BCs1cUoZS0rqhftIGBl0MZ6cRCXVme1Rz1JPkwtbknz6QvoPvOW98h2AOxFqxCb6Vkce3Xk45Go546X7zbhDkvN\u002BTdUfZHC04lYIUV7b5wcrUTjAOLEDvV6T0dlDwiBhQKgd7HpR3u3SZf8jMJMLXfye0Hx/f1Y\u002BepB2i5aXdRw1qxC2vfqM1XJO8da14IzPiHPcoPGj4cVR43Hl21dbOvDe6Yl\u002BVKAGEfsOMI2DhJoDqwMiutAulcVPYNqEpvoa97bh2vcHTTPT2pL6lbE30lrb5jBQOIAcsFfAMvPFfWr88zzWnami/FnPUuBBNAAUF5KDrMDFyr82xSqjQx5AClkn\u002BaJwYTCtOOXahOmj23hXrBthRdCqNyiBo9iC/7k/j0SHHTpdo7Zd0nPa70XRku2uT5cC3sSIecJ58r1YLjksnvWhHLpB9gxlA3Nc00vmrBDq0LAmPKyD\u002Bqd756z5BaQ6rlBMMHYzbFmKmd9RK6p2k0asbVmJBmJFISIWyg5fb/3PJiD7ln\u002Bau2Ram6LRLtL5AVBqTJRKrafyCw9UGKZLLy3dhgGFfvzHEbX1Mm6/c/ZPGcS98R9lgHh9CY9sRp6\u002BD2xw96TNd4ZTozriUX85MpcZBP7diT4OdAGJCHFxWssXNyL\u002BTnxNgaZCak3ghy79R9r0U0Gf4IYyYn\u002BnQGsQ4kRzyx5YOuAaz4NYnyLsLfDWj8SaeQuJd1acz\u002Bv8pj07MYQFcLgQoQj22YO\u002BR0VjQjSK0LSmdmU86lfLv274GiVGHWma6rk4weq7p6OLyywROYm3cdWIlLsiyIpkSOWZ\u002BsNaeCnbyFt7Ug7J6tLFsR8nuoXlRKRTvYSyeCIy0HkFHajcMVMGNW0yOCPKvq3oWRdrPJJjtLYbBrqhKVA1RH2RwMkl5X/MIYEUswiEiP7axh8Ky5fqpWjyxSqUYQwc\u002BPOiNP3gwnOXmx8NSwWtln2/ymMxLnzpqxtgNyBVO7xw97oU5lAA\u002BgevczB02V5nRTKo2Jqs78p2tInigI9PQl9emFNLlKwtutBbhbtIcM28/O3xqGMlxAvvni3GInl0XDDRGj0LG6yCfyHGUWoPLke8IYOdXZX8NNRLW/aCZ5Ra5yWKd1qMteFBcy1BX3Kh4HPqCfz11wKa1OFow8O2ABuJb25AhLbtM2\u002BeX\u002B5ovtVlqXuGlF2bYQwm76J1J/Yhi28Vu\u002BwEXVu4/NqRV3cQMhYIAxZEM2u97g5eGZUUdAt5fNR/VwbpYUgfyZuDBgmVErmIaSDf2VQDW8nhpkPCoITPG9qilN8TIqHOJGnQOuQAxQrfjA7mmaOAe/89B78EXSUSt\u002B4u9n3edUaDDbTqMxzh3N045xR55H47Hhzj1h7iyctAwYL50dKM/RbEY4/ulkjeWybdy3YQlM9z99Rc/qMrnEfpqW2d6A8Kr\u002BX9sYTyTIvQBXr0BP5RMCi3hd36LAJ3nMNEAOzbPG8b0x\u002BMEudKfadMiPUkM5tFmHVE5mItEH/nhhDBqk\u002Ba\u002BMUL2DHewR1FbQQ2raMJU2koAmR7lloM7sKfqIjShNdbsZAwGFtpZtdUA3lZ\u002BmLc3jarmavnI2Ju/u1vQxiQcuQw3vwO1TcRvpuRI5bcsvBjws5WKu8vcI4txRlt\u002Bie\u002Bw4yRKR9mzgUDldsMVgPPjk/5D4BOPkf5BWpt3RAZp8Rz0lwGS4nU\u002BPDFUpEQHx6OYjrNcO6ncIVEmCew9PD05fIWmIenxULCIBKThOuy6OZL43rZSDLVzF3avbNiJAf/0Gyi\u002BYKa6pz0C1DYF\u002B\u002BZla89aRV2H5nDPMwlzQePY/wOk7R/E\u002B9jsPjd4UDh/bhyPSgAJL7uibTS47i2dR2VZKtQzYA7HoG/2bQclDpY3UMTs4/biz9BHAX/qDA2rT/fRHyVjSw0Ox6qREsG0fF6egJ5osGNvdlsD616O3ZNiSx4QVO9w0wS33hxMUbwPkoQhTIxuQ56TYqjJX2CugOoWLsajpChuLayZsdJHIySe9FjabJEH9Ad/fPFHp3OkCF4xNSP1a\u002B5csx7f1ZLMTD\u002BDK2sH1BNZDjq/JCg3J4Y59alzFe0BqIlqfblyKB91si\u002Byw3sInTNK2CfpNkfFJIyYpuDpWTdRgoLhnFZa5uUbSXH4hGMKMFd1KTzGF3FBpFkt2oI\u002BjFn4YED5JgHc8PJBzu3VzKAojnWIczD6i2sQoPf9LQxj3LwYACQiEAlWmThKhEmEa9e4BEsMthkp/dTV6IYJ3sLl3vIwvcx7BX1sMtr3sAchizQfRCjAViWj7wNPTSeCTLp2ZKZXVK4LPf/OoIQ/MUzNtF1S6pmaJYfMjM3IK7hV6eUfgUxgyjeGEwcp8bahZL23gpnKMGIg2z4eisfgQxFGeLaeH7AAbOkly9aScDPRKigQEakfi7iD/qUNQT9wpdD243n/A0QMthWvpWSLjmsLTWCf0DFoJu39GiEL8yqptSYFm4260SbjA1qTb\u002BVU9286AfTf0NSejbyLAugjAcM=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "XwM18IyEBJ353wpc4AnoQg==",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C704740AE5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3fcafbfb-4d2c-9311-b134-7540bd23cf4a",
+        "x-ms-content-crc64": "WQn2fBvSXL0=",
+        "x-ms-request-id": "ec263aeb-401e-005d-4caf-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37359f19-a44d-4052-f350-661302124d7f/test-blob-c7222130-e90d-1b37-aa2d-1588bf02b9b1",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a5f495dff23ee254916da22c3069d93a-9a2d657e6719fb4d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1aabcc8e-883c-b78c-71c5-143dba91f718",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C7046F9EBD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "9KARY/y/QWaswj7JlTEYhQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1aabcc8e-883c-b78c-71c5-143dba91f718",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec263be2-401e-005d-35af-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "gAEfZR8jpIElvosg3pPcv5An\u002BgLioKsY8HcaLsRB9xTegAi\u002B4lOSQBAnfnmMEMwaAmVl/JpMs\u002BBVB3WnCXW85MZ2QV6LHtw8lLryuiExi9\u002BqACtf2/p5kc0nadre6jaaa5qzFs9tjuSIKGfgWvi\u002BI3yW/QlJXQnM/LCRY7QBXqmDV0\u002BHfnQQPHFH1rKSmTfUaUZeR\u002B0tUA2R5hoe3Csvhsq\u002BXQOpN6QIhsCYAoZWOWN5vfpuoxa7VgZB9pda8WBFF0/o1DszKjGiVcEtlE6GOq22pR8xweKzAgf8Z0AMrZVfUuo3bmQnRZLIy01VjcG4urvqo0tBFFZtNNEzNsLwlqgszkFjT8xJj2CMaPWUXnRFRK2FIQpJHj6UyTqS8w7P1zWlKL\u002BAVGvvoRTrtKxg2NVc7vIVa3Sd4q8DzoWStptRvJDA7zW1xe9BlYD1XmqSNPFkNQUbumzBCEYPfIblXep5mfcboOmfpygD09Xzp4NFcZqTLYCVNQIk/ubvpkhpXDiWfMVzd5MIxI7cGOaWzWDCyQvrUS9q42P09qECrwHgmXedXSq\u002B0voGimjxuBwcjjGGLdw8fQoJK5lhfoDxBhSN/H9v\u002BXA1A/cR5MbGeCpG2GhwfIIkoxtskzGRXVN5FYRTZLydrJTAUCnkK5lEQrNuGqYYgYqSaFhjAmU\u002Bo6ajmM9CchRuqSvTrytYQHiCKFF\u002BI0KtYZP6wftjOqovgqyDQZPJAc\u002Be/3F6RdFeOSjg4NoUwH9j9TY7SLEZC26Boy1\u002B1f7luSaB3yTQMxvCm4fSglrPG8EsH0tcjbkehfMD\u002BKGj32Qq\u002Bye0kuFbk8IaeawpR4gUsohsUrWziStsY1owzTp6Hrsjp4czG4jg0YyJQRQM9D5r7kYYN42ud3H7Ry\u002BGKsWHoFrxBp8A4Zb/i4ApKUgWYG4cxd/zYectdDAVN9RZWabGAqC6G\u002B6eag2wGasNhE0p5ObAamXmkz5zw5Ju6qrCpjHaYienXEWAfVrRQ0g7IO/j7FLtmO5A4G5iRldbMH9j7XN5MiImgoihQO0LFFD1N6Kii/5X1Q1DmYK5RBXtJE3ablbVwe7NvGnKS1gBNcwdbA\u002B1uaSBCxhlNpmfbT1ytBugMKX6IHW01c6VjYm0QWS2m9gGN2uoWWM9b4pULU8rV5Y8YQUmI0yZAeTV7H6OsPU16dJlbH2w99ZCvLDrX6d/aTXzd\u002BBej3eMbDaG0m3kr76VH0N8xusZjGku42ebrqE8VoJImzkU1lpa2f9GKSRpXQzxVT9kAqNJ2et3MKsQ8L2USXzqmxSFgUnpIezs02JExIVaqVlh2FPf/8JNnKWuSulBst\u002BnfsL4bNP2e\u002BC2XQaIMmsmtUZkMnEpC5xSN\u002BSjOtcDqiGCnUXDYj2Fal1yKKG7xWo5iJSi3X9ufXMlpjTvU0AJs7PlBZUmYlMI3scTt\u002BL6lnJ5abJCYcyhFB/RnrsJlhcdaHXu1r/VEyVAmf63WsaRKg/BdemOxlLmQ/F1VMSX/kiw9k5tDL\u002BzpFWMAsfO6rlZQHOsSCAtj6EiCJPNYL9hqJu2B2R3Ix1PDdGTAcSLF1g3GxNQ67YngmesSgQs5USWKlkrGONV4h1VXDtPmY3dl/A6lkSrEL3kjoT9ytkZIyeN/ddrX/914jn2\u002B4571\u002Bjaz7IU8U//6hmcRoleWBhEOzkTwpy2cjjwxbMLtRUuababIvomBTHYjRO9zhh2Foogsr9VZxVMI116Iyyb9DQEbd3SwjUdHTYHOjWJ\u002BKMgeq4p6gNW2AKhT/6drOEFPJjeuGE7o1NUA5SITizfwyu5Wql\u002BcQoxrZTaMXM2gHFUAf2cq0BC5dda1OZuzYrVwYzT5FE4h8uOrAvMYHLgHoIiM0wvQxjqdnXSI5wjwt8KBW/nYpwfHHoyDv41doRkerZkTJo\u002Bpn5z6G3cZWMuauorwVoC\u002BLzmAxbR/DQatQDwbanmv3ZFzF/wc3kuQrYXA6QTCbQqYYH6fUmDbKlKWTNs7Pi6SKp05fX6EoVCt8BguviQBqtLxQsn7EEtwl\u002B2phlGwVa\u002BXLv5nyS\u002BL0/8t8WII7GwuVOHISbsklxpRyKVRGxr/PVqoV09l2eHjJa8KzR7pJ\u002BuBezGv6Av0cpekFgCKevikLrQHoFTciLs/5SQMGcn7aKD5z6ApT1UO8\u002BT3gcOhWOr2Zp5q4YdWpPK2b8MnqFiNqO1f0GsYut9e\u002BOxv5Ma3Xow5VbMrkEcZY2rtct9SJwuMadkWQYi/nev\u002BzCibJr/r/xE27lKlYhhmBm0AawfADNHgo7stYR0DubfHbIRefjyrAXPOGzi5JsfAsDsbfzKj/v8W\u002BkLE/p30M3SanjWUB8gwVWnT8fGZJ7zzbLDiKDpFY22FB0P55kLV2ifD3oiSLKgy6ynIz80NvdLF0ZHs0cs6VTqIDsBEdm8m/hfJlUj0YQAIr30QvJOgt0mw89TxKMgcyYmOCd2n7nS64dH1RChKEbBRpGKOKZhnJ5d2k0KaddUPrMu/ZhciYMDIVZrBq3NhJuJkX0SlTp/xJyJGMRryIKw85ZccyquZL0NhxZP9pXwkFaygNdZQah4rzj803C/l1jUuhMWcRFw2y2/BQ4jL80GmYhuuUeqV7Lt5MTxsZFNTvC\u002BezuC2R9EQaWqmTuaVH9q9TnnUN4RKWNgKI1NfimccrYeZbSSg79pKXehAL12U49Fh7tXZv0RrFHXIbGS98J8DSeFfO7K2HJ6fSc="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37359f19-a44d-4052-f350-661302124d7f/test-blob-a4a9b464-1838-ab31-addf-24f624954f95",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4ffc04a2e6bc09630f160bdd49c6b72b-4defabfa3e8da7e0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f0b1259c-b578-160d-c914-3ab163101834",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C704740AE5\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "XwM18IyEBJ353wpc4AnoQg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f0b1259c-b578-160d-c914-3ab163101834",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec263c8c-401e-005d-4eaf-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "umIO1zG0JfKW8dege65J3OjVqz0nMTfblO/LDskay281Zh4QbKb2sUo2D/n\u002BXIxJJGgk42B8O4grMkJB6RcpeyVnaxSQOXBC3/ry8SE93Tdjgulh9ugPuSqV5DljtccyDJTUl/F3uOv34QRmiUpn7VUL3mctyIQ8V7Hq\u002B1Q23ioyv\u002BWNaUVG68n\u002BaRTkqTDgLffkWNdgBUQPlz9Ajb2WwQLaM8ll2YQQxPKdL19wWK6BCs1cUoZS0rqhftIGBl0MZ6cRCXVme1Rz1JPkwtbknz6QvoPvOW98h2AOxFqxCb6Vkce3Xk45Go546X7zbhDkvN\u002BTdUfZHC04lYIUV7b5wcrUTjAOLEDvV6T0dlDwiBhQKgd7HpR3u3SZf8jMJMLXfye0Hx/f1Y\u002BepB2i5aXdRw1qxC2vfqM1XJO8da14IzPiHPcoPGj4cVR43Hl21dbOvDe6Yl\u002BVKAGEfsOMI2DhJoDqwMiutAulcVPYNqEpvoa97bh2vcHTTPT2pL6lbE30lrb5jBQOIAcsFfAMvPFfWr88zzWnami/FnPUuBBNAAUF5KDrMDFyr82xSqjQx5AClkn\u002BaJwYTCtOOXahOmj23hXrBthRdCqNyiBo9iC/7k/j0SHHTpdo7Zd0nPa70XRku2uT5cC3sSIecJ58r1YLjksnvWhHLpB9gxlA3Nc00vmrBDq0LAmPKyD\u002Bqd756z5BaQ6rlBMMHYzbFmKmd9RK6p2k0asbVmJBmJFISIWyg5fb/3PJiD7ln\u002Bau2Ram6LRLtL5AVBqTJRKrafyCw9UGKZLLy3dhgGFfvzHEbX1Mm6/c/ZPGcS98R9lgHh9CY9sRp6\u002BD2xw96TNd4ZTozriUX85MpcZBP7diT4OdAGJCHFxWssXNyL\u002BTnxNgaZCak3ghy79R9r0U0Gf4IYyYn\u002BnQGsQ4kRzyx5YOuAaz4NYnyLsLfDWj8SaeQuJd1acz\u002Bv8pj07MYQFcLgQoQj22YO\u002BR0VjQjSK0LSmdmU86lfLv274GiVGHWma6rk4weq7p6OLyywROYm3cdWIlLsiyIpkSOWZ\u002BsNaeCnbyFt7Ug7J6tLFsR8nuoXlRKRTvYSyeCIy0HkFHajcMVMGNW0yOCPKvq3oWRdrPJJjtLYbBrqhKVA1RH2RwMkl5X/MIYEUswiEiP7axh8Ky5fqpWjyxSqUYQwc\u002BPOiNP3gwnOXmx8NSwWtln2/ymMxLnzpqxtgNyBVO7xw97oU5lAA\u002BgevczB02V5nRTKo2Jqs78p2tInigI9PQl9emFNLlKwtutBbhbtIcM28/O3xqGMlxAvvni3GInl0XDDRGj0LG6yCfyHGUWoPLke8IYOdXZX8NNRLW/aCZ5Ra5yWKd1qMteFBcy1BX3Kh4HPqCfz11wKa1OFow8O2ABuJb25AhLbtM2\u002BeX\u002B5ovtVlqXuGlF2bYQwm76J1J/Yhi28Vu\u002BwEXVu4/NqRV3cQMhYIAxZEM2u97g5eGZUUdAt5fNR/VwbpYUgfyZuDBgmVErmIaSDf2VQDW8nhpkPCoITPG9qilN8TIqHOJGnQOuQAxQrfjA7mmaOAe/89B78EXSUSt\u002B4u9n3edUaDDbTqMxzh3N045xR55H47Hhzj1h7iyctAwYL50dKM/RbEY4/ulkjeWybdy3YQlM9z99Rc/qMrnEfpqW2d6A8Kr\u002BX9sYTyTIvQBXr0BP5RMCi3hd36LAJ3nMNEAOzbPG8b0x\u002BMEudKfadMiPUkM5tFmHVE5mItEH/nhhDBqk\u002Ba\u002BMUL2DHewR1FbQQ2raMJU2koAmR7lloM7sKfqIjShNdbsZAwGFtpZtdUA3lZ\u002BmLc3jarmavnI2Ju/u1vQxiQcuQw3vwO1TcRvpuRI5bcsvBjws5WKu8vcI4txRlt\u002Bie\u002Bw4yRKR9mzgUDldsMVgPPjk/5D4BOPkf5BWpt3RAZp8Rz0lwGS4nU\u002BPDFUpEQHx6OYjrNcO6ncIVEmCew9PD05fIWmIenxULCIBKThOuy6OZL43rZSDLVzF3avbNiJAf/0Gyi\u002BYKa6pz0C1DYF\u002B\u002BZla89aRV2H5nDPMwlzQePY/wOk7R/E\u002B9jsPjd4UDh/bhyPSgAJL7uibTS47i2dR2VZKtQzYA7HoG/2bQclDpY3UMTs4/biz9BHAX/qDA2rT/fRHyVjSw0Ox6qREsG0fF6egJ5osGNvdlsD616O3ZNiSx4QVO9w0wS33hxMUbwPkoQhTIxuQ56TYqjJX2CugOoWLsajpChuLayZsdJHIySe9FjabJEH9Ad/fPFHp3OkCF4xNSP1a\u002B5csx7f1ZLMTD\u002BDK2sH1BNZDjq/JCg3J4Y59alzFe0BqIlqfblyKB91si\u002Byw3sInTNK2CfpNkfFJIyYpuDpWTdRgoLhnFZa5uUbSXH4hGMKMFd1KTzGF3FBpFkt2oI\u002BjFn4YED5JgHc8PJBzu3VzKAojnWIczD6i2sQoPf9LQxj3LwYACQiEAlWmThKhEmEa9e4BEsMthkp/dTV6IYJ3sLl3vIwvcx7BX1sMtr3sAchizQfRCjAViWj7wNPTSeCTLp2ZKZXVK4LPf/OoIQ/MUzNtF1S6pmaJYfMjM3IK7hV6eUfgUxgyjeGEwcp8bahZL23gpnKMGIg2z4eisfgQxFGeLaeH7AAbOkly9aScDPRKigQEakfi7iD/qUNQT9wpdD243n/A0QMthWvpWSLjmsLTWCf0DFoJu39GiEL8yqptSYFm4260SbjA1qTb\u002BVU9286AfTf0NSejbyLAugjAcM="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-37359f19-a44d-4052-f350-661302124d7f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dcd0bd6564bc837b40b62395c4d9bbb6-2bb0aa7c86fb8502-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "94a1b45a-06df-86a0-946a-c62b3c831f9c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "94a1b45a-06df-86a0-946a-c62b3c831f9c",
+        "x-ms-request-id": "ec263cbd-401e-005d-7aaf-a39b06000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "352153769",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(32,1024,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(32,1024,30).json
@@ -1,0 +1,2563 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b2683ae6f12a02c1e37b50a7d8e76a4d-a4626a62ae2e5428-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4cd1421f-e948-b58c-ebad-0fd4a83dbf08",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC9C7EB4\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4cd1421f-e948-b58c-ebad-0fd4a83dbf08",
+        "x-ms-request-id": "682899f5-501e-009a-12b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-2d478dbf-2c13-5516-c7eb-857ae39c8f4d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-dc1659b60125aa054d681365e8467505-e83b29d6dcb33b7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b1d5a8f9-5e0a-e39e-eb91-dde5ffefcf5a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "b\u002BiFFV4AX4vpSGkhsJylfPsrb2wg5EEaW9CHYOY5qm4UXPRZDUo4hkSCla1T9pErf2dwDRMQuYqna7mOeP6lr577DFOoS26x8\u002Bknnk\u002BTxmU\u002BW\u002BF\u002ByJxaBKNpsqGQqg1F3eUOWOk\u002BgzT4vxoq6Ro7E6VTTxwdJucBoAivPpjNIEjb4cFphW58ANithQmCMBqILZ78PFvwKLb\u002BDbfhj0SbK57RTgdZ0o43105EcKDdf3DtJhD50OPt6rkLane2mnGTEVpqsOESL1oQxWUMrLcVII1G9Gg0oVu75GNOTmcWgD3dsF5Gc8\u002BP2ve16Qt\u002B4D4B9Urqb6UJX3D\u002Br8t9xODz\u002BUQoL/tZzq2\u002BtxpwfrdPPAMlTFkdLBCX1FHtR8MDERUXwu/HVrFDqCacK7iLmOG4r3LIWHeH1c0zkFuqa4bqu6UEWbvIiOZS4qQygAFYCztwNJhQOrmekOwik8VWmTyfsm8Shz8l8CeMdXbSVFTL2oQgOTbumYDsZcnOpfQg/Elnks6RRoT7SkNxxMVDyzuXV7lBNl8GsRnvJSJ2V0sza3ktasKGOZQAJO/yfdS7qZmONk4638bqYeC0oiBihfL4PllLFWB4ER0lQBFvEzRFM3yI6CD9\u002BIuzQwnh0Zdznp78\u002Bj96b5M4FSUxFZ60ek6sb2\u002Bk2Z3S\u002B0XOmNJXlj\u002BGsaJzchj1ysPpT9L7zOLs/si6NWInz8QBKv/5rNfA4X7mqmP8QQg1t6Wru4rK1i5i4ZoKnWHcXuLecUcZ/B3sKG5UFCF/8Ly/hH29fBQ6N1TQlss8tkMcCUyBHtDBG7uHvpIcdsEN4/DdShjjH\u002BHNpDrzSWVSr3IqNwvU/dLs/mnCNb2BHcCSwrPaX2srOOlrs3mWzdJVNQ4g8T\u002B2OeUe8EuvIeojTIZ5YIeyd1AG//4haUpYVjCWbQCuYSyB3InNvG4gexf/R2fzHG1Lo72\u002BGfFAlM\u002BbxZoaGLPpdOpZ94T\u002B5bvh5oTmIiLiZTnDS8lD8Ec7QUe5MffUBWNjFdJ8miXpTb4B3DNtWnGtuGBgV8zqpoSjHrY8RLPEDeAhgg1QZsoU2v4LQRQTzebWC3iWdK6WeW5N2XxurAgKPc9STNdkXVKVS3zN3mVwj1DPZjk6LZkyigieAoxOpS32AANEwYEPca4mASgxyJsJ3UornkbP0BA2IMHOxlvFR6VP191hK87OwPSKFCtwAMJtlCRCIgbmJzDyDqC/QapSYLqC4vG9qLJ7XN5SRLvkxSD/YDI2gySeaa\u002Bsbh0tD35JOLNx7h7Rr\u002BtyxsYnk\u002BN1DkiAwOB4HN2W43lBETmUTk1gCQwIc9cBLrBGxLxddtXMN2DUrU6e0BvV2wulj56x3Xh4x4rXbA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "NOWYQ3ROPqKCTZz8Jvm\u002Byg==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECABD6A8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b1d5a8f9-5e0a-e39e-eb91-dde5ffefcf5a",
+        "x-ms-content-crc64": "O44Kz\u002ByUV74=",
+        "x-ms-request-id": "68289a74-501e-009a-0cb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-cd5f3035-e455-8598-180c-3a39ce069eb7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-e3072d21ee8b1ceb97a442d1acba04f0-096d8ceb856a9613-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f0bb2686-2bef-3cd8-8406-2e234714bfb7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Y9FWt\u002BfdpBkBgabp1iHj\u002BiaMPtg9KwCbHpYDJQvUBc072YgvaQJinGEfwc\u002Be0oLO9l0h1le9uzjRu5hQ2n8NLHvYrvyYtJEkKaJ2HWox/EsUNC6usy52fh5QXq5pEsLhEpVTxSSFNkLM/ay0Rp3Nn75NO6VQX3lNYi/dR1bjuhfglQvU3Tcmj/7s4raBwTiBgr7vHNcckbMbBmL1qO7r6EKV07GS\u002BMKGJqymY33DzKD3XMWX855AwwNYudbUMecQAPlz7O2H7on7aPYrdS01WDrB/kwoU/SkVBCtOj/rsvTFlmODT9\u002Byb207nIunFU7WImCcEjOb560Ezpfd2rRJD7YBZd/KsghaDo7e7bdp/D/B1hjfT5/BKq62f4BI1ZW48YzUpq9uDG9XQgSlvPr1mtJYGwScasAXQDswEzKIETn5JvsqlVaPU8moiAybG220wOSu8LmRHIfMvWVzPvg8zzDKq5X\u002BygV7yMg68\u002BK0fCTOe1NO2SGAaAlzXtjxHBTQa7jb0HDYtfXfMyjwViilF0FApcKl7vYPSUOMi2wtiau0aogp2Ku09cVdb6X4jxHhzUaXsHZRKnzCzIYsTCqJsal8POuffD\u002BVi6/8SH9QFroxqr0lltk0Yj8LZgwkiKmb0738fFMmQVEHASXHVOL9crXM\u002BqFtZBvQR9mskxYzcQMFYXTBU5pmC2hrHZWzbQ1cDvNWV40ILm6hLDR5ea071I8hwfNuPB8bZu44AUeGHNnMUIUi3Bl1/TMFHyZl7JG6MEkFkqwa7dLUOvGezywnGxBarSkoGfd2q8S/aRz4tXpdfdD\u002BgYktsWKzTaEo1y0G3QQWCj5okhdRjubnWoS13IV3QVFcKZmGLfvHdMtVTdSWuYsX4ao79Ou5rPKjRVfe/XEcsZXbqrRqkN1CoR5L\u002B0ARUaH4nvraO01monyn4\u002Bek6XZZOZw/uw7XrVDN\u002BFPMbbGxkfS25V93QnVIdAg3w632nrin8sKk0pWSIfGpDUL5mTTK9VHy7gMX4vYn90YGn\u002Bmj1lqaJXvvDb5eI8NuzTUyTtrTbc1bA6\u002B0jw/LfdtPi4EHBjboXnS52\u002BiTk8o/qRXB9KhrMzIcSNKq5pZrJJDjD5dCZ8f\u002BSu9mGZHkyG/ldOb6CYgy41hP6r1jPXjdTbdYsIQz/UJNwqq5BBmgN39ixXGvcRoHsCs/8nwJmgx2iMzajBfrsXekrUfeed8\u002BrrI\u002BAHgGLtydUf9Z9AvFQyedQntNxqtndxP6C8TSKDdMAEPJy5qTb1rvPToYkr1s32kfQTZj8egH1olkDCIYyijIDPPH\u002B3iNCdIgXYhwT\u002BVWjixas\u002BcA6A9bwvUQL2M313MST4XKpePxkjdjQpNflg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "gXJWzaKyVoEiEuz6PyB6pQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7ECAF0A5D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f0bb2686-2bef-3cd8-8406-2e234714bfb7",
+        "x-ms-content-crc64": "Lh/QqLjciIw=",
+        "x-ms-request-id": "64d6a34c-401e-00a9-7eb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-7860fa35-1255-3ab8-aa4b-343bae52e6e5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-a59df49159a04fddadea18ad479eabf9-1b4bb9403270601f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d85f3a0e-df34-ac6a-a695-c9da76221284",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/8I48DKXzFyeEpTmQ\u002BWvSvXKxWIuvG6ew7SjngEaxNgc2HkFUuc6A6Ui8x2dcd1TvVl/DhNeckNTmSx99C1ag028yWtrqfcOkMK8C8hQAVLWUOGom7bEvmY2sbm6vA54yHDQ4Kdy5xNhcX1RomZ6A5fZp6RMsuiW9wsFNfc\u002BU9SzRENYfyCqZGjNRik4chsAu64h4RVqLBWHOeibbbEcIx2pnl4iIoN2LkI7fmu\u002BXoXvBXlIHHK/SBcu0EY3D/a3sSMMjtS93Zkrq7LSL62qydtjq2g30war6lVG9FE9Ph9LhM1Iss\u002BwMifgHXG/7BlqhAdr1GOOf90cYKR\u002Bd\u002BlH7myThqrgYRYLs3lAV7WV7P483HBK0Wq7vQXvK1IrMro\u002BmC8FLGVuiSLxYCHpTScoh3OlQZt5/RwB18ml8TbE34C/Ar6FkMCYzVJNWXFJ0m/dxqTehfAexZsTA1WcyZjsLIGgKktpovezDXRJK6SquAVaxyqR5VmPoD0jcoxq/AS5YSzwqKckdCSsK3h81Zn2aEtQQgFuWkcnEIkNRi9qSBFwj8l4uQ9dNlMF5brgE8ujLAlBGroCSwflyJgdFi30QeJmC0bQfq878gutaHSMRvy\u002BaRomKS1XbUPBk/F3Px8lEKPXegiE061aBiiuVOOSWIGbXqwTzhi0D50CDuu\u002BxLLsiFfRtMz0OZZsyyIFqRlgLjpv2\u002BBzEkKKI2pqgsTBnEF1wsyLwaO0piQVpwL1r2aEod\u002BwTujSeHUURpFiirfSqi/hj\u002BdM1W2WujS7XWtAlXME5eHkEU1Yo0lWdnsSUhxtQvzSFB9\u002BN8xyGZSzFhoK1LEdXaTW7pniiOyd9l7yhGcYThpubYBUha0Vcfe5pI0uS6HJ9PR3l1Ri8Isy4UFtgJUsm8f/nGcwydj2wHyiKONfb6q8KJByobbGDHz0IaRsp/FhjAnFLq86mSscgNbXv8en03KWsFgFufkQOY/qO6c0ihmLQJzamUD6go5kViHg7ky0TE4x1faYXNIQtPUfT12D6PW9TH8rzToynC7JoGPYMEtDNu5ZArUi8\u002BTJyuRL2zMx4G4rIqHNiX8U/znIzrxvOIOp3BluKuZAmlmaYgNV58D6mL/1rA2pdq1vRQJ7WiQnWZJgof4awraI64hIMid7vhh4zTb8eot1AGZs/\u002BXjxD81cwhx9EXC4NUJbMGFYEOF84bpA4ztK94G66CYrsPRpCZJE78eCsrStuxg8w3K8J8i5gte\u002BsGyR0gpawmlKjIROMiaO0yEZ\u002Bm8Fk2gjDfRO/oAdci4cqpllsx39Z/BLYu6T7tFMLRSnn4iouNzEroQWC8OpLRqWcUeNKWADXJJ\u002BunB5T18iwtFrddJlQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "eip40w9zMDPVq/Q724U1Zg==",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7ECAF0A5D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d85f3a0e-df34-ac6a-a695-c9da76221284",
+        "x-ms-content-crc64": "IakYLUAfN6c=",
+        "x-ms-request-id": "69fcc878-201e-0029-12b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-1b15570e-91f5-09f4-1909-06695e1ea27c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-bce193feba37ae29cbb1dde76b9e8dcf-9a92e3b937180f64-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0d1508e7-e7b4-2183-8c7d-858afe31de3e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "D9KQDNin\u002BbItfZTMJMn23SHE9VdCIm\u002Bm1dpIYOqVSIZkDzbbRjy9KM0/VpTS0EvokvkuMf/PuOxi6jf\u002BX5nIlzQNZxWTG5fkB82JA8za1AWPX87wZxeHlFZJeFsFvsgzd79fxWg1VXZiSSoxRbUghxYyb//L1y8dhdK\u002BSaI730gEVowNew6cWQlXjh3tVU\u002BhKPBF0k/JaJ\u002BPQj\u002BVdwzUJmnhLe8pEwwHlRX2c0kSMDCDHSCx9Q35O\u002B7sfTjOBuL9g2ezCyhfeBXjPT050vRWfBIPElrrIjBc6PEBPJXUOY4z\u002BfDhXiQIJKQLzbfPv2j6lQAmvvSHEWA2ViM2Xjt/DwSuBdkDdB7tB\u002B614FR4jCiJBqaVrXqarOePqgcB0cVpjL2zIbqO9iDiOLYG0jEMvsn6rFeU6mKKE1nyc8oW7DUoTFOWxWtu\u002BhCFsnTDk9m2g\u002Bw\u002BBiVu1KJbKQ1gnIJWzEyA3oXddfhei7FGDjftxoB/O/De2OUQunixO5xdDV6OL\u002BYoQrVU2A7z33tzJ8VqbmKN4WCSePNmcCMNKzpcAX5TuN9QxIPKK2Ph6vhqnZOzRs05zyz\u002B/LfywtKRRqzUl978H27lGanew7b9sI77/NKQWuRtIjFSVbwoXQKxOOS2DVIabX4kzSwjWwx1AEso98UAAezIZnWsqsqxvbymLYrRR6I74Y5Ua4y4Scck3FRw/2Y8sDf47qbdbcOzcxBwfC2CpLmp7RY3q5ZfDx2uh851QL1VaXxT2Fn7XXTLoPh8R8yZojebxxJPBQShmd6JL\u002BX0PjJSGhOwLstgrY\u002BibAud4shQFOWW2nmrBmR3sj96ci6O1mLGKiy56HNrOhqCrZn5A7YVOBv/XWS5phSuOHyL5TthE5Wp17eclytxKp9eKVnLfq6JZTkTjnj9DIQYC6/24FTfIJkDUCv\u002BeaHvjjPEWn274rrOAoABToQcq8ozhIt7ekpKfwi/xy6DiuyYIwBFObIHXCj1KN3U3dIU56Rgy/QVdBToedp0\u002BxqMS3eUaSqE1nEYLCdihlFsdqE2quCJIr/3gq/rXb/XkmEOaN1lQHSnkBEzSJ7Nsu3CewM5PlA6Aym4nOZ7mHixQJnFVB1zBjUsjhrPVtkhKdDBKeK8nlQQ1GW0raOOLPiYgQgEB17PTnTNDLA2aq1Pl3IWuW\u002BW9aJFtYC4v1mSnWEhNtXQHCJx8tpt75Gk2mm3ZBYweHOJAYxmv1LeFo8bO25OFDTYfnpQpMeUKQUQoNoWAVpCYSXumDRIal3Pk9tKUrQiVcU13\u002Bac39Ss9NiGVR53xxU02NlJYHz/jxMcgRDrStZR7ksV4SF0poFRQaRbwhU/V8zFFXna2PVINVDSf17DwA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "TkbRJA4VpusJ2DIXFQb6Cg==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECAF316E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0d1508e7-e7b4-2183-8c7d-858afe31de3e",
+        "x-ms-content-crc64": "49wafLPgjG0=",
+        "x-ms-request-id": "16e8c1ec-e01e-007b-2bb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-d303ec7c-26a6-ac61-d40c-83c7f8daa675",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4deba37ada57e1b219aaf1bd325ba396-92529d6d9e976429-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6df30a24-050d-c9cf-57b6-3f1dd1f7bfe9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/t0pRCY0XHYVVcyr0aImI46B\u002BlmNrmz05dFVR4Ph1nCSg9OiNH6adaW\u002BUX2WOiIeCzRpnd5JP1BwNF5U3hXzNH9bGU3OhO4P54S0zlzvXqquNzxOdziSSEODMQAfRZeQyx39OiHUT4dGWrZalXHzgda0pqfYpLxGydEKS1Lu76LtJAI/8SSJ2ei1CB2COLLSj7Apa5/vtydgt3BQygM0V2oTbHFutJCxKsy/I5ufw5EeN7yixIMD/W3b3zqzOA/kgLCyb8tBZNofeEDSMJOLwPPfMpNGkpPmEG8DktVW/vK92qLr7FTF3NLhgkxDMM3ZUB5G0wZ7ne4dzF5cPdIFyXlOFVXwoNOfGlXAZQ9Ho\u002BCiKkG3DyvrQTy0zSD2aZ4A3LnS9Bp36LBKp7mwuzjf1ih9uROQTrlOYtQYPNKzqLC2v4hWdK/FKkKRbGhxOoUE1ff4eK\u002BLcI7/hJFGXqvel/4J\u002BfywiGJ5t47R/uFR3ChOFGfaui8AK076Vu8df8yWs9VpaECIU0yVf8EgunGsrqdp90lEA9zPCM6utTJyWzjCOksM53TnxcEbRTtu33HcTadItIeDUa/4ml9y2p4ZIySJXn8moMczgTGIKb2hYChd0WiKKqawP\u002BibE0wUdeojASIX5YHxtqzgFDJV\u002BijxVjk3FAk1jvl92B\u002BXio16HgxGZSibinunbBu7qhV0WkTAqbwS3WDh7XIpmQxhWisfZfYlDpUAVsy\u002Bj6jteuTkCH3a1uDQaEGsZXi1cvBvRRHwm0QeTkyvv1PwVE639HKNRJGOh4NKT/20eakdSuPbTkmW/d6fxboxKxeN3xPz9HEFJy1f4L6OpUxGatWiknVvFQUEIfaU7X/XXVxsvW/qwYU4FyK2e22LCFiSWFrkj5ihHcoN7tN6cTmtiINiIufdXKhQanpSuZmYeRmdAZUk8s3DyqCk3NKxvaboCPPqKeVwtfyylCUdT2MxdXW53G\u002BkiJa1nldGOIDWnqzUabGmrVAzLEyYcl2opXs9c2dd9\u002BA3Q39cNIqNKnx83PZ4SeWxisclhq8iCxY4DPjcCcUYeKbLnSUySXnFpQLQHJZnMFuVi\u002BifOHEwFDdoJCeRsCG3Y2NPray/f0FNX\u002BCtUu\u002BA0dycR33ceEA1mojuySVSM/ThGbkyF4Kv1gynUdiQg8JI6FJK9Wmj2uoiGhIk0bYb\u002Byzsyzg1Tbla7XFwNSZopBbGpeDSBz6KPT7PEP1wiwRVi1arpLiJE5uZ8Af4MqXDunX7XSzWSfTuYY75Zjy86mJsG6nQvABePJFEORc2kgqZC1WHdC3Yf0JhvUMpj6xe3QakjBf78v11nSGakRDdt86DYFrnNHU1k5tmbv69NKzk5Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "VFmdS48nqoCy0kHlUWB5IQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECB2DA5F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6df30a24-050d-c9cf-57b6-3f1dd1f7bfe9",
+        "x-ms-content-crc64": "uaT7Dc0e\u002Ba4=",
+        "x-ms-request-id": "993da02f-d01e-0002-63b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-c1beb7a9-134e-e83f-f569-47e90e2c113f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-3c7b1058d1354fa953461a258b282c68-1b8ee8d524141f19-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b339a9e6-cb91-17ab-1faa-b934e79a8011",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "XKHAG74Rl7YkAfue8hJlhCqPcgQ4dmBdJutluDUYQwdY4AD9tYK/yOt7LNdKm\u002BpikWhnzF87feVAY/XSq96ADL30RRIRaM6o0KkZvEqJEooBAyfNsHanHWIbvFGM7B0M\u002ByAaVVXXUSiZv/y2IcGat1Bq0ae2s1xGTSiv9qt8G\u002BOMDMEqb701KbL/M/B68fuhgAUBIht1VUfE0wgtJ1t9HaMYKhT/cEiTNaf1t39ry1wtDnWme/nIFrd5Zpu0CAFXghZNYcbnoQ\u002B9be10f57IWAer/xnl16GqUBNdhgqs3i2lnjVoHmqVRmxl6A0MVJcYsA2TCQjocat1ohGziRsFEY6/zuFoYDqdFrmtf\u002B6Tnvx8RNX8GNUlvSyK83tY4bxQX9d\u002BTIW1r1DT9vJOOvG84QQVN0RGCfi5mhG03m2\u002BRTT9XR8XFVJ2xpSEKSLj1oI6zhF3Q6p3CVbexbF0AdHjFLC9UN3RpcyynnCvwd/V1sOOeRBbRwKKhVPJOE\u002BgAsXDoRRxJYakaChFxaQ5x0d3CO/t5YfAh82uM8qKCG18EZyr7CDLZLA96hHnFoJdUb4LUi9gsxw\u002BAhlGwvK7Gl\u002B7yLMHjdsnq6Q\u002Br/t12XFLUeIMf7Y9HF2AbOkGhKG\u002Bgs\u002BxLE3OVcPj46aKIQQgyCmo\u002B3EQrpqofaxVhyHxISYDgCwrxK0kffseKZsQs/tZX6TAXokvrtQ1CK6heM6i8cJ/h6HX9AN8hH528YT\u002BmMqw\u002Byd8MMKd09FY9rz\u002BggQtfDjZkCtZgmqgRNoLub1PNnDj8HymJcD/4rPPf/5HfQF5SXRMJQeeVnm92\u002BzokhoUCL9LG5KHhlZ32a53iQJsWcbZkXBIAxFoRJkC6UnUFlCZu3Y\u002B\u002B2Ju8sId1UtZJs12UYIlDwCpywWu49b4hJ0NosJe3s2LLV1kap\u002BtKy3FDx7MjJfHrgdP8PBxkBiLdW0lEDKI\u002Bkj/6iQlwKVh/KDX6NS4LPgFRfS7D\u002B3dGpxF2PQyiBr6PRTVzaFzou1h7fRQmahE00l0H8o\u002BzOtaIdCH3\u002BiwL3OF3au/4l5XkaMGWSH5jID0AQWqvWlPvHAoeqvQ68IFsb2Ay7z9hPDqHY0nN3PKYJVPk97iBnIKNSA6lmizhqXhAahjecHE9nwUwJ/bKIX9XhkWgVjjIqtLdpWcwu6IN5fnRTXKZufTipxizkXSLwybPTdOnARN/d79FwMrKDSOjIgI8\u002BJPMvgyQva7gVRleUaIAIW2OpqSmUhXzU7kp2Jo1EK9yTsqSwo/HFoNknyKmJ68oyeu2FLtdlma92WpTZuUUq0Sp7ALXrR6dh1AhAfMzTSwKAQ6ufvvz1Lij1Olls6\u002BeUDOd/DusERyNGE0rQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "uPmydgT\u002BKjLHM/fZLNn7Uw==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECB3C4A0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b339a9e6-cb91-17ab-1faa-b934e79a8011",
+        "x-ms-content-crc64": "bkK3hUW\u002Bys0=",
+        "x-ms-request-id": "146c0ed6-a01e-0055-5eb0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-8c6ba004-7386-a357-0656-5e4b0c4fdb8b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-0f3c7af56b755ad680a8c5f5e025ed28-2b95819573c26e11-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f4661de4-703e-6230-c420-9836136ce6bf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "dKYvUXeokG/4fJSD/rhodLWstMwlyZDCQo8jnilVrTTp\u002BEiOfJNts4AiDXYJlFhZbpaIQX644asVbQ/ohfFGos5gmgZv2fgiPgFMA7sauK02yi\u002BSzWy2MRadeQ6DhS2O22qnqPpS6ZWeZgN8bN7v\u002BrRisbvBtNRiqmjv0V/pnrjTvSdQchCy5OCa82doOcQ4rn5aIdNyzCaWRf6SYhc1tcdKqa62noikr83aJ8Ft\u002BXCjtyPgjn3kYPEBui0SIILIZD2gHo8VghD2tXEGmKRlKEuN7qv0VSZJZUm9teNbko9LEcODzNvhjjUT6tkM3shMm5LhhDLX1A8XVrhGWM0smyPhu4bg4ltwrF914WpNPYeAcRlReg1cdD20bHUjmjZn5k\u002B1KiJBa7k2cNjSYfKkyRkwxeaz2iEWhUdJLHXlTRIpDvoblxJkPwZfGwk0ihNKEKJc8tRPtAwun6Xb9z9DUCPGqFP3iTIHy4bgVL4X4fo0/hzTiVo92lnu7PhtiUjGG8vlbuHAUoZwVCZOb19NFr2qp/gib8bIiM75CZw5mUI\u002BGTjzMnMYdKuVYzQ072v5oNY6wuFPpKsEHeUTxknpNrvjEFUnWeRKkjNMjAySlJlj/2jG/tdh7nWM7xWOBK1irCx5UN8V0kfx8C\u002BuAhefcohLsMfgIjfjgiHgm2nPu42G6uDfGEO6Tiwh1A6ns\u002Bxd7H2MQlTlgYn0ls6\u002BNDbdIjSiJxc2v1lFkWKav00pPM40gq7sQ3g5oWhW6oJ0\u002Bxn2Q7LZBYvUJy0jR7HySsI7y1r/ibKH8N\u002B8aYav4NTX0JVIpHubUDZDX1uByPzHRlamGh8odXJnblPTHZsEJUdYTHYbqaVGoHsjvCpWBSjj9CIvCMW1r1sj4TUoyDOaPjkUKXyFrJ2wX3qkBLhHEGkq7yh51B2Bo5wb\u002BMdwHthIiH3wQtyrXUiFf6hKEKqi29HM/dgKIWkckobgarPVQEGhXHw7V86Mf5Hg81V0NpLxeRz2pCAAPWYT1K9Wy/OUsD5nqbQuZoQDP35GKS4UqFvz7vCX3pwgoR4VJ4MeNrSeS0MXDY3dwxKY82SiuhM4/ytTYtwC/dGiRgeWGD8A5AjJqN7r/ZrNFive/us3fucK3SdXytTXm05xdMaFR6rSmA9b2BI1TAKRhkywI/7ma8ggizoXqRk08gyPeYjUR86BDGbc26XV1ZAlxkSIJndPign\u002BZbtvu\u002B71J\u002BYFptJ6vD59LxeYCo8jS7ap8uLVrMuVP\u002B9\u002B1eISEVB357S\u002Bzy\u002B\u002BqwkGCvZft4B62xkFxckMH3oab2bj\u002B\u002Bdbah3HISPbZHuH60bZz6HUNohuBPrIDUyHa8c5o2DJ2q8iqqDYmJZcnnaefQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "LfN4/1euqouZZaULlU/1xA==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECB4AEDB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f4661de4-703e-6230-c420-9836136ce6bf",
+        "x-ms-content-crc64": "Wn4k\u002B\u002B6Zats=",
+        "x-ms-request-id": "68289adf-501e-009a-72b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-be659163-16b2-09f6-9560-cd4fc715a084",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ea8da05f88a6272ad74b29705eaac189-eed61fdcf6935d7a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6a50f681-3233-152e-272c-e13f61ddbd9e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "YdXgT4EKx/1VQ8F3v8eFmrsiYI/BKXScqCgfpx1VGJCHdRFfgOQr54vQ1e03rtaRExZmtvyZDTdgQ6dZ6x/gACsw70q2JhnX9nkE8FOHZPpRjZQG7mKT7mfZ/jw90vxr8NTBBr6M2\u002Bz9j7\u002BDlB3k2d\u002BtB12L2hLInAHi3CfcmSR8mQB\u002BxV07xbKnCV6iEFlK9SRdkMqe4BbC\u002BWm9qf7EIPabBvscZRSBcUKr49CzJoyomOcDfghZ3rjqvMzzfhuz4uhoBgldLZAQ3B6H8/xFDtLdFBEXwaHtQShCMqhHjfMn9wDoSx\u002BDS2pW8qLq0uq8pK35FmkKmyFGesXgGvrnyE8rYPv7XMKyWcmmwc//A28\u002Bho77TnaKHFzfodFaozFwbylTv3HuwUfqRr2gZNpRR3dVopRs7HrYoEOfG7rxWLaXNVKlrET\u002BT8VGEAe46biCjlpZBQGdBIKueh4tTqWN\u002Be4HCC6Iq5szVlLOJttzILeLHY1fmFK0\u002BjHP9zEm0AEfuBcYseCK\u002BeK/Jq6vzt6mO1pmojEYLWCcUg78ubRpDYVRr23EW27WASOqoHKkBSxTKLvXvy7PBou2fF7SjUAuVhgoXR5w4uDrkKENbozu903hqZD4kk1XganhDd8QA3Pie0pZe6cO4kXb6y\u002BNwpj\u002ByIQR8eSvNcPK0dx1j9QB2owtKvJClHyl08ZLHKYeyb4R4kVa/xKPM0aGjqrKmFNx2hCiYJelvDMIax0dZBgdqwgeY6yOptt6nvesuwXR2jpz2UKVfGgmayYRUpP0cs4taeKirDSm4jQ1KMKg\u002BAAtNpHjqYrWiC\u002Bf9/iGfFNIhiwpf1IiLy0FzfcOYFSmhnMl5BsBEMhDVuGzArU8IGXg7aGWd3mtCgZk3dyTyCjb\u002BHCFYJg4RnVj5Shxbyx3ya2RLXKyEA/5d9kVnTPrsI641wpEt7/MqKYsMpFRPJvZ7BQvAZq1Kehhi\u002Bi/I6hBeDWauJgiMxHtxYXMhd59qDs\u002BO7EevK7zA60i4izWDYX96rpct4MCt7kDQjwU6KQJ5OOtgef3IryGprTqAFDlFrcAzpojIfG3O4P4G3py3xsJGP5IKYydBcf\u002B1RDPGLZoHSuEExoJ5cPx9UVj/wdBFMaZ4ehRnO0rY8jSJUvg6CPNj/1O7csA/zI7VzNGOQbAvMFKNTbOFoE9WbBRN8B3EQ0ilm8J8yb7mOG1FkW65CrCEWmJlrPs/nh8EZQbr8hyw0UmI6KWt8mbT5xVGAA8g3SFjyVW7XtZNpj3jOGR3\u002BkYQ1L/lMGIK1qg7kYWluV4QI4glSCjG9bKzOwKnyrnCm\u002BzPNWtPO6z/WPLtv80Q6CyfkxTcUnIdSd8NcfUfYwvuOTXYg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1AjNwpNZsfCblfhiagBC4A==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECB9902B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6a50f681-3233-152e-272c-e13f61ddbd9e",
+        "x-ms-content-crc64": "/ydecZdaG5Q=",
+        "x-ms-request-id": "993da05c-d01e-0002-0fb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-401ef730-e41b-f126-6183-961d2b6e94d9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-7b600648836156cc83ce8bb732cf1805-7d824c96758f6bc4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f0b3b1f8-1549-44dd-671b-2e44ee6d672d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3pSYJerHrjAHJ95/15v9G13gRaKySbQEsQycwqWfP4gma1EkS7F4k2Ga/HiOGOU8Z7w4qAa1bpTglHTeKuyLZ\u002BdWWWxK2M\u002BraLJAF0w7dZgnYFrpZ5aBcfy8RLY9mml1DpWQOL948Y/sjD9UdFZIpB/btsmRov9R1edvjpQZbs5Jywm3qz3Yrm7L/NtWLP2lc6CXYuOf42yVP2LXCGP60h5xC6hNkPnhAghbxqUk\u002Bqjqyhr0ggzrqeecImzaAaUK0Cq95SFUWOOntV/aQx3GcUW67T5IBlARhmHBsG6NBwFjUPZ7ZhWGlnE3TMysEGbK1bAmHxNmwsnZq17Ak6d1Gq5ed/MmSwovNFbMEbmDZXX69tq9Zuft/I4sobu2xQPKwTIeTplzo4ql9uu8mbAPVUboxpzMt7PGcHpk\u002BqlPeW9TAk\u002BGZRfch1NQF2/8MGPdHEt1zf9m/gl\u002BV90eDqnhVn18aJdgiPAuDD5IfKBEyj8Xh91d2qtv7ANGCA05vXiqbsHxf8fLfJNbRsHAHoJpOYydB4fLhHvSDHyTGoDi9U7Gng3eU0p4SwpJAZTqr86B3M6Am7bx3upGH3NLOGITeFBz\u002Bn90i\u002BZCJbt9goLn6FytET2yYVmX1MAjlzTWLBOnNolDdrVODVHnPnb7dFxoXjcXniYkYBf32yW/UfOya/in1Uv5pHGnXgTryyPinGBkuzn8v47sgtVyS5uPj7teNNN9U54QbrrGbz8iOZXzFD/EW5a6tatqu1J2h1jVF85IjJZPZUjBU0x\u002BNlBOyUlAfjdcyjMlpH8nEphMmedi8Fdw2qz/pK72AgdJO39bHPEINgkheEyaIugXJ1KvdbpkHEX43e\u002BdQNqIZscs22j/zPanQ2PeQHgK1bfD6HxcRo1N5R85Yj4Ba/UumRKFbkd/F1pcCDFWhtvN7Qc42VhdKx863vZIxmq4pdhur6dlhWdwRNEh/z1b919EbHQ2yJKd0W3zSo9QNlHwpGNZ59Y0Z2egyJSHPCzh3ueXBFn1gdxF0d45cjrXHw2AMFvaAQ\u002BIEAQNlgD9FZRBEWunuDL3\u002ByKGFBb4\u002BvQsyKiHBwvQBt3YD/NV6OvcSLtJ\u002BGHPL2baiDU4VO34kBYP4M1XdQ6JcAqOz6k\u002BoRM3qsxargKTXZlCrH7WmLLv337dRQgehNKsv4dWQGC8nOYhAKohnuETfIIzFcmQsthYn\u002B8rYFwLGSX6ru56PR04hRCXtJcHzkGdycmF6m8JHA2u/aFwkTuKFueEJ/DymT5k\u002B5C4\u002Bf5BUNCujpaShS628JHhzD98x/PUDJ2vg6dRqjCKIe7eUCMOba3QwgOk\u002BJG4zjZeEMz/5zOc4\u002Bxgkc0pXONlB2M/16Bu0w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "8nR2SMz463wP/4RMn9eV3g==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECBB3DA1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f0b3b1f8-1549-44dd-671b-2e44ee6d672d",
+        "x-ms-content-crc64": "EG7bYc2ty\u002B4=",
+        "x-ms-request-id": "68289b12-501e-009a-24b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-7be81f45-1dea-93d9-c1b5-2cee45ef20e0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-3fb5c275e8cecdc498ffe2051e3f1f84-c6b565e5641f50a1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "af464295-cd2a-c954-01f3-b16e1aeb288f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "u0JsNq7b36dmID7wLXj3lfA9bWw7Lquz2FSbGLhpSQF7KoSUNDckg7IEntDxI99\u002BvdsCXPYe/YyWuF5aQMbu/dY9dQP0YmG5GOm6NpDbwrV0HFvcZuwLXSz4/XvYykPrFaH5tK7cilt6SUMMZMb7u/ap5SNrEpbqMRfW\u002B2Tm4E2mziHv4g0GmJIAYhyp//hl/EKEL\u002BUgfwMKD4KWBY72k2n2ZpWlDNnookyQa695QDIecP8iYbFohU4d5NKKcJMECc6zs5ljwO9pm4yZjxRTkM5Qd5SO0zK3jeBGiCgGXTK4i2Lgxo2Yu7APucUlzvY6yVMEOvj\u002BdTWc\u002ByW5HDjHYj1a4AOyc8pAt7zkfhpskr/qDL7UASM5uhYsRMpo3554SFaIyu7yiFaJw4I8GvYbMGllzxB582EaICbthS7/2NcdazbE5MfQ\u002BINnSj6g/J8fERRhAhCO/1T1banHBAInieuqH6/AVkuhlNeMEagjeSSGznQantXHjmzhz3YdCfOBQMFS9tzwX7rIv205Ae2s0vSFQDaNDeoW45BC3ofVg4vjCtHn0INIlm66Ut5njYx\u002BNfyCmMi99DLWPBJLrYAy8jzhVvccxAFwPKrH0roMrlYExKiKU\u002BrDJhaeEZRx/Onuh1\u002BihTaVYnH7EVse9iF3yY27R\u002BjYp59RHjDgfbJs/z/A2UpbaSgfbmE3j0GOpS/1JkcHtbUAFeC/UGcGteS\u002BjhIbXR3WHF9knNiHoBhewngA61dqZUqKv8NqmxjBGLl9eAAvckcSHwnnohnceXTIYY7uBsmNUyjIkZ5Za4BGo4MfCigXL08x7ctNgsMwrUVOojqK0hLv7yTYZuGpubOJof6VvW9MsTE\u002BvRn\u002BP9Bll\u002BRYC8lGvNFxLxoDP8huhzQYxOHEm\u002B/WAfEISxT58bBUcs/9Ua3qQuQtJI5VSXJp0Dbk5XvuoPv0gQnXPXC8eD1qr8z4cDWGLYH9l3dhgbh/n3reFAs0ZdHTCc\u002BjEgVzcKxQ65qlcF8AXrf58QmEkgBRWJ713WMyNUn6JWdm4hp8iSbKEZUe2S4b3rZTOnTITnbPUrpmfpNIHrVQqkv4mnudfWjjuoFqM35v2v6t3vrVMtbxlpBgFQuTgvPfzS/jIkQ6tr0L5ZT0ZB4896OUmj\u002B7end0BgPqPGhdTzeOi2VPi7e6cic9yU1B/DJxJB5n/uezJFK3bxxBUHlUrpVcZtm57Wvs2igYfbEqMwnQeBhK9VBQ2mYTlxybeSKt6Bq45ZZZuDayeyS/mqahjTwScNhhCrlEDItypVVOUWAFapSWcU5zd7/hl3oskT\u002B/cQrgiAhKTN5hdNgK5hPhYyrDuTASChvun/gYf3I\u002BGHpLszRLbg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "F3S2JE6WvzgbpcTTCSKDWA==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECBD3919\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "af464295-cd2a-c954-01f3-b16e1aeb288f",
+        "x-ms-content-crc64": "YRHuADxvYls=",
+        "x-ms-request-id": "146c0ee5-a01e-0055-6bb0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-17b9c2c8-d00e-7e23-6a73-5c2e80d8dd26",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-6e6fac28463f2e8d52fa03f1ffb2368b-59e85914f93312de-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "abafd316-b726-3602-c836-a053e60f1dda",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "D61m7vLoEDHNayNbXr4y3pX1YWv\u002BEVvWHXg2Zmx\u002BPu2vojwGzV1730eJUUsRoRaqXs1rPu/82f5RkNB5sqnFTiw1rLuCLBE4eYEkdMAQxXxiiwieE//\u002Bs8k\u002BtD2MAi2ewwIe2/VbJzK8MsVu2GQ\u002BQctUFyahJzssN/jyRHjUrHdUhrC98emGBmTW4uA6j9tkAHJxN\u002BoG/ZzH8aP8aeO56IZNGVKzgFDhzhDCy0Vb8qcdjUQFYnSMTYkU9QBGiZ2AHPlZ7HaJsH8ikGnZQzFXbP7739ufs4URwMzJn4pPmkRzQa5LAQYxlNzF49ILswlXvYkBSqnB4Wh0RyuqwBH00vUkZgGDC2r4yUv\u002B2dCzBg3CceEATk\u002BasWBF1rnah9TL0BDc5kwH07EfCIFewweYwUAd504v84OlibWhPTSwHUJ3Mwm/1h/Bup0w4UbOPO5YrRV4vJ\u002BFm92NN12XZpZ8buo\u002B54/\u002B2esgXC2w/xI91k3HSI8fN2Ci8ZcsMp7CKlMHs3JbkFVeWtQqV2Bx1ZzLT2EQzx0GXTeJnPX40qZMXjLZqEuf4Ub3aO279d8AMBv7YeI9slo2AFY70vRfZogt3fkumCxQK24aGGYvS2dXiGva/HHED6vYo6j1ZA5SmAJljhfl0pjuqzV0IprzBrTu40mIhWkXaM5OVvSEWsZfyIBkyrxQcrbS61E7UOwQ5J3zB4HFyROYTSVJl3ykalBuFFoajzv3nnGTtpkY2xjhPXFWkFNFmv9sy3yXB9s6LYEAzDuS9lVi\u002B2gQMhJ5gHINZ1kKTdr8KXpbrcS\u002BYJeVWIgYFw7cT0cc9JTqNWfs80oKip\u002BBL9\u002BnBKPAN0iRo5vRetmKYWljMBcR7llFEfMTbrp5tNb3FCmocRNrHBj\u002Bi1H5GbqOYpHhp1qIcEGGYfKwrciOF\u002B7F2maw4fBV\u002BBP\u002BEmIITPg4hAwolw17bqToIg8hu25PcHNiMz9U3oChi69GiV3efRX5dyi8Zn/hSWvBx7/hND2lrqLvphi55KaLhwxeNOVHCaT5J0RFkwr0gOrTkhbBwFdxodq679f9QJKCMd5zghSGer0a5w35XxuY\u002ByUu5VGQyca17JMKjBrN/Oexw2IrgP7VTRdYp9lJeEG/IvSxz1pB8WcYvpaBe\u002B6jTOolR5y4bHonWJc5OCLta3NSSmkmGy2Mb9H7E8JnVNIptVruIzClBrZ5inbDB7lEKlIiLjCEfDG8mdfKvVm4vwTFD4LI/0dCrESzrZG3yWcYtuhvRCWhpDkpMopY2klcwcpy/fc2fCsL34Ls0c\u002BfBdBwsgdwSHveJGtJnsy96dL6VuvGRcxv4Tm9ZGSjtNNpiS266ChB7HlPk9iM7N1eTvaw8Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "DmxpD9e5ifgzl5dJWh7VEg==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECBFD0CE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "abafd316-b726-3602-c836-a053e60f1dda",
+        "x-ms-content-crc64": "a2\u002BMdqfzOIU=",
+        "x-ms-request-id": "993da078-d01e-0002-2ab0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-a709f4cb-242c-129a-1d8a-7e66b737ac71",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-e883547582222876f96685ca081afb3d-a6750dfe833cff23-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4658a739-7c3c-5169-7895-2a9754037924",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nwIAqblqcnex8\u002BP1W18WbvPCWYavbbboWHQ5lTlYaPUMyL5L9QY4D3BiDhAc2nJTzadIrT5ZZTJMGFBFMd09WYvu6JOhynnsikkVTV6lzH0B5seRELu2s2KL/t22896TJLSFLvHesgItWyP0QxfTpkzSQ0oWrEnQNzUxFcycNpZrgimqIJ2MIzTEY7SXwm9Kt1iQ47CTfXdqtfa8rZw2kSWMicHuKYauRh8WUUiVOHXG5l50C1Pm1wWxP2um0HWXjdKPCjmuXI7R4pyQfSsv1XyB9cY\u002BwoXSprG8POkaCHaqfsR1BS08GIrPoim2VVrZgmnuJNqvWcpMvWSH8R\u002Bkt9km5v5mudBPRN07biBcG1BW4rqALOOc\u002BiX5KUjJtCZrK\u002BpPkG9cc8iZn9/8c\u002Bqp8KETMQ9lI4v2ievYbJCHhpC30EI1DYvg\u002BW/x54wDn4c6UDmntYMWBQhfWAaEhAY3ERlPRaOoc\u002BMVMjegczz\u002B8\u002BpjnRxX4NAMoMo61rSFXHVoutVzs1nkktxVkYJMdZLLYGUcIObp4DBIQ6XYbZ0ukNbBN7lmi0CQfwpAAU9NwCo4b3VPaTuPf9mkKnC0CyU\u002BJwCsij7ZZNUli6Dbqd7h\u002B4J6oP4n3yeaMbjfwWHP23TlAdpOoTXsXgqgKt2btNb6wy/tOmsnFkfZEVmF\u002BaJ0Va8s9acEkllNjkHzh7VK/33i5P4x4qEJvuqSdY/cZ2VnK9Qtbr4u9jDVn6wpM46SjxLbohSkQnMOIze8cR3JcSbci1zgHJC/tO7NXEL134pcAOZ9AMRQw\u002BlhHkuGcoQTCy6FTagysXKBG\u002B4m1uYxGUOtYHA2THBii8hyf/1FOEFpuVATcJLiKU90/OXWKuwDMAUH2RIT3L\u002B\u002BI8HfwDF0O\u002BKsvB2VHamxyjchwlCLi2Hcb0/4PV8vVdyQVUzQAmgd/8ACKW3PbRJcVg7a8hpvM5dgA1HifP2DfWZABcdc4MjOA8KPiGLzDAI8m\u002BdQVGPCICK1b/4XO4PDfqwHj2dLAHZGDO5X4Ko1bfZOpuAWMygDfeSlpnDJtsg\u002BzAm17H2a8JpxCUh1akB4gAIHyJSirEqEBBGDplkFfVUlGBOgf4F5tLVGpCrfjROjLCZtwe40nB\u002B/MedsFkpBa4zzT1Es1wCBjhPfXAcgpHb\u002B33kzl7tn8Xz04U6ZDJ1qBTmd7D7BdlUl7DPaVT8XnoxxbjfRDdTRjF7UOPay6IF1dFfOgrg4PGkkDquHjJw83ELCJ55mmfdkzGDf7D5ecwSyZODoSBzTOTHOrP8pSf/CmFyz8MDiD9pfarVYWFAqxZum1Si7VJMm7u1tmO34O4JgHVThqoJDz1UGiN5meuHho\u002BZjgnTXBw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "aCJN2LlxqFOt5\u002BqRTgW5IA==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECC3C7D6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4658a739-7c3c-5169-7895-2a9754037924",
+        "x-ms-content-crc64": "UJlcF28MSpM=",
+        "x-ms-request-id": "68289b59-501e-009a-68b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-6954b562-7db5-74ca-fb6a-1076c1aa13e8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-12ba039fefc68221899f4048ba387ed8-38dcecbe9e404b97-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3e1ab915-d7b6-959e-7369-97fbe8f54be8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "GGMF07TMtcBzDIz1BpS4DokWERkdgXBa3hkhrzOCpuVZy0sebgNSdxPNjsbogObSdiRuJOov/ZfzqvSbqwWM8GanmzpJmZ\u002BFw5kGT/Oqcl4zTjkOFIH6Ks20K8QPt8wNQJ1fQeSridyF6WBQKa6kSTeWaFzMftzkrHFslG3adQzN\u002BA9VSjF5h8RciCogqgAfD\u002BKMeU9vQcHAe5VzPvRuqnNUgjGeTv8GHOCYcPayxAFwTYWLTvy9XrdNlM6cBUjQ7d22zCfPgMHjhlxu19DLDreTA/Fv41x3liR5UbkwaRaYx4MY\u002B/faoMzDp8ifT4fmgoYXCQJWYAmBPzUDVi8HsxxF1Q9NshO/uGIkqzuU2Eeck84zGGAUQWd5l7vB10qdu/SrWXl4mNByWFCgMrTN7GftZsNg1Jq7MZSo1BpX/eEYhu9H6H7OJPr\u002BwL8QdA\u002Byq6pU03GHPedZ7yjl0MS1G1pvh6vEhgToH0HJYRTaq72E9ShvAilwkUkI7fhW6VQ1SaRloOxj7SSmbLQvvdvTfkRqYNqbRRgx//ZivJkMkjbtkxhvdQrQIQgEyZZ1QNNtNW6064h5mQOMM6H2ADCKmtl\u002BQSrDZAk5mT7Rl3yBvL4i9IcrV6atc/kV4kFp2iDYei\u002B89v\u002BpqtBkelFKqAKGCnfj0wypXkIz0c0wroHH0L8e\u002BRxNxMW\u002BeUq2xt1UY8v2jtjJhQcULhvsiSUxePtPnaqSK6/lOEWyJVnB8pdl324COR\u002Bo/Uu3CcoBYDugjABOZykywTccEVWSF1\u002BtUzyDh6m3Lz/cpp9f2iLk5NgJEphYcotuMh025ijJFubrCraNftiR6FzBcsCJ0uYUNyx9iAXHVOCxFFSMgEkXE5C5dNBsVmb/dyk7lwDL5GA2Iq77TI3gJLXV3GmDBWgTql8v0F4WqODGfRDbi73g5TD0VV6aG8cD2FAblnn9e3LBKO2hmxQBIHnONc58BZj49PY4jrAKeY6XLPcN\u002BhFmyQGeGmPPP0ob8jTky\u002BX4htO3I6KCxO3Bt65eCW4d9CVnZ2zM3eo1KLWsHZt8Ja2pnqUjVtdv4wUU3WO0cTbc/v4OfGR5LKnpgfvs1qZRRJEBtWrI\u002Bp5O\u002BINnt/\u002BGgbZ\u002Bzx6dbalJL3L8OdTcggxew5jSs7vLEwRgwITgEnSqYgBEbgaIs9fouIX3zMDJcXV2CfNmtM77s7waPK0kaB39UtfTmBQG1g/B6fo11EZEl04OaQmAQ60ySbtKbXcpw09o\u002Bnro9dlgcDPkpMrTxd521qVeFf4TfA4poU9Zu2iYmCarzNnLW6F0rvnWnJ7jXoPc1JbSyq5RVX1sv1SKB7XKSwykKPgEqnoE6WcFPeBvRkLLfefRxg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "PKSXIe53ghtstqqkfQ\u002Bs6Q==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECC4D929\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3e1ab915-d7b6-959e-7369-97fbe8f54be8",
+        "x-ms-content-crc64": "C9zzYqzCoew=",
+        "x-ms-request-id": "146c0ef3-a01e-0055-78b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-502306d8-78e5-a3b3-28a6-fa8452bcc633",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-92835e671e4cdc59bcfa3ff153e1032f-9b44b938c88a8f03-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9a81a602-3ae8-866e-b066-57f6147d1b51",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "i9cpG83gRksXnfx4Eb\u002BJzfiFPizOgKhK3rf/wMExj90IDD\u002BmvbX47DEOYL9jIzsrHXYTy1MRaAsu3j0W4YaK5Q4ecAV/4xBCjFL7wCDo57t71KJKHsOK9qM0d9544gurg3qxRLI1qzpm0D4BFqjqRfeCmg3jP8dKlHphSmsxyapHUDylN6IIRSho5E2EieD7STHn9kf9yESzZrA41GHPNQaTucZsRQ5UeVTlelp5xQuZZgA5SdNjSYf38tDyz3HGma9H8M8ZjgQjknzzGE3pOaClnm1gleszMG8\u002BdFM9YqriHuGrMtQ7f9f8FrdWbzE6DrgwTTEEZgPEE8Bf2xqx5TDSEPlrPgfLaR6VZH8z3MA\u002BA2WaDRV53rje5h4U3KS9SjCGhF83z9CxZOMSbwGEkDf/INi0FtgbWTJBjVfoto162BpOrVhhBzSV6agxZm\u002B3WVbnFbvMCDNYayot9UF5yK1WmJbnNePfnRmjHy0v6fLDijMAAaHRrs/m9kItNBHyHCD7287Y0CRzCHihKOkGKIE3aWsOeMcMhOnHAD6gsWkHsQIMNA4k67oOjfgpL4bl387B9cqm46NZ71bkEM/m0lYOmnbn\u002BvRyE36x/\u002BrO4lRj4iFw37ueYc1eskS4P9rrKLuhGpUP/uTZTuJL9eO5igwBgS6tdfKacDioiEivudSkxdcvLMi\u002BVOM8lpDZUmzppSg4tr6sPbLIB6ldZ3acKpUNpy8MiV1DQy1Kcd9hwB3MvuIfdwMV94gkZiUeYextn2z7zKo83RzK9HORYsvTZ0aMkaiTfLOR\u002BLCm6CI3JOJA3NFyZfRyj\u002BHGVYKPhJW9UP/fks9E2iK5adP6lvT5ks\u002BRUYb6YAFRGQLHzCcxAnMa6ZgjWJIS\u002BwKuufwgd/jtzcKy/jMPwu/\u002BjXjNfQ37h2dg4Kxc1To9flWES6YEMaEJ2f9lfgNACyaoJMsZRH70szGUwJdLkPeIdH/eindI\u002BVzXxKMNlQhkINSGs7FvIzrWj5d0cHAJvUgI3QqDYYCvYCpuQoDb5x0pMJ/Dxd1GGFBFB/vf04nrzQdaBbj\u002B4b5T1lOGAOG5\u002B6h5S0DQRvdrwcS5PVmF0IyhgnR5gOFlKk/hcO\u002BKvxhujAxTZYdJG4cP70PzRKNlzQbG5X1tQHrGFCHx79UI4AKsSrFNMmoEV2ftaZGdceWrfKLow9qaAUuRjFFmWCuxBw5BR/ryF5ubwY0WgNbpKaI7RXMzHx0nEkhlu6UZnv88O2KCXCrruWQGTQJNg4F1qGOuKhK3fujxGTWxjFz1giON2kR0Zsx4UIwPLNEa2o7H8BNCa3TshL15kUL0OS0HEMvev6k9AEGWNdmGqFEW1j6n6ptJsxauoQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "CHOUalzg3NZ1bapowQ1f1A==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECC65F84\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9a81a602-3ae8-866e-b066-57f6147d1b51",
+        "x-ms-content-crc64": "zBLwK9quixU=",
+        "x-ms-request-id": "993da0a1-d01e-0002-4eb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-cacceac7-7484-4d71-2a95-acc214235173",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-03a561718f00d22e31dfa2cdd61658e5-c129b401767e51de-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "42f97354-b173-32ff-e8ca-a3e0fd9178b1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0aw1mmbba2O7BE1Pkb5dtDAeVLYFbAyxwiehNQ\u002BaI8Jgq3cH4RM6ehuXGYU2x81IvlIL/ZDT6mSfhNg\u002BOjVTIOCK7uZHVtMc49mbbVOGe/paWHe8jiUyjcASZ1w7/D/lRPmkrNnnAWd/7xm2OHwRGQne5OG\u002BlpK6V2ElNO524eeatila4c4hc1cPPZ4MfFVEAU1TXBhdJ61m6VR3wcx4CQ4yHIJStzc6vHGKrlnzrtsM4TKhIoTOPI588/d6qbGKljSQ2WDT8UoWGZ\u002Bm03hUczt5a\u002BCZ1\u002BaKY\u002BDz1sNAvxK/ABckY9V6OfDoignkKGgWJ4C8AT7R8L9NBXWA4BqG1VmM59JhLw9l/jHwsUzdpjt33K5DhL7U7hBY1l1f\u002BlnVYrWvV0CVtPhwVgIN4T9ycF85CANsQlGauPnCCViyBQPYGk6XLk/64Si20y28xwzQ5mb\u002BJfJWaR9jFJ5H06ufvlD/NMbw2kIQPifatW8j3vHs8SLys98RgrEuMxmwsw58FxXcvZJF4Ask7efKe7OwQDasW\u002BGIrQpw7bIVwqcoX4sZXp5ZRyFfphEXzcX4Rgf9ffPiBFgs82kKa8/gMB1k\u002B45bsRwVV/gVTbTPcd9EeKarF0SzRlsz7Go0TttRf3X0s9I3nZXq6Cb6zbejXYKKxvMoNRnZsLUyJ8Wx4AgdxM4\u002B270NDNoRwC4duXikj47oqojnKElcGgMcBXXPOAce3QnoZILFfLkZFnTru/c8jpc2yTaANZuE4sC68QdkQYgm/9tvuysMIy3OzhHVcF8M33fdmW/QnqduZILBCouytNTsxLsbzdJsKqYJsWaJr3JhrhGQhqgZVWE0AVepShihGxo86Kyj8BKkcW/Ix\u002BxA5LUPYFx6Ii0s025a5sx7w9\u002BNZ5ZMTMbFvb3\u002B6xU5UI518xyhmem8J/nsEBU9SQlGKa2PO2BW9JfuSqOfezYY84Pg5POv2Sr20T\u002BcXzyxiHSzuMJnqRUuH/6Esk9GHKzC1B2RXWQWlk\u002BDmWkguZRbPcEv7MN0sElussX0KibbsLST2YsfHysPnCFy5BCrDWVqKXWNFjDpTiTTI6qfIWwop\u002Bi0jOAJPB2WIE\u002BhAss5wqRfigGxTZmEqotmS/uAb3u1STwn9oCFYOxX9/bhR0tYmmEGP5drd1lPMOJVovAiFbDU7LiPEcwj2ikUWlaiomI/DrGaejDjSdLi2MWeL738NeFGDVuTyYmU4mRtVh0DrI5/FpQ/h5t/8KLmrDgGhatrGCR1XJUHq0QoBZjLdfO13yw3Hxkpva1Gxhy4rR1Qjly5Aj74jU/4d2pPFoEDs3qvMMwLz2aRQlp2LpV4Tv4n13c7EnO0vFHcPqeu2aYsQxKhCQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "aXJBvZLILMywXtKhm5KuTw==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECC88219\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "42f97354-b173-32ff-e8ca-a3e0fd9178b1",
+        "x-ms-content-crc64": "I9smwF\u002B1vBE=",
+        "x-ms-request-id": "16e8c26a-e01e-007b-26b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-b18e9677-5b13-e98b-02b0-400e8345223e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ce2896a331dc21a6f3849ab775c82a10-893720705c260adc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a1a10e8d-d983-11de-d99e-fb389b5bc3a0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CcehB/p0ei\u002BRvuNotErrg9dFgtaSuUTqtNA78iK9fkKxZyJ7cZoOCNYVLThEVi83czep4\u002BlRrFCDtlIpOIcM00Cgt00nbxE8Nnr/fIsMpl2hA37rFJtZYLrR\u002BLpH5M9PCFr3pJ/iDwQlbKxvUS/Fdg/1iDUIIb6kRleSVndX9VGrsHQxFAK\u002Bv/R6xqju6g6KDIGqUlyZRuebU11IT7mMzndbxKG7k2INNslAjlsWtlxICEn2rKL1EWmNlcGkdm877fgwkiZsznkfnBySWbeLhZwB/0ZvliHUZrM3Lv6gab9ZBaBj5SM22znQ1g\u002BGYrexAQ8lo3coy1fWWyxzNaB6fjNcOVMXKKB4yyMNn78RTgP7hS3ue8VIMDpJjIn2w6aZVVjbKSlkmthvrNhTGyuXxA0peK9yjANtFAgYzpsWgQd9c0lnNiTalutVfs7t9BQOsch7zUv2J8hUbRUgTMw8WCvQ1qjiMI7pTuHEHQ00gB/zCRzTm7O8hkyAEsgPukoeGCajHR5sLIE5kn9pMgm7IO31LEKvaL13E09bYR3F2ZSXpQTnkGMAh92bmQg0U1NCxfLbGY0Ib7BoLAnOEMtkdLjr0Y0F04\u002BJ9KVkE861QsD7GZsq6sAGjzVUfmRZMXYSNyVPSYHGPfFjUSToo1zhs\u002BlJ0/cvOYn45UJXsFQrMMIuUtypZfk\u002BNdupx5mcHezZc8t6EF5/4v2cV2M/b4ydOCFhulCAOE7vC50chXLwXMdWfj2JsCBkr3DeDA6W/sVODI54OmObWTp9iwTAY1yKrPuc6fFPFIgA/QvgoSs/WQzYzXnjdyFkuiQCCyQbo0sTU2AT\u002BRXU//gGdz1XurcPPTL46JXipjTZNy7MTAhj5Vq/zU3KLF/2A86B3QDkDP9t887yIrq2MKwsOcHmCLLvo5HjmO1qRBDSAuXHYck09CsvX1g6ccOfCZygnvKeEPobkTpuAXQRA669ICDU7s/j90WWt6latTHOQ45RyaYeNPHrq8\u002BPxfK3HVyqfFCiyhrNvaatB1hRwdsIoL7lwDkIn\u002Bwu6UL/UzFS3plNrznhK3h0hAv/cCyZmurzhyU00l0iod1kdODXzml1Wii/AxGiJ3RFcDwtCS6/lU9YC8wLHgw7Kg1bfLeYnLWiiRYD2pbZUGCx72Eh9JiupN\u002BQf8KcaTsbg9gDR6q9rdSGi38XvLu5frpsWi\u002BrGjZ1rNfXBxzyBSDb51a91Qm180GMm2kZl\u002Bgk1wAIMA8McGiijprS5aW3k4VfPNRk\u002B6mwtmbtHn/NXBXvsy8c6tURznftG0dv4w6c1QjjuVoTv9tXWHmoHlHp1DGE4jF2m6mwTm1dduBhQNNYUUh36qK73PRTxJFcaA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "vO/j09V4chThrHe2pX7lnw==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECCA568C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a1a10e8d-d983-11de-d99e-fb389b5bc3a0",
+        "x-ms-content-crc64": "75fqe1NDR2U=",
+        "x-ms-request-id": "68289b9c-501e-009a-27b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-cd5f3035-e455-8598-180c-3a39ce069eb7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-52df6fe87617937165d47da70d92b488-4e65713adff090e6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ee53631b-d6ef-602e-cf58-0aba34e8270f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECAF0A5D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "gXJWzaKyVoEiEuz6PyB6pQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ee53631b-d6ef-602e-cf58-0aba34e8270f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "146c0f06-a01e-0055-0ab0-a38109000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Y9FWt\u002BfdpBkBgabp1iHj\u002BiaMPtg9KwCbHpYDJQvUBc072YgvaQJinGEfwc\u002Be0oLO9l0h1le9uzjRu5hQ2n8NLHvYrvyYtJEkKaJ2HWox/EsUNC6usy52fh5QXq5pEsLhEpVTxSSFNkLM/ay0Rp3Nn75NO6VQX3lNYi/dR1bjuhfglQvU3Tcmj/7s4raBwTiBgr7vHNcckbMbBmL1qO7r6EKV07GS\u002BMKGJqymY33DzKD3XMWX855AwwNYudbUMecQAPlz7O2H7on7aPYrdS01WDrB/kwoU/SkVBCtOj/rsvTFlmODT9\u002Byb207nIunFU7WImCcEjOb560Ezpfd2rRJD7YBZd/KsghaDo7e7bdp/D/B1hjfT5/BKq62f4BI1ZW48YzUpq9uDG9XQgSlvPr1mtJYGwScasAXQDswEzKIETn5JvsqlVaPU8moiAybG220wOSu8LmRHIfMvWVzPvg8zzDKq5X\u002BygV7yMg68\u002BK0fCTOe1NO2SGAaAlzXtjxHBTQa7jb0HDYtfXfMyjwViilF0FApcKl7vYPSUOMi2wtiau0aogp2Ku09cVdb6X4jxHhzUaXsHZRKnzCzIYsTCqJsal8POuffD\u002BVi6/8SH9QFroxqr0lltk0Yj8LZgwkiKmb0738fFMmQVEHASXHVOL9crXM\u002BqFtZBvQR9mskxYzcQMFYXTBU5pmC2hrHZWzbQ1cDvNWV40ILm6hLDR5ea071I8hwfNuPB8bZu44AUeGHNnMUIUi3Bl1/TMFHyZl7JG6MEkFkqwa7dLUOvGezywnGxBarSkoGfd2q8S/aRz4tXpdfdD\u002BgYktsWKzTaEo1y0G3QQWCj5okhdRjubnWoS13IV3QVFcKZmGLfvHdMtVTdSWuYsX4ao79Ou5rPKjRVfe/XEcsZXbqrRqkN1CoR5L\u002B0ARUaH4nvraO01monyn4\u002Bek6XZZOZw/uw7XrVDN\u002BFPMbbGxkfS25V93QnVIdAg3w632nrin8sKk0pWSIfGpDUL5mTTK9VHy7gMX4vYn90YGn\u002Bmj1lqaJXvvDb5eI8NuzTUyTtrTbc1bA6\u002B0jw/LfdtPi4EHBjboXnS52\u002BiTk8o/qRXB9KhrMzIcSNKq5pZrJJDjD5dCZ8f\u002BSu9mGZHkyG/ldOb6CYgy41hP6r1jPXjdTbdYsIQz/UJNwqq5BBmgN39ixXGvcRoHsCs/8nwJmgx2iMzajBfrsXekrUfeed8\u002BrrI\u002BAHgGLtydUf9Z9AvFQyedQntNxqtndxP6C8TSKDdMAEPJy5qTb1rvPToYkr1s32kfQTZj8egH1olkDCIYyijIDPPH\u002B3iNCdIgXYhwT\u002BVWjixas\u002BcA6A9bwvUQL2M313MST4XKpePxkjdjQpNflg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-bb0c8654-152e-6b1f-5fe2-c8d43362cae4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-f2518d5fffeea9c7a4c7ce67b386256d-e93ae4e431c9a093-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1523d58f-eecb-2908-1707-9d1b298cabe9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "laA51iQAkL3wdAu5fT0Xs4ABwSuMKlapscyLbNd4H\u002BsIGw\u002BQLYOnPxxM5cpI9at4vXGABqRaE2tJjyVYdSTmeFUgsWEuh4X8WYIPP0SMYbsgE65l9xhGrQikR55eT8n4Zm11J0NJSjbsg60hS9MnvS5pN2F1gYA92QRZiUDnngq4F9nWFjl41sl4eXRqJGI0fYlw9RdnguTtOE4/8MD2BOWjaDP6UKb08WCY/QgM0rShJAy2d6jyUJX06d7rOOYJgXSOx7suOizjewS2z4Tc4GaZncuzQI08sBieBmbICLh6j3uTfQr4c\u002Brg0vukO4EQFwl3UpoaVUHnUhajjzTGGnNLPD8ISWJboCrh022Rl3SWju5dULUdXzk5qyvzVeO2GriIWf9BB86mHLJwOILUVrqhDQFFaMq9LdwGzp03Z0pGK7i1CT51VYYftjQDrSa3ZVVxUkjicLHtyisiOzkxb7RnKQ3JH0x8LLh7JbGVuYC2T2lHxhUCZLoHxz4TUxlN7keAnIMZ7UUJ9CaQZkr/WBCqbOzP6qmeZMVSwlgNadmeLjdqFR39nWEjPdHvcv1wCG8taOYtfQOd4Te9xivt\u002B4tM8TgTlELzrc\u002BKq6zYrvHH4rnp3wDycbA0zDPmP9Y2NkJFooHFXXMsOroXotFWxTJF9uRxAxuLWoCH3sgODG74U3VqkwxwAYVGvKVG2s7f3QcAoUnxxTImukcAPn6rHi5LHk9c7DIm1PRfKkd2RICypwHBDWslB45CQ9nEcMMHmp52\u002B7t\u002BgvDU2sxUkprrsHXHTpZ86hDDJRfBGqhZYmQwWJCo/0nFMyUQ7DOe0HXzV5Nj/SItirCOs9WjvWhHe3doJDkKQrAsAhpxa/3dJFWizcIV9mVBA83fGkxzIXa8yHG7Naw76RTiNvsIux6ysY\u002BAAe\u002BlMYQSJiBrKidkueCjtKKMIe6oZuSuM8BqOUeuLWm98x\u002BGFpbsqA6Lz77tfn0aZAZ7Jo\u002Bg15oL9/7EqO3Yvf29p8XBHZ4Mn3jfHJcmwLVDUNVBMgbaHByEex6YKP8hsxLAL9e3WEZob4YWwboD5DdJgVgXl4r244qpPKGAc3Z5vWmFZZHei/eO2cN/w1thgZbnT6anChyIyUxMDhuk6PwQnQNRfn\u002BmavVhiL7Hdx8vSLsLmCTP0bNN/JxEkn3b6vHGbyZXEAMXQeSwRoFdwVIsHMVgmU/XQMtPA4HjYdh4hZ7NAAf52De381c/Hosy7ztJGHW3elCh7i9aCAyCNN8LOMDikMBKM0SOqab3lyFAHBRFmUhjwQpOKxHYns8rNb53NObLT157/uUxKdGpqVYOGuv4PZuWqHe1lGWvcpR0YnTnf2M6dcy1yZpjMQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "f7A/3L6jM8T48geazj55Kw==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECCE9BB0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1523d58f-eecb-2908-1707-9d1b298cabe9",
+        "x-ms-content-crc64": "ckTAii68Nqg=",
+        "x-ms-request-id": "69fcc93c-201e-0029-44b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-d6afdda3-48de-6363-94d5-2550ccf08f04",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-250136d48e9bc57518585a73497bce7e-3ab6e6f0dc65c7eb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "381c1e96-d507-3eb0-2fc7-5aadeb35ef6a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\u002B/YXpVDNCHLqj8kGPSLWF1PlvTdymktV03srDhi2Ns0mq1jOerYX4h2RW4Yh\u002BZ8DZEffhi9\u002B1mCqwdHVofpaNFj74JLJCJyczdoZ4D7EM9rbKKrQ17Cdp9T4I7jlQkEjNictJhgNOlurQrhVZPYh5o73\u002BXlQilyoXTi90eXkt4uZ9qkXlwzBzu1OJZT3SELe1j0q7UnH06zKhMnfT2l2x4stvG5MCk\u002BBNSqLAWXIsRX23/qouclB0SL9TBJD4X\u002BE110JyovTkcvuqLgeO9FHAtOz6W9uzg3B6\u002BtLT708PVSrByoHvueJIk4uuhERIpZRtUo\u002BkPcPFQhQSN6gh0IOsWtjczSnQEPsKcchPxT8r8hV\u002Bplz/q1cnPEhtnYI6ZoLIAilra9hqXUGUmYw7db0VJgVS42om7K\u002BB9dChYnN40AsFR8LVgEZ81AjbKxGLK4bLWLe854NY4VV56bYHyPsOW4mA9i26P2W/Fc8hC4Gd9ooJ1gn7vChH7Katm9bQNQsNzM9ICjWZERkSPdG0d5WTnDLsPfLxEp\u002BhOMlHDKOO7uDD0z7yVayUsITw6b5Wk7UQ2f/j5DcYXPov5tEsEgS1Qw7w8KRW4UZGV00twGkhSmVUdnLj6wrpq3ZEgm7baF6Ae2ZvZeMQufh5nUyp6pxRDpxr19uR0ZgEBwUt0l7Xay8urYTCseSCQ7y6ak2\u002BP8DZ87PSb5CC7qnOK17d4qdZYjJdu30XTly36ZQfF2cKhcdEU97qxTuea77bNIaFpGEVIMhbYIRDgqUXWkX8o9cCg6VXmY6Irpz2/w/\u002BPFnWMgUzCjZe7yVCwJF5k6r1ocen2HDhLgrSTHJrZKF0RYYLASgAyVng49RAFJj9TtryAR1IFmPo9QQ6YP2D80qEDnsLbpJCtNhtxvScYNmx1P2XuWND7G9iYgwkBmicHPBJ/AYd8iBIb4xE2g9vDFQqSIvALHonQCIL6QxGHm5vkeoEUqTTVCLdDwnW/xIf8xW4Of3c3DC2Ynvj0gkUAhEeFQhlavnvFvRo4t0wEEEQK/X2jiSwkvW5TfBpL0HZyQz4uOnJ\u002BkgbySLJdDlThhH6k\u002BYTHXQsrYJSrBzJRedyjtmQN5eXRnFt2oTBpx68ZceebpubxuuYi8sndw5rEkM7VuUfg066I020pQLvasZjlgZVaxdL1sguN2uMb88jAsgBhlB5nOJ45AsN5yGo6WDEw\u002BDIFedr73/dMUwjLbN\u002BUaJ6raS16jlj3EbMPi/mRU3Kh6vuWuzg1dcQXGuWFfZXz1V/bju8TtnnpDmgX7FQNuw\u002BGKYHUDb1WdfNpY2NzYZQdG6apxcSTjiSBrazQHYlgCW/WD1QUH8eSdRj7ulMGdZzA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "k93OkoNmPQ9/eJOstylsLQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECCE74A6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "381c1e96-d507-3eb0-2fc7-5aadeb35ef6a",
+        "x-ms-content-crc64": "i/ktuuobfxo=",
+        "x-ms-request-id": "993da0cc-d01e-0002-73b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-371f6d72-7b74-2e94-322a-1c3e353b1c11",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-8006b8a8b0f746554ff0944058f91063-dbae4a06da706544-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "151eb868-d911-1f9e-c08a-68579cde6e9c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "\u002BcyLULzGXMIq89OlHkJzADN333vv5PSpEI8vfMOf18tfEbz9DhJ00NziV8f23sbwhCOtFI\u002BZzBTX4kAsl\u002BD\u002BixsHRQ2GdfEgAg\u002BfDYwtsjHJP/ig8cM8xUSnJizRRzn848yr7pi5ag4xjBKA\u002Br\u002BIqS8PY1jnXplXy4DI3k/FTrrVoinAgcSYENTqbmSxvMuFH3z8wuThFIUyUyMY8Iu\u002BbD1XqliVxydrdlKD/fA0pg60Q7/TyIvV9I2kjS6hgB9JKwEmWRJz71dUkUySXReU/qwUY63M66SygbXK8Tn5yvYyOtHuDU38QVNnfjY/Q5Z1D4\u002BBjBxyfEBcdNdcqP4eWsdWXyNGpfBfFyJaZWxtcj0fVOGqeD3ZwL6QkZl1oJhUSCNv6ORzL2mfIXT5GBbT7wGZPFMdc\u002BKJfJ9ltRNW6XeJBRxJ/YpZqyV3ClbJ36invaKX3GNEN9VA5mtFDnlWSDf9cBL6ivF3QJEupWmLwJ32vvhxvw0TRM1HCBceFJysIcEfy2\u002BVrDKwH5vSFpJrtSXOTlCA5Ikp6itFsoHZWCv0goSnbPUtYRHGwJ9xQS4721PyUMVMKzw49eFDUPqx18dw3ZQNxEkwoO0/uiTquKj9CdYu5whmqFZHbncT6hAWFOnYAWOZLRYKwa/YDHEYTj04RUYjgu\u002B\u002BCTU9xlbRHbbcKKU7EbZFZNu/JCVYjZvlLyA62qTJ85L5GfcuW2fAOKT5/OPL3TyG8\u002BFrY17JZXyZWJc2l0IREjUTQfi\u002BFgh0/\u002ByBX5C3GlHjs\u002BfCXo8zMLN7lAPQiqBi5\u002Bqut5tEyNzZ92RySAbr4T5FUuRbT7Ol3xFEQoEEo3RLHnelCWK1nusK6Wcrweisj7LFizi8B5g3CNeKAIVb1FPvJimPRdjcj7T5UGZMeh4pl7POPxg8jxfebgCKK55lrxQTO5u\u002BHUna6PuEw7Yy6465YWjSjJU7s5YRsdfXUWQVk6FROD6Canpp9FYcuMxhq4Ny0Mk2kyJ/2IcErWtyApeXbi8U4bJPNvfuaJc\u002BHvvKrwZTZYCb3/9/0mC2fr0O9vK/hUmcTcrRI5rRSCqKQLmMOv1lH50W/I8wlA5RmLg633KlfpixLWI7gUHmyZbU9JGmKkS/qNZUqYm5bLi7f4ril2i45cIh2gybKp1bLzP4W6B8q25zejebUNUO\u002BMCpfwK2BDEuHA7PhU83JH45\u002BXlWwREXP9Qcbh0wHJTsEuJL8aqbpCsByT6RrCYeO1a4YldbuDevkUAumpYU/gB643Js7DLUnVROVPfThpKt/TLGd7k9kFqrnGBpbQqU7cs\u002BF8mzsU8j5MQDDWM/2wutgJxjTYZGPFIYwU/SajBKuWcrlW7J\u002Bkviow==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "x09UMfmv\u002BuAf8fttyBhKyg==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECCFD402\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "151eb868-d911-1f9e-c08a-68579cde6e9c",
+        "x-ms-content-crc64": "QqJ0Md8ITl8=",
+        "x-ms-request-id": "16e8c296-e01e-007b-4ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-fcb93c20-6638-8d10-bd44-77fb808f3031",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-81f29132398f7a4ece733eaaa233cc15-ce6c022bf37095db-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "71b24e4f-956d-b4d7-461f-78eee17fbf47",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "d5vw/1F5lLhT/BRGneSFUICq81ACziJVj36vQ9yIx\u002Back1FfW\u002BNRGWCBL/pXebfWZxyw9VGn2Kh4m3DTylDcyzQtqgmSJvWdWNrwgZ4n/RbG2Ny/19KU9buo5r9zfk4PpWTGKc\u002BtQ0AnE513t1cKUZ1ZDPJ0HPNimbRO6kA2KtmL4Ns6YdRGGJSbmMQ0HT5knpUhGXJbm4hwY5AbX1kA8OjD69Z70O/JEvNe2IQvLXx16kurFBFnMERTyf1DK7k6m6fccTFn6c6lVwZ\u002B/cIEQTYUpXQOVNzXXLuSJwbxheY5JD3cU7xKDQF9BbwK6DOCT4jHL4ZFK0bLBBR21cHHs9IfRNiFJ\u002B55yZdzkU8fzXSIENh\u002BKlVg9Pj2EU6n0zhAtVHq6qNa/CeaTWbu0Zr3qzeg7sXoSYl8v1DgjxWf0vVfM9z9NOLQLhOx49zvcSJe/2UXB\u002BVyV2vIbitTeW0S\u002Bntwj56\u002B\u002BXdVz8CyN2WtjE0tgo\u002Bvh8sP7NtwNcW2fbSln\u002BhhfuKEnwXuwjclwCAFGuHeJffdYnOwYKLDTcSxnlEMDJh8Sw5rqOKKwMWT6iu7axrk11e8yDx1sR0/wFJBPCPlGbSHiM/Tc3wVU6GtHHZ2COKpzcf6T0RbB5rwK\u002BiQSYSirdB3M\u002BJLEGTap3Sax5SnyLhvl29c68lwK4E040eUhAkdC2\u002Bl/9QAXrxiH6jPwT8GSWMvIbEURcEGBwdgFy0dRSNqfbwlAcnkbzmy\u002BcwhoGpCLZnkZWNYCMWtn/fNn0aPRdmFZEOC4UeZSrF3YUz15GacHumTON\u002B/EnT2d2LRF8/yI7TynDwmv0xSShqx4KZ5uLqRMIBd\u002Bwz5xVHPi2nlyDPhhT6XAkcpdV\u002BcQe7EDTLNfb\u002BnQOZPlSeo\u002BNfqVzPjbILnz1to4bVyZ7ohwLodNLcfAQ6pPYhNku8W7wpwPx4rudVs3T7WZZsKNdgsLdRtisMfylUkOS76mjxrUfKrASic9QflsVd5SZxynwivIGUbqGRGUHTIBn\u002BmcUMBaxOpXzOwjzfMiNhspYG5spomSnnXT6iNZLCz1O\u002BIPkATeN2JyT/U/5EuTiCM2aryDlTkfybKKhtqHPqC/LtIREqYWS2kMOlaUkvnqQGIAIoFwMWao74ZSE7BHqxEUQLV5QrW84B9Tt5rii3b4oAa4RtwfDv2raGLfxDe4hE8FQBIEsP2sg0JiHLmLxmRPWbNpj2R1NTH3zdpSnRwnmzNLnQsktC9JC8OZvTJD36H\u002BkGqETvTq0EsgTKLjWeYmekFGQClZKuVEIINgm7f/dC54VAzxo0w\u002BYMyABGdMpbIdswKw/Z\u002B4paVFAG4xijSTINi0qwWZdNc1B98cmOa\u002BN3sRQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1imUNhvg\u002BB425PIOi1jKew==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECD4402B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "71b24e4f-956d-b4d7-461f-78eee17fbf47",
+        "x-ms-content-crc64": "TNkK268/QoA=",
+        "x-ms-request-id": "68289bf7-501e-009a-7db0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-5fdd400b-58d1-d98f-f2de-8903f8e13523",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-0293968767c73e1b27b4439f9ad7d4f4-8594859eb39043dd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4e088f67-fc2b-7b2e-0d2f-5a82ae3c637f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "jTpg6rER\u002Ba7u1gFwMvscI8yAHDB3SYiWrVvHIdBc7CIRrwy9fQKU\u002B6gmSwM5jYihlWissj4vPEOyyTxVSdjekurfX4LuX6XJ7CCIUf6FXSDTJYtnsDnj4XPJCrTGPrLPSLkYWi4FszbD4sUep\u002BpFLGsbgSNMduGx\u002B30OJVTwA65uuQlEbQLxzXJVpM1zxDqJg95IqryOgtHXZl6x943h0t8XsO7hAL9pKbSx9tIUPTZChaJ2p1nx3zY3bQajQNbldNHuXBRMqIIf34AI3Yv/wignbnLrayqGJtC4qZO4xejezIIAJuEi9t0fV8jY6QKqOKrde9Jk\u002BQinaDZElP7vZhmXKhEI/5xHBXeUzBRirTzNDXHo2kkVetJ6WL6r3WLeMPCuQL7xoTgOlnZbzy30RLr5d4aNBozPgbA\u002BjqbdmycUtpsjtGx922w42kPTuqulhRQEsmbcUSpk3r8OsxKRMPpORxiR0JBNe5saVCtI/McFmQmS2enBOGVxv9WtbyhZpqpJhHOSE7WDtjfLwvz\u002BG\u002BH3CRkJ/1YRjQ\u002BzIBC7nwxywK6B/3dUcoZUDiOx9nVpc6PztWUOUKdTN/dj3/OkyBYqWAFOfBxqo5eTtPAzX5eZSq1tx\u002BqnZG8GLsiA8JOTsEYMh51zGvaGiRLOepu2INdgypVGNgEsg/OSR05U6bIDAASqJtj5JS\u002B25j3X2OnUUA7wHyb\u002BTXlE4AOq4dOnMp9fynqWC/n\u002BZ6Rlj1DDVKoKvfZAY8qMBbOLZUbVT0NbD7Sedw5uPUUU8riBmL0ogYtYnyTdZs7V0sTHCqWzKBhgCn\u002BcJNycm4CxLHERC231Y\u002BS6fa8ffqjlyKVJpzKfYMqgII0\u002Bi1yuuwSjKzpdw8ZX0afB\u002BapoQYzWtlw3UvNNEsumcevft9eHDMGre1JuiATe8taK3WcfN94BZ9UAd2gQVhlutlLbdxrQOe3ovcU5aC5XWGAdwjRkhjkM3lACh5VYmiU4ANGyA3q7uqR6NnoZx/\u002BmqR4I85PlCi8ZzpnKzrJYjyOgAGdcpFXmYQiQ6VC/8xdRW952UKeRU/ahmDTg8ezyIqZXecaXSQTIIZGLVSDfWtuCeXLT4T97Dq1xugsgBXAbncapZ3lQuRHZri8WBf7Vwj5ZXnh5HkFn22oZJY74qBsgcLdZNvJhMb9g\u002BjMPZQmunPjNx6f4oX\u002BFQYwPN5SC4QUT9ZVHe4tM9yy4GSQOWHZga4mWK\u002BB0KM431PRlUvor3Rgt\u002B290ZiBsgM96P4hbd\u002BkWrssK7LYkn83GEKaX5qQyjTsL4FwG7ARoKaoQ\u002BuhF3F0LT6QuIPBiCFyhrVZ51ZkrSLFNT5aMD8HHosMLFKTlgTNJjJcAA21KqQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "bIrURXkmNfOfoYVSoP7RLg==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECD4402B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4e088f67-fc2b-7b2e-0d2f-5a82ae3c637f",
+        "x-ms-content-crc64": "yaI3mU6zBYI=",
+        "x-ms-request-id": "146c0f20-a01e-0055-20b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f6b3b6c5-cea9-0cac-5d91-792f0399aea2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-43fc972433ce97c9f5717d2ad4dc27c2-7fe2f98c42ed9e0d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "528675de-7177-1a1c-43bc-132bbb2b9351",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "4md\u002BLVf0t7wsIjBJAipERAKmvYypghmzb/ku8q6IpoMNVx6b7h1R5EipEou\u002BCg\u002B7bfL25gnxll9Oyr1dxcQNo3ysO6sMqFXlVNlDAG\u002BN9WXqc4S7ksB6G8C\u002BTSNf9B6Dm24OEc5krsScEJIvrZbvwNVXc1JAURG7MiDqTVsxhWC6wGQBfuOXhsS/H4EuSm0qzoxOCIDLQ0ldU9\u002BueWBpaooxde0x7kHywO2OgDKPjeiywH/O433f73wboysE6QxjVrT3/NWA\u002Bd9LW0iTPcMXzcX2/Lnhm4YNUoZxFUsV7tbhKil\u002BmJESMsafg4g1S7G4BNVmDe1Sgrst6alPDuOUNWxxshKZmDUz5MrzQhf\u002B1wbUuBF1r\u002BHpjqhuUK7nwyPjCk4bxJifHmufMigiX0CjLhKie1bRH4WLhyNpK0eHTCCnDzfJ4xNuNJmm1Xy4xi9oyiKcREjMEevIjzx0NvMjGOYIe08I2kv\u002BNEa9K0oJ08D0AGAl6wfY2v5MAFPW\u002Bf6lgr2WsErgYPDWnQ8BD\u002Bahv7x8gDWS/SzeL6FRvNn4JztHF6iMciJ1FKBwT0731ssXq0GWWnjJE4SQuICpjqMW3XXUuvc9FE2aBmyUIq7e5lnVORCYYs3DfgQk/LqizIX8WnHYIxzT2pf0/FQMNPHWsdEn01WTfXqoETvzGReT9zrmmMc8BcM8AV95pGZ4tkkTTUvoe/gwadz2MBHg4MGAYQQaJZwpmqsN6tL2GdkUL1rx4MvLqnxBti7rRdWxXCGd\u002BUNhXpGt6bOg2pAmOU8C4gG37gD1tLaH2G5tPVTWXI6wWCCWstHJRPYYK8/rG3zf6GLT\u002Bm0gqESM2oUiQKxeyX4CdeEvbC8w7aoJ3InnnL3xjlTxAmEgj6/cCdhLpgRKumFQ6aWbsHwzowzDF8y7pT3HMLFXbMYd4uUxUmJX5EalvyInlrIXVt7Yvl9VXXjjIGSahHZS802aMwfAaV0a3L/FHVipkw6Lr9rTf61nx4RsTjH9vF/QU8vVjGOrV\u002ByAveKfjz8gOoxWD9ScfnSfM2uCUxsrHB9f9cmM1Aer31jtU8HLyDhFSxOkp6yLNNRXNVn3KQTQVaHDQJp1lGWFqzB8riuz1GoyPQcHhnVy08H1NJ6us7VUHP4fB4eez7etH/t8DoWppGDuxOz8yM4rUGzYgF/H1vd7KJEtk8zilG1QWmd69sQ7TJA\u002BwO7IV1Qv9LcbxU5X5kgDAebzexCUCzB\u002Bq25nsVqnnTTPiRYJstA9/Z8Vx84f\u002BHMedvTeSNB/qbS\u002BSqvlyEJddCgaiF0x\u002Bk8VtX1xfkRhX7P7SDtlyFRjT99hSmckWDVcuFOmBHAV7HulyJNTDipwXer46X8H9w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "C44cn6p3RsrRFrAX5Stp8Q==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECD9E4AC\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "528675de-7177-1a1c-43bc-132bbb2b9351",
+        "x-ms-content-crc64": "beW5JQEIM54=",
+        "x-ms-request-id": "16e8c2e4-e01e-007b-15b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f533ebfa-bd5d-c83f-acdf-0a5adc0c95dc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-8e14bf0af84aea0661576407d905a9a1-a6a1b12b7b70bc60-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "38a36c64-10b5-9607-8c14-28c8ee527c75",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "QuZcv78AwRBBtPHtfSxutVXAp9JOOJYczL7XNgv6ZH\u002BikLYDI0g4qhKm98rewmrE7pK/BknoDAlPP/MBKIsERlBxSux1apENiPy/p0DMPQlUEkh5O102uoOstORUN4GHorB5bXh9T4MAsX5MKGXJggHprBZCiwvyO5BpyLatuFB7OAWQUtCQ18PEeInf6pIe4zHiaoprRBakhzLoFIbNU/kt0e9gODAxWdVSfhKCE1D\u002BSuWEyk3GD/Tu68ueqMM99yWQsRmivqoBsRG0GcYDIXTh6smhSIirZ8H7cU1kkrASFYbt8mE3W4w6ghk7EfUt6slWvL75m66d5EpXpkxdnB5hogM/Fi8SqY49Z8Zub1XLzoeDDtXyGXnXTw4W4LU/3OX62m/y7dOaQxMvvDToLnT0i9jF2o5Ib4mJaMYh/MnY/orgdJXm2eCz6crCwlxF7yGZIVXdeQJWsWvmaIUMeEdJVr6pB7neDrH4EfDEhqwsRHmlh9p0\u002B4SIicIqAHFap3CCeWuem\u002BdnuhKj5WcRkiu\u002BuSQMZ/Bs1Vs5IX33tA5AnWp/QQxAjaiRPc3H0BYcdveXa0ZMTkCAFaMQZXppcAYEY0f9klAefix8eykjpQREHauGX0nI808q/yxpMCguJ83Gw23OH\u002BSmeO0Z0NMWXHCfy0fO4xC9PG/40pIktU4DTVNbXOGXdf7H3\u002BdbriJ8E6O7ymTgX0O9CYf91kxRgsOfFoJ/uwCOB1VJBwQpYY1MfL7vaOvpI\u002B4QnlJamZ\u002BxdVwjvJif/FiiLcIOllc/k6j5sVqNYhrXtfOUbxytM262mJKnBaT1rH9mTDso24yW0AqqYehFIxJCSwelC4089flUV/7Fl44DBATbJxbfrtlm/p4RAtKFcXR/ZLmdUKHxKlZB1ION0Dh8p1zkafz8Y5wtPgzvKvMnzuaJRjPUZrRi6f2/ndpV2C5llFt1oQd4ggEcbxGUAv9jGgadBIkFp0CogX/\u002BPcbC12XeiZWXsS3eEcQxuPaizef9W4PUuNSkYOwazB\u002BIeUQ7WZestnlpzGjYvvLF0\u002B9KBrOYAOFC7h\u002BQOimofOQNVpd/9l5f9hdulI8b\u002B/nh3oz90MZs73hj\u002BGt3G3tQwU\u002BDy2haRt2R6g\u002BbKmxSJ/Mlr1ycq6wdoWYfHP3z59ucHtJAlzCRhpeua\u002BW30MULENF3UWwfsxWiZioBOyrfngM0/wuaEpDClCjF7j/GZtChEwsse5VvfWq9nTAGj0tsz83igtG5cf5Atb1DWcXV3P9ZYCgfsiJtxYKg3HRfvAXdWB5y5OT/56EM68bYKyOl58ExrC8iTRyqdL1OGJWJ4fi4ZgGmY/cbWniGEsdclZlf\u002B/SzLRDVugsCxw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "XjZhuu9XYVb5AnYzgz29QA==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECDBE029\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38a36c64-10b5-9607-8c14-28c8ee527c75",
+        "x-ms-content-crc64": "aLuXfp6PWC4=",
+        "x-ms-request-id": "146c0f38-a01e-0055-34b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-c935530e-39db-3c88-94d1-0240de60d559",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-9fcb3a79beb0ff8862017fbb49610436-bd50400fb3894367-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4ec692bf-5a88-649b-8fac-b415abb376be",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "tps6VU7fI\u002B8doNaz5\u002BKs9qSbiPSqqnqPvI511T37b\u002BkXvx8e0Kx5kAPAsWusVuY\u002BGCtb6EEhpgwhq5i/ak6yIjDtnCjCjSX3Ivfw6fkO42aoN7wRn4en9RgT/SUTuSa1Do47vrq\u002Be4sGY8ZJMb0TEscyFzORoYKpRaYPr48A5GnRO9pq0yWs6bsxCjzAXcRbAOtd4aHzI20MkXgTrsv8Bn9cePXiqD6ihi13YJZG6OjitK\u002BjogPH3hdtXkGsmTrwNAS8ZOXPeFetu1pzfMPWxamQMPocWGR8lJrddEr89e3zhyuSiYQCEzxX9uaoVGJUlpiYG2hA09ugP89L8QMMsMVtgPSXRDwljR2\u002BxGJ91EA3id6yZNqFsrNQ8Um0tyE4SkUgOtNtvFJbc41Kgg54ImuOE2glWkzr6M5BR1PycNb7hXocXJptysyMVvBMOjCk187eJaS5EvD5NVEFK3X\u002BaQO3TvyUW8bQIUmbmQNbnq6dnHCEE0oyQXKJIydJaJ5WjeztlOw0EHsIDQRaHnnsnZajZ48Fela4hQyJCjieh7mqRAwWbgrBaYz0ewZF1yP5nYaRpgAPURKWNA/fqwVCaoVLsNlt1S6M4f4DEP5Qc67pj22yDeG4m/P5gDr64r6GshGA\u002BidKjMdXBMQBC0AURsFg9huYkFyjkhTlc1X0kf5AfV7sz3iHngOlWggct5Cy5Dl5muui7SG13GcSZBhxY3PGwY7iKHZI2VcY8jVUhtuEMo8cevcSnY88N/MRdDrqNPeVVvUB0LzCMcGUivvsYVWMjjGJVeh8syP\u002BpvGDNmQdLb49vi/lgmLTWUk2fhOUT9adheYIYd4OGaPRAinKPvpcdl08rqIlpgvPtvufRTQQalYb5bF9FczfL6WME4A4CBpO2Qi2V6EzeN/bOavjbtNvwZjTr1hJ3mGQXX/8mZKLlq7gUWwrWhK1523Sotwh/MDSHFLnZVjCBfqnJfohN95NT6L8Ah1mQ2eFHcjqdjyEb2G/KXw/ozBVHktxhDUYk6\u002BPhVM5JPmibNjrYkeP146\u002BIrWYYg5hDatxpuPR9b8xbIoYW/HoS0tnHL2kVEHpxke9smF/fzChLXenx30V0XYZufW9d3ud1ddpMUZQvblqiOCcFEJdsuxZdi15QYPOUUpGi5pLLE7LH92KFk7qUHC\u002BPT\u002Bceb00uwcJYwBNJJRTm\u002BD7CjEeHlyR0PRk05yebya9ugRDMteNEdCSQshOfvtINnpt7kY\u002Bnx7jCqjIz\u002BhravTakGmQD2gIbvhhjNuTQ1L5HJwhMIDffhrlYCcvxEHnJ9jUdO2RuCYSZX9N3RNCUMdVzrNLSjpz\u002BhFOqq9A2am3eWQDvs9laGN1DssBkQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "lWSLUI7Gh9zgdSGVUul81g==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECDD8D9A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4ec692bf-5a88-649b-8fac-b415abb376be",
+        "x-ms-content-crc64": "UBK0ToYFEzg=",
+        "x-ms-request-id": "68289c5a-501e-009a-5eb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-0d09e62f-40ae-08c6-77eb-49c9c4512f50",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4155a4eb967ec60f2af187178fba785d-fda0e7f8e1887c1d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5c097e13-2e8b-83ed-f6ba-589cd5ae5f45",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "d9GM1pZjrj6R9/BmUNY7b3JocEcHn\u002BD/syndh2VdVYkmVv49Piv7PlhjfmjokD3GoS7uEGv6BdfwjCJshSbZM6JnP/nX/TBGbTHuoyB3FyPrF\u002BY2bkQdK1AnTLIIj7gxikvGgVBD7qP\u002BqKM5C2G2eXT/gG1AosRdSRSpsLB9Pt55vRnVsJbSpylCOMag5B/ucNM9CQ5L8eiHaDc8mj7ygWnFwE5I4cjeLdhE/Wn9vGX0ukDdPzXPLswwTkhelQ3qT7Zc2yPQpo4KXts1BvN/iavRSN/9FEE09ZKCGJOAf5fLWa2yoOFCIxSx0\u002BBZmifYscSdjU0t7Dt1KOWRTo37it9EaqxFzOjJjyTLTEFg21tqqmfO4/JJnWxyPXj8sdWGtkkBFDB7k\u002BXb0/0oYqD5FEyKJqQmLKfs\u002Bsw/0o5wzd5PRJX4X8Yr7xaC8hD1ITvMeSgrcooxYImiFRpkO8BWawUe2R0KAbWGXjaNpDmX9tmQc1llRVtTHuQLVkmsx7RWK4cK1kcewXdzpBNUpLxQCx5B08dm8CWpy7s4/6ts2peBNniyjCCRcrLi8qBI/3kou0sqavPt7zphYQuM5cHMBsp70m1Dnn7\u002Br2EUhP6FYMtBEENgQW\u002BklEY9UCoVBYzwFevVzS0M5R3MLLuS2Gs83AA/StV\u002Ba8Vb1z0nBU5U6arUI24Sr5OeNSsmlBWzEbvbAXMp1bq3cqomevbv5d/Pd0MRvrX9KS1toRWpWNewp8WCTATaKhPvHLDE7DScrlBLVhzRolMG3ddGvDOlDhrSddMxbZna9E0vIaEEOD340PLEXQG73gRxe24tlG7fSg6W8XZga0G3cWLPooCxAqWaTetA4LAZF5fOv/EqrWDfT9eTbUbGl2SxDeye6zuEv3nJkkaCnmpdfdrekqxPjMMC71KoHpRe07WHjtLDeitbSv94YRoZXbFtNfBs5wW4YoEpnPzp26Hlar6R\u002Bg\u002BXmgKvgkis1iqo6JKhO\u002Bmj8uywzyxRmt0vcm5ek/dbiGKh1pvuvGS9C4xWgLRpSKC3QXjS4SvjRf8lgBDZTkMzTGAw/2VOtTWH8sOg\u002BhopxSnNplF\u002Biac2vZCbyDxU471IIzRTOEg7aYxCS\u002B5nQ0vl/LrmDKfxtMO5\u002BkLUsuz5Mw4GV9fl1Y3hkj3FOz24znpFtsyBbdcVV25wmj4GZragSRjgYexz/yctBXppLHiFACvHj/wfd8U28ABpdTpO2iuGJPIl2G2O0balVGhdqyr16pkTPta6gNFTqXDsCors3ipO4weGYCi\u002BOb5FeiNc2UTVc4qgO5tUy6Qh0i78occsuHY\u002BDsgib4pxVAQYdAWt9tArFpb/S6KO\u002BRdiZI36wZj2GcGsHg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "0H501q9cKa1a6NOBfL/KEw==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECE1D2BD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5c097e13-2e8b-83ed-f6ba-589cd5ae5f45",
+        "x-ms-content-crc64": "DenY8fJ9mZI=",
+        "x-ms-request-id": "16e8c319-e01e-007b-45b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-b0219dfb-e463-c0c6-63f6-608bbaffe94c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b5bf81e1a129fdf264f73966caa813b9-25a033058578110a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2c018ada-1aaa-2433-4b58-91bfbc9a06fa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "MS1t068VsL8K/XaTbCJbRAHXBq9kkf8cu/e9wMPwsZzxDcTrVNlvtczy\u002BQK4UyoZ\u002B1pyBFchJp8tUBe3V/D7Gkzaol9db/AnaFHjcZj9Y2jNpMVpfaxEz\u002BYlvgPBt13c9t\u002B23rHKvItqSpsGPrUHMO2v6rMqkpyfltJ5N7HsZrHzB3q5R4W2A\u002Bc5/jMRPZAwHo4WEc2qsWRCF0feUITZfuTqEzc7Tehn\u002BOfL8JNpjVhBSRkj1VXkSFUVdjA917JjX4BOJypZ9dClrhjl38DQ2InunQdqtqiPBcrhJda4KiE1Z5ESGmYu6FNIfSc8/mmVRZ6mTjqq\u002BKjYvyFfd9D57IT3sHcvvb4iv7SzIjmBUgdhTOA4Etvmim7oOlpFz3GDTpGiRE7xZoffhI6G9tZvV20Z/ivvwdqpECUIRoNj3PBDMNOn3g65b\u002BZYWI5MYJSYeOLtK9FFk423\u002BTMo6R8DfKeeQsYDx3hfYI9Fl2hMXLCRcM6gdrEf/ZxF8OXakYbGVNznrh7NlLBqjstBAPwlapyDlnhQYwb1f0QpvtaThM8IfkKLZa6Rw9sdNufl3f2gH4VIVvoNdvHW8S7Zo9bZ1gn7OIK5mQXt8dKdMi0eD6FHiZ5QSi7U\u002BwhRtXN/uB8FRF/e6qR75oWAW2QocEPEt\u002BGNkRo3iIzaJj15aOSRbjmymO7NQCX8zKMY0O/KrIrFjf2S8iYFzbvSA8NnAX2h7uwrddhU9ne7kMV2HredEHqytNvn/3sSrMoz\u002Bz1ilcsld\u002BICnjaycJeF12Fhj64DNfJJtEyiue9wGMkNIfs6Wfr6UKbVmnFDAENDYScasR0cL8VKGeF\u002Bg77zkYZtpU\u002BcSn5mZj4HLpuABbQJXlfHVmar8fE18EAZfM3o4Qnr1Vvzpxeps0reFAEqyRMtdCRmLDofwbNeZlo9TepxHkyRlTBZFbZAHaMczdzvCyYt7AeogbXOyxOnlUG8a2ZfbPa1mDTi1F9tJg6XA/TXb1o0EGHjyJyWw8kdsYB1hLI8vGDmOXPxShioO1unNsgfzyXmh1oEfKRZHtRrxSLe\u002BKFcWkeT8TXnQ8ZJOo1A74wB/uJajvxXOD\u002B8jBuehoT1ykK6S9yBi97w/kSUu0EWGC9HasdAg2mlBCIH12QaSb1BU3BKhqSwf3IEapC4wnz9pXTsVhu9tUbZFUa5ebR51rSHUmjRzJGKl\u002BpUPBnZ7UGmCTHwLvOhhJ4qcHFd9wW\u002BipTbMHAULNniYb8xaHksACcEEnCCiajB5s7KplsgLJ/klrGF/bzRkt1YDcw0bxsk/XBJWeSVOwHsGkqhSoV9wjQfTdLHpwJrMoCTKnzbjHaypanr1tO7TlqwmONxMEhX2kqXFQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "C7D75kyWrmQYnjkYW2GgSg==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECE2E406\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2c018ada-1aaa-2433-4b58-91bfbc9a06fa",
+        "x-ms-content-crc64": "m30PWmkimO4=",
+        "x-ms-request-id": "146c0f50-a01e-0055-43b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-2d478dbf-2c13-5516-c7eb-857ae39c8f4d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-337b993054c171c43cf310c041cb54e3-575cbd950d56037a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4bc22826-32ad-8f9b-4f30-3f2ee86fedc1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECABD6A8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "NOWYQ3ROPqKCTZz8Jvm\u002Byg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4bc22826-32ad-8f9b-4f30-3f2ee86fedc1",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "68289cab-501e-009a-27b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "b\u002BiFFV4AX4vpSGkhsJylfPsrb2wg5EEaW9CHYOY5qm4UXPRZDUo4hkSCla1T9pErf2dwDRMQuYqna7mOeP6lr577DFOoS26x8\u002Bknnk\u002BTxmU\u002BW\u002BF\u002ByJxaBKNpsqGQqg1F3eUOWOk\u002BgzT4vxoq6Ro7E6VTTxwdJucBoAivPpjNIEjb4cFphW58ANithQmCMBqILZ78PFvwKLb\u002BDbfhj0SbK57RTgdZ0o43105EcKDdf3DtJhD50OPt6rkLane2mnGTEVpqsOESL1oQxWUMrLcVII1G9Gg0oVu75GNOTmcWgD3dsF5Gc8\u002BP2ve16Qt\u002B4D4B9Urqb6UJX3D\u002Br8t9xODz\u002BUQoL/tZzq2\u002BtxpwfrdPPAMlTFkdLBCX1FHtR8MDERUXwu/HVrFDqCacK7iLmOG4r3LIWHeH1c0zkFuqa4bqu6UEWbvIiOZS4qQygAFYCztwNJhQOrmekOwik8VWmTyfsm8Shz8l8CeMdXbSVFTL2oQgOTbumYDsZcnOpfQg/Elnks6RRoT7SkNxxMVDyzuXV7lBNl8GsRnvJSJ2V0sza3ktasKGOZQAJO/yfdS7qZmONk4638bqYeC0oiBihfL4PllLFWB4ER0lQBFvEzRFM3yI6CD9\u002BIuzQwnh0Zdznp78\u002Bj96b5M4FSUxFZ60ek6sb2\u002Bk2Z3S\u002B0XOmNJXlj\u002BGsaJzchj1ysPpT9L7zOLs/si6NWInz8QBKv/5rNfA4X7mqmP8QQg1t6Wru4rK1i5i4ZoKnWHcXuLecUcZ/B3sKG5UFCF/8Ly/hH29fBQ6N1TQlss8tkMcCUyBHtDBG7uHvpIcdsEN4/DdShjjH\u002BHNpDrzSWVSr3IqNwvU/dLs/mnCNb2BHcCSwrPaX2srOOlrs3mWzdJVNQ4g8T\u002B2OeUe8EuvIeojTIZ5YIeyd1AG//4haUpYVjCWbQCuYSyB3InNvG4gexf/R2fzHG1Lo72\u002BGfFAlM\u002BbxZoaGLPpdOpZ94T\u002B5bvh5oTmIiLiZTnDS8lD8Ec7QUe5MffUBWNjFdJ8miXpTb4B3DNtWnGtuGBgV8zqpoSjHrY8RLPEDeAhgg1QZsoU2v4LQRQTzebWC3iWdK6WeW5N2XxurAgKPc9STNdkXVKVS3zN3mVwj1DPZjk6LZkyigieAoxOpS32AANEwYEPca4mASgxyJsJ3UornkbP0BA2IMHOxlvFR6VP191hK87OwPSKFCtwAMJtlCRCIgbmJzDyDqC/QapSYLqC4vG9qLJ7XN5SRLvkxSD/YDI2gySeaa\u002Bsbh0tD35JOLNx7h7Rr\u002BtyxsYnk\u002BN1DkiAwOB4HN2W43lBETmUTk1gCQwIc9cBLrBGxLxddtXMN2DUrU6e0BvV2wulj56x3Xh4x4rXbA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f62ab00a-8802-ce2e-8c2d-52f0f0be7843",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-e066d53d214e82df0ee2082e56989d59-6cbb2189d99d051b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9499a1ef-bad7-074d-5e5c-fdda0875b2df",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3JLsYWP\u002BdxcPH/kCODxPMkN3VGlHU374rFdMSSuHVp1Bo3pIXTaxI9JGRk7kJCvFwVLNFX\u002BFXYkU9LQMsS3rh8hbwZTBB9QMxjCWAQwvE4grhojZukAeu0bxM2mBpHKkW7\u002BFiGOWBLl\u002BwE9P7lt85OAs4CqlEcyIPQVO0NNqiyG\u002B8qZNqosklILOWvrxzs3qdE\u002BJVMNH/kny/UpeSDPlFDUtkPy1LjlVB0yo1rfSlm43Y1uE4DZdd/NdW61AxkxP6UbFxD7QNUYWM013nyeRH2bbJuTXYTP\u002BzxkIV9KLFUD/WO1wDdEwZi4Vbqzp5tfLyzxGZKBnd4cTxvQkyN1zih4Md0Y6IBGUq7\u002B2wvOGFelBPIyVRLCgmOFmXUfdDJ5QoeON3G6RkaorsrnhsbSUjLAL4oxR3kVubN9k08PJt54gZSEP\u002BDh7sKrhapL2vuct0tGW0ikS/8OeH3COLL3nYfoawEuShJR3kDLhb3Oyd634NgHxMuV1DmZecdjI7IPs\u002BQiY3P2bm008H0L3MY9P66fClvW89S8UpbLkMxK7r6Ou9HZrGpuvXJu0tROjfd3XD4YwBlWNMAPZgzZLt2c6gW\u002BeSTwZ5NAMEjpZB0AbcSjUDSSMiqhNIMNykZdkY6U0eTOjBDSgviq2JPMbNCnDvhEOdqlCrvbGUCl5plI5p66VJY4Md2zzNE/51Wa1Muyar9OFVu378so93bQKJhfYfXxEhg6atkalGkJZSNiQER483/d/s1HBmTLDz5q46A04IVjqcavd//iM4DuqoqryrcuVzkcfWMkqgu3c1\u002Bes7DE0ISZ/pp9yX\u002BD/8tIWFvaI0SLOIhrGGMmPv\u002B6\u002BAScR3/MJdoCDcgYrIm5nIGX2FGz2UwXF3soWbgld8OaxtF647RPfDKB2BF8bogCsXvdjmKqCx60hSwEp8wd3JoEfem0QrzJSFwjLgE6mqTvKag8R\u002Blg8Lu2wlqIRtRiY/t7d\u002ByeSnK/EEIChtkZfe6HFX4n3ZSso40uAXxmQQGHwM4Fvya4TOM1gTenYmnimURsAS1aPoJiztBfcETyVM88esYPE77Lzsie7lxhCUEnT2g7\u002BkPQKYJLpvBSWNyaRyhkZuej04WFpDZkv1AmAcGTOCDcul6PaE1Hw2zOdXHoAKcz/KJdg3vislYNb24uJaEuvxy7uYzN1PqWXBAUuy7AeLqo9gUjNbio/gQIgfzjFZ3Pn7pRMEsaZienxydrzfcnSPKzgTOcC4lkEr\u002BEwVb9s0Z2SR90c0hzkpPhe26VPTAQ5TUOM5BuM5As6SGLlaDMqhfc9YDbstmqQ/Kjuowe0tGPd9wh84OyCBWLR4Ym5/jvENFatEuvNTJbY\u002B\u002BdynUAEhg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "FI0fxFdyDQ/8gdDDoh3IGQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECE66602\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9499a1ef-bad7-074d-5e5c-fdda0875b2df",
+        "x-ms-content-crc64": "Aw4ihUVMpmA=",
+        "x-ms-request-id": "993da12f-d01e-0002-49b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-4144b1a2-253f-4bf5-1f49-aab7df3a4d77",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b56cd33911d4029190e4e86322df2cbe-d35e517d7f969647-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "463ef293-59d6-2ae9-5dae-c2be4a498a71",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "bSpvsQaheA\u002BqcaPkBA9oIs1a9bn2yZmGsaJXkPoxwfgl6QVz0VN/8of5x7kKwAas8rFNeusdCKOQ6P9kSecVea\u002BrvxsJ9VB62gIy/AHfe/Gcq51I5EYMB\u002BFi4uhTG6if5E4KXwDqov1g05/o6wuhsW0OyJ5JzJRonrc6pxJoJr9Zkhiz1RzwsQig5xCnJBzVwDF7RVMKVRe5ocBJsPvq\u002BKzgjljz7ttQHhaVqeSEwXmaZObh7eFsTzwA\u002BjNcpgAMtu9jxpbD4tJVKic8dKwyNeBGr0wUCQvLdD8c8vOo9HcVifL1IPrj1oEUi8K6L9qPzsVTFfe0\u002BK3kmFJXp/DerTavJuu5PRTlY9jK/31IEURkjSMuVd\u002BAYJFFEYiojC\u002BRNt6MCgjv1ZGwbrIe6vgvm4YN8xrMr1hXL8VadCuMPNapOMmfvAY7dLeSfeYtYXaYFnUBmpkVxIaFNNtClWFlIzHbdbEuj96A0X5iOjJxKs1PwV22i6E9lHRCGYcr\u002BN9VLVm1UezEaoaWgckasopUFAoN89MDrpiQnuA97HZWVNmfDQzYvNjhi1fXHwrYIuLp7gR9HgULUX7BJbILhn4QPyzwe6R\u002Be1gxK2d8LI\u002BOt3z\u002BVP1x2TbTk7uNF5cl1gXZx9/d6KY9a3KsS/KdjiXvM202DDKAnmb1HOfp8GTBDFVio2WwsM7VwOiLxI5ENQSWnuMp7snSWCh56My\u002BVHoN6z6dO\u002BvAP4KeYUtJ9NnXsebjUlKAlx2Lj0o8NsgCFmxtfdlPpvoZ1V5gio19iWNOoTbl2wEojFQhEquggwi6nEvf23cAhwrsyXzzHwyQDQbn7ZSRHTpqRfGFLpRPeFJWpu5Bnq3sTRor\u002BBKENGxHkQSkuZZzKX4RdJaFe1l2nVAqnXkeTm5Y\u002Bp96ZiQo5hGEPpyPqr\u002B74nxwMCkXZtLAtVvBWZbzKEOVTL73\u002BcJZ6I6EAT295vKRb7v8rh1EQZPNubDIZ4x7kRVZ\u002Bl4BxOm6FkebkmWUA85oL\u002Bra9nolUAoqKT8RkIEBCW8oY\u002ByUkKvSQpfVqa4uObbiXzeioJuaM6lT1pqpqIXGmon1a5/i1J8/CLPiT6dc/PCJLzBKX2jUjS9DQboQKJoSDw8kOM0W/4uXY5jnuOQB99mqIHhUezsgId5wn5LlLt8Y0ECYN8QicjCls/vQ7NVLQUrgZQgivZTTBBbvpl/5sTS5zuekaL8Uh61Hr8g/UDQIJF1IBMnW9hOrxDOuM8zQqwHHFh7tp9iKy91b2g3LlLPh54EBsK1q49jU\u002BKSMZlTgdgPHeDkWGnyFvTjrexsF4DB/zExKzvtUXDNGGa80/mWIemQJBBx6y8wEfPJ0f2e8zhd0DZoIlg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "hHyko8Bt9LgE2JwYFrDBFQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECE83A6B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "463ef293-59d6-2ae9-5dae-c2be4a498a71",
+        "x-ms-content-crc64": "u5P/6DkM6cQ=",
+        "x-ms-request-id": "69fcc9fe-201e-0029-7ab0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-13bffd01-3926-734e-6e52-233692d6d0a4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-fd7c7b05bcaf4b856d03eba950a30bbd-1a036bb5607da494-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "154740e7-6c36-1609-5591-7f9a841593ba",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EwUBf0VSCN/dzIlKl8Dxy4DjvAGQAHT6yjcrM6AcZgXTO2AHmIhQVf\u002BTPjlHtjaQzgfiHfv6SxKQBrQOJtU/wWWEdltf6TL3k2YB/cI7sxQBmmSYOUkK2fBNd5LUQi4qVHzTwj/aMeXV64qU\u002BE5PVVKgDYxwpocceZ1rEXGfIlE316lFZ/DUJ2l/w02/deGi/SFAMzSiua31t0mibh9zNcg4XCGkCu5hzOYj8eM6XQS8yRRPX\u002B8clB37UK\u002BnMbhJC42Ehhi//fMz3mZOf8fKullF5qQLI9XZHMgDqbk\u002Bupot2eZVtdfr/MwgHIGIzRVVMZZWYksUPue4q2lQvFM69CPLIabhdQSCWenX6wdUUE6yrngj6FdPGJv\u002BnQptmkB45SddvKtvc7uR0whiPFPgY1obng3bFwzMfAkK4tj5Fb\u002BoXgXf9pSjQzq8kRRP7NtIHjmwUvwync4akT\u002BiZJHjl75Jud1NAG3Gd1rTHoX4fY8twsSfScPDdsE3xGVUAN\u002Bp2flWBTP9\u002Bh7L6dqiX35IIhSvdKHMRE36hkMcFjsIcnZ6KkWMoXdcL8im01/oIBdC7qFQpIw\u002B3JSsW3/w4ePiw3djJzQ5vIGdU0XYJnHuEmUr2SeZt83qPE6w4Eb3a07kww/ohfniCTIgs1BHZbUjvUkaxAi8SAupeevmiNw7puf39GNhBYxrSc/1eQR9o9aYjSL83KdGKHsDPgwN\u002B4FW5QxpT3FSwbi8rns4x88HLNUVTfq6PslAscvoXceAXU5NnpP3E1NkRstpPy0sDWGr/BI2\u002BK2HnKZDKJ6lamTwPFEs6ig7DxiBsAcuUP6bFKNqPGC1SWWgxgLttOu0vtxneQPc/yM4b\u002B35tEimWEuopxT7Oi0DO/LrjCMlTlstzfEqx9f6vxSAMsxzu5Uc\u002Bm62RQzWuYSvYz0R8HP/EiCSy\u002BdWe5B0rej/ewhgj39dzpG1bwlOVhRte2OZ6c6hgB\u002Br4e\u002Btxn/dQpck1z17TtO9tCHhSqMXRHXT6f8s28QZXfrotK6PrwgS1y1xKX/W8S2P3DSsvzZ8lJx62t1/sGbTC3lDkpolLQQZz3J2pRv1/ffSnP6PbJ3EbB8RFdUrkifGnh0Gk16Saq4vk/DDBe\u002BBhdzmrRNnQ57bfiZ6Exgv7j1LsAb972qYPzJQX9mtAGcwj4/4ReQTXlp/KhQ4GFeWAKWyeFXohJZyTW3hF\u002BTFLX6/SYOINqlZN1KsfsRVYCfaul8z\u002B4cSSAv5hfd2MUZ2uf2Wec7UDcn8WUECPAbRHe1GB12EkjL2rQF3jrGx4gULNcTGvuZZBqyVN6JGDwsEJ2gJMCrp8SfLoMzMXH8YSnY79gZCCl4G7QCw71qPr532cw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "xus6/MHy/3MPJ0IkDREzLA==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECEBBC58\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "154740e7-6c36-1609-5591-7f9a841593ba",
+        "x-ms-content-crc64": "odQ15RLVSqY=",
+        "x-ms-request-id": "146c0f62-a01e-0055-53b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-09e91d7e-a8ba-e40d-badf-d6b8de76ee51",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-f06ce65c7ea1a611bf4c5848a5b61568-9efe56e6d22edb06-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0ad7b2fc-7402-483b-f4c5-8546406924b7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "KwsYBcIdCQNDKTgCzDvwLtbpGM6ixGDUwqUPQOxgV4NxbmSkhfCwST\u002Bkb7HpQdDALey2wBWuSWarQ0MdDckX4tK1kV3XTKjlOc6O/lWv6oDVThL/qZduwiX9\u002BUGtkzt2jYzeNLBy6eFD0YZGIEsR\u002B1jCSL\u002B3Fzg6R8442VNnN6WTGHDJ0LbQYmUwu9gQJ6La7P3o60p8v3ZTo\u002BzhOQ\u002BO3JngswfaSCui8eVZhltfKh8sXu1VfktbFln6dS3K7yhVot8/L3Sa/6PSRvplIzga9HnNtNsiOF1NhZyu4NP\u002B1wG8BOR7IPqqkl5JgzhR9fMg34Cz/TtMM2mC8anY6x/Q1G75qB5Tn9R\u002BIiJ92LQk/JCpjgFSStrGb9B6\u002BC5R0qY/eK/KWEzUzECsNdoYz1q0XvUZLl0efoqTMjhO2aalLFB7PWAFWqND1MHApRQAraB2xZo4OKNJIfkkNiUUhvOaBwiKnZH6rwRS1VqbXdl1k4SY2BMMbfSsMRxm4CN9L07OJp4LdRAOexaW5mJJrsQgr6Kge67fjpoU3mt1lM7g1KYLzTY6ah50iVz8doaSY4NYRTGA3LOg7pgE9pelmedItRK7PeCN5USELPFR4hgTgnrnHE6cYPfya9\u002BeNnOHz/B0tMB01iWjy1/s\u002B7DCTguA8HQcvXyYrFQaydIB767R/V0A3S5Xn6xVRFHur2RHMBzUHUb\u002BahF02whrWQxTotywG/5SwXHcKVHIx3kqqfzw05i2LdFo0pNLjAEm60WfAaJ1PpRm9G\u002Br9/T1NqKYSTELe4V0nHQKSEhqBzRvtj4LKcXXtGtoit8pCjXdc5zws0LPGm/AKmUta/VL\u002B\u002Bw6O0C16gzdwZTGo/GmS5I/LdWrelTxoJzOSv5gqkl2HY7y7s/1J4mPEvGtCXZ\u002BGt/S7j0gn4CYSJuk558OfBdKT4Zis1zCSQVMHGdiQ5YlUDAfjbwMVX0OWqUzUUDpgZbaYrnwG2eCEKQ31IMYNQUFfpdu7\u002B9bPvoIVFi3jvjFYprRh\u002BDcNTTJnH0X1IH69SSgLtKpe5KmfyS/58cOy4GrcXHpR60kKElipFJxQ2p4Dl8zFmAmHOYHKgi8HE1tu9D7a2IPEa13fAaJRtY/NTy5R9lo2rQhhVSL4RylZwv89OmCddcIaP2xvJpanNYPx/XLA9VzBeAb2uYNhC\u002BQ0RX6jVHtvb9lsd7cth4ax\u002Bh\u002Bexkn2mM2iO8JZpvx\u002BuPNIOuFXw\u002BEIgo2ZlH2l07BABP9jgkWafaxwwRi41Ykc7b6D5UzlWfY\u002BlgP8XMSQPChR2WH82zat7f005wKIj6zEvKb\u002B4i4jmusJJSwBniDn4MUwZzwnIBKIFfePsHKzdcZW96BdkVo6A==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "RzEk2L7uoMAQeE4iBYVvYw==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECEC3176\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0ad7b2fc-7402-483b-f4c5-8546406924b7",
+        "x-ms-content-crc64": "XlV7Jp//3RA=",
+        "x-ms-request-id": "68289ce9-501e-009a-63b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f2efdbdf-64ff-681c-63d1-d2ec01bfb949",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-70623328b824f69323591750843eaef5-41c14bec073167cb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d19e28bc-893e-31b8-b849-64ad149f9484",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "clDbMNlQqeFWvJarmQIoPqzY4/bBsHL1p5/NjbHXdneYaQ4laTcOaFH4eBqTBaVvDNtKiL/Ms8Hd5Yk6ghwwf0YfEjDzAtR0ynqlyTdYYqH6XYDWjO23zLVMR4St1OU0yPnUdPJ1fAkH1b5FJ\u002BqJhYLnQCWbWvJYZ0Z6prpPx/WUcAA\u002Bg\u002B2uhOF3z7YucqTLwsIBxpTAmW4Hew2s\u002BtVOtw7IsLfpSwKVOLtDI4s7KfShr\u002BP4TQBh09aSNwfgAooMKBeoZsLt4Xe/bI3YfXXiy1IYC0rxVmoNZtzgVxT7tDYwN/pzk8Mys85sOOFziVZgr2u1x/Y/GtKtmv/lDYpixLdWp0Z7bziO5Vd8hR2Imt2Gf6epRew/8RwnxvjETaZECnQpHOEQ5UAzJuGfwpS1JAAhXo3iuH7KF7YpU6g/ypiwOHupX338dppmdR8KoC6IcqH4ou8ZYVH1XgUq5pKX9FxJ7ooZDMWCJefze0Nfv3aIoeAHRiepl9YqswB30ZAHz4HCwbKjbmXcdn0HJuUOlZ6PokWxkK40oFez71jEClNX66zBnf7E5DJ6KtCqonDxGx5h6C9LVT/TjSFa8H8NF2sprzs5TPigyr4SN2Xdiv3mwtM6YyIkDJZt7g/dafOzbRNkgPI1t88mwR5wOB7Z9QMjdC2r07NJBaKlzF7owmHKXslReAoKsAsDE6IDs9N3k/gMuvXGCJpfG3pQkOtxPf69ptpUiHz4GMMip78RRVLOLThl3AhrA1Yv8V2PuiAgktajRg35Igt7E6ExpGDaTtYogmOyC2D1UaKEJZYfaV6jAhTpbf5F1Qot6slnOl/1VKOHZzi8bYd1rvVqdP10XKpDjaJL8eDX46xYhCGWjhZCjtDzmAEl5pSNc78J2mANuY0fI6y9qmPCr4SLZOlm3iDfJ\u002BYsgcSoHacNvX0hzghLS8uTd2ppheRtMOh9moKrJ5WfKrJ64TfJdwUFsOzmoeB7Pxge0me1daIBvlHbKoMkYpbngqRW0WqTyQBlY9X3h48HAlppjFQu6bQPeCLm7kyC4U1W/h48JG6uiglmUBHNCjfB0ygputVCuZjvRlhHrdqz44KHoYlxy93suwJLx5miQm3rJBskWCZ3E0SFTN4VZtwus2yPRWmtUAhKPf/S9/L\u002BTQPqXIm/j4pbD41E637/1lQlHBMsE/wEPdMT2RsmpRxShv/aKgpTbiTiMzbcaWWJS2arrNre0jkH5h\u002B1rLVuNGpw8WR/JKtK0q3vSt/GKNRuiY21e/hCdLTF00TrnsJuc/7La3cACie6Ydos7odZQL1KRyInublyLnyvuVFnXzPrgdbh\u002B71cbX9m\u002BhodFYYtbJKHoFefRrpFWDz6UA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "b\u002Bht0rAVu1IC\u002B3s6FdDUdg==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECEF3E4F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d19e28bc-893e-31b8-b849-64ad149f9484",
+        "x-ms-content-crc64": "kLFvqUap8F0=",
+        "x-ms-request-id": "69fcca40-201e-0029-38b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-c2390579-4451-58bc-efda-5847639595f8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-9151f3a7b52b879f6b732d1b6d9adfd7-1476ad74bdae555b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "17897278-52cb-9f79-1cd0-aa2cf5ee39ba",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nlQY9oJMvuC/3Ew7G5uigGEcLpCmGHbUGXvzTYaxffyF\u002B6cDIwTNAxdzQsr0MZXdo4CNvHQwGIXeRNwHWXFZDV5QtSD0nlxcTit5Mtas4OfmFqoGJMCIVOIhJd8nxqqlGjRrpHt06QQjMG1Jt\u002BWvMWP0IULHUumdx2E\u002B0nh8NYiA0xihQDxrcS2l4vNTP538cfN8MqVn3sdLztwaNhaLp/vlyOTMDvEniK8VIW/1SojEQWCEAALjGPRRVXJgUTsXGTv4bXa5L2MCVan1UbxXVYNUVvW1B6b4Aq/ve7h\u002Bxzd0/gg0/dwRChH9gqtY7cY4\u002BQDvC/pFYRKV/2vGybSqhI1ygVO0I1imQkvjt4T7oBXptoK4j7s9Lpz1nv1xSkBdUv4d5mtzhNWnSMiuYaqNml9W3RMx8vTSNVO2voVaNfgKhmSG3bqpdTKtEEfyjszyaASeGmwtLGAJSrEYvMVQTBLQpNtFBrykrGjgg\u002BGt4KaGw1aAvBqL3FoEfZIJkbhsXcQ0IerxrWFI\u002BW4ETah/W2oKkflv0JD3RMeAQIkpmxuvcyYceb68lRb1N8Ksh4\u002ByhSEo//\u002B//Y00PN0jcG3XHl5SVNmBYuKsTvzjepjNSr03zrtoAZsb8HaZ6DzhmSSpHRhjWTK2MCI\u002BfLAD3IP0ZvEf66Kxbx3CN2Rj6HmmyrXYOVx/afCKgZ2YKYXrGBPzpIFKwa2B9677oSLNUkipl7H7KqImdf0AlGoFGUWY1x9RcEP3XAkHV0Kug8jOvS5V7pHU7\u002B1xzC6ESSxCe95oY8kCfOIEsTuo89NgePE1Mtc7sCqzxOgx4KMUcxLcxdtkRSD\u002By0BLUD1WLPsaEFQ8TxdVBsuztJ/h0Zw\u002B7z4pyy73\u002BzLRNmaW8GDtXZfsF89P1yP7hr4QsJCAHfqkDWD\u002BLWDNIhUiaxmwvxZrxlcH9LnM7xgaLUVw50uhUBhr8eL/7jA3H/S6LWwKSsenpek5eShB1x1I5P8aXDvJgBoARc0za9gnz9XFEsGrEON\u002ByEJhZ9bvKhnFtwowHMK48KxSCQX5czkREqpTe8RbnNMcnJT5aBlDEBqzbrPN9rISDCIVWQbehFQIT1UsnK5UaRo2FIAuv4eTDvnqRQWGQxz3QG\u002BiRkPNPRg/8RjDFnNrXwWZl\u002BEy5E2bgkoN8z5Pggw5NVw/siLXaddo781vz/eFfub/7aw6xVwhBsT4wErZ728MiuEXLKziwS4KyvR/K7JTh3RYT5Vg/m//Hatd3qiMjv9eYkQWbVI6HCt9MPpnotsSpTjWgKDZrIxxGA4AheOFfTv0IMltPRohHTJq4s11l3vQSzlwtg1fhba4pFVEOpdH\u002BLO/coERpGgetGJtb8q//A==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Ta8W\u002BdRqY5ptENKyXpScNw==",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECF139CA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "17897278-52cb-9f79-1cd0-aa2cf5ee39ba",
+        "x-ms-content-crc64": "61xl5LjSKUo=",
+        "x-ms-request-id": "993da16d-d01e-0002-01b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-7860fa35-1255-3ab8-aa4b-343bae52e6e5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-046dba52e4a60ae0fe6d7ee48b3eb748-6339a6932df47589-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a2345ef4-7c16-1eb8-4753-d870c7b5ad27",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECAF0A5D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "eip40w9zMDPVq/Q724U1Zg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a2345ef4-7c16-1eb8-4753-d870c7b5ad27",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da1a4-d01e-0002-32b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "/8I48DKXzFyeEpTmQ\u002BWvSvXKxWIuvG6ew7SjngEaxNgc2HkFUuc6A6Ui8x2dcd1TvVl/DhNeckNTmSx99C1ag028yWtrqfcOkMK8C8hQAVLWUOGom7bEvmY2sbm6vA54yHDQ4Kdy5xNhcX1RomZ6A5fZp6RMsuiW9wsFNfc\u002BU9SzRENYfyCqZGjNRik4chsAu64h4RVqLBWHOeibbbEcIx2pnl4iIoN2LkI7fmu\u002BXoXvBXlIHHK/SBcu0EY3D/a3sSMMjtS93Zkrq7LSL62qydtjq2g30war6lVG9FE9Ph9LhM1Iss\u002BwMifgHXG/7BlqhAdr1GOOf90cYKR\u002Bd\u002BlH7myThqrgYRYLs3lAV7WV7P483HBK0Wq7vQXvK1IrMro\u002BmC8FLGVuiSLxYCHpTScoh3OlQZt5/RwB18ml8TbE34C/Ar6FkMCYzVJNWXFJ0m/dxqTehfAexZsTA1WcyZjsLIGgKktpovezDXRJK6SquAVaxyqR5VmPoD0jcoxq/AS5YSzwqKckdCSsK3h81Zn2aEtQQgFuWkcnEIkNRi9qSBFwj8l4uQ9dNlMF5brgE8ujLAlBGroCSwflyJgdFi30QeJmC0bQfq878gutaHSMRvy\u002BaRomKS1XbUPBk/F3Px8lEKPXegiE061aBiiuVOOSWIGbXqwTzhi0D50CDuu\u002BxLLsiFfRtMz0OZZsyyIFqRlgLjpv2\u002BBzEkKKI2pqgsTBnEF1wsyLwaO0piQVpwL1r2aEod\u002BwTujSeHUURpFiirfSqi/hj\u002BdM1W2WujS7XWtAlXME5eHkEU1Yo0lWdnsSUhxtQvzSFB9\u002BN8xyGZSzFhoK1LEdXaTW7pniiOyd9l7yhGcYThpubYBUha0Vcfe5pI0uS6HJ9PR3l1Ri8Isy4UFtgJUsm8f/nGcwydj2wHyiKONfb6q8KJByobbGDHz0IaRsp/FhjAnFLq86mSscgNbXv8en03KWsFgFufkQOY/qO6c0ihmLQJzamUD6go5kViHg7ky0TE4x1faYXNIQtPUfT12D6PW9TH8rzToynC7JoGPYMEtDNu5ZArUi8\u002BTJyuRL2zMx4G4rIqHNiX8U/znIzrxvOIOp3BluKuZAmlmaYgNV58D6mL/1rA2pdq1vRQJ7WiQnWZJgof4awraI64hIMid7vhh4zTb8eot1AGZs/\u002BXjxD81cwhx9EXC4NUJbMGFYEOF84bpA4ztK94G66CYrsPRpCZJE78eCsrStuxg8w3K8J8i5gte\u002BsGyR0gpawmlKjIROMiaO0yEZ\u002Bm8Fk2gjDfRO/oAdci4cqpllsx39Z/BLYu6T7tFMLRSnn4iouNzEroQWC8OpLRqWcUeNKWADXJJ\u002BunB5T18iwtFrddJlQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-1b15570e-91f5-09f4-1909-06695e1ea27c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2cc2ccaad657932852088d47acb6cd9e-483b27c3b0daa658-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "96378ceb-96b9-62a4-ea0f-eba87e628391",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECAF316E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "TkbRJA4VpusJ2DIXFQb6Cg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "96378ceb-96b9-62a4-ea0f-eba87e628391",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da1f0-d01e-0002-74b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "D9KQDNin\u002BbItfZTMJMn23SHE9VdCIm\u002Bm1dpIYOqVSIZkDzbbRjy9KM0/VpTS0EvokvkuMf/PuOxi6jf\u002BX5nIlzQNZxWTG5fkB82JA8za1AWPX87wZxeHlFZJeFsFvsgzd79fxWg1VXZiSSoxRbUghxYyb//L1y8dhdK\u002BSaI730gEVowNew6cWQlXjh3tVU\u002BhKPBF0k/JaJ\u002BPQj\u002BVdwzUJmnhLe8pEwwHlRX2c0kSMDCDHSCx9Q35O\u002B7sfTjOBuL9g2ezCyhfeBXjPT050vRWfBIPElrrIjBc6PEBPJXUOY4z\u002BfDhXiQIJKQLzbfPv2j6lQAmvvSHEWA2ViM2Xjt/DwSuBdkDdB7tB\u002B614FR4jCiJBqaVrXqarOePqgcB0cVpjL2zIbqO9iDiOLYG0jEMvsn6rFeU6mKKE1nyc8oW7DUoTFOWxWtu\u002BhCFsnTDk9m2g\u002Bw\u002BBiVu1KJbKQ1gnIJWzEyA3oXddfhei7FGDjftxoB/O/De2OUQunixO5xdDV6OL\u002BYoQrVU2A7z33tzJ8VqbmKN4WCSePNmcCMNKzpcAX5TuN9QxIPKK2Ph6vhqnZOzRs05zyz\u002B/LfywtKRRqzUl978H27lGanew7b9sI77/NKQWuRtIjFSVbwoXQKxOOS2DVIabX4kzSwjWwx1AEso98UAAezIZnWsqsqxvbymLYrRR6I74Y5Ua4y4Scck3FRw/2Y8sDf47qbdbcOzcxBwfC2CpLmp7RY3q5ZfDx2uh851QL1VaXxT2Fn7XXTLoPh8R8yZojebxxJPBQShmd6JL\u002BX0PjJSGhOwLstgrY\u002BibAud4shQFOWW2nmrBmR3sj96ci6O1mLGKiy56HNrOhqCrZn5A7YVOBv/XWS5phSuOHyL5TthE5Wp17eclytxKp9eKVnLfq6JZTkTjnj9DIQYC6/24FTfIJkDUCv\u002BeaHvjjPEWn274rrOAoABToQcq8ozhIt7ekpKfwi/xy6DiuyYIwBFObIHXCj1KN3U3dIU56Rgy/QVdBToedp0\u002BxqMS3eUaSqE1nEYLCdihlFsdqE2quCJIr/3gq/rXb/XkmEOaN1lQHSnkBEzSJ7Nsu3CewM5PlA6Aym4nOZ7mHixQJnFVB1zBjUsjhrPVtkhKdDBKeK8nlQQ1GW0raOOLPiYgQgEB17PTnTNDLA2aq1Pl3IWuW\u002BW9aJFtYC4v1mSnWEhNtXQHCJx8tpt75Gk2mm3ZBYweHOJAYxmv1LeFo8bO25OFDTYfnpQpMeUKQUQoNoWAVpCYSXumDRIal3Pk9tKUrQiVcU13\u002Bac39Ss9NiGVR53xxU02NlJYHz/jxMcgRDrStZR7ksV4SF0poFRQaRbwhU/V8zFFXna2PVINVDSf17DwA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-d303ec7c-26a6-ac61-d40c-83c7f8daa675",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d04c2db8eb511e97b58c32f316d5e0fe-0e3b5a882408a9ee-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3a84e58d-177d-ba6d-514d-be5c3561a23c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "ETag": "\u00220x8DB71C7ECB2DA5F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "VFmdS48nqoCy0kHlUWB5IQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3a84e58d-177d-ba6d-514d-be5c3561a23c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da243-d01e-0002-42b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "/t0pRCY0XHYVVcyr0aImI46B\u002BlmNrmz05dFVR4Ph1nCSg9OiNH6adaW\u002BUX2WOiIeCzRpnd5JP1BwNF5U3hXzNH9bGU3OhO4P54S0zlzvXqquNzxOdziSSEODMQAfRZeQyx39OiHUT4dGWrZalXHzgda0pqfYpLxGydEKS1Lu76LtJAI/8SSJ2ei1CB2COLLSj7Apa5/vtydgt3BQygM0V2oTbHFutJCxKsy/I5ufw5EeN7yixIMD/W3b3zqzOA/kgLCyb8tBZNofeEDSMJOLwPPfMpNGkpPmEG8DktVW/vK92qLr7FTF3NLhgkxDMM3ZUB5G0wZ7ne4dzF5cPdIFyXlOFVXwoNOfGlXAZQ9Ho\u002BCiKkG3DyvrQTy0zSD2aZ4A3LnS9Bp36LBKp7mwuzjf1ih9uROQTrlOYtQYPNKzqLC2v4hWdK/FKkKRbGhxOoUE1ff4eK\u002BLcI7/hJFGXqvel/4J\u002BfywiGJ5t47R/uFR3ChOFGfaui8AK076Vu8df8yWs9VpaECIU0yVf8EgunGsrqdp90lEA9zPCM6utTJyWzjCOksM53TnxcEbRTtu33HcTadItIeDUa/4ml9y2p4ZIySJXn8moMczgTGIKb2hYChd0WiKKqawP\u002BibE0wUdeojASIX5YHxtqzgFDJV\u002BijxVjk3FAk1jvl92B\u002BXio16HgxGZSibinunbBu7qhV0WkTAqbwS3WDh7XIpmQxhWisfZfYlDpUAVsy\u002Bj6jteuTkCH3a1uDQaEGsZXi1cvBvRRHwm0QeTkyvv1PwVE639HKNRJGOh4NKT/20eakdSuPbTkmW/d6fxboxKxeN3xPz9HEFJy1f4L6OpUxGatWiknVvFQUEIfaU7X/XXVxsvW/qwYU4FyK2e22LCFiSWFrkj5ihHcoN7tN6cTmtiINiIufdXKhQanpSuZmYeRmdAZUk8s3DyqCk3NKxvaboCPPqKeVwtfyylCUdT2MxdXW53G\u002BkiJa1nldGOIDWnqzUabGmrVAzLEyYcl2opXs9c2dd9\u002BA3Q39cNIqNKnx83PZ4SeWxisclhq8iCxY4DPjcCcUYeKbLnSUySXnFpQLQHJZnMFuVi\u002BifOHEwFDdoJCeRsCG3Y2NPray/f0FNX\u002BCtUu\u002BA0dycR33ceEA1mojuySVSM/ThGbkyF4Kv1gynUdiQg8JI6FJK9Wmj2uoiGhIk0bYb\u002Byzsyzg1Tbla7XFwNSZopBbGpeDSBz6KPT7PEP1wiwRVi1arpLiJE5uZ8Af4MqXDunX7XSzWSfTuYY75Zjy86mJsG6nQvABePJFEORc2kgqZC1WHdC3Yf0JhvUMpj6xe3QakjBf78v11nSGakRDdt86DYFrnNHU1k5tmbv69NKzk5Q=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-8c6ba004-7386-a357-0656-5e4b0c4fdb8b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6b347b9404e0968aff8ab00b217bdf42-44d78f83a991e85a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "991b6a88-48dd-3614-25a9-922b7b549df3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "ETag": "\u00220x8DB71C7ECB4AEDB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "LfN4/1euqouZZaULlU/1xA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "991b6a88-48dd-3614-25a9-922b7b549df3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da2cb-d01e-0002-3fb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "dKYvUXeokG/4fJSD/rhodLWstMwlyZDCQo8jnilVrTTp\u002BEiOfJNts4AiDXYJlFhZbpaIQX644asVbQ/ohfFGos5gmgZv2fgiPgFMA7sauK02yi\u002BSzWy2MRadeQ6DhS2O22qnqPpS6ZWeZgN8bN7v\u002BrRisbvBtNRiqmjv0V/pnrjTvSdQchCy5OCa82doOcQ4rn5aIdNyzCaWRf6SYhc1tcdKqa62noikr83aJ8Ft\u002BXCjtyPgjn3kYPEBui0SIILIZD2gHo8VghD2tXEGmKRlKEuN7qv0VSZJZUm9teNbko9LEcODzNvhjjUT6tkM3shMm5LhhDLX1A8XVrhGWM0smyPhu4bg4ltwrF914WpNPYeAcRlReg1cdD20bHUjmjZn5k\u002B1KiJBa7k2cNjSYfKkyRkwxeaz2iEWhUdJLHXlTRIpDvoblxJkPwZfGwk0ihNKEKJc8tRPtAwun6Xb9z9DUCPGqFP3iTIHy4bgVL4X4fo0/hzTiVo92lnu7PhtiUjGG8vlbuHAUoZwVCZOb19NFr2qp/gib8bIiM75CZw5mUI\u002BGTjzMnMYdKuVYzQ072v5oNY6wuFPpKsEHeUTxknpNrvjEFUnWeRKkjNMjAySlJlj/2jG/tdh7nWM7xWOBK1irCx5UN8V0kfx8C\u002BuAhefcohLsMfgIjfjgiHgm2nPu42G6uDfGEO6Tiwh1A6ns\u002Bxd7H2MQlTlgYn0ls6\u002BNDbdIjSiJxc2v1lFkWKav00pPM40gq7sQ3g5oWhW6oJ0\u002Bxn2Q7LZBYvUJy0jR7HySsI7y1r/ibKH8N\u002B8aYav4NTX0JVIpHubUDZDX1uByPzHRlamGh8odXJnblPTHZsEJUdYTHYbqaVGoHsjvCpWBSjj9CIvCMW1r1sj4TUoyDOaPjkUKXyFrJ2wX3qkBLhHEGkq7yh51B2Bo5wb\u002BMdwHthIiH3wQtyrXUiFf6hKEKqi29HM/dgKIWkckobgarPVQEGhXHw7V86Mf5Hg81V0NpLxeRz2pCAAPWYT1K9Wy/OUsD5nqbQuZoQDP35GKS4UqFvz7vCX3pwgoR4VJ4MeNrSeS0MXDY3dwxKY82SiuhM4/ytTYtwC/dGiRgeWGD8A5AjJqN7r/ZrNFive/us3fucK3SdXytTXm05xdMaFR6rSmA9b2BI1TAKRhkywI/7ma8ggizoXqRk08gyPeYjUR86BDGbc26XV1ZAlxkSIJndPign\u002BZbtvu\u002B71J\u002BYFptJ6vD59LxeYCo8jS7ap8uLVrMuVP\u002B9\u002B1eISEVB357S\u002Bzy\u002B\u002BqwkGCvZft4B62xkFxckMH3oab2bj\u002B\u002Bdbah3HISPbZHuH60bZz6HUNohuBPrIDUyHa8c5o2DJ2q8iqqDYmJZcnnaefQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-c1beb7a9-134e-e83f-f569-47e90e2c113f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-36e4658f4da43195852a4d053200cc65-79b7a26ede142eb5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cbd4bd95-0946-725e-2b4c-deb84f4e3487",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "ETag": "\u00220x8DB71C7ECB3C4A0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "uPmydgT\u002BKjLHM/fZLNn7Uw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "cbd4bd95-0946-725e-2b4c-deb84f4e3487",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da32e-d01e-0002-1ab0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "XKHAG74Rl7YkAfue8hJlhCqPcgQ4dmBdJutluDUYQwdY4AD9tYK/yOt7LNdKm\u002BpikWhnzF87feVAY/XSq96ADL30RRIRaM6o0KkZvEqJEooBAyfNsHanHWIbvFGM7B0M\u002ByAaVVXXUSiZv/y2IcGat1Bq0ae2s1xGTSiv9qt8G\u002BOMDMEqb701KbL/M/B68fuhgAUBIht1VUfE0wgtJ1t9HaMYKhT/cEiTNaf1t39ry1wtDnWme/nIFrd5Zpu0CAFXghZNYcbnoQ\u002B9be10f57IWAer/xnl16GqUBNdhgqs3i2lnjVoHmqVRmxl6A0MVJcYsA2TCQjocat1ohGziRsFEY6/zuFoYDqdFrmtf\u002B6Tnvx8RNX8GNUlvSyK83tY4bxQX9d\u002BTIW1r1DT9vJOOvG84QQVN0RGCfi5mhG03m2\u002BRTT9XR8XFVJ2xpSEKSLj1oI6zhF3Q6p3CVbexbF0AdHjFLC9UN3RpcyynnCvwd/V1sOOeRBbRwKKhVPJOE\u002BgAsXDoRRxJYakaChFxaQ5x0d3CO/t5YfAh82uM8qKCG18EZyr7CDLZLA96hHnFoJdUb4LUi9gsxw\u002BAhlGwvK7Gl\u002B7yLMHjdsnq6Q\u002Br/t12XFLUeIMf7Y9HF2AbOkGhKG\u002Bgs\u002BxLE3OVcPj46aKIQQgyCmo\u002B3EQrpqofaxVhyHxISYDgCwrxK0kffseKZsQs/tZX6TAXokvrtQ1CK6heM6i8cJ/h6HX9AN8hH528YT\u002BmMqw\u002Byd8MMKd09FY9rz\u002BggQtfDjZkCtZgmqgRNoLub1PNnDj8HymJcD/4rPPf/5HfQF5SXRMJQeeVnm92\u002BzokhoUCL9LG5KHhlZ32a53iQJsWcbZkXBIAxFoRJkC6UnUFlCZu3Y\u002B\u002B2Ju8sId1UtZJs12UYIlDwCpywWu49b4hJ0NosJe3s2LLV1kap\u002BtKy3FDx7MjJfHrgdP8PBxkBiLdW0lEDKI\u002Bkj/6iQlwKVh/KDX6NS4LPgFRfS7D\u002B3dGpxF2PQyiBr6PRTVzaFzou1h7fRQmahE00l0H8o\u002BzOtaIdCH3\u002BiwL3OF3au/4l5XkaMGWSH5jID0AQWqvWlPvHAoeqvQ68IFsb2Ay7z9hPDqHY0nN3PKYJVPk97iBnIKNSA6lmizhqXhAahjecHE9nwUwJ/bKIX9XhkWgVjjIqtLdpWcwu6IN5fnRTXKZufTipxizkXSLwybPTdOnARN/d79FwMrKDSOjIgI8\u002BJPMvgyQva7gVRleUaIAIW2OpqSmUhXzU7kp2Jo1EK9yTsqSwo/HFoNknyKmJ68oyeu2FLtdlma92WpTZuUUq0Sp7ALXrR6dh1AhAfMzTSwKAQ6ufvvz1Lij1Olls6\u002BeUDOd/DusERyNGE0rQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-be659163-16b2-09f6-9560-cd4fc715a084",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-4115dba28e7aaa02f202bd257aaf19f4-c1a486e9e10a9eb0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "be950d82-d17f-66ad-67ab-4019a4675b1d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "ETag": "\u00220x8DB71C7ECB9902B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "1AjNwpNZsfCblfhiagBC4A==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "be950d82-d17f-66ad-67ab-4019a4675b1d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da3b5-d01e-0002-18b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "YdXgT4EKx/1VQ8F3v8eFmrsiYI/BKXScqCgfpx1VGJCHdRFfgOQr54vQ1e03rtaRExZmtvyZDTdgQ6dZ6x/gACsw70q2JhnX9nkE8FOHZPpRjZQG7mKT7mfZ/jw90vxr8NTBBr6M2\u002Bz9j7\u002BDlB3k2d\u002BtB12L2hLInAHi3CfcmSR8mQB\u002BxV07xbKnCV6iEFlK9SRdkMqe4BbC\u002BWm9qf7EIPabBvscZRSBcUKr49CzJoyomOcDfghZ3rjqvMzzfhuz4uhoBgldLZAQ3B6H8/xFDtLdFBEXwaHtQShCMqhHjfMn9wDoSx\u002BDS2pW8qLq0uq8pK35FmkKmyFGesXgGvrnyE8rYPv7XMKyWcmmwc//A28\u002Bho77TnaKHFzfodFaozFwbylTv3HuwUfqRr2gZNpRR3dVopRs7HrYoEOfG7rxWLaXNVKlrET\u002BT8VGEAe46biCjlpZBQGdBIKueh4tTqWN\u002Be4HCC6Iq5szVlLOJttzILeLHY1fmFK0\u002BjHP9zEm0AEfuBcYseCK\u002BeK/Jq6vzt6mO1pmojEYLWCcUg78ubRpDYVRr23EW27WASOqoHKkBSxTKLvXvy7PBou2fF7SjUAuVhgoXR5w4uDrkKENbozu903hqZD4kk1XganhDd8QA3Pie0pZe6cO4kXb6y\u002BNwpj\u002ByIQR8eSvNcPK0dx1j9QB2owtKvJClHyl08ZLHKYeyb4R4kVa/xKPM0aGjqrKmFNx2hCiYJelvDMIax0dZBgdqwgeY6yOptt6nvesuwXR2jpz2UKVfGgmayYRUpP0cs4taeKirDSm4jQ1KMKg\u002BAAtNpHjqYrWiC\u002Bf9/iGfFNIhiwpf1IiLy0FzfcOYFSmhnMl5BsBEMhDVuGzArU8IGXg7aGWd3mtCgZk3dyTyCjb\u002BHCFYJg4RnVj5Shxbyx3ya2RLXKyEA/5d9kVnTPrsI641wpEt7/MqKYsMpFRPJvZ7BQvAZq1Kehhi\u002Bi/I6hBeDWauJgiMxHtxYXMhd59qDs\u002BO7EevK7zA60i4izWDYX96rpct4MCt7kDQjwU6KQJ5OOtgef3IryGprTqAFDlFrcAzpojIfG3O4P4G3py3xsJGP5IKYydBcf\u002B1RDPGLZoHSuEExoJ5cPx9UVj/wdBFMaZ4ehRnO0rY8jSJUvg6CPNj/1O7csA/zI7VzNGOQbAvMFKNTbOFoE9WbBRN8B3EQ0ilm8J8yb7mOG1FkW65CrCEWmJlrPs/nh8EZQbr8hyw0UmI6KWt8mbT5xVGAA8g3SFjyVW7XtZNpj3jOGR3\u002BkYQ1L/lMGIK1qg7kYWluV4QI4glSCjG9bKzOwKnyrnCm\u002BzPNWtPO6z/WPLtv80Q6CyfkxTcUnIdSd8NcfUfYwvuOTXYg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-401ef730-e41b-f126-6183-961d2b6e94d9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6e8d94d1aa9a9d8d4872f2073f844db7-889857f33bb23c87-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "42357feb-76b8-f507-a1cf-65030b8261e3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "ETag": "\u00220x8DB71C7ECBB3DA1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "8nR2SMz463wP/4RMn9eV3g==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "42357feb-76b8-f507-a1cf-65030b8261e3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da42d-d01e-0002-06b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3pSYJerHrjAHJ95/15v9G13gRaKySbQEsQycwqWfP4gma1EkS7F4k2Ga/HiOGOU8Z7w4qAa1bpTglHTeKuyLZ\u002BdWWWxK2M\u002BraLJAF0w7dZgnYFrpZ5aBcfy8RLY9mml1DpWQOL948Y/sjD9UdFZIpB/btsmRov9R1edvjpQZbs5Jywm3qz3Yrm7L/NtWLP2lc6CXYuOf42yVP2LXCGP60h5xC6hNkPnhAghbxqUk\u002Bqjqyhr0ggzrqeecImzaAaUK0Cq95SFUWOOntV/aQx3GcUW67T5IBlARhmHBsG6NBwFjUPZ7ZhWGlnE3TMysEGbK1bAmHxNmwsnZq17Ak6d1Gq5ed/MmSwovNFbMEbmDZXX69tq9Zuft/I4sobu2xQPKwTIeTplzo4ql9uu8mbAPVUboxpzMt7PGcHpk\u002BqlPeW9TAk\u002BGZRfch1NQF2/8MGPdHEt1zf9m/gl\u002BV90eDqnhVn18aJdgiPAuDD5IfKBEyj8Xh91d2qtv7ANGCA05vXiqbsHxf8fLfJNbRsHAHoJpOYydB4fLhHvSDHyTGoDi9U7Gng3eU0p4SwpJAZTqr86B3M6Am7bx3upGH3NLOGITeFBz\u002Bn90i\u002BZCJbt9goLn6FytET2yYVmX1MAjlzTWLBOnNolDdrVODVHnPnb7dFxoXjcXniYkYBf32yW/UfOya/in1Uv5pHGnXgTryyPinGBkuzn8v47sgtVyS5uPj7teNNN9U54QbrrGbz8iOZXzFD/EW5a6tatqu1J2h1jVF85IjJZPZUjBU0x\u002BNlBOyUlAfjdcyjMlpH8nEphMmedi8Fdw2qz/pK72AgdJO39bHPEINgkheEyaIugXJ1KvdbpkHEX43e\u002BdQNqIZscs22j/zPanQ2PeQHgK1bfD6HxcRo1N5R85Yj4Ba/UumRKFbkd/F1pcCDFWhtvN7Qc42VhdKx863vZIxmq4pdhur6dlhWdwRNEh/z1b919EbHQ2yJKd0W3zSo9QNlHwpGNZ59Y0Z2egyJSHPCzh3ueXBFn1gdxF0d45cjrXHw2AMFvaAQ\u002BIEAQNlgD9FZRBEWunuDL3\u002ByKGFBb4\u002BvQsyKiHBwvQBt3YD/NV6OvcSLtJ\u002BGHPL2baiDU4VO34kBYP4M1XdQ6JcAqOz6k\u002BoRM3qsxargKTXZlCrH7WmLLv337dRQgehNKsv4dWQGC8nOYhAKohnuETfIIzFcmQsthYn\u002B8rYFwLGSX6ru56PR04hRCXtJcHzkGdycmF6m8JHA2u/aFwkTuKFueEJ/DymT5k\u002B5C4\u002Bf5BUNCujpaShS628JHhzD98x/PUDJ2vg6dRqjCKIe7eUCMOba3QwgOk\u002BJG4zjZeEMz/5zOc4\u002Bxgkc0pXONlB2M/16Bu0w=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-7be81f45-1dea-93d9-c1b5-2cee45ef20e0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1e40e078d59fbcc33cadef133ea7fc9d-9b70c840ab05ce42-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "242d1022-1931-2864-cf5b-e5c0f4d23e9e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "ETag": "\u00220x8DB71C7ECBD3919\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "F3S2JE6WvzgbpcTTCSKDWA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "242d1022-1931-2864-cf5b-e5c0f4d23e9e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da4a7-d01e-0002-77b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "u0JsNq7b36dmID7wLXj3lfA9bWw7Lquz2FSbGLhpSQF7KoSUNDckg7IEntDxI99\u002BvdsCXPYe/YyWuF5aQMbu/dY9dQP0YmG5GOm6NpDbwrV0HFvcZuwLXSz4/XvYykPrFaH5tK7cilt6SUMMZMb7u/ap5SNrEpbqMRfW\u002B2Tm4E2mziHv4g0GmJIAYhyp//hl/EKEL\u002BUgfwMKD4KWBY72k2n2ZpWlDNnookyQa695QDIecP8iYbFohU4d5NKKcJMECc6zs5ljwO9pm4yZjxRTkM5Qd5SO0zK3jeBGiCgGXTK4i2Lgxo2Yu7APucUlzvY6yVMEOvj\u002BdTWc\u002ByW5HDjHYj1a4AOyc8pAt7zkfhpskr/qDL7UASM5uhYsRMpo3554SFaIyu7yiFaJw4I8GvYbMGllzxB582EaICbthS7/2NcdazbE5MfQ\u002BINnSj6g/J8fERRhAhCO/1T1banHBAInieuqH6/AVkuhlNeMEagjeSSGznQantXHjmzhz3YdCfOBQMFS9tzwX7rIv205Ae2s0vSFQDaNDeoW45BC3ofVg4vjCtHn0INIlm66Ut5njYx\u002BNfyCmMi99DLWPBJLrYAy8jzhVvccxAFwPKrH0roMrlYExKiKU\u002BrDJhaeEZRx/Onuh1\u002BihTaVYnH7EVse9iF3yY27R\u002BjYp59RHjDgfbJs/z/A2UpbaSgfbmE3j0GOpS/1JkcHtbUAFeC/UGcGteS\u002BjhIbXR3WHF9knNiHoBhewngA61dqZUqKv8NqmxjBGLl9eAAvckcSHwnnohnceXTIYY7uBsmNUyjIkZ5Za4BGo4MfCigXL08x7ctNgsMwrUVOojqK0hLv7yTYZuGpubOJof6VvW9MsTE\u002BvRn\u002BP9Bll\u002BRYC8lGvNFxLxoDP8huhzQYxOHEm\u002B/WAfEISxT58bBUcs/9Ua3qQuQtJI5VSXJp0Dbk5XvuoPv0gQnXPXC8eD1qr8z4cDWGLYH9l3dhgbh/n3reFAs0ZdHTCc\u002BjEgVzcKxQ65qlcF8AXrf58QmEkgBRWJ713WMyNUn6JWdm4hp8iSbKEZUe2S4b3rZTOnTITnbPUrpmfpNIHrVQqkv4mnudfWjjuoFqM35v2v6t3vrVMtbxlpBgFQuTgvPfzS/jIkQ6tr0L5ZT0ZB4896OUmj\u002B7end0BgPqPGhdTzeOi2VPi7e6cic9yU1B/DJxJB5n/uezJFK3bxxBUHlUrpVcZtm57Wvs2igYfbEqMwnQeBhK9VBQ2mYTlxybeSKt6Bq45ZZZuDayeyS/mqahjTwScNhhCrlEDItypVVOUWAFapSWcU5zd7/hl3oskT\u002B/cQrgiAhKTN5hdNgK5hPhYyrDuTASChvun/gYf3I\u002BGHpLszRLbg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-17b9c2c8-d00e-7e23-6a73-5c2e80d8dd26",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-63ba0dbdc04bc81bf8b58fcf447cf556-0dabb96c0aed7797-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fbe05244-3d54-fab1-ac42-424ef40d3464",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "ETag": "\u00220x8DB71C7ECBFD0CE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "DmxpD9e5ifgzl5dJWh7VEg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fbe05244-3d54-fab1-ac42-424ef40d3464",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da4e9-d01e-0002-34b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "D61m7vLoEDHNayNbXr4y3pX1YWv\u002BEVvWHXg2Zmx\u002BPu2vojwGzV1730eJUUsRoRaqXs1rPu/82f5RkNB5sqnFTiw1rLuCLBE4eYEkdMAQxXxiiwieE//\u002Bs8k\u002BtD2MAi2ewwIe2/VbJzK8MsVu2GQ\u002BQctUFyahJzssN/jyRHjUrHdUhrC98emGBmTW4uA6j9tkAHJxN\u002BoG/ZzH8aP8aeO56IZNGVKzgFDhzhDCy0Vb8qcdjUQFYnSMTYkU9QBGiZ2AHPlZ7HaJsH8ikGnZQzFXbP7739ufs4URwMzJn4pPmkRzQa5LAQYxlNzF49ILswlXvYkBSqnB4Wh0RyuqwBH00vUkZgGDC2r4yUv\u002B2dCzBg3CceEATk\u002BasWBF1rnah9TL0BDc5kwH07EfCIFewweYwUAd504v84OlibWhPTSwHUJ3Mwm/1h/Bup0w4UbOPO5YrRV4vJ\u002BFm92NN12XZpZ8buo\u002B54/\u002B2esgXC2w/xI91k3HSI8fN2Ci8ZcsMp7CKlMHs3JbkFVeWtQqV2Bx1ZzLT2EQzx0GXTeJnPX40qZMXjLZqEuf4Ub3aO279d8AMBv7YeI9slo2AFY70vRfZogt3fkumCxQK24aGGYvS2dXiGva/HHED6vYo6j1ZA5SmAJljhfl0pjuqzV0IprzBrTu40mIhWkXaM5OVvSEWsZfyIBkyrxQcrbS61E7UOwQ5J3zB4HFyROYTSVJl3ykalBuFFoajzv3nnGTtpkY2xjhPXFWkFNFmv9sy3yXB9s6LYEAzDuS9lVi\u002B2gQMhJ5gHINZ1kKTdr8KXpbrcS\u002BYJeVWIgYFw7cT0cc9JTqNWfs80oKip\u002BBL9\u002BnBKPAN0iRo5vRetmKYWljMBcR7llFEfMTbrp5tNb3FCmocRNrHBj\u002Bi1H5GbqOYpHhp1qIcEGGYfKwrciOF\u002B7F2maw4fBV\u002BBP\u002BEmIITPg4hAwolw17bqToIg8hu25PcHNiMz9U3oChi69GiV3efRX5dyi8Zn/hSWvBx7/hND2lrqLvphi55KaLhwxeNOVHCaT5J0RFkwr0gOrTkhbBwFdxodq679f9QJKCMd5zghSGer0a5w35XxuY\u002ByUu5VGQyca17JMKjBrN/Oexw2IrgP7VTRdYp9lJeEG/IvSxz1pB8WcYvpaBe\u002B6jTOolR5y4bHonWJc5OCLta3NSSmkmGy2Mb9H7E8JnVNIptVruIzClBrZ5inbDB7lEKlIiLjCEfDG8mdfKvVm4vwTFD4LI/0dCrESzrZG3yWcYtuhvRCWhpDkpMopY2klcwcpy/fc2fCsL34Ls0c\u002BfBdBwsgdwSHveJGtJnsy96dL6VuvGRcxv4Tm9ZGSjtNNpiS266ChB7HlPk9iM7N1eTvaw8Q=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-a709f4cb-242c-129a-1d8a-7e66b737ac71",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-796e8db65b3978aadf154aac0531cea6-ad30c9e0d7224672-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a17c1bb6-43f2-2f49-ecc7-1ea733381da3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "ETag": "\u00220x8DB71C7ECC3C7D6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "aCJN2LlxqFOt5\u002BqRTgW5IA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a17c1bb6-43f2-2f49-ecc7-1ea733381da3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da566-d01e-0002-22b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "nwIAqblqcnex8\u002BP1W18WbvPCWYavbbboWHQ5lTlYaPUMyL5L9QY4D3BiDhAc2nJTzadIrT5ZZTJMGFBFMd09WYvu6JOhynnsikkVTV6lzH0B5seRELu2s2KL/t22896TJLSFLvHesgItWyP0QxfTpkzSQ0oWrEnQNzUxFcycNpZrgimqIJ2MIzTEY7SXwm9Kt1iQ47CTfXdqtfa8rZw2kSWMicHuKYauRh8WUUiVOHXG5l50C1Pm1wWxP2um0HWXjdKPCjmuXI7R4pyQfSsv1XyB9cY\u002BwoXSprG8POkaCHaqfsR1BS08GIrPoim2VVrZgmnuJNqvWcpMvWSH8R\u002Bkt9km5v5mudBPRN07biBcG1BW4rqALOOc\u002BiX5KUjJtCZrK\u002BpPkG9cc8iZn9/8c\u002Bqp8KETMQ9lI4v2ievYbJCHhpC30EI1DYvg\u002BW/x54wDn4c6UDmntYMWBQhfWAaEhAY3ERlPRaOoc\u002BMVMjegczz\u002B8\u002BpjnRxX4NAMoMo61rSFXHVoutVzs1nkktxVkYJMdZLLYGUcIObp4DBIQ6XYbZ0ukNbBN7lmi0CQfwpAAU9NwCo4b3VPaTuPf9mkKnC0CyU\u002BJwCsij7ZZNUli6Dbqd7h\u002B4J6oP4n3yeaMbjfwWHP23TlAdpOoTXsXgqgKt2btNb6wy/tOmsnFkfZEVmF\u002BaJ0Va8s9acEkllNjkHzh7VK/33i5P4x4qEJvuqSdY/cZ2VnK9Qtbr4u9jDVn6wpM46SjxLbohSkQnMOIze8cR3JcSbci1zgHJC/tO7NXEL134pcAOZ9AMRQw\u002BlhHkuGcoQTCy6FTagysXKBG\u002B4m1uYxGUOtYHA2THBii8hyf/1FOEFpuVATcJLiKU90/OXWKuwDMAUH2RIT3L\u002B\u002BI8HfwDF0O\u002BKsvB2VHamxyjchwlCLi2Hcb0/4PV8vVdyQVUzQAmgd/8ACKW3PbRJcVg7a8hpvM5dgA1HifP2DfWZABcdc4MjOA8KPiGLzDAI8m\u002BdQVGPCICK1b/4XO4PDfqwHj2dLAHZGDO5X4Ko1bfZOpuAWMygDfeSlpnDJtsg\u002BzAm17H2a8JpxCUh1akB4gAIHyJSirEqEBBGDplkFfVUlGBOgf4F5tLVGpCrfjROjLCZtwe40nB\u002B/MedsFkpBa4zzT1Es1wCBjhPfXAcgpHb\u002B33kzl7tn8Xz04U6ZDJ1qBTmd7D7BdlUl7DPaVT8XnoxxbjfRDdTRjF7UOPay6IF1dFfOgrg4PGkkDquHjJw83ELCJ55mmfdkzGDf7D5ecwSyZODoSBzTOTHOrP8pSf/CmFyz8MDiD9pfarVYWFAqxZum1Si7VJMm7u1tmO34O4JgHVThqoJDz1UGiN5meuHho\u002BZjgnTXBw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-6954b562-7db5-74ca-fb6a-1076c1aa13e8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6f88ff34e26708ef4c5909983f4b3e70-72e36f25a5ecc36c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d897c9f1-9290-c971-b515-c64ca1817951",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "ETag": "\u00220x8DB71C7ECC4D929\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "PKSXIe53ghtstqqkfQ\u002Bs6Q==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d897c9f1-9290-c971-b515-c64ca1817951",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da5db-d01e-0002-09b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "GGMF07TMtcBzDIz1BpS4DokWERkdgXBa3hkhrzOCpuVZy0sebgNSdxPNjsbogObSdiRuJOov/ZfzqvSbqwWM8GanmzpJmZ\u002BFw5kGT/Oqcl4zTjkOFIH6Ks20K8QPt8wNQJ1fQeSridyF6WBQKa6kSTeWaFzMftzkrHFslG3adQzN\u002BA9VSjF5h8RciCogqgAfD\u002BKMeU9vQcHAe5VzPvRuqnNUgjGeTv8GHOCYcPayxAFwTYWLTvy9XrdNlM6cBUjQ7d22zCfPgMHjhlxu19DLDreTA/Fv41x3liR5UbkwaRaYx4MY\u002B/faoMzDp8ifT4fmgoYXCQJWYAmBPzUDVi8HsxxF1Q9NshO/uGIkqzuU2Eeck84zGGAUQWd5l7vB10qdu/SrWXl4mNByWFCgMrTN7GftZsNg1Jq7MZSo1BpX/eEYhu9H6H7OJPr\u002BwL8QdA\u002Byq6pU03GHPedZ7yjl0MS1G1pvh6vEhgToH0HJYRTaq72E9ShvAilwkUkI7fhW6VQ1SaRloOxj7SSmbLQvvdvTfkRqYNqbRRgx//ZivJkMkjbtkxhvdQrQIQgEyZZ1QNNtNW6064h5mQOMM6H2ADCKmtl\u002BQSrDZAk5mT7Rl3yBvL4i9IcrV6atc/kV4kFp2iDYei\u002B89v\u002BpqtBkelFKqAKGCnfj0wypXkIz0c0wroHH0L8e\u002BRxNxMW\u002BeUq2xt1UY8v2jtjJhQcULhvsiSUxePtPnaqSK6/lOEWyJVnB8pdl324COR\u002Bo/Uu3CcoBYDugjABOZykywTccEVWSF1\u002BtUzyDh6m3Lz/cpp9f2iLk5NgJEphYcotuMh025ijJFubrCraNftiR6FzBcsCJ0uYUNyx9iAXHVOCxFFSMgEkXE5C5dNBsVmb/dyk7lwDL5GA2Iq77TI3gJLXV3GmDBWgTql8v0F4WqODGfRDbi73g5TD0VV6aG8cD2FAblnn9e3LBKO2hmxQBIHnONc58BZj49PY4jrAKeY6XLPcN\u002BhFmyQGeGmPPP0ob8jTky\u002BX4htO3I6KCxO3Bt65eCW4d9CVnZ2zM3eo1KLWsHZt8Ja2pnqUjVtdv4wUU3WO0cTbc/v4OfGR5LKnpgfvs1qZRRJEBtWrI\u002Bp5O\u002BINnt/\u002BGgbZ\u002Bzx6dbalJL3L8OdTcggxew5jSs7vLEwRgwITgEnSqYgBEbgaIs9fouIX3zMDJcXV2CfNmtM77s7waPK0kaB39UtfTmBQG1g/B6fo11EZEl04OaQmAQ60ySbtKbXcpw09o\u002Bnro9dlgcDPkpMrTxd521qVeFf4TfA4poU9Zu2iYmCarzNnLW6F0rvnWnJ7jXoPc1JbSyq5RVX1sv1SKB7XKSwykKPgEqnoE6WcFPeBvRkLLfefRxg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-502306d8-78e5-a3b3-28a6-fa8452bcc633",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-487e26f10c9aa2e877fcc74b495e7548-a4e2e3d36fe36ab4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "69b66adb-45a0-4513-3597-23fd2a68e1a8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "ETag": "\u00220x8DB71C7ECC65F84\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "CHOUalzg3NZ1bapowQ1f1A==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "69b66adb-45a0-4513-3597-23fd2a68e1a8",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da671-d01e-0002-11b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "i9cpG83gRksXnfx4Eb\u002BJzfiFPizOgKhK3rf/wMExj90IDD\u002BmvbX47DEOYL9jIzsrHXYTy1MRaAsu3j0W4YaK5Q4ecAV/4xBCjFL7wCDo57t71KJKHsOK9qM0d9544gurg3qxRLI1qzpm0D4BFqjqRfeCmg3jP8dKlHphSmsxyapHUDylN6IIRSho5E2EieD7STHn9kf9yESzZrA41GHPNQaTucZsRQ5UeVTlelp5xQuZZgA5SdNjSYf38tDyz3HGma9H8M8ZjgQjknzzGE3pOaClnm1gleszMG8\u002BdFM9YqriHuGrMtQ7f9f8FrdWbzE6DrgwTTEEZgPEE8Bf2xqx5TDSEPlrPgfLaR6VZH8z3MA\u002BA2WaDRV53rje5h4U3KS9SjCGhF83z9CxZOMSbwGEkDf/INi0FtgbWTJBjVfoto162BpOrVhhBzSV6agxZm\u002B3WVbnFbvMCDNYayot9UF5yK1WmJbnNePfnRmjHy0v6fLDijMAAaHRrs/m9kItNBHyHCD7287Y0CRzCHihKOkGKIE3aWsOeMcMhOnHAD6gsWkHsQIMNA4k67oOjfgpL4bl387B9cqm46NZ71bkEM/m0lYOmnbn\u002BvRyE36x/\u002BrO4lRj4iFw37ueYc1eskS4P9rrKLuhGpUP/uTZTuJL9eO5igwBgS6tdfKacDioiEivudSkxdcvLMi\u002BVOM8lpDZUmzppSg4tr6sPbLIB6ldZ3acKpUNpy8MiV1DQy1Kcd9hwB3MvuIfdwMV94gkZiUeYextn2z7zKo83RzK9HORYsvTZ0aMkaiTfLOR\u002BLCm6CI3JOJA3NFyZfRyj\u002BHGVYKPhJW9UP/fks9E2iK5adP6lvT5ks\u002BRUYb6YAFRGQLHzCcxAnMa6ZgjWJIS\u002BwKuufwgd/jtzcKy/jMPwu/\u002BjXjNfQ37h2dg4Kxc1To9flWES6YEMaEJ2f9lfgNACyaoJMsZRH70szGUwJdLkPeIdH/eindI\u002BVzXxKMNlQhkINSGs7FvIzrWj5d0cHAJvUgI3QqDYYCvYCpuQoDb5x0pMJ/Dxd1GGFBFB/vf04nrzQdaBbj\u002B4b5T1lOGAOG5\u002B6h5S0DQRvdrwcS5PVmF0IyhgnR5gOFlKk/hcO\u002BKvxhujAxTZYdJG4cP70PzRKNlzQbG5X1tQHrGFCHx79UI4AKsSrFNMmoEV2ftaZGdceWrfKLow9qaAUuRjFFmWCuxBw5BR/ryF5ubwY0WgNbpKaI7RXMzHx0nEkhlu6UZnv88O2KCXCrruWQGTQJNg4F1qGOuKhK3fujxGTWxjFz1giON2kR0Zsx4UIwPLNEa2o7H8BNCa3TshL15kUL0OS0HEMvev6k9AEGWNdmGqFEW1j6n6ptJsxauoQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-cacceac7-7484-4d71-2a95-acc214235173",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d88d1d645f0bb2530ca0885a6f34b323-3c57464ded10c8c8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "377166b0-10cb-b9b1-bc07-320054689afd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "ETag": "\u00220x8DB71C7ECC88219\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "aXJBvZLILMywXtKhm5KuTw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "377166b0-10cb-b9b1-bc07-320054689afd",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da6ef-d01e-0002-0bb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "0aw1mmbba2O7BE1Pkb5dtDAeVLYFbAyxwiehNQ\u002BaI8Jgq3cH4RM6ehuXGYU2x81IvlIL/ZDT6mSfhNg\u002BOjVTIOCK7uZHVtMc49mbbVOGe/paWHe8jiUyjcASZ1w7/D/lRPmkrNnnAWd/7xm2OHwRGQne5OG\u002BlpK6V2ElNO524eeatila4c4hc1cPPZ4MfFVEAU1TXBhdJ61m6VR3wcx4CQ4yHIJStzc6vHGKrlnzrtsM4TKhIoTOPI588/d6qbGKljSQ2WDT8UoWGZ\u002Bm03hUczt5a\u002BCZ1\u002BaKY\u002BDz1sNAvxK/ABckY9V6OfDoignkKGgWJ4C8AT7R8L9NBXWA4BqG1VmM59JhLw9l/jHwsUzdpjt33K5DhL7U7hBY1l1f\u002BlnVYrWvV0CVtPhwVgIN4T9ycF85CANsQlGauPnCCViyBQPYGk6XLk/64Si20y28xwzQ5mb\u002BJfJWaR9jFJ5H06ufvlD/NMbw2kIQPifatW8j3vHs8SLys98RgrEuMxmwsw58FxXcvZJF4Ask7efKe7OwQDasW\u002BGIrQpw7bIVwqcoX4sZXp5ZRyFfphEXzcX4Rgf9ffPiBFgs82kKa8/gMB1k\u002B45bsRwVV/gVTbTPcd9EeKarF0SzRlsz7Go0TttRf3X0s9I3nZXq6Cb6zbejXYKKxvMoNRnZsLUyJ8Wx4AgdxM4\u002B270NDNoRwC4duXikj47oqojnKElcGgMcBXXPOAce3QnoZILFfLkZFnTru/c8jpc2yTaANZuE4sC68QdkQYgm/9tvuysMIy3OzhHVcF8M33fdmW/QnqduZILBCouytNTsxLsbzdJsKqYJsWaJr3JhrhGQhqgZVWE0AVepShihGxo86Kyj8BKkcW/Ix\u002BxA5LUPYFx6Ii0s025a5sx7w9\u002BNZ5ZMTMbFvb3\u002B6xU5UI518xyhmem8J/nsEBU9SQlGKa2PO2BW9JfuSqOfezYY84Pg5POv2Sr20T\u002BcXzyxiHSzuMJnqRUuH/6Esk9GHKzC1B2RXWQWlk\u002BDmWkguZRbPcEv7MN0sElussX0KibbsLST2YsfHysPnCFy5BCrDWVqKXWNFjDpTiTTI6qfIWwop\u002Bi0jOAJPB2WIE\u002BhAss5wqRfigGxTZmEqotmS/uAb3u1STwn9oCFYOxX9/bhR0tYmmEGP5drd1lPMOJVovAiFbDU7LiPEcwj2ikUWlaiomI/DrGaejDjSdLi2MWeL738NeFGDVuTyYmU4mRtVh0DrI5/FpQ/h5t/8KLmrDgGhatrGCR1XJUHq0QoBZjLdfO13yw3Hxkpva1Gxhy4rR1Qjly5Aj74jU/4d2pPFoEDs3qvMMwLz2aRQlp2LpV4Tv4n13c7EnO0vFHcPqeu2aYsQxKhCQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-b18e9677-5b13-e98b-02b0-400e8345223e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8c1aaa8b67028b6ac07934a1d28e4595-0062b8879b1adaf5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c44d7ea0-aaf7-aadd-6d80-3e36521c25fa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "ETag": "\u00220x8DB71C7ECCA568C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "vO/j09V4chThrHe2pX7lnw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c44d7ea0-aaf7-aadd-6d80-3e36521c25fa",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da784-d01e-0002-0ab0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "CcehB/p0ei\u002BRvuNotErrg9dFgtaSuUTqtNA78iK9fkKxZyJ7cZoOCNYVLThEVi83czep4\u002BlRrFCDtlIpOIcM00Cgt00nbxE8Nnr/fIsMpl2hA37rFJtZYLrR\u002BLpH5M9PCFr3pJ/iDwQlbKxvUS/Fdg/1iDUIIb6kRleSVndX9VGrsHQxFAK\u002Bv/R6xqju6g6KDIGqUlyZRuebU11IT7mMzndbxKG7k2INNslAjlsWtlxICEn2rKL1EWmNlcGkdm877fgwkiZsznkfnBySWbeLhZwB/0ZvliHUZrM3Lv6gab9ZBaBj5SM22znQ1g\u002BGYrexAQ8lo3coy1fWWyxzNaB6fjNcOVMXKKB4yyMNn78RTgP7hS3ue8VIMDpJjIn2w6aZVVjbKSlkmthvrNhTGyuXxA0peK9yjANtFAgYzpsWgQd9c0lnNiTalutVfs7t9BQOsch7zUv2J8hUbRUgTMw8WCvQ1qjiMI7pTuHEHQ00gB/zCRzTm7O8hkyAEsgPukoeGCajHR5sLIE5kn9pMgm7IO31LEKvaL13E09bYR3F2ZSXpQTnkGMAh92bmQg0U1NCxfLbGY0Ib7BoLAnOEMtkdLjr0Y0F04\u002BJ9KVkE861QsD7GZsq6sAGjzVUfmRZMXYSNyVPSYHGPfFjUSToo1zhs\u002BlJ0/cvOYn45UJXsFQrMMIuUtypZfk\u002BNdupx5mcHezZc8t6EF5/4v2cV2M/b4ydOCFhulCAOE7vC50chXLwXMdWfj2JsCBkr3DeDA6W/sVODI54OmObWTp9iwTAY1yKrPuc6fFPFIgA/QvgoSs/WQzYzXnjdyFkuiQCCyQbo0sTU2AT\u002BRXU//gGdz1XurcPPTL46JXipjTZNy7MTAhj5Vq/zU3KLF/2A86B3QDkDP9t887yIrq2MKwsOcHmCLLvo5HjmO1qRBDSAuXHYck09CsvX1g6ccOfCZygnvKeEPobkTpuAXQRA669ICDU7s/j90WWt6latTHOQ45RyaYeNPHrq8\u002BPxfK3HVyqfFCiyhrNvaatB1hRwdsIoL7lwDkIn\u002Bwu6UL/UzFS3plNrznhK3h0hAv/cCyZmurzhyU00l0iod1kdODXzml1Wii/AxGiJ3RFcDwtCS6/lU9YC8wLHgw7Kg1bfLeYnLWiiRYD2pbZUGCx72Eh9JiupN\u002BQf8KcaTsbg9gDR6q9rdSGi38XvLu5frpsWi\u002BrGjZ1rNfXBxzyBSDb51a91Qm180GMm2kZl\u002Bgk1wAIMA8McGiijprS5aW3k4VfPNRk\u002B6mwtmbtHn/NXBXvsy8c6tURznftG0dv4w6c1QjjuVoTv9tXWHmoHlHp1DGE4jF2m6mwTm1dduBhQNNYUUh36qK73PRTxJFcaA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-d6afdda3-48de-6363-94d5-2550ccf08f04",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7523de843d54b952ae533606622cbe22-4028fc1ebe205c93-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d55fb1dc-d61b-6c05-f258-45552bea0531",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "ETag": "\u00220x8DB71C7ECCE74A6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "k93OkoNmPQ9/eJOstylsLQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d55fb1dc-d61b-6c05-f258-45552bea0531",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da818-d01e-0002-0cb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "\u002B/YXpVDNCHLqj8kGPSLWF1PlvTdymktV03srDhi2Ns0mq1jOerYX4h2RW4Yh\u002BZ8DZEffhi9\u002B1mCqwdHVofpaNFj74JLJCJyczdoZ4D7EM9rbKKrQ17Cdp9T4I7jlQkEjNictJhgNOlurQrhVZPYh5o73\u002BXlQilyoXTi90eXkt4uZ9qkXlwzBzu1OJZT3SELe1j0q7UnH06zKhMnfT2l2x4stvG5MCk\u002BBNSqLAWXIsRX23/qouclB0SL9TBJD4X\u002BE110JyovTkcvuqLgeO9FHAtOz6W9uzg3B6\u002BtLT708PVSrByoHvueJIk4uuhERIpZRtUo\u002BkPcPFQhQSN6gh0IOsWtjczSnQEPsKcchPxT8r8hV\u002Bplz/q1cnPEhtnYI6ZoLIAilra9hqXUGUmYw7db0VJgVS42om7K\u002BB9dChYnN40AsFR8LVgEZ81AjbKxGLK4bLWLe854NY4VV56bYHyPsOW4mA9i26P2W/Fc8hC4Gd9ooJ1gn7vChH7Katm9bQNQsNzM9ICjWZERkSPdG0d5WTnDLsPfLxEp\u002BhOMlHDKOO7uDD0z7yVayUsITw6b5Wk7UQ2f/j5DcYXPov5tEsEgS1Qw7w8KRW4UZGV00twGkhSmVUdnLj6wrpq3ZEgm7baF6Ae2ZvZeMQufh5nUyp6pxRDpxr19uR0ZgEBwUt0l7Xay8urYTCseSCQ7y6ak2\u002BP8DZ87PSb5CC7qnOK17d4qdZYjJdu30XTly36ZQfF2cKhcdEU97qxTuea77bNIaFpGEVIMhbYIRDgqUXWkX8o9cCg6VXmY6Irpz2/w/\u002BPFnWMgUzCjZe7yVCwJF5k6r1ocen2HDhLgrSTHJrZKF0RYYLASgAyVng49RAFJj9TtryAR1IFmPo9QQ6YP2D80qEDnsLbpJCtNhtxvScYNmx1P2XuWND7G9iYgwkBmicHPBJ/AYd8iBIb4xE2g9vDFQqSIvALHonQCIL6QxGHm5vkeoEUqTTVCLdDwnW/xIf8xW4Of3c3DC2Ynvj0gkUAhEeFQhlavnvFvRo4t0wEEEQK/X2jiSwkvW5TfBpL0HZyQz4uOnJ\u002BkgbySLJdDlThhH6k\u002BYTHXQsrYJSrBzJRedyjtmQN5eXRnFt2oTBpx68ZceebpubxuuYi8sndw5rEkM7VuUfg066I020pQLvasZjlgZVaxdL1sguN2uMb88jAsgBhlB5nOJ45AsN5yGo6WDEw\u002BDIFedr73/dMUwjLbN\u002BUaJ6raS16jlj3EbMPi/mRU3Kh6vuWuzg1dcQXGuWFfZXz1V/bju8TtnnpDmgX7FQNuw\u002BGKYHUDb1WdfNpY2NzYZQdG6apxcSTjiSBrazQHYlgCW/WD1QUH8eSdRj7ulMGdZzA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-bb0c8654-152e-6b1f-5fe2-c8d43362cae4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-19c3181d0973612997991b8ec3a9c9bb-dc18d670ab086b5c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a05afd9a-50bc-60de-6f13-5758fc781a5a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:50 GMT",
+        "ETag": "\u00220x8DB71C7ECCE9BB0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "f7A/3L6jM8T48geazj55Kw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a05afd9a-50bc-60de-6f13-5758fc781a5a",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da8a9-d01e-0002-13b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "laA51iQAkL3wdAu5fT0Xs4ABwSuMKlapscyLbNd4H\u002BsIGw\u002BQLYOnPxxM5cpI9at4vXGABqRaE2tJjyVYdSTmeFUgsWEuh4X8WYIPP0SMYbsgE65l9xhGrQikR55eT8n4Zm11J0NJSjbsg60hS9MnvS5pN2F1gYA92QRZiUDnngq4F9nWFjl41sl4eXRqJGI0fYlw9RdnguTtOE4/8MD2BOWjaDP6UKb08WCY/QgM0rShJAy2d6jyUJX06d7rOOYJgXSOx7suOizjewS2z4Tc4GaZncuzQI08sBieBmbICLh6j3uTfQr4c\u002Brg0vukO4EQFwl3UpoaVUHnUhajjzTGGnNLPD8ISWJboCrh022Rl3SWju5dULUdXzk5qyvzVeO2GriIWf9BB86mHLJwOILUVrqhDQFFaMq9LdwGzp03Z0pGK7i1CT51VYYftjQDrSa3ZVVxUkjicLHtyisiOzkxb7RnKQ3JH0x8LLh7JbGVuYC2T2lHxhUCZLoHxz4TUxlN7keAnIMZ7UUJ9CaQZkr/WBCqbOzP6qmeZMVSwlgNadmeLjdqFR39nWEjPdHvcv1wCG8taOYtfQOd4Te9xivt\u002B4tM8TgTlELzrc\u002BKq6zYrvHH4rnp3wDycbA0zDPmP9Y2NkJFooHFXXMsOroXotFWxTJF9uRxAxuLWoCH3sgODG74U3VqkwxwAYVGvKVG2s7f3QcAoUnxxTImukcAPn6rHi5LHk9c7DIm1PRfKkd2RICypwHBDWslB45CQ9nEcMMHmp52\u002B7t\u002BgvDU2sxUkprrsHXHTpZ86hDDJRfBGqhZYmQwWJCo/0nFMyUQ7DOe0HXzV5Nj/SItirCOs9WjvWhHe3doJDkKQrAsAhpxa/3dJFWizcIV9mVBA83fGkxzIXa8yHG7Naw76RTiNvsIux6ysY\u002BAAe\u002BlMYQSJiBrKidkueCjtKKMIe6oZuSuM8BqOUeuLWm98x\u002BGFpbsqA6Lz77tfn0aZAZ7Jo\u002Bg15oL9/7EqO3Yvf29p8XBHZ4Mn3jfHJcmwLVDUNVBMgbaHByEex6YKP8hsxLAL9e3WEZob4YWwboD5DdJgVgXl4r244qpPKGAc3Z5vWmFZZHei/eO2cN/w1thgZbnT6anChyIyUxMDhuk6PwQnQNRfn\u002BmavVhiL7Hdx8vSLsLmCTP0bNN/JxEkn3b6vHGbyZXEAMXQeSwRoFdwVIsHMVgmU/XQMtPA4HjYdh4hZ7NAAf52De381c/Hosy7ztJGHW3elCh7i9aCAyCNN8LOMDikMBKM0SOqab3lyFAHBRFmUhjwQpOKxHYns8rNb53NObLT157/uUxKdGpqVYOGuv4PZuWqHe1lGWvcpR0YnTnf2M6dcy1yZpjMQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-371f6d72-7b74-2e94-322a-1c3e353b1c11",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6514fe60101209301052102fadc89494-1bf8cca182ac2257-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2dbbbab8-6490-c675-2c37-ece888786238",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "ETag": "\u00220x8DB71C7ECCFD402\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "x09UMfmv\u002BuAf8fttyBhKyg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2dbbbab8-6490-c675-2c37-ece888786238",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da93f-d01e-0002-16b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "\u002BcyLULzGXMIq89OlHkJzADN333vv5PSpEI8vfMOf18tfEbz9DhJ00NziV8f23sbwhCOtFI\u002BZzBTX4kAsl\u002BD\u002BixsHRQ2GdfEgAg\u002BfDYwtsjHJP/ig8cM8xUSnJizRRzn848yr7pi5ag4xjBKA\u002Br\u002BIqS8PY1jnXplXy4DI3k/FTrrVoinAgcSYENTqbmSxvMuFH3z8wuThFIUyUyMY8Iu\u002BbD1XqliVxydrdlKD/fA0pg60Q7/TyIvV9I2kjS6hgB9JKwEmWRJz71dUkUySXReU/qwUY63M66SygbXK8Tn5yvYyOtHuDU38QVNnfjY/Q5Z1D4\u002BBjBxyfEBcdNdcqP4eWsdWXyNGpfBfFyJaZWxtcj0fVOGqeD3ZwL6QkZl1oJhUSCNv6ORzL2mfIXT5GBbT7wGZPFMdc\u002BKJfJ9ltRNW6XeJBRxJ/YpZqyV3ClbJ36invaKX3GNEN9VA5mtFDnlWSDf9cBL6ivF3QJEupWmLwJ32vvhxvw0TRM1HCBceFJysIcEfy2\u002BVrDKwH5vSFpJrtSXOTlCA5Ikp6itFsoHZWCv0goSnbPUtYRHGwJ9xQS4721PyUMVMKzw49eFDUPqx18dw3ZQNxEkwoO0/uiTquKj9CdYu5whmqFZHbncT6hAWFOnYAWOZLRYKwa/YDHEYTj04RUYjgu\u002B\u002BCTU9xlbRHbbcKKU7EbZFZNu/JCVYjZvlLyA62qTJ85L5GfcuW2fAOKT5/OPL3TyG8\u002BFrY17JZXyZWJc2l0IREjUTQfi\u002BFgh0/\u002ByBX5C3GlHjs\u002BfCXo8zMLN7lAPQiqBi5\u002Bqut5tEyNzZ92RySAbr4T5FUuRbT7Ol3xFEQoEEo3RLHnelCWK1nusK6Wcrweisj7LFizi8B5g3CNeKAIVb1FPvJimPRdjcj7T5UGZMeh4pl7POPxg8jxfebgCKK55lrxQTO5u\u002BHUna6PuEw7Yy6465YWjSjJU7s5YRsdfXUWQVk6FROD6Canpp9FYcuMxhq4Ny0Mk2kyJ/2IcErWtyApeXbi8U4bJPNvfuaJc\u002BHvvKrwZTZYCb3/9/0mC2fr0O9vK/hUmcTcrRI5rRSCqKQLmMOv1lH50W/I8wlA5RmLg633KlfpixLWI7gUHmyZbU9JGmKkS/qNZUqYm5bLi7f4ril2i45cIh2gybKp1bLzP4W6B8q25zejebUNUO\u002BMCpfwK2BDEuHA7PhU83JH45\u002BXlWwREXP9Qcbh0wHJTsEuJL8aqbpCsByT6RrCYeO1a4YldbuDevkUAumpYU/gB643Js7DLUnVROVPfThpKt/TLGd7k9kFqrnGBpbQqU7cs\u002BF8mzsU8j5MQDDWM/2wutgJxjTYZGPFIYwU/SajBKuWcrlW7J\u002Bkviow=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-fcb93c20-6638-8d10-bd44-77fb808f3031",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f071841709fc56f63190e6cf4bdc4b2f-75af1fe09f3c3906-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "429fb367-edbc-b0ca-42b2-d3129c5d7369",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "ETag": "\u00220x8DB71C7ECD4402B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "1imUNhvg\u002BB425PIOi1jKew==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "429fb367-edbc-b0ca-42b2-d3129c5d7369",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993da9e4-d01e-0002-2eb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "d5vw/1F5lLhT/BRGneSFUICq81ACziJVj36vQ9yIx\u002Back1FfW\u002BNRGWCBL/pXebfWZxyw9VGn2Kh4m3DTylDcyzQtqgmSJvWdWNrwgZ4n/RbG2Ny/19KU9buo5r9zfk4PpWTGKc\u002BtQ0AnE513t1cKUZ1ZDPJ0HPNimbRO6kA2KtmL4Ns6YdRGGJSbmMQ0HT5knpUhGXJbm4hwY5AbX1kA8OjD69Z70O/JEvNe2IQvLXx16kurFBFnMERTyf1DK7k6m6fccTFn6c6lVwZ\u002B/cIEQTYUpXQOVNzXXLuSJwbxheY5JD3cU7xKDQF9BbwK6DOCT4jHL4ZFK0bLBBR21cHHs9IfRNiFJ\u002B55yZdzkU8fzXSIENh\u002BKlVg9Pj2EU6n0zhAtVHq6qNa/CeaTWbu0Zr3qzeg7sXoSYl8v1DgjxWf0vVfM9z9NOLQLhOx49zvcSJe/2UXB\u002BVyV2vIbitTeW0S\u002Bntwj56\u002B\u002BXdVz8CyN2WtjE0tgo\u002Bvh8sP7NtwNcW2fbSln\u002BhhfuKEnwXuwjclwCAFGuHeJffdYnOwYKLDTcSxnlEMDJh8Sw5rqOKKwMWT6iu7axrk11e8yDx1sR0/wFJBPCPlGbSHiM/Tc3wVU6GtHHZ2COKpzcf6T0RbB5rwK\u002BiQSYSirdB3M\u002BJLEGTap3Sax5SnyLhvl29c68lwK4E040eUhAkdC2\u002Bl/9QAXrxiH6jPwT8GSWMvIbEURcEGBwdgFy0dRSNqfbwlAcnkbzmy\u002BcwhoGpCLZnkZWNYCMWtn/fNn0aPRdmFZEOC4UeZSrF3YUz15GacHumTON\u002B/EnT2d2LRF8/yI7TynDwmv0xSShqx4KZ5uLqRMIBd\u002Bwz5xVHPi2nlyDPhhT6XAkcpdV\u002BcQe7EDTLNfb\u002BnQOZPlSeo\u002BNfqVzPjbILnz1to4bVyZ7ohwLodNLcfAQ6pPYhNku8W7wpwPx4rudVs3T7WZZsKNdgsLdRtisMfylUkOS76mjxrUfKrASic9QflsVd5SZxynwivIGUbqGRGUHTIBn\u002BmcUMBaxOpXzOwjzfMiNhspYG5spomSnnXT6iNZLCz1O\u002BIPkATeN2JyT/U/5EuTiCM2aryDlTkfybKKhtqHPqC/LtIREqYWS2kMOlaUkvnqQGIAIoFwMWao74ZSE7BHqxEUQLV5QrW84B9Tt5rii3b4oAa4RtwfDv2raGLfxDe4hE8FQBIEsP2sg0JiHLmLxmRPWbNpj2R1NTH3zdpSnRwnmzNLnQsktC9JC8OZvTJD36H\u002BkGqETvTq0EsgTKLjWeYmekFGQClZKuVEIINgm7f/dC54VAzxo0w\u002BYMyABGdMpbIdswKw/Z\u002B4paVFAG4xijSTINi0qwWZdNc1B98cmOa\u002BN3sRQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-5fdd400b-58d1-d98f-f2de-8903f8e13523",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ea75bd535cd4d7c739045689f04980e7-386e69331713654c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d580a52d-1fd8-ff7c-5a17-c723cd2e735a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "ETag": "\u00220x8DB71C7ECD4402B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "bIrURXkmNfOfoYVSoP7RLg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d580a52d-1fd8-ff7c-5a17-c723cd2e735a",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993daa80-d01e-0002-3eb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "jTpg6rER\u002Ba7u1gFwMvscI8yAHDB3SYiWrVvHIdBc7CIRrwy9fQKU\u002B6gmSwM5jYihlWissj4vPEOyyTxVSdjekurfX4LuX6XJ7CCIUf6FXSDTJYtnsDnj4XPJCrTGPrLPSLkYWi4FszbD4sUep\u002BpFLGsbgSNMduGx\u002B30OJVTwA65uuQlEbQLxzXJVpM1zxDqJg95IqryOgtHXZl6x943h0t8XsO7hAL9pKbSx9tIUPTZChaJ2p1nx3zY3bQajQNbldNHuXBRMqIIf34AI3Yv/wignbnLrayqGJtC4qZO4xejezIIAJuEi9t0fV8jY6QKqOKrde9Jk\u002BQinaDZElP7vZhmXKhEI/5xHBXeUzBRirTzNDXHo2kkVetJ6WL6r3WLeMPCuQL7xoTgOlnZbzy30RLr5d4aNBozPgbA\u002BjqbdmycUtpsjtGx922w42kPTuqulhRQEsmbcUSpk3r8OsxKRMPpORxiR0JBNe5saVCtI/McFmQmS2enBOGVxv9WtbyhZpqpJhHOSE7WDtjfLwvz\u002BG\u002BH3CRkJ/1YRjQ\u002BzIBC7nwxywK6B/3dUcoZUDiOx9nVpc6PztWUOUKdTN/dj3/OkyBYqWAFOfBxqo5eTtPAzX5eZSq1tx\u002BqnZG8GLsiA8JOTsEYMh51zGvaGiRLOepu2INdgypVGNgEsg/OSR05U6bIDAASqJtj5JS\u002B25j3X2OnUUA7wHyb\u002BTXlE4AOq4dOnMp9fynqWC/n\u002BZ6Rlj1DDVKoKvfZAY8qMBbOLZUbVT0NbD7Sedw5uPUUU8riBmL0ogYtYnyTdZs7V0sTHCqWzKBhgCn\u002BcJNycm4CxLHERC231Y\u002BS6fa8ffqjlyKVJpzKfYMqgII0\u002Bi1yuuwSjKzpdw8ZX0afB\u002BapoQYzWtlw3UvNNEsumcevft9eHDMGre1JuiATe8taK3WcfN94BZ9UAd2gQVhlutlLbdxrQOe3ovcU5aC5XWGAdwjRkhjkM3lACh5VYmiU4ANGyA3q7uqR6NnoZx/\u002BmqR4I85PlCi8ZzpnKzrJYjyOgAGdcpFXmYQiQ6VC/8xdRW952UKeRU/ahmDTg8ezyIqZXecaXSQTIIZGLVSDfWtuCeXLT4T97Dq1xugsgBXAbncapZ3lQuRHZri8WBf7Vwj5ZXnh5HkFn22oZJY74qBsgcLdZNvJhMb9g\u002BjMPZQmunPjNx6f4oX\u002BFQYwPN5SC4QUT9ZVHe4tM9yy4GSQOWHZga4mWK\u002BB0KM431PRlUvor3Rgt\u002B290ZiBsgM96P4hbd\u002BkWrssK7LYkn83GEKaX5qQyjTsL4FwG7ARoKaoQ\u002BuhF3F0LT6QuIPBiCFyhrVZ51ZkrSLFNT5aMD8HHosMLFKTlgTNJjJcAA21KqQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f6b3b6c5-cea9-0cac-5d91-792f0399aea2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9099a15e503ab5d7e7a3be565101daec-e18747d3e1b998ee-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f7e57118-9edc-7f90-6f28-d748dbab4a49",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "ETag": "\u00220x8DB71C7ECD9E4AC\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "C44cn6p3RsrRFrAX5Stp8Q==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f7e57118-9edc-7f90-6f28-d748dbab4a49",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993daafa-d01e-0002-30b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "4md\u002BLVf0t7wsIjBJAipERAKmvYypghmzb/ku8q6IpoMNVx6b7h1R5EipEou\u002BCg\u002B7bfL25gnxll9Oyr1dxcQNo3ysO6sMqFXlVNlDAG\u002BN9WXqc4S7ksB6G8C\u002BTSNf9B6Dm24OEc5krsScEJIvrZbvwNVXc1JAURG7MiDqTVsxhWC6wGQBfuOXhsS/H4EuSm0qzoxOCIDLQ0ldU9\u002BueWBpaooxde0x7kHywO2OgDKPjeiywH/O433f73wboysE6QxjVrT3/NWA\u002Bd9LW0iTPcMXzcX2/Lnhm4YNUoZxFUsV7tbhKil\u002BmJESMsafg4g1S7G4BNVmDe1Sgrst6alPDuOUNWxxshKZmDUz5MrzQhf\u002B1wbUuBF1r\u002BHpjqhuUK7nwyPjCk4bxJifHmufMigiX0CjLhKie1bRH4WLhyNpK0eHTCCnDzfJ4xNuNJmm1Xy4xi9oyiKcREjMEevIjzx0NvMjGOYIe08I2kv\u002BNEa9K0oJ08D0AGAl6wfY2v5MAFPW\u002Bf6lgr2WsErgYPDWnQ8BD\u002Bahv7x8gDWS/SzeL6FRvNn4JztHF6iMciJ1FKBwT0731ssXq0GWWnjJE4SQuICpjqMW3XXUuvc9FE2aBmyUIq7e5lnVORCYYs3DfgQk/LqizIX8WnHYIxzT2pf0/FQMNPHWsdEn01WTfXqoETvzGReT9zrmmMc8BcM8AV95pGZ4tkkTTUvoe/gwadz2MBHg4MGAYQQaJZwpmqsN6tL2GdkUL1rx4MvLqnxBti7rRdWxXCGd\u002BUNhXpGt6bOg2pAmOU8C4gG37gD1tLaH2G5tPVTWXI6wWCCWstHJRPYYK8/rG3zf6GLT\u002Bm0gqESM2oUiQKxeyX4CdeEvbC8w7aoJ3InnnL3xjlTxAmEgj6/cCdhLpgRKumFQ6aWbsHwzowzDF8y7pT3HMLFXbMYd4uUxUmJX5EalvyInlrIXVt7Yvl9VXXjjIGSahHZS802aMwfAaV0a3L/FHVipkw6Lr9rTf61nx4RsTjH9vF/QU8vVjGOrV\u002ByAveKfjz8gOoxWD9ScfnSfM2uCUxsrHB9f9cmM1Aer31jtU8HLyDhFSxOkp6yLNNRXNVn3KQTQVaHDQJp1lGWFqzB8riuz1GoyPQcHhnVy08H1NJ6us7VUHP4fB4eez7etH/t8DoWppGDuxOz8yM4rUGzYgF/H1vd7KJEtk8zilG1QWmd69sQ7TJA\u002BwO7IV1Qv9LcbxU5X5kgDAebzexCUCzB\u002Bq25nsVqnnTTPiRYJstA9/Z8Vx84f\u002BHMedvTeSNB/qbS\u002BSqvlyEJddCgaiF0x\u002Bk8VtX1xfkRhX7P7SDtlyFRjT99hSmckWDVcuFOmBHAV7HulyJNTDipwXer46X8H9w=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f533ebfa-bd5d-c83f-acdf-0a5adc0c95dc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1140c29dcd933658d7d291e68cab152a-f00e9a4036b0383b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5b0a3f0b-7b49-4d7e-c59c-d079ff9fe93a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "ETag": "\u00220x8DB71C7ECDBE029\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "XjZhuu9XYVb5AnYzgz29QA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "5b0a3f0b-7b49-4d7e-c59c-d079ff9fe93a",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dab96-d01e-0002-45b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "QuZcv78AwRBBtPHtfSxutVXAp9JOOJYczL7XNgv6ZH\u002BikLYDI0g4qhKm98rewmrE7pK/BknoDAlPP/MBKIsERlBxSux1apENiPy/p0DMPQlUEkh5O102uoOstORUN4GHorB5bXh9T4MAsX5MKGXJggHprBZCiwvyO5BpyLatuFB7OAWQUtCQ18PEeInf6pIe4zHiaoprRBakhzLoFIbNU/kt0e9gODAxWdVSfhKCE1D\u002BSuWEyk3GD/Tu68ueqMM99yWQsRmivqoBsRG0GcYDIXTh6smhSIirZ8H7cU1kkrASFYbt8mE3W4w6ghk7EfUt6slWvL75m66d5EpXpkxdnB5hogM/Fi8SqY49Z8Zub1XLzoeDDtXyGXnXTw4W4LU/3OX62m/y7dOaQxMvvDToLnT0i9jF2o5Ib4mJaMYh/MnY/orgdJXm2eCz6crCwlxF7yGZIVXdeQJWsWvmaIUMeEdJVr6pB7neDrH4EfDEhqwsRHmlh9p0\u002B4SIicIqAHFap3CCeWuem\u002BdnuhKj5WcRkiu\u002BuSQMZ/Bs1Vs5IX33tA5AnWp/QQxAjaiRPc3H0BYcdveXa0ZMTkCAFaMQZXppcAYEY0f9klAefix8eykjpQREHauGX0nI808q/yxpMCguJ83Gw23OH\u002BSmeO0Z0NMWXHCfy0fO4xC9PG/40pIktU4DTVNbXOGXdf7H3\u002BdbriJ8E6O7ymTgX0O9CYf91kxRgsOfFoJ/uwCOB1VJBwQpYY1MfL7vaOvpI\u002B4QnlJamZ\u002BxdVwjvJif/FiiLcIOllc/k6j5sVqNYhrXtfOUbxytM262mJKnBaT1rH9mTDso24yW0AqqYehFIxJCSwelC4089flUV/7Fl44DBATbJxbfrtlm/p4RAtKFcXR/ZLmdUKHxKlZB1ION0Dh8p1zkafz8Y5wtPgzvKvMnzuaJRjPUZrRi6f2/ndpV2C5llFt1oQd4ggEcbxGUAv9jGgadBIkFp0CogX/\u002BPcbC12XeiZWXsS3eEcQxuPaizef9W4PUuNSkYOwazB\u002BIeUQ7WZestnlpzGjYvvLF0\u002B9KBrOYAOFC7h\u002BQOimofOQNVpd/9l5f9hdulI8b\u002B/nh3oz90MZs73hj\u002BGt3G3tQwU\u002BDy2haRt2R6g\u002BbKmxSJ/Mlr1ycq6wdoWYfHP3z59ucHtJAlzCRhpeua\u002BW30MULENF3UWwfsxWiZioBOyrfngM0/wuaEpDClCjF7j/GZtChEwsse5VvfWq9nTAGj0tsz83igtG5cf5Atb1DWcXV3P9ZYCgfsiJtxYKg3HRfvAXdWB5y5OT/56EM68bYKyOl58ExrC8iTRyqdL1OGJWJ4fi4ZgGmY/cbWniGEsdclZlf\u002B/SzLRDVugsCxw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-c935530e-39db-3c88-94d1-0240de60d559",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-93a666efb27b3c298c20bf4944547b25-36cc78dcebff53bd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9c3c15a1-efa0-bd00-9cf9-88018946551d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:51 GMT",
+        "ETag": "\u00220x8DB71C7ECDD8D9A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "lWSLUI7Gh9zgdSGVUul81g==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9c3c15a1-efa0-bd00-9cf9-88018946551d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dac2e-d01e-0002-56b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "tps6VU7fI\u002B8doNaz5\u002BKs9qSbiPSqqnqPvI511T37b\u002BkXvx8e0Kx5kAPAsWusVuY\u002BGCtb6EEhpgwhq5i/ak6yIjDtnCjCjSX3Ivfw6fkO42aoN7wRn4en9RgT/SUTuSa1Do47vrq\u002Be4sGY8ZJMb0TEscyFzORoYKpRaYPr48A5GnRO9pq0yWs6bsxCjzAXcRbAOtd4aHzI20MkXgTrsv8Bn9cePXiqD6ihi13YJZG6OjitK\u002BjogPH3hdtXkGsmTrwNAS8ZOXPeFetu1pzfMPWxamQMPocWGR8lJrddEr89e3zhyuSiYQCEzxX9uaoVGJUlpiYG2hA09ugP89L8QMMsMVtgPSXRDwljR2\u002BxGJ91EA3id6yZNqFsrNQ8Um0tyE4SkUgOtNtvFJbc41Kgg54ImuOE2glWkzr6M5BR1PycNb7hXocXJptysyMVvBMOjCk187eJaS5EvD5NVEFK3X\u002BaQO3TvyUW8bQIUmbmQNbnq6dnHCEE0oyQXKJIydJaJ5WjeztlOw0EHsIDQRaHnnsnZajZ48Fela4hQyJCjieh7mqRAwWbgrBaYz0ewZF1yP5nYaRpgAPURKWNA/fqwVCaoVLsNlt1S6M4f4DEP5Qc67pj22yDeG4m/P5gDr64r6GshGA\u002BidKjMdXBMQBC0AURsFg9huYkFyjkhTlc1X0kf5AfV7sz3iHngOlWggct5Cy5Dl5muui7SG13GcSZBhxY3PGwY7iKHZI2VcY8jVUhtuEMo8cevcSnY88N/MRdDrqNPeVVvUB0LzCMcGUivvsYVWMjjGJVeh8syP\u002BpvGDNmQdLb49vi/lgmLTWUk2fhOUT9adheYIYd4OGaPRAinKPvpcdl08rqIlpgvPtvufRTQQalYb5bF9FczfL6WME4A4CBpO2Qi2V6EzeN/bOavjbtNvwZjTr1hJ3mGQXX/8mZKLlq7gUWwrWhK1523Sotwh/MDSHFLnZVjCBfqnJfohN95NT6L8Ah1mQ2eFHcjqdjyEb2G/KXw/ozBVHktxhDUYk6\u002BPhVM5JPmibNjrYkeP146\u002BIrWYYg5hDatxpuPR9b8xbIoYW/HoS0tnHL2kVEHpxke9smF/fzChLXenx30V0XYZufW9d3ud1ddpMUZQvblqiOCcFEJdsuxZdi15QYPOUUpGi5pLLE7LH92KFk7qUHC\u002BPT\u002Bceb00uwcJYwBNJJRTm\u002BD7CjEeHlyR0PRk05yebya9ugRDMteNEdCSQshOfvtINnpt7kY\u002Bnx7jCqjIz\u002BhravTakGmQD2gIbvhhjNuTQ1L5HJwhMIDffhrlYCcvxEHnJ9jUdO2RuCYSZX9N3RNCUMdVzrNLSjpz\u002BhFOqq9A2am3eWQDvs9laGN1DssBkQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-0d09e62f-40ae-08c6-77eb-49c9c4512f50",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-11b7749823b8d6f9e6c6ff589244cfd1-2d80bded3bed8285-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ead7cc72-4c62-4d99-801b-c15736e8356b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "ETag": "\u00220x8DB71C7ECE1D2BD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "0H501q9cKa1a6NOBfL/KEw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ead7cc72-4c62-4d99-801b-c15736e8356b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dacbb-d01e-0002-58b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "d9GM1pZjrj6R9/BmUNY7b3JocEcHn\u002BD/syndh2VdVYkmVv49Piv7PlhjfmjokD3GoS7uEGv6BdfwjCJshSbZM6JnP/nX/TBGbTHuoyB3FyPrF\u002BY2bkQdK1AnTLIIj7gxikvGgVBD7qP\u002BqKM5C2G2eXT/gG1AosRdSRSpsLB9Pt55vRnVsJbSpylCOMag5B/ucNM9CQ5L8eiHaDc8mj7ygWnFwE5I4cjeLdhE/Wn9vGX0ukDdPzXPLswwTkhelQ3qT7Zc2yPQpo4KXts1BvN/iavRSN/9FEE09ZKCGJOAf5fLWa2yoOFCIxSx0\u002BBZmifYscSdjU0t7Dt1KOWRTo37it9EaqxFzOjJjyTLTEFg21tqqmfO4/JJnWxyPXj8sdWGtkkBFDB7k\u002BXb0/0oYqD5FEyKJqQmLKfs\u002Bsw/0o5wzd5PRJX4X8Yr7xaC8hD1ITvMeSgrcooxYImiFRpkO8BWawUe2R0KAbWGXjaNpDmX9tmQc1llRVtTHuQLVkmsx7RWK4cK1kcewXdzpBNUpLxQCx5B08dm8CWpy7s4/6ts2peBNniyjCCRcrLi8qBI/3kou0sqavPt7zphYQuM5cHMBsp70m1Dnn7\u002Br2EUhP6FYMtBEENgQW\u002BklEY9UCoVBYzwFevVzS0M5R3MLLuS2Gs83AA/StV\u002Ba8Vb1z0nBU5U6arUI24Sr5OeNSsmlBWzEbvbAXMp1bq3cqomevbv5d/Pd0MRvrX9KS1toRWpWNewp8WCTATaKhPvHLDE7DScrlBLVhzRolMG3ddGvDOlDhrSddMxbZna9E0vIaEEOD340PLEXQG73gRxe24tlG7fSg6W8XZga0G3cWLPooCxAqWaTetA4LAZF5fOv/EqrWDfT9eTbUbGl2SxDeye6zuEv3nJkkaCnmpdfdrekqxPjMMC71KoHpRe07WHjtLDeitbSv94YRoZXbFtNfBs5wW4YoEpnPzp26Hlar6R\u002Bg\u002BXmgKvgkis1iqo6JKhO\u002Bmj8uywzyxRmt0vcm5ek/dbiGKh1pvuvGS9C4xWgLRpSKC3QXjS4SvjRf8lgBDZTkMzTGAw/2VOtTWH8sOg\u002BhopxSnNplF\u002Biac2vZCbyDxU471IIzRTOEg7aYxCS\u002B5nQ0vl/LrmDKfxtMO5\u002BkLUsuz5Mw4GV9fl1Y3hkj3FOz24znpFtsyBbdcVV25wmj4GZragSRjgYexz/yctBXppLHiFACvHj/wfd8U28ABpdTpO2iuGJPIl2G2O0balVGhdqyr16pkTPta6gNFTqXDsCors3ipO4weGYCi\u002BOb5FeiNc2UTVc4qgO5tUy6Qh0i78occsuHY\u002BDsgib4pxVAQYdAWt9tArFpb/S6KO\u002BRdiZI36wZj2GcGsHg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-b0219dfb-e463-c0c6-63f6-608bbaffe94c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-16658e941ad39b51298c3e6757d0b877-f0f46fa8c24461cf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bd8e035b-6b6f-86ba-1bc5-53766719166c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "ETag": "\u00220x8DB71C7ECE2E406\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "C7D75kyWrmQYnjkYW2GgSg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "bd8e035b-6b6f-86ba-1bc5-53766719166c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dad46-d01e-0002-57b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "MS1t068VsL8K/XaTbCJbRAHXBq9kkf8cu/e9wMPwsZzxDcTrVNlvtczy\u002BQK4UyoZ\u002B1pyBFchJp8tUBe3V/D7Gkzaol9db/AnaFHjcZj9Y2jNpMVpfaxEz\u002BYlvgPBt13c9t\u002B23rHKvItqSpsGPrUHMO2v6rMqkpyfltJ5N7HsZrHzB3q5R4W2A\u002Bc5/jMRPZAwHo4WEc2qsWRCF0feUITZfuTqEzc7Tehn\u002BOfL8JNpjVhBSRkj1VXkSFUVdjA917JjX4BOJypZ9dClrhjl38DQ2InunQdqtqiPBcrhJda4KiE1Z5ESGmYu6FNIfSc8/mmVRZ6mTjqq\u002BKjYvyFfd9D57IT3sHcvvb4iv7SzIjmBUgdhTOA4Etvmim7oOlpFz3GDTpGiRE7xZoffhI6G9tZvV20Z/ivvwdqpECUIRoNj3PBDMNOn3g65b\u002BZYWI5MYJSYeOLtK9FFk423\u002BTMo6R8DfKeeQsYDx3hfYI9Fl2hMXLCRcM6gdrEf/ZxF8OXakYbGVNznrh7NlLBqjstBAPwlapyDlnhQYwb1f0QpvtaThM8IfkKLZa6Rw9sdNufl3f2gH4VIVvoNdvHW8S7Zo9bZ1gn7OIK5mQXt8dKdMi0eD6FHiZ5QSi7U\u002BwhRtXN/uB8FRF/e6qR75oWAW2QocEPEt\u002BGNkRo3iIzaJj15aOSRbjmymO7NQCX8zKMY0O/KrIrFjf2S8iYFzbvSA8NnAX2h7uwrddhU9ne7kMV2HredEHqytNvn/3sSrMoz\u002Bz1ilcsld\u002BICnjaycJeF12Fhj64DNfJJtEyiue9wGMkNIfs6Wfr6UKbVmnFDAENDYScasR0cL8VKGeF\u002Bg77zkYZtpU\u002BcSn5mZj4HLpuABbQJXlfHVmar8fE18EAZfM3o4Qnr1Vvzpxeps0reFAEqyRMtdCRmLDofwbNeZlo9TepxHkyRlTBZFbZAHaMczdzvCyYt7AeogbXOyxOnlUG8a2ZfbPa1mDTi1F9tJg6XA/TXb1o0EGHjyJyWw8kdsYB1hLI8vGDmOXPxShioO1unNsgfzyXmh1oEfKRZHtRrxSLe\u002BKFcWkeT8TXnQ8ZJOo1A74wB/uJajvxXOD\u002B8jBuehoT1ykK6S9yBi97w/kSUu0EWGC9HasdAg2mlBCIH12QaSb1BU3BKhqSwf3IEapC4wnz9pXTsVhu9tUbZFUa5ebR51rSHUmjRzJGKl\u002BpUPBnZ7UGmCTHwLvOhhJ4qcHFd9wW\u002BipTbMHAULNniYb8xaHksACcEEnCCiajB5s7KplsgLJ/klrGF/bzRkt1YDcw0bxsk/XBJWeSVOwHsGkqhSoV9wjQfTdLHpwJrMoCTKnzbjHaypanr1tO7TlqwmONxMEhX2kqXFQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f62ab00a-8802-ce2e-8c2d-52f0f0be7843",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cf993da8fd023fb289f53e224cf784b0-2a3ec9d29537a145-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "33fc839f-7759-cffc-62c7-dc6801fb108b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "ETag": "\u00220x8DB71C7ECE66602\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "FI0fxFdyDQ/8gdDDoh3IGQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "33fc839f-7759-cffc-62c7-dc6801fb108b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dad7d-d01e-0002-0bb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3JLsYWP\u002BdxcPH/kCODxPMkN3VGlHU374rFdMSSuHVp1Bo3pIXTaxI9JGRk7kJCvFwVLNFX\u002BFXYkU9LQMsS3rh8hbwZTBB9QMxjCWAQwvE4grhojZukAeu0bxM2mBpHKkW7\u002BFiGOWBLl\u002BwE9P7lt85OAs4CqlEcyIPQVO0NNqiyG\u002B8qZNqosklILOWvrxzs3qdE\u002BJVMNH/kny/UpeSDPlFDUtkPy1LjlVB0yo1rfSlm43Y1uE4DZdd/NdW61AxkxP6UbFxD7QNUYWM013nyeRH2bbJuTXYTP\u002BzxkIV9KLFUD/WO1wDdEwZi4Vbqzp5tfLyzxGZKBnd4cTxvQkyN1zih4Md0Y6IBGUq7\u002B2wvOGFelBPIyVRLCgmOFmXUfdDJ5QoeON3G6RkaorsrnhsbSUjLAL4oxR3kVubN9k08PJt54gZSEP\u002BDh7sKrhapL2vuct0tGW0ikS/8OeH3COLL3nYfoawEuShJR3kDLhb3Oyd634NgHxMuV1DmZecdjI7IPs\u002BQiY3P2bm008H0L3MY9P66fClvW89S8UpbLkMxK7r6Ou9HZrGpuvXJu0tROjfd3XD4YwBlWNMAPZgzZLt2c6gW\u002BeSTwZ5NAMEjpZB0AbcSjUDSSMiqhNIMNykZdkY6U0eTOjBDSgviq2JPMbNCnDvhEOdqlCrvbGUCl5plI5p66VJY4Md2zzNE/51Wa1Muyar9OFVu378so93bQKJhfYfXxEhg6atkalGkJZSNiQER483/d/s1HBmTLDz5q46A04IVjqcavd//iM4DuqoqryrcuVzkcfWMkqgu3c1\u002Bes7DE0ISZ/pp9yX\u002BD/8tIWFvaI0SLOIhrGGMmPv\u002B6\u002BAScR3/MJdoCDcgYrIm5nIGX2FGz2UwXF3soWbgld8OaxtF647RPfDKB2BF8bogCsXvdjmKqCx60hSwEp8wd3JoEfem0QrzJSFwjLgE6mqTvKag8R\u002Blg8Lu2wlqIRtRiY/t7d\u002ByeSnK/EEIChtkZfe6HFX4n3ZSso40uAXxmQQGHwM4Fvya4TOM1gTenYmnimURsAS1aPoJiztBfcETyVM88esYPE77Lzsie7lxhCUEnT2g7\u002BkPQKYJLpvBSWNyaRyhkZuej04WFpDZkv1AmAcGTOCDcul6PaE1Hw2zOdXHoAKcz/KJdg3vislYNb24uJaEuvxy7uYzN1PqWXBAUuy7AeLqo9gUjNbio/gQIgfzjFZ3Pn7pRMEsaZienxydrzfcnSPKzgTOcC4lkEr\u002BEwVb9s0Z2SR90c0hzkpPhe26VPTAQ5TUOM5BuM5As6SGLlaDMqhfc9YDbstmqQ/Kjuowe0tGPd9wh84OyCBWLR4Ym5/jvENFatEuvNTJbY\u002B\u002BdynUAEhg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-4144b1a2-253f-4bf5-1f49-aab7df3a4d77",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e13b86b429b44f64c7404bd7c4db67bf-bd0f9dfb2349bd58-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e4d71abd-e31c-9f13-40ae-c048c9ef1b5e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "ETag": "\u00220x8DB71C7ECE83A6B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "hHyko8Bt9LgE2JwYFrDBFQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e4d71abd-e31c-9f13-40ae-c048c9ef1b5e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dadfb-d01e-0002-7fb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "bSpvsQaheA\u002BqcaPkBA9oIs1a9bn2yZmGsaJXkPoxwfgl6QVz0VN/8of5x7kKwAas8rFNeusdCKOQ6P9kSecVea\u002BrvxsJ9VB62gIy/AHfe/Gcq51I5EYMB\u002BFi4uhTG6if5E4KXwDqov1g05/o6wuhsW0OyJ5JzJRonrc6pxJoJr9Zkhiz1RzwsQig5xCnJBzVwDF7RVMKVRe5ocBJsPvq\u002BKzgjljz7ttQHhaVqeSEwXmaZObh7eFsTzwA\u002BjNcpgAMtu9jxpbD4tJVKic8dKwyNeBGr0wUCQvLdD8c8vOo9HcVifL1IPrj1oEUi8K6L9qPzsVTFfe0\u002BK3kmFJXp/DerTavJuu5PRTlY9jK/31IEURkjSMuVd\u002BAYJFFEYiojC\u002BRNt6MCgjv1ZGwbrIe6vgvm4YN8xrMr1hXL8VadCuMPNapOMmfvAY7dLeSfeYtYXaYFnUBmpkVxIaFNNtClWFlIzHbdbEuj96A0X5iOjJxKs1PwV22i6E9lHRCGYcr\u002BN9VLVm1UezEaoaWgckasopUFAoN89MDrpiQnuA97HZWVNmfDQzYvNjhi1fXHwrYIuLp7gR9HgULUX7BJbILhn4QPyzwe6R\u002Be1gxK2d8LI\u002BOt3z\u002BVP1x2TbTk7uNF5cl1gXZx9/d6KY9a3KsS/KdjiXvM202DDKAnmb1HOfp8GTBDFVio2WwsM7VwOiLxI5ENQSWnuMp7snSWCh56My\u002BVHoN6z6dO\u002BvAP4KeYUtJ9NnXsebjUlKAlx2Lj0o8NsgCFmxtfdlPpvoZ1V5gio19iWNOoTbl2wEojFQhEquggwi6nEvf23cAhwrsyXzzHwyQDQbn7ZSRHTpqRfGFLpRPeFJWpu5Bnq3sTRor\u002BBKENGxHkQSkuZZzKX4RdJaFe1l2nVAqnXkeTm5Y\u002Bp96ZiQo5hGEPpyPqr\u002B74nxwMCkXZtLAtVvBWZbzKEOVTL73\u002BcJZ6I6EAT295vKRb7v8rh1EQZPNubDIZ4x7kRVZ\u002Bl4BxOm6FkebkmWUA85oL\u002Bra9nolUAoqKT8RkIEBCW8oY\u002ByUkKvSQpfVqa4uObbiXzeioJuaM6lT1pqpqIXGmon1a5/i1J8/CLPiT6dc/PCJLzBKX2jUjS9DQboQKJoSDw8kOM0W/4uXY5jnuOQB99mqIHhUezsgId5wn5LlLt8Y0ECYN8QicjCls/vQ7NVLQUrgZQgivZTTBBbvpl/5sTS5zuekaL8Uh61Hr8g/UDQIJF1IBMnW9hOrxDOuM8zQqwHHFh7tp9iKy91b2g3LlLPh54EBsK1q49jU\u002BKSMZlTgdgPHeDkWGnyFvTjrexsF4DB/zExKzvtUXDNGGa80/mWIemQJBBx6y8wEfPJ0f2e8zhd0DZoIlg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-13bffd01-3926-734e-6e52-233692d6d0a4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bf2f0a2e3195bd074190bf03d92a567a-af3b7141eba8ccab-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e7aa0647-2c24-f66e-c69d-c81a97e6eabc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "ETag": "\u00220x8DB71C7ECEBBC58\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "xus6/MHy/3MPJ0IkDREzLA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e7aa0647-2c24-f66e-c69d-c81a97e6eabc",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dae88-d01e-0002-7db0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "EwUBf0VSCN/dzIlKl8Dxy4DjvAGQAHT6yjcrM6AcZgXTO2AHmIhQVf\u002BTPjlHtjaQzgfiHfv6SxKQBrQOJtU/wWWEdltf6TL3k2YB/cI7sxQBmmSYOUkK2fBNd5LUQi4qVHzTwj/aMeXV64qU\u002BE5PVVKgDYxwpocceZ1rEXGfIlE316lFZ/DUJ2l/w02/deGi/SFAMzSiua31t0mibh9zNcg4XCGkCu5hzOYj8eM6XQS8yRRPX\u002B8clB37UK\u002BnMbhJC42Ehhi//fMz3mZOf8fKullF5qQLI9XZHMgDqbk\u002Bupot2eZVtdfr/MwgHIGIzRVVMZZWYksUPue4q2lQvFM69CPLIabhdQSCWenX6wdUUE6yrngj6FdPGJv\u002BnQptmkB45SddvKtvc7uR0whiPFPgY1obng3bFwzMfAkK4tj5Fb\u002BoXgXf9pSjQzq8kRRP7NtIHjmwUvwync4akT\u002BiZJHjl75Jud1NAG3Gd1rTHoX4fY8twsSfScPDdsE3xGVUAN\u002Bp2flWBTP9\u002Bh7L6dqiX35IIhSvdKHMRE36hkMcFjsIcnZ6KkWMoXdcL8im01/oIBdC7qFQpIw\u002B3JSsW3/w4ePiw3djJzQ5vIGdU0XYJnHuEmUr2SeZt83qPE6w4Eb3a07kww/ohfniCTIgs1BHZbUjvUkaxAi8SAupeevmiNw7puf39GNhBYxrSc/1eQR9o9aYjSL83KdGKHsDPgwN\u002B4FW5QxpT3FSwbi8rns4x88HLNUVTfq6PslAscvoXceAXU5NnpP3E1NkRstpPy0sDWGr/BI2\u002BK2HnKZDKJ6lamTwPFEs6ig7DxiBsAcuUP6bFKNqPGC1SWWgxgLttOu0vtxneQPc/yM4b\u002B35tEimWEuopxT7Oi0DO/LrjCMlTlstzfEqx9f6vxSAMsxzu5Uc\u002Bm62RQzWuYSvYz0R8HP/EiCSy\u002BdWe5B0rej/ewhgj39dzpG1bwlOVhRte2OZ6c6hgB\u002Br4e\u002Btxn/dQpck1z17TtO9tCHhSqMXRHXT6f8s28QZXfrotK6PrwgS1y1xKX/W8S2P3DSsvzZ8lJx62t1/sGbTC3lDkpolLQQZz3J2pRv1/ffSnP6PbJ3EbB8RFdUrkifGnh0Gk16Saq4vk/DDBe\u002BBhdzmrRNnQ57bfiZ6Exgv7j1LsAb972qYPzJQX9mtAGcwj4/4ReQTXlp/KhQ4GFeWAKWyeFXohJZyTW3hF\u002BTFLX6/SYOINqlZN1KsfsRVYCfaul8z\u002B4cSSAv5hfd2MUZ2uf2Wec7UDcn8WUECPAbRHe1GB12EkjL2rQF3jrGx4gULNcTGvuZZBqyVN6JGDwsEJ2gJMCrp8SfLoMzMXH8YSnY79gZCCl4G7QCw71qPr532cw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-09e91d7e-a8ba-e40d-badf-d6b8de76ee51",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bf2e8d13f14a341e37ecd79665e5bdcf-d74910e50182c0b9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c301a605-3444-2239-4aa3-646b3555af6e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "ETag": "\u00220x8DB71C7ECEC3176\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "RzEk2L7uoMAQeE4iBYVvYw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c301a605-3444-2239-4aa3-646b3555af6e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993daf04-d01e-0002-74b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "KwsYBcIdCQNDKTgCzDvwLtbpGM6ixGDUwqUPQOxgV4NxbmSkhfCwST\u002Bkb7HpQdDALey2wBWuSWarQ0MdDckX4tK1kV3XTKjlOc6O/lWv6oDVThL/qZduwiX9\u002BUGtkzt2jYzeNLBy6eFD0YZGIEsR\u002B1jCSL\u002B3Fzg6R8442VNnN6WTGHDJ0LbQYmUwu9gQJ6La7P3o60p8v3ZTo\u002BzhOQ\u002BO3JngswfaSCui8eVZhltfKh8sXu1VfktbFln6dS3K7yhVot8/L3Sa/6PSRvplIzga9HnNtNsiOF1NhZyu4NP\u002B1wG8BOR7IPqqkl5JgzhR9fMg34Cz/TtMM2mC8anY6x/Q1G75qB5Tn9R\u002BIiJ92LQk/JCpjgFSStrGb9B6\u002BC5R0qY/eK/KWEzUzECsNdoYz1q0XvUZLl0efoqTMjhO2aalLFB7PWAFWqND1MHApRQAraB2xZo4OKNJIfkkNiUUhvOaBwiKnZH6rwRS1VqbXdl1k4SY2BMMbfSsMRxm4CN9L07OJp4LdRAOexaW5mJJrsQgr6Kge67fjpoU3mt1lM7g1KYLzTY6ah50iVz8doaSY4NYRTGA3LOg7pgE9pelmedItRK7PeCN5USELPFR4hgTgnrnHE6cYPfya9\u002BeNnOHz/B0tMB01iWjy1/s\u002B7DCTguA8HQcvXyYrFQaydIB767R/V0A3S5Xn6xVRFHur2RHMBzUHUb\u002BahF02whrWQxTotywG/5SwXHcKVHIx3kqqfzw05i2LdFo0pNLjAEm60WfAaJ1PpRm9G\u002Br9/T1NqKYSTELe4V0nHQKSEhqBzRvtj4LKcXXtGtoit8pCjXdc5zws0LPGm/AKmUta/VL\u002B\u002Bw6O0C16gzdwZTGo/GmS5I/LdWrelTxoJzOSv5gqkl2HY7y7s/1J4mPEvGtCXZ\u002BGt/S7j0gn4CYSJuk558OfBdKT4Zis1zCSQVMHGdiQ5YlUDAfjbwMVX0OWqUzUUDpgZbaYrnwG2eCEKQ31IMYNQUFfpdu7\u002B9bPvoIVFi3jvjFYprRh\u002BDcNTTJnH0X1IH69SSgLtKpe5KmfyS/58cOy4GrcXHpR60kKElipFJxQ2p4Dl8zFmAmHOYHKgi8HE1tu9D7a2IPEa13fAaJRtY/NTy5R9lo2rQhhVSL4RylZwv89OmCddcIaP2xvJpanNYPx/XLA9VzBeAb2uYNhC\u002BQ0RX6jVHtvb9lsd7cth4ax\u002Bh\u002Bexkn2mM2iO8JZpvx\u002BuPNIOuFXw\u002BEIgo2ZlH2l07BABP9jgkWafaxwwRi41Ykc7b6D5UzlWfY\u002BlgP8XMSQPChR2WH82zat7f005wKIj6zEvKb\u002B4i4jmusJJSwBniDn4MUwZzwnIBKIFfePsHKzdcZW96BdkVo6A=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-f2efdbdf-64ff-681c-63d1-d2ec01bfb949",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-87ecbafde824b315fb88314526a2202a-6be56c7b30dfac27-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f1157413-27e4-2277-cb9f-220bef618a55",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:52 GMT",
+        "ETag": "\u00220x8DB71C7ECEF3E4F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "b\u002Bht0rAVu1IC\u002B3s6FdDUdg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f1157413-27e4-2277-cb9f-220bef618a55",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993daf8e-d01e-0002-72b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "clDbMNlQqeFWvJarmQIoPqzY4/bBsHL1p5/NjbHXdneYaQ4laTcOaFH4eBqTBaVvDNtKiL/Ms8Hd5Yk6ghwwf0YfEjDzAtR0ynqlyTdYYqH6XYDWjO23zLVMR4St1OU0yPnUdPJ1fAkH1b5FJ\u002BqJhYLnQCWbWvJYZ0Z6prpPx/WUcAA\u002Bg\u002B2uhOF3z7YucqTLwsIBxpTAmW4Hew2s\u002BtVOtw7IsLfpSwKVOLtDI4s7KfShr\u002BP4TQBh09aSNwfgAooMKBeoZsLt4Xe/bI3YfXXiy1IYC0rxVmoNZtzgVxT7tDYwN/pzk8Mys85sOOFziVZgr2u1x/Y/GtKtmv/lDYpixLdWp0Z7bziO5Vd8hR2Imt2Gf6epRew/8RwnxvjETaZECnQpHOEQ5UAzJuGfwpS1JAAhXo3iuH7KF7YpU6g/ypiwOHupX338dppmdR8KoC6IcqH4ou8ZYVH1XgUq5pKX9FxJ7ooZDMWCJefze0Nfv3aIoeAHRiepl9YqswB30ZAHz4HCwbKjbmXcdn0HJuUOlZ6PokWxkK40oFez71jEClNX66zBnf7E5DJ6KtCqonDxGx5h6C9LVT/TjSFa8H8NF2sprzs5TPigyr4SN2Xdiv3mwtM6YyIkDJZt7g/dafOzbRNkgPI1t88mwR5wOB7Z9QMjdC2r07NJBaKlzF7owmHKXslReAoKsAsDE6IDs9N3k/gMuvXGCJpfG3pQkOtxPf69ptpUiHz4GMMip78RRVLOLThl3AhrA1Yv8V2PuiAgktajRg35Igt7E6ExpGDaTtYogmOyC2D1UaKEJZYfaV6jAhTpbf5F1Qot6slnOl/1VKOHZzi8bYd1rvVqdP10XKpDjaJL8eDX46xYhCGWjhZCjtDzmAEl5pSNc78J2mANuY0fI6y9qmPCr4SLZOlm3iDfJ\u002BYsgcSoHacNvX0hzghLS8uTd2ppheRtMOh9moKrJ5WfKrJ64TfJdwUFsOzmoeB7Pxge0me1daIBvlHbKoMkYpbngqRW0WqTyQBlY9X3h48HAlppjFQu6bQPeCLm7kyC4U1W/h48JG6uiglmUBHNCjfB0ygputVCuZjvRlhHrdqz44KHoYlxy93suwJLx5miQm3rJBskWCZ3E0SFTN4VZtwus2yPRWmtUAhKPf/S9/L\u002BTQPqXIm/j4pbD41E637/1lQlHBMsE/wEPdMT2RsmpRxShv/aKgpTbiTiMzbcaWWJS2arrNre0jkH5h\u002B1rLVuNGpw8WR/JKtK0q3vSt/GKNRuiY21e/hCdLTF00TrnsJuc/7La3cACie6Ydos7odZQL1KRyInublyLnyvuVFnXzPrgdbh\u002B71cbX9m\u002BhodFYYtbJKHoFefRrpFWDz6UA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e/test-blob-c2390579-4451-58bc-efda-5847639595f8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-3f11bb3109d17f4c5f82f88a8286e6c3-4e18f19733c548b8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c157c808-bd3f-3489-536f-438b1a6103d7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7ECF139CA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "Ta8W\u002BdRqY5ptENKyXpScNw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c157c808-bd3f-3489-536f-438b1a6103d7",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:49 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993dafdc-d01e-0002-32b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "nlQY9oJMvuC/3Ew7G5uigGEcLpCmGHbUGXvzTYaxffyF\u002B6cDIwTNAxdzQsr0MZXdo4CNvHQwGIXeRNwHWXFZDV5QtSD0nlxcTit5Mtas4OfmFqoGJMCIVOIhJd8nxqqlGjRrpHt06QQjMG1Jt\u002BWvMWP0IULHUumdx2E\u002B0nh8NYiA0xihQDxrcS2l4vNTP538cfN8MqVn3sdLztwaNhaLp/vlyOTMDvEniK8VIW/1SojEQWCEAALjGPRRVXJgUTsXGTv4bXa5L2MCVan1UbxXVYNUVvW1B6b4Aq/ve7h\u002Bxzd0/gg0/dwRChH9gqtY7cY4\u002BQDvC/pFYRKV/2vGybSqhI1ygVO0I1imQkvjt4T7oBXptoK4j7s9Lpz1nv1xSkBdUv4d5mtzhNWnSMiuYaqNml9W3RMx8vTSNVO2voVaNfgKhmSG3bqpdTKtEEfyjszyaASeGmwtLGAJSrEYvMVQTBLQpNtFBrykrGjgg\u002BGt4KaGw1aAvBqL3FoEfZIJkbhsXcQ0IerxrWFI\u002BW4ETah/W2oKkflv0JD3RMeAQIkpmxuvcyYceb68lRb1N8Ksh4\u002ByhSEo//\u002B//Y00PN0jcG3XHl5SVNmBYuKsTvzjepjNSr03zrtoAZsb8HaZ6DzhmSSpHRhjWTK2MCI\u002BfLAD3IP0ZvEf66Kxbx3CN2Rj6HmmyrXYOVx/afCKgZ2YKYXrGBPzpIFKwa2B9677oSLNUkipl7H7KqImdf0AlGoFGUWY1x9RcEP3XAkHV0Kug8jOvS5V7pHU7\u002B1xzC6ESSxCe95oY8kCfOIEsTuo89NgePE1Mtc7sCqzxOgx4KMUcxLcxdtkRSD\u002By0BLUD1WLPsaEFQ8TxdVBsuztJ/h0Zw\u002B7z4pyy73\u002BzLRNmaW8GDtXZfsF89P1yP7hr4QsJCAHfqkDWD\u002BLWDNIhUiaxmwvxZrxlcH9LnM7xgaLUVw50uhUBhr8eL/7jA3H/S6LWwKSsenpek5eShB1x1I5P8aXDvJgBoARc0za9gnz9XFEsGrEON\u002ByEJhZ9bvKhnFtwowHMK48KxSCQX5czkREqpTe8RbnNMcnJT5aBlDEBqzbrPN9rISDCIVWQbehFQIT1UsnK5UaRo2FIAuv4eTDvnqRQWGQxz3QG\u002BiRkPNPRg/8RjDFnNrXwWZl\u002BEy5E2bgkoN8z5Pggw5NVw/siLXaddo781vz/eFfub/7aw6xVwhBsT4wErZ728MiuEXLKziwS4KyvR/K7JTh3RYT5Vg/m//Hatd3qiMjv9eYkQWbVI6HCt9MPpnotsSpTjWgKDZrIxxGA4AheOFfTv0IMltPRohHTJq4s11l3vQSzlwtg1fhba4pFVEOpdH\u002BLO/coERpGgetGJtb8q//A=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-c5448978-d12e-479c-6c9f-9a666fe5785e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d26f03d2df7264fcbc763d767fea519f-30e24029b64ddf2b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "26027119-c809-2315-9644-3c29379daed8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "26027119-c809-2315-9644-3c29379daed8",
+        "x-ms-request-id": "993db003-d01e-0002-54b0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "394577007",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(32,1024,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(32,1024,30)Async.json
@@ -1,0 +1,2563 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-89ea63b1be2f696d55d455bc39115a5a-0a6869a59e29e70c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b666fb39-0a33-d419-357a-fe221a477dff",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7011911D6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b666fb39-0a33-d419-357a-fe221a477dff",
+        "x-ms-request-id": "d3b7b531-401e-004d-60af-a35e6e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-aa4a4e63-c0a5-db96-777a-26a59c165357",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-55d487ad70652f4937e2f207719d7731-531fc6ff72156e5c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fc0cc958-24ee-5139-b621-36c7425fbe69",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "S0h83boljHnRynxdKbCFhi7DCI0DS77LJ/ig\u002BFZLh50OZvk6tsK1a4NALJUkkPlgsdqffxbjFwCKsbXBhJMjhULfT8O3S9BrDZ0Kwh8pppf\u002BQEd7qwiGK0/5rwUN9ObvHaZTRUE2qWUKM3J52FTgYAodw0RMp9k5WCNzvZvKXRm2GqV41WBVyJbhcHeVDVL6GE/68DCho3XMGewdwuvJQNZZwr6vaIqqx/quazdhpEvReaVMz23oFXcvrLx0OAWqFzChO0qTSrDEUCg28zg\u002BanSgS0hGfHBoca1Hf7vONY/1BFMGwGgBPS71iH5EsSE/8UFH0\u002By8ZJrAOMqdTMv09RqZQe/kOKoLnw0aUPTxI7\u002BLB416hmKiOJ\u002B4RYeeY/FjAZJjq3AyWrmWOzPeohOmzhQKEkQ9eW\u002B49glPLPIjbTwct09hjnhOWK3U40ovxJWMEXdylFGsJYcjq7Vn4y3Hc873wevERECcu7mXaJYkiDJzwxt6sNjqcJHIPuLC53WADW98OAKpyMw31diYFbzw/yKC9B8STMP1DFFa\u002BwZd2dRDF1smp1AwyftOQ9oAUlrU1z\u002B/P/JVbcGrhiuwT8zG2fwEVP5hyVfSUiokwwnp9bn2hiPHnpnh7qmaeyAlf3ouiGne/P5ccg3n7e3IMam4wpFxucmo/ztiImZVx042rdOw9jufC/m7mhMW37CsGLz/4riPs8Wwhogue9mXBqu/sUAZGDptGLeYtR61kiCLtQmpVeWWp/kN/3CzcY8fI5NoVi1wkgCCkskA9v2n\u002BvNoo8XP7rHFKApGDBjKuqcoeJKKTTvyGyIIJ8MclbD8ZgV8Ss3JTzXioi0jKYbot9ch2H1rHKy3doejx8fuqZNZSqUTTm/ZXilcqKsNzvGbIHDr\u002BrwykUpYxNRFJohu9Piayd/h1WhoR3lUDnMBqqeWB6ZWAq7WJ7lbu4mbkzig7rSycwUSuksHg7ND3YLXVhosrx7hF/FJxKImhhnfzLNBsx\u002B\u002BTzaig0xbT3/7k0k2hGVubuQZvtfDaK5i7DQxJ7b/ASliGAfjiSvShsdyTjFY7wG0cF3PJ/VI\u002B\u002BaIP5cYKSfI\u002B5Ef02tdi\u002BS4RzgPURp9Cv0yfLdZMNk0GhwgW0qUuVyfqVKfOBuWVuV4FuC8OKrLCjWa5axwb8q467lOPS\u002BaJI3bcKfI3tLhnCbR4Br5eOFyVVAV\u002BtSvLjqH501hRxm23vJS4MgCAyxiuEmGn46wvnLX3OjehSq5K0FsQPeFf1UMGwIop5cZb1EkskGLKY\u002Br1yjaimox11jImbSGlsI13TnzeYOMiBfbvmyWudPpLgKywWnOqvXq20SpYA3ik9mP79UIl68LHk8R/sv\u002Bmx2F3g==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "l7xpP\u002BUCMquIydApehjLaw==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7012A3D2E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fc0cc958-24ee-5139-b621-36c7425fbe69",
+        "x-ms-content-crc64": "pZl7i7eyZhQ=",
+        "x-ms-request-id": "d3b7b564-401e-004d-0eaf-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-8e1a767f-9980-cc29-052e-df05cc827df7",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-a408b42674c82b8df0f5e36da25b752d-d46c8f2b7d0a7540-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1139f96f-9804-f32b-4015-844a2098a359",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "kgbK/eGWU6aiGbysKes/JiOBojC\u002BBDaIosSNEMw7JwcFoGuUU4f91F4uMj\u002BqhhkdXxm/pmbJbI7QQVscCELaZvK0poiAqtOcg87RkNH23hyqb7GyfIChPDTdxBEs4cscU8xM9d\u002BQnbRGIiOY99u82WM/cZmRJ\u002BpxE2pUoubBcKECtTwFqeg8GtL9bFldCERYIOqu7G8yiizh2\u002BF0PPvNhLKBlkKety96AlfHk7qREwsl\u002B4H7EoMx0CoQI84GyN3WL\u002Bim3HIBuWm7M\u002BoYa/ZxUMfWT0B50XEvT8YYjpNhczp58GPS6jeZI0IXQN6YGWQzn9IGMHmdXF52d4yr6SvVWcCwnnuTnmaPPSv9YpCSljVh5e7BWkPB3JMFXHKr7ToWQuce6HvpoAFrd/JNn/rN4\u002BBWSgQ8FP9878LnjUHz5E/w5x\u002BpdK66eETtVeNQczyYOHmSVKM12i7novi4AhK/eJKjXLjaI28ynNG/T74bK3yGTlXIYZCsuwzxwdG1AnUxLt1RrRaDvhQKX7jRdYtvy3Z8MrO99hYC9qGr6GGdfJlcjSDgyn5lApBAvgHX2kWBgfVbOM/CdDfHTrZ019WzbOIededqjwH3Fy8jfTcUKhtcKmZrQUPJmRnoGHvH8Cq6jVEeuWVdF/L0ZCGgnvcAsiSaGK1uRyufVNvOgXaFMCYEaO/m9XC2/hJ0dt0hKfsi6GZXLNh8TEYmf2SJj5V7bzP7mzUHGbyz5Bmb\u002BdBOfSvfq5kQLQNNhxypv3UMLG99\u002BQepJo7GG86po0i\u002B4VJ12AI5quT8akEwrhMZXVpHp7iqHgDJpFedGY/KZ4q7jqbJNOdz04KLgI7FeXh6rL10YvyPFMNSqzOrm5BUMgO3dB9tTyly09M1Hp1yBCrfImzRVQWNK3rid4izxzfyN02KDgVYDV2UAY4oWvYm36cJzHkjgtz\u002BKUili9egvwybQ\u002BdP5/UlhhQPPVN2ZdGDvJfgqvu\u002Bz7Rxi\u002BS8s4KG9EKCjBcO1viy40ZkE0WJh8R3Ic4/vxUQ3XQy3lsQadKSiEkQ9Ni6deWfLsa1Wbtv5wQgRJKzRjQtca\u002Bi3PecoXpz0ov8eJPrvazpoJFOW4S4w/dX8CRA3kIU44IpF5nuAo1MQYcwc29wNYflyqai3xUr6RgARLFVMvNI55UQwqYT\u002Bp0DAhr8iE\u002BH57qcWhSccgRt/S2A7r7c9g6T54vaYHLh0s8In9z7LmDIeF32uNffrHWQo8R4kgzfJwsLaKHErYZIu4hEk9Incc/Mt3Vg5j03tDsWSbytaEDCKXfR8MW/BMrWrf1PmhiiaTH1rNuXf0DN1LNmrWTKmlJIgmpbVoAJDLKriThA5xoidN\u002BKuLxkK6k3Aw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "f6mr5mShMSBolynmliRmBg==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C70132C769\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1139f96f-9804-f32b-4015-844a2098a359",
+        "x-ms-content-crc64": "H/BY2n\u002BGFkk=",
+        "x-ms-request-id": "d3b7b5a3-401e-004d-3eaf-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-fead5347-0ade-78b9-658b-3fb8e373381f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-969b6c82fa87ba971f4d5aad73017af7-94573dc0b1609ed0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "48586ebc-ac25-9264-c553-721a6b721cf6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "KOv1CI3smUM4hT/ileNWwCRSZPezW0V8JZXfAnUtzNnMHTw/tC51L3gVHuDNMBQkwewjwE3068ymeOL4DZbOC7hlFXimFgz13TR\u002BnT1lr/SAu0CICguM2DJvmTtLfSLhRxInaBucfavgLeMYdU2PQcnud1JWRQGt2DxFN3zRqV8RnVYqPUbY4z2UqNwnc2Pk31hxXQbQiwIReo/eV0YuD4SEB9f3ZQOCFZMUwZ0lhmTZYFckX0xZQBFUGcO3\u002Boz3ZplYo2yL7XpU7kdyvMlk6/QqBfbuCq83K8bGo0xAyxsHHVsEzeL4TXPdz3EE5oRH7y3PjfWVCFvpIHemxUotEyMsa55uYB4RMreDETs\u002BMkRBfrMfcT4lcRQAGqxrUYgor7tN2Hvm2Y8OvVo\u002BEvcgq\u002B0zZEaWDqLkBvqKbkVypuAuWmF/8FrJW6UkEbPj514d32\u002B\u002BN\u002BxBkaEZaNGBXGpKmxd6D7iWoLqTaQmhcv3uAR6bbI7VtG7z7MjAZoeISP862XWcaNimhz\u002B1K83jnx6kK2ey5e/cdOephyLv1ToyCiEKZ5iHUphG9eVOIIigD0ypHDsg1WIQXWWO8uG1trEFgiCr2DiFHNjObPAJjVNeCHfVRbn\u002BEjS/\u002Bgkz\u002BV\u002B3kD40SZ5o9DcUI/9iUmlxB9ASL\u002Blp4HD3BnDr7N4uUiN5Ftyy1EO09RRAwSK6nMDLTvM4IMl2TbDNPUMufAhY5dDb6TuNvzKMXTnVKR9OPGmwIJ7q9TJaAsgr5JYAhnkL59tR3rOEPY7Aq8KPoCSRfgHZfVxqbu\u002BegeZyYdqcjNfAyUFD/V22K\u002BIPKklvymKkmmWUJggcoXnrslzMEtyzIx/rztbiTYGjIlJ5W0OlL7eEzcd1CGbOoyjIWEsB6hgGWwYqg/uLwUzk8QO2okY1RYKlSEUUPhu5HSquGfU1ojg6c/88e6y7\u002BAx6kBdiGAHikxLIXKHT8R3rcWXQ3adXrk7Ley9G\u002BMrW6U84mq4EVgUpy4bibUWWZ4LhUQlG6xtkIuHIlpzRm5pI8nNSmlZv5xpgphEhdUEINBSsZKfAj/001HfMPL9oVy/smXrSRMwrcmru5kQKQ62fv2KHJTbzh2J1HsXfoqpa907hNNvGNvBHgPI80qm5KpDKLHxd4DL5\u002BBIYXSYGTM\u002B/k\u002B/1KA7R2YlyP6REtrW5u/Q0FHYu/RYc6DzJrtjKQTQifT65wwGC\u002BFPz66GNtEFdXqEy0TdZkZbY2T/SCCqwqP5wIjl2//jyshsiOhF1jjP6a1A2mG/8yOun4erBsPApQkOiHZII5l6pPx8cN1aEY0oM15zaehCPdFlOzh4OMAIr\u002BfjO03Gh8oXxjVhP35GUI32ftdlUTsgzEg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "EPJy/w/P53H98OKjNB0REg==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C70135D43B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "48586ebc-ac25-9264-c553-721a6b721cf6",
+        "x-ms-content-crc64": "woAJADAZYqQ=",
+        "x-ms-request-id": "a00ada53-901e-004e-64af-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-a4a2a627-ef2c-ca7f-247e-a577e0910ef4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-115ae69047a72d588e97dd0d661dc577-e6f74ad14c015028-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b28dc13b-5b3f-5e33-1765-479a4510fc9a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "F\u002Bnttz\u002BUyLmroG57KNaqMJvAyWc4bbDxSjLuUjZs7cVK9Dxl2nvTE3AAbJ8sk/Qaky4bzxADrKo4\u002B20NpnWCPrOoMDSaRFUf7bX3NwAQxbc\u002B074IUR21R0iSLd8OxW37fS7sg2LAgE/Y\u002B\u002BJaC3SqJza2z9K2euyW8\u002BnsBxd2ESdI/LrSJEFVflNvL1Y6WzvU6AWoWPabRANBVpB403g3Yuq7Eg\u002B51wP0YVF\u002BRkuWW5itFx8Szbgwrbe2kM2x3KraN81rf0grGhABs/alHP24q/v4yrxZJZQximVYA0c1Q4SnpA59K9tPgv0OEBnBipC6/uXSuBLtgBI4OfXi0xfIzG9y/njuOn8fqEi/SxV6cP/UngRiYotyuSP8RfHmba7mRUOpT4wYy8Nlsw/JLjX8vcn1DTUSZmnkAEVV8fWOOTuZ2AXS0CBzvNJA/K97qIrtAIco8F9409/ZxU9Gw9nO13nUL1UwKu2oglFi0Wm6aVe6Z/FuZUncIQUm\u002BAvRLPn5ciU2p3g0vdWaf20OFQJ1H1v3jFznX3Ew9w5QCTLh11ZYaV5Eg8Lehakc1ObbzgsCsNiv2aCcERK0Bq9q5LOjuKcXtayjMZyZGQayy4uKVCkDTlhZMf61u1dMj30SdKH2eRs\u002BxBhfX388Fr\u002Ba6kaGKbKGZ5ZbSYepYfpUV6EehqVkvFJwTI8Qo\u002B7ZHRo\u002BG9AQxWXLjAwLmi\u002BTlWMdCgfdHY8aNS70Ft0idcOngitsa0UqQ5E7U/qYWSEi3LYr85nn\u002B/\u002BLI\u002BahHK\u002BIqBdJZBgEJyke88Z2ocqVgtwN0jom94IqwIYr4UdeiCfis6vjTvUIHrSNDf/ScVk19qEKlEp0YbGVH6OR2Ebiv2ufk\u002B4fsTPmBLOFmemCV08t9uqmVPPcbVL5TS9RdkZuqk6UMt1rFURtI5CW78fHEsdUZOFbO2p4wyWcJWMElY1tFu\u002Bb7iVxwuCmOTFjRn2KMjto/BJkEm7jHG\u002B4z/DgaI4CKdnYLCSh46IAtQI5FHynEfMonJh7CAOAt9K2uPPwxdCiYB2ksQUWxhlwY11sqgfyEL39t8z1hiDVWHVS6yquEO8ylrRfAl/tEtV/C6SmFAzLw6c18g0Drdr8zlmQxNvuwVNtOhNTkg1dEKX2dXt7L0RohyeCeR3hLunZYjQGXE36kUpRONr4dzGZ2OJoDDhfgZ8UJz2za0c1iwsqeS/ZVrNY/OMwKvZqbw/26KA6eSGweuGU8TQPRyUCG63Ozv4BwIEvEBBULleoqrguvIKn\u002BhHqef5ORGV\u002BSLS\u002BLQ5JnKEQ9SgfC2kQXEyK7Ed84YqiWyCb5FQAsnscscdblgBJXw4WHcdah\u002B\u002Bo2R2yxFgdAWYqG9LtrQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "xYl5dwqPKYVTT2bldrpCbQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C701386BEA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b28dc13b-5b3f-5e33-1765-479a4510fc9a",
+        "x-ms-content-crc64": "w9vlaDI0u\u002Bc=",
+        "x-ms-request-id": "ec262127-401e-005d-30af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-485e2ffd-5469-7579-bca1-29f55a71e892",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b91fdffd0b9abc005c19a1ada137c099-02cbe6b0567cbf6e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "aadf5963-6ae4-dfb6-95a8-e396103f70bd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "w0jUMfMLNk7uIv6vYTF6LluxVsgNhKyElQYkVmaDzOWaombS/ry6rBbBVIsFqkCDSxzl2uGdtT\u002BcT5vt5\u002BDna1YYFL7KqDCf96qyTDAhfurFoAtJnfED/e0nNq4gzcU22eg17JaCuKPsRuM362kOetCxJ0bVns1kFRfRonKCfirke3JH7JJUQ\u002BdnXVcOyxGDGbvdb6V\u002BYTsa0NZ\u002BsBUxase5Um/3xo4\u002BXONebUF2VkoFTYm2pA\u002BEZRo2LBu81ZLRNvKQVXihjFItnxLCH/T6pHmMeWKMesW3NO1VwJlygYZRjTZO5gHRY8E3iQX9wkUlO4iiMFwvRbst2CCLTMu4uh2LcJK9rL54uhWhVPG/unKnL4UR0FEqIUd7IQ3hRRf1f87ocVGzaI/KKXVHjvDJbR6u5BxGpunLYU9KQoqwl3T9q9Ui10gg88f1Rqbc4pJXsbTuM2H6r9jkHA8CaCYEGpIASeMbppbVjfFVUGBD7n6885DWwWQTA/v9Pro5Hoqg8SwU3JmvOwodGaVwpV54oS6QRXWVLVgu7UbnHmjbnG5mtF8zLxLlDbeGuKi\u002Bo12dhJyMqNkVCsTT5e9TyB2iQnw3CfD/RHIbqzi9D3SwcEnoSpnLT/SUUKmaX0kjkUWa5HYshplsnT8qcfyhV/tPI3Wla32D1vKHorhGZOUo9xryIyv9hOmwe6xZod748/muSzvTfibHFg2DpOTgJjhaAXnirjTPUp\u002BM9O/QKjQUj66/mBmpVXj0KwwdeeAEz1V0/6BkFUXE3/icR4k29uzZbxQ1II4fsKwB7YIosdi/hySaXCuUsHlp\u002B7ggDQ3uvTQfRArLz6/HVU7zYyjCmy0g3cBknJnBRL6ayyXV/qOfEi9OCGzN87d10wfcoE1Rp1\u002BLADBMiiGaXgBLMQOJ8laqVFD4dJLAUukJ7siS5KNxSCTFSf1zUogOs6psgcK06\u002BGwMUv8WTPMyq1GQ5tZCHlc2ujfxKhZNwHI6sDoVNAnVAPn4bJXdO/w\u002BH9PLA/ttaowEKfZ1Cc5V/pKNG9y5HbcHu6YcSfHBGX57ssoCQry2jUWt0MpToDbroq4DUCAfRQJcg4gVUODaQxB4OZbEE3vV1k6XCwys9BuvMOdDvYleXC3H5b80YXxk043522agJ08yLbmRSHn1r89spiA5VoVHGd1pPC384XTSMje\u002B8ti1DwlYUY/PzNPz0nWvx/tca3zIcsGJNuthNUwEv1YCdvz2t5cWoQU1t00JtSn4DRm5tcb69n/XK9geNxxDiw29sVu4\u002BRBkBco3kvu0v4HBaShyiwmPR4B9H4u\u002B\u002BKoo8ew/TAOOP1PJFXA8gyOEYmxWXI4z0QAD7inbe5lEpU0gDuEPQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "6Loso4e9L0f4Bzhr0PvVbA==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C701397D30\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aadf5963-6ae4-dfb6-95a8-e396103f70bd",
+        "x-ms-content-crc64": "Nb7KItU4/Vg=",
+        "x-ms-request-id": "d3b7b5bd-401e-004d-55af-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-26ddc0f5-d9e0-57ca-d4e2-d95f654298d3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-cf3337640120d6b1b6a7453c29893067-464e434f3f258b4d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ec379cfd-5231-47b5-c1f6-a577fb315454",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "b3DTgrDtd2fLDukRwIty0QrTteJgpZF\u002BnimpbpX6DHGV8sQPZwGM5leRAZhnkxba10BoDj\u002BaQsreVeSHRAnR0QJ4fM7GYmoJR86LzqT5FgoTz5ZUkv0x\u002Bq/6MBEcBaJNvy\u002BV7xdHFHTWX8dxD3Mm5T/adHRyfT8ER4EezDJY7EIrPQ90Yyfzy7ohfTI1v\u002Bs81EvSQpEt20LwkKiVKUhCfnOFRdFksYIY56i6UP8Mz4eW4ffmhamx/WLMhNJ\u002BXaFy3/\u002B/sHkZ1yLIulvoc4pD48Eh/kdQW/jJ1EhvlyywmYkHSHH/TR8NfArVHstOyIrXiaEQXV5ZIYMH9tsxqj/1GCDR4SsYQ5aiE4I9ez0segu9lw6LoDsqrSbu\u002BFZD29HK3waqfedev0YLbUncHKZF2nzPcxMxanflpjQFKks/Xjiwcpw2gvwkX9jIgDLyTpB/qB3adGe\u002BmXWOxdazWZX6yw8RLKkKDlh/qxQ7aelF8lijhYEtZOrQ8dkmqLwmcQVDzbQi4CLndZnEW8lSgy\u002BLSNJ\u002BENQTzWYkQDrQ42acWTkP\u002BJw0IhI2vBDnaQkhfW6pm1/pqGExL/9N/qDnFpEzKAGPQ4uTViXAR1PDK2RdA8LMJkgGsrDY3sic5iRxTqV/tEAHkjriFUQ6KWANbQOb8PvdG/BJLHZRtmXC928BTvmuRHcjVXCI6RADzIhQy3DEAPUplDO0NYfJttzVHx7UONpmXiiMd5uKVTHfRWDtAOr0/fZ52LrF\u002BQ7vWp6Us8nyLpOu6W1IOIhanj8B1e8n3Lbx4SEnWmAgoGQZnR399aJn7RbMPxZ9rMVuHzl6xCQfx33no9KnytQyjUgJLppqXKidmujYWp2fdDRcuTsnpdw/\u002BtWgFVLPvyJCmrHNdH4qA8KQ3So7Rm3gSC6dSxCZC\u002BhsyTPFykdVzdrGlsDr0QC2MbZ4lseyA7Rov80kMnQRqY/JYatKZTh7OxBPda\u002Bs9HYu5hlaIHQgucV\u002BXAp5MZpltOwxInBVa8t9/Vu3Yo0Eu8pX9Uxat4gaqKjlzAktAQl16cHDe9IF2XpO3CMZaFY3eaBAIjtOC/1jFnnHb5/CT/tRQXjMQT/4URzRDNplAT9RrlNo7d7NJ97EX2VYPWnbi40nxyfdajdgR9AefP4i/hU5dsBMWWEdgxqaB\u002BHanxOy9oBNPTkYdEMbB6YNrqvfoWFPHsepjjErCkMNQ2NWhqi9bIV\u002B1cDbIQJ8MVK7D9RuumV/ioBLCWdPITP1CzDgxIH9UEIlYcyhc/3FLF3fb/punoj91vsncWIeLrSM5RXRnGzQvb6SSVmZ3haDhtwKcLE4h22o4\u002B2F1t/gBzIXFI7n9JDwDrI73FQvY/jkow==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "xoa5ZPlFofBOhEK8TKvghg==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7013DC253\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ec379cfd-5231-47b5-c1f6-a577fb315454",
+        "x-ms-content-crc64": "2j8xLyQKhBw=",
+        "x-ms-request-id": "a00ada96-901e-004e-20af-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-b4bb4a7c-ef14-d2b5-2d2c-e78ac68970b3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-906f9e179276b40bf526f7f41b0dfd0a-4b89815bf0017cad-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7399fbf2-8408-828c-b53b-f04e108160c7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "JoHJiJuRTBlh//2qGXl/9aAy9FrzdBXBLz/L13HCy1wqEQjhL1wIWDn5XANWtI\u002BvOYmqtOtXTrFsB1lbxnSnnjSgfwdwncZEKpsh\u002BRgRanuwG57oGBZx08JWdScDrJLEUb3PtTSIP5vDZolPNVWZW53eq6vWv4YdL6tEGSieQX4JXahaQrVGKNwCJbGNIZ1tvRmKJADn7ZI2sYaIQyVyJCUKRtitPxjol4PO05nVjw0O1lwOFBx\u002BIW8VI5AuveS2jwGMg9vEwH0AoYx9GBn4YSJ4emzJZA8IjCRplxuIudqeGEOYSAwySRbeDXOPAAlVHMFttkJ37Cvyg/a2WylieOiy3v/VYBgVRjFW61aceYsbE3pZGgKXJywYpcUVe\u002B7sfJWK3CIJf7ypWHARIAHVVgprm0euCF3lG7fTvbpT/8pCam7AEZxoEZO9sMKShQYqQk\u002B7quCmPnQ4pMFrNsICVVimz7aTFURtAoqz8FeaU5WwqHtrmFXqmyv6h23a/dvRu1tq7LZPlywKTahV800cnVAsuo1Hl7wCuzOKmY3XkgSv4TX8L2ffYBFOYEuslKje3ekcrkJNiiSfZzCCxf6fM7qjphEXIG7oTVl7\u002BDdxVieLrLujuuTCYVcQXMg3XJsTryyQCO2Wxrx7M2Ho0ZHtLREI9xlC\u002B3nW4UW6B8OmsfC\u002BaEkK4E069OX/KIaD2Y/FIy\u002B2LmSC0LSyuSan3L/41YJwKmhI4kzDzgMzQ9LzUwi29OSU74OMO5iVWCcnkhcmBlIEEq4mfUDi819hT4zhv2Yd8efaZOb\u002B4\u002B/Qs4olnDzrDT2A7kBZj3ejsvwjK\u002BwLs5jACaAvS6FrBS\u002B/Vcq2vFYidUFPYdAmxGJwNrLq27gCxf/xZZKcu8KcFOkRmjmt7fWlAbWqvFLImUU\u002BvxTvgSp2vJDKxVfEhrl/s0znFSkow0m9RNoCWAmsKMtNXvyurJK\u002Bmt2o4iie4Xr7KwgG4IQbFfvKMjxQc2SHHZyLdii90Qa5KHpMf\u002BAgHmNfBywApkdGMUgA43pVbiZ4IcSMEmpSPloCTLgJzpUaqhPZ8Gw4h3dURUTfve6LZLlT1F4clAz5DcnS/VqPPWOz5TlnfH26QJpNOMwlcoFsduf\u002Btfo3/hUG3\u002BOjZYkcxAjhLNe0JOc7mZTDzls/1JpIZodykIdoe\u002BcjYZ2aF9oRMXPEQ0apt1H/whxmcy\u002B5xgpJW/8BqTSAebDvkcNKoYK5sp3oe5FTnq81cs1qAgi3aZqSUbvbD4c/Q8qWuSWOtSGarMGS0Ut59b1PzDZmFnanOCgouFDG3qIWqTfGvOSJpr2s0FVGJZdPGFv\u002Bi0NQ2C1T7oH8ZfzQ080eeygUszjYxSV4uQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "MwWbdZ\u002BwR\u002B0VRPhigPgT\u002Bw==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7013F48B3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7399fbf2-8408-828c-b53b-f04e108160c7",
+        "x-ms-content-crc64": "uriqECIiF8E=",
+        "x-ms-request-id": "ec26215d-401e-005d-61af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-20811296-e7b3-2414-6507-74867a19107a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-434fb9f806a3742bd437b28a07141499-c22af17dd434afad-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0085eff7-e098-ac4c-30fc-886fc5169dde",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Yo1Bwdz9iCepbztlIyXFHdcf6DKNbmyMXNsLer\u002B2Vwo/anY45LfdSJg5aSGdO9GijkHtsSFBQPQhtGUA8Q5n8hcxJbmvjDkgQZ\u002BZUwRK7iAKaet\u002Byabp/imBFy9S3VaK0XYJbBUY8gEHzW\u002BBp\u002B3v1sVE9Ygi6SlxRyePLXQJzWNJDoKOQYIK8nbpdvw2Z1Y8kkFpDejNaOdNmCTuiMSN/f8LN5hqYZRDOgMSOHMtOuDQU5syoL97fKaaQahdG2mxXHj8Ki\u002B90TGsJtPkujB0H15EHjUpWl0/kLvy0B/r5R6ZYdv6MA\u002BwEoFphXnslsF2JSFKGf00hwIavZp0ygARwUC1S1lUee5Okwuzv9TkU/n5fKr\u002BocwgZdnZ4HN0O0iAWMQ4NktnIqwz\u002B4XygMctNmqhek5VEx90lOaAepl72lfDMmcPqxytkVr\u002By6VGLuQRrKkJ08H5K0Wkw6Fl56cStyEtL05gHYpN8\u002BjzV0d6LmYBbs3vcQaWyQciaud6SKqy6xOEGP6WsY4eu\u002BDYBtP9KpU7Y3jaI0YalmZGPbOj06o\u002BQGs09hVna70/0LUmvsIzJEBSP\u002BUx2MjMaYKYT3Pbe\u002Bg1mcVnyTSA0/e7m1KQ9NejEhlyUJPFDWijZ4yTzxtJY1XN8CX9y1sM0mztdTx2PHSq9TxaaCpVcIxcxGGn7ATccjf8wwSypUa\u002BZn4n15crLCsX6Nne7/oqd3\u002BZoAf5ZeVnEQMFeXlw\u002BE/2nAKsLZj0MJc2jwMq/YI90kuEGAU/xAGZv8aUJrOxp/CK6FP4fkrmpW9vwtXhPRSAyKYt699KttcBEm7SYArkhOcToBQvRVQBnnOV0AIruIGyE14MhLsRQDJ79mvbFERliz3tzZ3/UINSLE1stObV1VrsH0ys1wAsAl/hs07oJYouL0XEPerkssPbuldupItMpiAR7vT4ubM8wcs9HZw0aQbDPYSgEJhvCGyI0ByovV3UlQ0t1zeVNXaRh3seppUmplBRq2cGq5aIoeWIb\u002BiXlARuaYiPBpLPLQcOD4gcUWLXYirMVxL1zep2pTVRDcaO\u002BfN3sDwMl5\u002B9gn1f\u002BJsOa1CDsA2\u002Byz3xeJyeGWFdfSBBgBWUpaElysuKDtSUltROZznlzVy4zy62hTegbn0\u002BYARdHniFecWvXuZCM7xoXeLHT7End7DDiLDm3SBphFtNTK3PN3dcyO50Nm52dpxyTihV2R/MFulUmZXHn5ylRdqK9ecPmCVqaofDs0FBTBIUdI/3E6s8gDXEep3ilClRzvCU7IG0YrUC626XCWOoE0yDsyoMrTIuTXSxSx2Hh9VdceVQrGCRXxHa9Sg9pHfSG2dRX\u002BH\u002BRSC\u002BZZ4MAheXemOYOZh\u002BVw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "mVmLbC94ycpgiVt2UflDuw==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7014366D2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0085eff7-e098-ac4c-30fc-886fc5169dde",
+        "x-ms-content-crc64": "7eNR6dHDzGw=",
+        "x-ms-request-id": "e3498502-701e-0069-7caf-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-0f785509-34b5-067d-0a0b-f9b3f13f914a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-33355cebd0cba3d5397ea30d5071cb11-1a15df5e0ede7014-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7f2fcc1a-7dc0-c3e2-bbf4-06e7e6f187f1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "9F8rxJJGwoRd\u002BkJ6xKRq31TDAGVtjuUTZ7N09Q8i5\u002BFEOqTabLnFHylt9h7vPkVNPh6La7bRu2Z5GF3e0sx0OhJhNon/kHKb/uA7/5fGIyltJrbxl3wqcn8\u002BYFRb501c\u002BLsMjge8Ta6r8G3VlbvOs/UzcKwVg6KVNsMKwC8ePxeT3gfbuZQisdgIRacOVNzDcK1eJ3agRnQZd1hDsox\u002BjbBWQre08vlgEb7TDT37huHnRlCBvxeg8peSwkI83v9Libj2uBIlD36z/ha4zTk3HfB2XGw8/M2ZtlAfIS\u002B2IzO/h4OEBc7PwTbSzcEB6CReW6VSxoKTD4zrXQLCBu1O/dri\u002BEW2shghp5o1ai4Ll80rwcaKZF2xLHj2mafLDLtJg9DnHu/eqKiMMB7nXaRd38Y0lkUmxJh8McvNvxhwVprf6\u002BddJHjeTBgd/TQ\u002Byc7TmLnhl3V2Ir44au0jEeiQG9qECHG9/7pNVkosCMdkPWf9\u002BSZfj74kaMkoJbqLujovjeFZusFcFZj\u002Bk0ArShn21CyFJhfBMYwbX5\u002BolNoAwpwP/HvmCoKmoOSOYPt9\u002BR6vMlGNBpMjblxUPlsitIG\u002B/tGkG06eD8mp34YzM9GQnWaB\u002BWKJcrwI7I4ekcwnhOtj0GEq2d3QESKH4ycM7zqLxKD1obseNIsVmy\u002B/f379glqa0GNvZsSIsOhAAo\u002BV/PxTk80sMuMwRJvVFT2tEJGkimHMcR/WG17bbPDT3jL8gJ8za\u002Buw0FB3aozHmlCH26BWm3guyYrdfXhvUcXyXWZp2JWdeqSl87kQVAeTD4ENU5FPfEK6zrcVVe5zQX\u002BKhQwlXsG76mD7sKe\u002BHXSCSm73Yv00o\u002BEjrgrdhyS1MrI5hc77bbC/UWkwU8ua\u002B7FCkwuAfN6CVuIrAq\u002B23WI8Rn71hZelht29NxGTA08ViLNZm/QYNLXUti/sz2oACHMH9A1MpXUZnAwuw0XN71OSFXr8XUJuIxHJIc5oubdyvC6diw5ByOM9P//n6nFvBsfcWbnwBKsxmdH7g4SmseNVvAYXL2NEUUyWvh5ChjmfWRoHjF/9griCbPI8RUVel44cki5rWNdjlwhtWUaM7hKYXClpniWEWDpOlMJxCAsHOCeQJvMLNABDpPRWkChx9n7fo\u002Bkb9PholzrzHcQU8o79ZSEf/McfjScoJvowLccR3J5DkWQh60MuJ465Fxc8LrFlWSoHUvm3wBbC8s39OGpy4kEl0GAq23rd8NU4ZXYQ7PhJytSdCYmljNFOX/h1Me8kRzTVFl1QO32wKmEjflqfsQbVtG2V1Ni3gESP3HyBZ77mFB5COtWa\u002BI9X7d8ngQ52rq3xoH2Bj3JbHpUZwV4BLsKjPA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "q6oh4n1FhnXe53GQZ8eutQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C70144ED32\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7f2fcc1a-7dc0-c3e2-bbf4-06e7e6f187f1",
+        "x-ms-content-crc64": "MTjhUKdIeSg=",
+        "x-ms-request-id": "a00adad3-901e-004e-59af-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-52c92672-77c1-9520-3597-4e0d7b2f5813",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-89b7ab3d3b6546365a931eed9372fc54-27471561a0325286-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2449a20d-019d-6f60-cbc7-fc1d721937a9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "zpDHQGWFq\u002BYbP4A3MFW/HIREpDlQNsFkwqNQimKPluSoMDOd\u002B2LX5JF3W/C7hK3oKNwKupDf3ZfPY37CNCCDjKmcjgAiISEibb\u002Bo2dvQqD31aGKGhNxTyFObzpjjFbBw885HH/Wtxga66EzRNwO8/rpBzMy\u002B/AjMSMashlKIPlcPOOUMiIlHR6Fby5uPgpFP3s/dokjksvfFe9YvAD\u002B0Mqn1wv4dsHYx\u002BYQqYjFtPMY0XaeCqpwOKobuRgyyGEdhp5nxmr\u002BSMi5ZrKjEuk/GWD4Q\u002BqOYMocN5pd4LmlpfuA9yLqXe6IGoip4KP7zSnA2KO3Ooh2jyXUS47MoGgPF7y3IhvGVLt2cCVh4HwmIGZwnQgZ7m9zCmv9FhJfu3ocnsznQK8N\u002BoPoQMZnFKqlsickXAdf9SVRRBezxT6pFrSrQUGvPuO7YqKELamlD/W9V2PrN192wKmnkfyXXjVBPy4Nu9Nk9nNHbPlg28d/qDgh8nHevd9ZNICYC6znIARtQu5/m1AiVFzwp8pmEeTmK\u002BnAdWvDZoFStIdSzO7GYEj095TVABDn/5oQ6hoU9yKbtePHIqqYqdhtKOLM04tyLkN9cR5MDSfU3HnNrnxrPcFgtxcPA0GeWE28Z9cuFygSor/Wl4YET6S77kIwzvtcBe8hbBxwYysB4xTQk6lQpslNvwu8kKY7WGtyUxD/bY1SYGHkCKcPnkOQ1LRtN7v/Z0d04w/zn3VI5hO1AhAaAnGLfjNHbJoiQhzIL7vxziSvduvNiop9YsDsnyaXWpwvetJC4bWIt/qpUqDvJ3O5VxvvCYskTHvrDh9uWs13juuAmLDpsuhvIr7xIDfpjjtRM0gKqE0RCy5aW9eWHl0pMce1boq\u002B06Avf\u002BbMNyhH/X/kGSeFbOaab5GGk1sU1QBhx\u002B5wMCOslmOn3yxqRNACFlpbsgU1p8TdHv71NEBFGqbmbnM9081YN4LD3Y26MCq9gHkAuSb7KBwlkxUgu2IjXsSFg9ZgxEKM/36GccY7JurUN7PHRF2D60JTFDy0N3wcoH7JMKxQXLw6c72odLZZ7mwqTIOuXBpnBZiQEawB1Mf\u002BZdFHbfI\u002Bg9r3jNCj23aP\u002BSnQjer8ckRkYi8XvE8MNJ71qg7lEnx578ykttNFxy4mBBSGMUrdAfeM4w/HJsOP51Q1qjFnquatVp4aV7t1Ipr88bg2igNQFKQbWDNsssUJGNN7DBj8vl0t1Nqoxq44F7x0yjULVV1Q5ZWJTFK3PKfZDT7r\u002BhJ\u002BADNbBLEop03140By\u002B\u002BiMAcNyJiqHc3IOepg207VzTBmt9sYFrFCoKD5Hl2kORES7SQ9/ddfn\u002BozBTI4Y8dOYhpMmxQUiilFuyfg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "E1Iz2jGYXTC8/5oHmxjCcw==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C70146E8BA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2449a20d-019d-6f60-cbc7-fc1d721937a9",
+        "x-ms-content-crc64": "bId6PeauoV8=",
+        "x-ms-request-id": "ec26219e-401e-005d-19af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-71816c1c-6011-62fd-947b-15a8ee603225",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4e905e9621974ecd1a26066b13e84e2f-f4da0ce52af969e0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "43d958a5-63a7-ce54-bb22-7e8c2e8b552b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "URjwo82aq8Q2et/P5jCugyr2fu6sLhMW8V2SO6OuOEDCOlF7ag\u002Bx4GMyysQtxPiy/PrLmvKQYSIE2rFvCHAgiEKfDavfMhgbRZ6LeWNO6Sxk4D6p4p1NMtgud5BdQdfzEkKCjrdN08nhr1VTBOe\u002BtfGECygxdqWlUdvTsLuHvgTGl2YhzFt1Fw11yDNH\u002Bi3wb8Gf2DavwZyc3TzbeiIOWvBRjGyBnemWD/MbvK5yXVeu4kH56OXOF9bKhe4emZ3qZm1C9m3Ab9LXCMlClAXuKn/lLZfhFHEKgnWWthf6d3VVMFVAL2bq7XJuIt8ci4LR21tvOWwFCVL7N3P3Kbi63ZFU7GSvrvoZ\u002B0AlcvKS7vfzxdu8iz4JUCYDRPfy8sS5tEVOyJ4eIi1gVj4s4JdfaUl8BGTd/VFSSpw9q2kDJgh7a76tRCZY1aOtXDUA3W\u002BPpNutdu5f27bz\u002B30B4HbEXDA1sHTYsiQjIy7AMKEcUm0trQeNVa8aG48IuUioVvQs6P8Fyi36t/G2ilK/n6sU1qgQ1DJvNgeAG5Tl0Pjce805k0ehF4hAMvYV18pdWnzk8\u002BKfmILCvbL4ha6ZFeb42g\u002BFhQtjc78gz6I8WV48IsAXAd0VPOJLd9aUqZLZpxwPHP272NVxgH8jf8jfhmNTu2LtgRQJ450sOg00zsktRiiFLDxhgUrrpoBd8rwaa/FzQe4v7CUIBjlfjp7HPLG29TifWlkm8joYAduTrPDgEs4cwY3b/loCfSYDAvKrJGnOp/2EehGYTE\u002BzF\u002BpKdFlIfnzPq3sj2vfenN0zI\u002B9HbN1xxQXzXJe9g3U\u002BJ\u002BdwuAjMuoN13HnuqswFpd0zZChfbKoN2K9TVSHlEScF5bIQbeTUZmlr0o9jgxo47ba5iR9M37s8Y\u002BBZeGRij8pS6MUZ9Tf5X/6/85kaqVSVGmdqLIcHuQb30woEe\u002B0ECUPEEZtUHvd\u002BwCohjOsiIbmLw13992NCSi6/IiEt9eMQu\u002BpWVpe5Qfxv62xd5i0a1LJQeLiPBxHfgsdslPvVUctGENABy8sh0oJhjQv35WMBpE5v3HwrgbTYdtPQTawAmZqgF9VcGQjnLqY1LXkG6JxjavCtZnVOGo8cKFX3UYXWYfNxVs6NpYtFiK3V9lM60o43beK7UjMkUvxGQPCz790hXsuGlJHO1cRkaN3HeSQ84VbGwOOiGg\u002B/TATRR2WakpjQs5eHtD38aJgdVupVXdjXCV6a7C/6f0S8xkeN/I1fytZF98WMtCwZylhLhMMlau8r\u002Bj0GAKVp1TRTy\u002B31b2sKvowTEGYSSlUygCLXrvqAl1xYYQJQWMow2yGROek/I1vsQcY3EVmIGa/o1H\u002BDkiY50jOQnA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "mpkg2drUciXHppjnpjRt3Q==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C70149CE79\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "43d958a5-63a7-ce54-bb22-7e8c2e8b552b",
+        "x-ms-content-crc64": "yONUcgTgA9U=",
+        "x-ms-request-id": "e3498543-701e-0069-36af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-aa4a4e63-c0a5-db96-777a-26a59c165357",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ba987e0639c8d1085ed752792887dd30-e687496aa0955ae1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2056453f-60fc-f32e-7cc2-f464f1cd8120",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7012A3D2E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "l7xpP\u002BUCMquIydApehjLaw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2056453f-60fc-f32e-7cc2-f464f1cd8120",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d3b7b5e0-401e-004d-77af-a35e6e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "S0h83boljHnRynxdKbCFhi7DCI0DS77LJ/ig\u002BFZLh50OZvk6tsK1a4NALJUkkPlgsdqffxbjFwCKsbXBhJMjhULfT8O3S9BrDZ0Kwh8pppf\u002BQEd7qwiGK0/5rwUN9ObvHaZTRUE2qWUKM3J52FTgYAodw0RMp9k5WCNzvZvKXRm2GqV41WBVyJbhcHeVDVL6GE/68DCho3XMGewdwuvJQNZZwr6vaIqqx/quazdhpEvReaVMz23oFXcvrLx0OAWqFzChO0qTSrDEUCg28zg\u002BanSgS0hGfHBoca1Hf7vONY/1BFMGwGgBPS71iH5EsSE/8UFH0\u002By8ZJrAOMqdTMv09RqZQe/kOKoLnw0aUPTxI7\u002BLB416hmKiOJ\u002B4RYeeY/FjAZJjq3AyWrmWOzPeohOmzhQKEkQ9eW\u002B49glPLPIjbTwct09hjnhOWK3U40ovxJWMEXdylFGsJYcjq7Vn4y3Hc873wevERECcu7mXaJYkiDJzwxt6sNjqcJHIPuLC53WADW98OAKpyMw31diYFbzw/yKC9B8STMP1DFFa\u002BwZd2dRDF1smp1AwyftOQ9oAUlrU1z\u002B/P/JVbcGrhiuwT8zG2fwEVP5hyVfSUiokwwnp9bn2hiPHnpnh7qmaeyAlf3ouiGne/P5ccg3n7e3IMam4wpFxucmo/ztiImZVx042rdOw9jufC/m7mhMW37CsGLz/4riPs8Wwhogue9mXBqu/sUAZGDptGLeYtR61kiCLtQmpVeWWp/kN/3CzcY8fI5NoVi1wkgCCkskA9v2n\u002BvNoo8XP7rHFKApGDBjKuqcoeJKKTTvyGyIIJ8MclbD8ZgV8Ss3JTzXioi0jKYbot9ch2H1rHKy3doejx8fuqZNZSqUTTm/ZXilcqKsNzvGbIHDr\u002BrwykUpYxNRFJohu9Piayd/h1WhoR3lUDnMBqqeWB6ZWAq7WJ7lbu4mbkzig7rSycwUSuksHg7ND3YLXVhosrx7hF/FJxKImhhnfzLNBsx\u002B\u002BTzaig0xbT3/7k0k2hGVubuQZvtfDaK5i7DQxJ7b/ASliGAfjiSvShsdyTjFY7wG0cF3PJ/VI\u002B\u002BaIP5cYKSfI\u002B5Ef02tdi\u002BS4RzgPURp9Cv0yfLdZMNk0GhwgW0qUuVyfqVKfOBuWVuV4FuC8OKrLCjWa5axwb8q467lOPS\u002BaJI3bcKfI3tLhnCbR4Br5eOFyVVAV\u002BtSvLjqH501hRxm23vJS4MgCAyxiuEmGn46wvnLX3OjehSq5K0FsQPeFf1UMGwIop5cZb1EkskGLKY\u002Br1yjaimox11jImbSGlsI13TnzeYOMiBfbvmyWudPpLgKywWnOqvXq20SpYA3ik9mP79UIl68LHk8R/sv\u002Bmx2F3g=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-54142975-bd50-91b9-34e3-d91ee5708adb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-aedab8b9a6945a03fa7485b2e2e4b8b0-91c3f561c5e8c229-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "19772923-f43f-2201-faa7-cd1aec70c097",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "M0iGA89IU2iESq1J\u002Bldmta6GToOHYXUtJUSYnnzhIrynuQaKrY3NxRVR4Hc260ooqrVF1nhn5tHTWN2Lr7XroyjwokFR3AcguYhtNYH99zr6b/PGnEtEP9M0tlWvQRVgZjxPRUkI182tJB3v\u002BbBQ1WCjkT/BJAfdrGJuHCWycHhzDc9ErrLx8ZglGXcuVEYi5OD1DLDVn0E1cZnmmruo\u002B7SlfOzgCyetsqCnmwuPrlgbSzdEvGTHnW6ODzwZClbdfR3CiddZQtm5R1kQLQM1pcJBy0\u002BDYz5Q3d9\u002BUvzqlKhJyh3uzSWAwglei3QKt29qWGl52D4HWRrecqz42/Ddz7OwxmPmR9idwAhGJdjKRSVvE/mScLxpQnACD1p5h\u002BYYgbvBWvEMhBCR3Bc1wDRCFCyGicf2Sl72RoPy4zh9IzgiLaMcCOszYo/pAZOlM4E8wPst8v4fIjZcyxNtGqHYE7jeE5OQJgxBUiY4DEnLURIBtiM9TzE6AwttvzzXxkjtEe3bxiDuq5nu7J/Y5hXtkXkAa2N\u002Bm8SHpBCII2bPaYzdSvtb74vyEwqJTmORYhz1fy3D11rlb3UpUyIPZogyH4IT\u002BpwZkqHuDVhZ9E1g9kHzkqM5DJIy\u002BNqFMZxo462CVi7gfWeA2\u002B2M1MkCi3soyFzgG9Pk\u002BRPw4QLBk2AFhSqq1p0egHjac7e2rDfIMGxfXWk/iMfanl0b8JxlvkiNhk6fV7TdCkjjBqgcLkzbJ7CVYjb2xfxi0DhAA5DcdLRuKCboKNi3gVIgW4Ifvm8QP8jr0FwRlsFSPYd8nQa4B5LzrQUm8/7X3eHj1ml6QhLIL8PH8KNYXZFklutRO\u002BNMZ1PwLBBq6kzJE/N7LsBX1/p0s21C8Bfum1BzwVwThqH9l24WiRYBXkV3/tyw3C/RDb7x3Ih1CXc8AZDA9ijvto1SfZZRQU3jc1Qny/E7Pr4gobSdIqkYh4332YeFQGgdh0hOXl\u002BYgMxxDWkzTT6FAMPSn1RzUpPkOfYIWmfFXjPsCkOp7eBfiCHoLBQ/5TlPcdnEs6ATqTW0aSRojyZkq682RkP63BPjchcziyZ/pFO8ueiOAaqS2WAO9IO79vj7g4BlCZ72VJXF4EGI3x0ONcTQrNY91qkEo23i7OeQKHseOAilGZu1xmRTyCBpCflD/76\u002B6koiva3XYGYxE2itNLjFaqcVaRwpG\u002BVy6g2Jm5lzn\u002B0o0T0x/Hpazrg1hLP7pZNno59RLZWilc5ksNOfTsTMvXN7hWN7k20tu5tj9JYydkV5Ifj6IXJXhTxuzEynuoD0aMc/gB8w7BAxJHH6P6A4MjqNJi3M0psBI/8mDMchhgAbb4zP8/UlSDTnyP0AXQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "pqEiHlimGB4tADUFQaNzMw==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7014CB43F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "19772923-f43f-2201-faa7-cd1aec70c097",
+        "x-ms-content-crc64": "nDgtfPeLjnY=",
+        "x-ms-request-id": "a00adb25-901e-004e-26af-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-8596e5b2-20be-1139-2866-bd456278a6d4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-99135bf4d2cacefd0878aa29afcec68a-e3429328529f7cf1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0569a5aa-3b14-0ceb-da48-d4caf856b534",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "SQ\u002Becd7QFGg/RGjd\u002BOQKngDGuYnVLA9ta8hH9qS1mAU9U564X45\u002BdYfOWs2wtlpCi409lmeACxwAMQYWiB7Eiqxin6VGUT9yR0MBB9FCvLRuBGoWeAGevEiCuC2IZ\u002B1pCtAgTRa0/DlOyk4jfwRKvXRRqIOzrRKrxONcw5kR6eBVmPwBIm6duQgwyK2yej1EN/q5N79ptVy\u002BdYkzWDifPOFuzeYHSZsGs\u002B97guRl\u002BEqlGIyeV7Ig7OKgQq3laWHPkYvLQ6xXPe5fs4PQ7TN3WXw/jj\u002BsAOQuTuEEZgbtIUmOrPFYmbWdTdqdP6QuUP\u002BvKOkwpdshIpCnnfXLUtbncZI6QkFBHsDHoUBlD8FAAP7iVT4dvXtubIlhsfy/0vsEtc0S9A29bQkpaQOavBPOZpz36f2XyrQWy9W44G3EB89FYFn0LQvwJOc19FN31LB1kkpfx\u002Bj9bOoY\u002Byk4BY2cZWI0VFu62TmRB8QVYtZhn/ckQk0iZD/mSPRu2zLiuB9amI7xQ39Vu7gRzcAk5wkUt1sxE8I/eQAiTQxnS/4Gr0\u002Bku8lHb1x4z4eUEJd\u002BwmDqWiTWsKRdGh6Oz/Vy7m\u002B6Ch5xfyxAzEf/uUQ6q2lpo4usffHaMP6qR6CquaBmBeAY2QV4DUIzqY7c1/dfIm\u002B1JStqxnB\u002B4NofxzeMlRKnmLNjItFj8JZIedNj/VkGSiUw9ZR1/D9wmvkqWEYLphN7NT5E/ACdUTSVIkydGuKBGXwSXKB\u002BMZxz84jYOZdPPdK/58gawk4kk6Nf39ny038WqT/K\u002BEpz/AOh0Ah4xRicReV53TMaZ1Yt7cn8HlLDgCAIwZBYhUSITOrEePFGrM2Lw5r0ePVM/ELonAqBdt2x3k/obwOIRL\u002Bg8ZFIVe5k50H7cVu3zggqvMVNb\u002Bk6BtUNE5miXT3KAn7bU4dkA6dThLTJhgWC\u002BRBHvbI9OtTVZuq7O0FUwokEMG7d3HqAxrke\u002Bus0cYDQixmJWqCKjcipBe2cqchl/8ErxVWWpB2Vxvf5Hj/pofRq67AoymfoeaOlM9eN5BzwufspCawqOeb89JOpkW6IwGP4Mb0YPTRZQkux8HFFCOLaCGVEv5hIP7HKK9bTP\u002Bc1HXNzlLJf2HzG0MZgeEh0tuyxz4gIQwDLsPIMThFehQJkfNP\u002B0nQvezDpfu/R6MZoVXXqIXBeLNlyp\u002BTAUolqaErE\u002B/x1duR4glNYH8UR\u002Bscro/mcdGOSBU/6iyqPbiimfhakDezK896RcZ8cBg0TYK0clK6QzvPmMfWseuq56BQrsaCvbO3bYbAaCwLEdf9C5it8c9l5FbAivtv2HXjz14mL8VRsZPPAQDP\u002BdcPxIrz2aZS/PHQ6sZvwjA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ia2bgasyedZfz/9TceBU\u002Bg==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7014F99FD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0569a5aa-3b14-0ceb-da48-d4caf856b534",
+        "x-ms-content-crc64": "M9\u002BsptHMFT8=",
+        "x-ms-request-id": "e3498575-701e-0069-66af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-52972964-031b-5ec3-b3ef-3c2d86df7d24",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ac731a8346a3348195456777dc3fcf15-224aee083bc28066-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4770ea9f-bb07-d783-2379-4140ff95e790",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "pnug7TCcH/\u002B04zSaFVBAuXvXRa5c78ZOj3joOEyTE4iAQZQ1\u002BwNcEvLkj1TymWPoQ/BaqfEO1ra1UV23s\u002BezINCrGtO8C714ezK8d2BxW/YV//RbOGmWcmrdf6qlpF8LMW6DR3\u002BPLDgy4S2/Ul9WQ/VnorPyWOdnFaho3osT09fTsEXx7hR3hdO7KFc71yALhzy1PQGrGNiGHDHWJ02tHw5W66EZZFXg8B3fNy\u002BQKz6HXVdPXpXWJ5hsatHjoF6GDglI5et\u002B8SLm1Ezky\u002BGp9vDzTsn2XsB4f8MIrfqD/VC\u002BWSgmSEVTCWw0aIlI8Vy3w3Tg71GUkLBIz2UndkQoY9f8JXK4gq2roEVdwfY3MI1nUemFog3/Ksl43njgK5IoDASyTMzp/kHGNU8LN866EJ/XvyVaosDJ/fuoQKM1ynSzNbXxhePBfVKnv2y99PL7vc3YCGxtzWlE6E/QQb2dkGvbVwIZyYu7FkHSs\u002BJTDAgIrYPWXMIHRWhLrZ2U8DyVCi4B4pzw4fRBHPIqmxmG8NxGx5M6xzSo0xKazRvuJyUFPai0UilsGMuOlEDQ3apOxb3ATimoWkP6WQ6JVhTYUvXMJV1x0p2y2a/IqzLz2PZnSwdeLdn8XOJlufka4sG2tkFKA7dM3fMfDnR54K4RBoAYIgoNeSUc0Ml6Cxikl/btEfXwqdU\u002BGm4UPx9kgnszVLJ4AsC3qTwcLjLu0tHaenZ\u002BjM\u002B5IF2r2Qec\u002BDoFt05NRrZlLJU1Nme503qiUEicOsSo5fWsejNVzCi5GrEBF3bjoIsadE7hSFVnAE3iCIi//711XdJYocyDEF9sfBu1t7wDv7C9gsV2x5ygRHrmcsSf\u002BhvzjLmkiv6/l2TudMw6skmQ30nYAX34/5U1uF1SnJ2bzIL/wisCXzSy/uphh1LQZpIwVpN6x/ie\u002B4wkb9KgbPvGU6dJOu8ejYAVJQOSlnhDZFLLIUYKIAWKYcae3u9iEpHvmzOqhiuiEsgTZaL0C2QT4Ap/1Eu0uzKiv9gpf6\u002BQsxNyo/tEmN0mKQ5997tillVhiv3k4j1FOt8ACMdSeZMZgrKPgWdpz0gtWas9N8R3PymDx/Sxq9DVLWkcRI8W07B7ZHQI0xTt\u002BLu1t4iSCAMbiciez7GeZ9bhuVT\u002BTYq4F4X6wdJPbmsUlc84\u002B/RIQyRmALrHeAP\u002B3P2eJxrA76ow/aACl0YxyxpciTriZmvimXUvmEzP8Z6C/OXUsUdRVKUkB/5URaveNTWgau7IG3WRvI2kkFZdYQsBgJtgXBrTCzSUvl5tjVPKUWMXL4ewueBwQ/W5rMNPxqbyU8QQfdgbzV66NF0WIy452j/zRjGEUce78BgkGV5xRfe4eg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "H5VFpSEAjsc5HmT0oDOdUg==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C701527FC3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4770ea9f-bb07-d783-2379-4140ff95e790",
+        "x-ms-content-crc64": "3xhZgiCbvFI=",
+        "x-ms-request-id": "d3b7b615-401e-004d-28af-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-09f539f0-adca-5566-ef02-2ce900732fbc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-403c12ebb1ac864a32c701073b60b1e2-16d13e42e01dfea0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0e2af988-6ee6-de2c-e54a-94d8190e4f32",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "hFyAdG4B/VWNwPaz/0nuZl6p9KohbGhKz1tbQjiX\u002BF6ajOzpd0MMOJJkRckGriitlhv6dtLUsRfzNaUSproc9ciYGXNcBe8bnLsYvCaeRCEyrqwdnYGLxdrV9UGe\u002BpHXR08BbZS1UJAs39oWvPTwVfGD3/gO/1hHDFSYhhCtfaIqQHXWnNaNfV0b8L2mdAjm5J9QGhqYyUf3umE/HMqAf2E47Hx\u002BGrgb9mKb8g6aoJdMsqJwXWKHkXYt3\u002BJ0TWCSm3FcboiMZ8rnNCO4/dc4XBrJ82ooDyH\u002BsFoFUTrVpqkBCFadPjEPv0rXiSg/z5Oe9IPHq1n2aoxPXb4thhaQEY55t/WBmx3pujMgUIb5v\u002BDHZly3DftPCp3JTeFy4Tg0R3eZxReeHVll3vAl1hoGVp3dZiC52AOTKqxXt008dtj76wkOX/nJKEkDUS8KKTSDw/dElHsYem50BptrRmULKWgXKuoQ9/ajFD3WtobUiAB31PRW\u002BOFd4nGamlleXeHj9yjG8v9KcswAoIA9QcTnn32a83JxtTGGuUd4dlydRbZc8r5eDZYBLWEnVVhhIKGssvrbw2puckL3QDi30fxvYlrJ4E4GiZLnmcYRSV/ZJZmmzMNhwoJM7YB7Zs1dSVtluPL9lz9Spilo9CmjXSjjHhqfEAU4DaDXffPOiyLFiU9rrJFs245ZVCaa\u002Bc1YqJBYl0iyvjhVLapSJRpMhBoGo2rZOLGWd0KMRrzfnRTSftRjdfPZE8sXFX7nGrVzDM8LlFVjf3DewSAGJXd8dY\u002BVf6ZF6Q4nLJCewiIyr12NGTns1Am\u002Bb/9jhLTT0\u002B5Tmp/vUZsOLSLB42fFxLxOrBLDeQs9j6GF1g\u002Bn4mVZVFmhSieCQl3CfusXK/Ci\u002BapCFNeiEFriFgv\u002BaXuLZ0u9Z48OI3qVzGm0AfogJmSw491lZM2Nt0P\u002BvzQcg9niNhagWcNhlNUwrUhu7Q9fwe\u002BnToadJgJ9L7BLD2RFeEiQ0srjgM2gT08HNLeFH8o0nv5FdTVSRBAUIioTFYRx6jT/3RpEe0EiBv42lfFL9w/mFnBlAAMTPY66z12ijTnLlkqChkKv8CO9I242HK4eyCsaLf4TC\u002Bow7J\u002BMiqvjf3nFa/\u002BmyXHNNiZNqNyV3CHfmwcyiGA7t4pgUZqiImZ32aP1cbCueP\u002B5TfbYxmINmw9\u002BrO6ksPcZirR1RnfXKhTA1s85n2pwMSMIeDtpYvAnUraKJHV30ims3Of8OTGI4iLiF\u002B\u002BT1PykDXvLnDe8ryfDTfTBTAaeSQOljMODdPfyf5UYh0oAlH655Rb6qzbx8CzAOOw8xpYbRM7s7Uc4IZmE2Ryioyjcwrl2B2bwo53NtJyWwzsLtQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "5D7CmQFOL6aUqTpgNz8dOQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C70155B39A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0e2af988-6ee6-de2c-e54a-94d8190e4f32",
+        "x-ms-content-crc64": "0rqUJhGk61E=",
+        "x-ms-request-id": "a00adb72-901e-004e-71af-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-bcb9043c-38d8-afc0-2138-d1cfe30b8a49",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-2c89020fd1ec209c1e43ad7580b63f82-f73b2019f06b6960-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "05b81cc2-d96b-13aa-3dd5-13b3bbb73548",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "BON2M8a/LyugMR45q6JdXngkY6Km5WCtEj\u002BGonMtzLNkT5HfxNfu\u002Bs/Rokv1bIrfZh79rLasph\u002BDyCCGOY23cmRr1VwQfpmhNmnT1EIUt6a1pjtVMB/9t6hyW/y3Z8BBGjDmipYtzueEW3ZN2dLdbhB60ZJSYkFFbh2zniOd6c6okbkSLi0Ph9hT0NSor97WlOzrPZUu77fuoBx5ejDE53KnpUcYy0Djakq5/5Jsnb4/3Qk2sqw4eaICI44Qlg2ojuliAAqWvcmsCNJLdPAlgQNeOZwmjTTFbiulFqey0tQ8EXCoCpyzqCA/iqra7QWy3KGKslxxgQG0nJLf8aYh\u002BjX9D2J/fXdnqpB75gOK64Em8joFJx94y5Bu9G0K1Ld5HZB03N2iMl8qIwfL9Zr\u002BKbEQuf5sG9IVhETSEIgJXNbZAchyFg6jhMDa2wMXrdX2cMq8\u002BRu5DAK9XliZzyHWIMYx8fPRixOibDQ9kkDP/ddu3KC9TWO7H/XGtbe2CrSeBLs95rvhJOW3Go3me3rB7mGBKvOBGNJjdtH\u002BCtVb62GAn46EkRcbjbe6BjPV1KR6BcdWNd/AHevo2m/p4hoPXC4rZdzsPVxJZZ08xhKfjaEtgwUOBbaCv4GinLenMaqcqqkFqm7IjsdqDM9ChFbYSUzNvF8VAVd3qaZaSaGloTTynxxomuIzZfU9o/jmPzsqylNq2XVLh6lSjQHIbUUmxWqbUOU6cK5pmlZp111ekGlrMH9OOsi\u002BpxdyFQzhavivFt6NS\u002B9W8FmkAD8e4bBL8/yXXTzG2Iui3KjNx1qhiC9eusB/0UV6FT8lqTmIn8VnJiIQSg276T1T6m5GiCj/AngPwCfvzCK3HEj9oC9RGT3jZqA4kT0iotCDK\u002BbWNIwWJafAed6ed1r/WC3FvkgOAdAxYiKIx3E77B5WbKE74Oi75nuHkKBeRe5GODgPXeSIdCkVpdFqjl42hYzARwu5xHhFCdfNhnEw0h0zQY84K485zvd3JTsXUFccUQsTnf3ijXTAylMMu\u002B245dKzNk3P/Vn9hnkUQZ48Lrh/sDRlHDUfUbQad2E8LRMKvkBoYxoKTVSxFheEzkvWg5yajQq4UsidlOWYtIX4wFlmCoNd08qedGLgtAUemoJoRPTFoaAIUWt3y880cZnOuFW9HsTIeK/R\u002Bxin2J7Df/ljMG\u002BRMx\u002B5XbgX5gj7agLJEvuwYHu\u002Bn8xE86WHYHnNtEzV0UEqPYU2A8ELsZKn1pEV3saiEx59pJCjTUB5Mfw/STG8JZnBntR2eV26su45nBwUcoGzK6EtWCywhvBFvdHEzGdg67H4U0DxK5nBwvKiabAjZL96ix6QjsxsEBjkMbyL9eWG2Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "EAeYHziICwUalfRWON\u002BgBg==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C701590E7E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "05b81cc2-d96b-13aa-3dd5-13b3bbb73548",
+        "x-ms-content-crc64": "4pUgFm7RJeU=",
+        "x-ms-request-id": "e34985b8-701e-0069-23af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-285598e9-9d82-b70a-c242-6218d7da5e3f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b86e0440cf0cad0a8671b44dcb38719f-5f9b8ed505ee900b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fd15547b-4955-d5c7-f672-af2ab32a94a1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EkpASc9c5YtCKAz63DbNDBuQ/rhIoDjJHokiNjIC\u002BqQPZHirpT0JVYWQ2xm1BCo1yCzyjEFpD3ERdipGOa5YQC1o63i9IWfehqkzt8UfFBpe7W4FEG1iplQGmi4SwxvXN5vsTRixd6fEFAaYNlis8WIQ50w/Ui\u002B/BUUktoY5y8KOW38pMscBrHXHQPtnynD8WqjMAtzPl\u002BRrLUjTjcAgi0hDCdrYg7\u002BbDzrWeBI0WDrVKFzebcnmv8OavQV\u002BLR\u002B0p7WzI8CVI9fpMPKh\u002BB/SN9UN/mVkQR1/XUoWPsW6HOEbIdFcgDR5PwSF9TzWRMakx4YwcC\u002B5UGWXNMZ2fuURLhQRhtdOdraglL5g30zhqBiEcnY\u002BiauxYdBrxExuA8Afc8Yoxb7vVlHPj9xxWXEZtout8Qxu0qVoXyUG4rFqMZH9QGuFuOJZlRslb/rPQAdfUg7AwBG0sKAhv2WZ6HOfZV1LdBgFk/2oU1zxSWOqmR8dppCjqXF/SZDLZPh9wKynhQmchMvvWr4QGGy1wmY9diZFe0Hj/LzsyyuIOi4FK5KvScRZDhRULkzRk5AEyoYpje7RN0VqxIlNr7mgZh\u002BPCuzaBXii42gS8U31EWkr6ACkXqxAM/NNRIU6C15bs8ctQYijKsUNhqqFv0X4dbIgIse4/AdyT9f4jMDzaNcJtj6Fx9Dgh707ltgCunSuVc/TGumWo7e/uvKwq50EGh7SfAgHcq3iP5oJfGUvb5RiSjfxIE3tchOHxg3dL9wfN3y6MD5sp\u002BIh8NtPjCZSj0peTmBmE/nQ5An0gKygBA\u002B\u002B6kXodT9V9qNUzy9ynubsNDbCf\u002BF7uSOC6Uw1dyc1gevLkaLhaRoLCFe9EUTKXUUjCEt23YUtQjAiZYzzIH57H01Dpw1DC8obt3eJvqffuIsGEm/bv6RmnU9yvwSOF\u002BfZQfL2hrY43/yAWiUOpISIQq0A7A4PoGCp3Qm\u002B0UvGjZ\u002BPsHy16DHVzjJyW2R/WPnK6XxXjSvZyaGSTamteg6xus2FfvMH01p7Kx7cnET8KoUP8\u002BjPb/90tubaI5qIKFMkwaCW\u002BdkGwxUh3GIM/S1clSMjnYcl4kvNEMgMLK\u002B/8gPKt9ukZTCrCS/SrZOcZ7m5fY13ZIrM/t9VyOgR\u002BZZlYulfQkVRuDDzd5NXUzW4MakOU68iSI14/rn8TpxHmhCZbEupPSV0Z8VdhO33dKqpnZc/AqXnQxlc50OMVWqTq92DvefpDvSDmuvpxcSggYkOUrEFB5hqsigxTVXi5xJaydgPdLfDwI6ju2e5/X5Vu2a5fQO5jqNEGAu\u002BuMGeobLZj/vrkA3SSpIiYUwwsLWq3JHvKGkOoTs1ylusBQfNBRq04A==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "239OWTG3euNTMEd5PSP7Vw==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7015A1FC4\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fd15547b-4955-d5c7-f672-af2ab32a94a1",
+        "x-ms-content-crc64": "aha06z\u002Bdr2M=",
+        "x-ms-request-id": "d3b7b648-401e-004d-56af-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-82f07fc0-c125-b84b-7945-e792db9771e3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-47ad2c051b7b1afcb33cb5839a1efc2a-6bdd2c54c0b31adf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "66383475-37a1-80f2-42f7-70eb1afa0df2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "L655SMrtwLXFsSZFilVcMnvQRidxZpZANp4LDt229FXxK51WoGsVgMK0ZafB7uZAzyWYlg/sasgYOBIs4rHXD7zQU1\u002B3BpEPu8VkvQHuf0e4yj64HV5GBMDVPmdZ6J4R3FXr8ZqGicmTiNpJh63GKbnKdBdyH/FdiU6e4scpttMmU\u002BCsA46tMUF0JJWD/X0TDhWtjnOHnr1jjWdM6KYCatIHIjTNGiYrHUPW/fpc2ozRi9SyfCdfn7UiSHUmYUiacrrDfNpIRfPugXEvsaDDB7Pael3SUO2qp4J\u002BqtGwBbz7O4s/mV6yiEXgw/q2MO4UX0HCTObqyCLMGNRXypsiPny0NHYVg21VKPEY8Yzz83eUakuQ7rnVEHJpc4CJWr6pvoV9Aft3/9zTbCP10taV2CRdwl9QkU/D3iQErA/ty80ybjMHdvJ8HGpuvYGV4D2b05pcLJdeWSw1uSLXc1PM5qBWw2SjjWIy4ab14dPOLv7maNh1kZ810xQG0r3PpKgXotfgPx3Z90U4KUrxaXhYZ4oj8Qt6VlUBIO9PnLulYzz93T/87e/hDHCTPWdURGqcrWoyq7OdnUuB3x8tiluJksYO9Iw4XHmbQuWa5xntrNuFsu5Qc7iJX0D0eg3QtIEVCaqhRlDdZFHwlmnNA7YxlDNDqNdsOB8OhJRLROFry45jhd1uTGWLp06cYNxOu1yKwubajQupqNCKk8K7kh9whMvban3Yw0fOtwGIz9hDv8k3wYH6kT2CudwM47ijzxQuLNsQc1Hesf\u002BeDNUKIdj4R9T4hNGedvONWLChy9\u002BOKujsWaP9M0t3WA\u002BBW4Rod5gDFJzkqktDkLbnghugPeUgD\u002BHtHsc1\u002BhSIgSvBHBpuJeEYnbdDqoCdqMntFbAw1xopYUuje1nRzhmIXCkfgnObeV05h6Au3GVhUHb9R\u002BRjWKkQl7vOy6qHR86duk1XfSVWUpxT9k96\u002BoTmQSvj04c1JAN/Duq4zK2yskDSkSIXCtJQp/VID2FZlpw26Il\u002BpHNHaJVK1287noXvoEQPqGlizjdYkiyR7RWhJXdNgeQjNA3MiimMzTJjFAlwWG8dSu4z0xpSJRJHtXqAqLH37hygy2w3Qh1A1gAF9X0jIZSlhNuJGq7K0Q76hdWuCyWBaybsz4wC5gjQ8v0ZTTCUJJTm2yTWbdNu1vpePL1Iksvbg4pXNlEHo53SuCewsITeZmBAxzABqv1SfvmSpKpLiGAxPsmlPe1D3ziGA7WsvSZ2f9VcB8qb2tmMBLdXdP7zhzDGf3K7OCly/ej4eqdIpsHTHCTU7oCVlmTwGTg162o5knyF5T6zu0es6Qrio18yRF72hFjZH5ivMOgNyh7wPBJ\u002Bvg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "m7I\u002Bo38mdwWC2tAuQkFfKQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7015BF443\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "66383475-37a1-80f2-42f7-70eb1afa0df2",
+        "x-ms-content-crc64": "hZon2Ai6NWY=",
+        "x-ms-request-id": "a00adba2-901e-004e-1faf-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-67ffe378-061e-9f39-f902-f996d6a7d847",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b82e42fc046b0406784581e7736a4afb-5a88a6509c2a28e3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7fb5b0dd-2df2-b3ff-b5a3-3142f7f6defc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2j9mEmBy49W0VabwKLus\u002BGPkdgeAnXNl9vz3kzh99AgNSRb9q2tedUftCy15cbRsWH5PD462VDzMARtke0\u002BdN2Gd49\u002Blr0z4hgC/k5JF7IVHiju6LeV5VvTZMKlQ\u002Bfr4UNTL247Vx6kxV4iO98GqhxWWHfET4gp8JIzqy36jp4wFxkK\u002BeRD2ccKSiNVc6l4zLqmTutwJ5W3JT7YB6/wqjrD7iDF\u002B7A0En6sugVk0Hzkut53UD\u002B2v/ODU9Cla9YbGaPolYWIstEKcjxox2mQTlTB90jNfVX7CS4tQqfjjqqkkaBlfDr7XAgJaOH/SfiJ8wV753SNSZxJ7YxXW2wpJuOVxDHFLtIZxpdAxBBz\u002B8M1p0\u002BiZ6cyG0gEG46upASb4EYCaYXKwMQzXhzdSIWL2fHJIbAghr84Y6jlwRNDbyKSpOfKcZI9auKLbwWKVM7GeEGY4YJQe1mGxgnY4QOw7/L\u002BSqOhvWRjj7bNmRu5sgraI0TRqomcQi2KR6uEYIni1oMSiAovILrZNVXPguJBzRf\u002B/r2\u002B40VpXgh2F3m83y8o7sKYpyYArv6J\u002BHEz0L9PSHqXhWHMI/M5pS4BuQ1BHFYqppQfpSXt/lO/MObQNY1JJsr/JVnJXMrTXv37/vXxRNwfCSorL6NQqYcSDO8IaXOgtJJCRfb8XUXJTEor8f9dzewKtSxjHfcnqn/Su0/bxvWOW0pjrwLpHqvkYeNZKLeHsEMDAbBDPZqbGpt7LaX58YlUmZq0\u002Bh7pIZaAfrwXzoHESwcM1MFBSxmvyJBrcfEF6nBaBI8Y0rogFeAZwsLah0wZsuKi6RjEE1J9BTGOgbOlepBLucXyr3hI7L7hJ4ha1UVAUb8OYwFblfE8n8mIlZQwdEQujsmGJwdmVfxZ5uvGJjPsSjPwlxuS8CfQshOywFcqsLNAKEZ7uiq7qA0A/bMFdnWVmEtgP90sn56htXDzt5GlLzI4gfntcIwJNO8KjfZ0yz\u002BaGSQLxnDWF4ir1gS1x/B7X9J8zPB7qCu/WwruIhGkLOo1WZ5tmWjBZm5tRZqHU2z\u002Bky4j\u002B/5LHnD8TGtp5/V7A6kegG5WDcJlu2qGCmKROAud85LjgDDr6j8tbUz9W3549kXtZNMCpIFvvjyXxRAObxRjy/Ril390NpYzKJx1aGPsCRQco9M0n0sNd8X0VCUrHwI4mY\u002BGFl7KeTI4z3/k\u002BlHYq7v77ctBLyytUSO1g95xBAmaOM7UZfa1Viqg\u002B8/PKH10G6xpLzE2925e2ME/EPVTy8t2Sr2DBEHFRpegoDNg4iimQWQyB9TUY0VgdYkxekExTTAAVOG/8RNqp\u002BiZllc\u002B/fqYmNORHcP2ned4IpK0k8xWc1MDYIg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "wVd/7loFJCw74\u002B3QaexWiA==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C7015E8BF3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7fb5b0dd-2df2-b3ff-b5a3-3142f7f6defc",
+        "x-ms-content-crc64": "GTc/XHVEC8Q=",
+        "x-ms-request-id": "ec262241-401e-005d-35af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-630f92d9-081b-2823-4d9d-af3cb578dc2a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-776db194eebea0790debf86d1c5492fb-7e2b561dd110656e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "690d5e46-8d44-1800-1326-2078ba621b7b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "aAvbA26\u002BkfOgLYQHEcnBDudcVGyhzhaXApfFon9FyX66uTPI5dSzkyegdART8/7qenp3iFLLupn1QwHX\u002BO5zWmQGTFeV\u002BCkSqMBEAVoRRA6Z2ygFzkAr7v6a0qHT3Jo4LBmgTaamVYFQZd\u002BRhrk\u002B4//yPR3Gbowj2l1Y\u002BiWIP8wmDNRBcfdn8oantGlhmmhFW\u002B\u002Bi4J58cr2MfXJJTVpbyCYSa3rk/XIIi0uXH7ojwUD1E5425V4tqZoWtPSFHqQrS\u002BtDTi/tYF59mlRT5VIDaLsxUzq7JOLH5cHgzkl9g22ma9PO4HIRCLNAuUsJ2sNHEks4U8pqbyYIe2ltDJIV/xbnrXl\u002BNYhIIEuHemuXvQr9mbv9RS\u002BiPPutxmUJo/shK7k0ISxJyN3D7zN/4vS7cb5eb3PWF7nnRXF\u002B0W8jP3xQZk\u002BxYpvdtNHdOVX8IlkG8lSmqjSHShMATdy7y/ZuoLC2LnylCQ8igLui\u002Bd5k6yIXd98afJRIyRw7sRS/IejabpmlRfTdYehFhCl45VA1m2K5pFQWVCQbbmVfalf6Yl7Tx4pEvqYuOhb21fdq0OPLBRWyBn2Twxp0idaOffeRSiHLpR3G8N28imo\u002BIH8ssZ6BlGRCR1zhPwRw0DXPoLwfZYrWnyrGBRU49nsTVaOaSNg4DOiSTgPF6WUZVSCn7OqtH7r1VhFzuo9PCVHgzepg1YddlpPUjBaHELXFra/0kAmRZjbopfLGxVFYQ0Wx5Rx7uH\u002BZSlZX2ZKjbUVbrQ3gWnhHT2e0dy\u002BVltFBe0nR1SuZSvUvW0WzOYyjRDesahdEeOjMapW0x0BPA7SEFV5J0pgawmMXsP8ylBXaEDP46Cu6/QJgBGqV5IK031eRLiMuWXKfkqizLMfpmdZ/2rYNVxuIyhhb6c4thN3gY9GnoWXxq7fBWFWDB9A6d2qUFQrMp4c8CWQL03CjcQ7K0sn2Qfhwji7/TP7FBMJHIHFjmG7SFLtJa5cA5thHHedHuTQHRDVyI4fczFuIdgShw7L\u002BQNif970OrNVgcKdWuC4XfkuOQNw78XXm9kdfwPWSXiIlSNwOp8F3\u002BZdgEbPghRQscPe5E4PVwk9juQF1ruzgzRGEMG9SCdeJFkdF29/BBnAzM1D92UufUIaNqu7AAUqrgEOiW1Wl2mcgL/w7j\u002BZvorKQQnqb4vTF5N/pxF/pyRX8mlucH6sbjVnp3alOZMCfHQc7ML7PD51P3HZ1uxUHN2XnP/WL04MHdLQhsgVKd4AfSaZXrZlWLIu\u002BTUI0pdJD4aZDZyTLFEqENLsJrVyYBGT2VnJur4nMkBJqzIZA0s7i3tFeBhBbUzVc03ndTX4vJUjdPk9f1DIcd9YRYUfERA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "XC0shTfd/4l/VG8UdNw1Jg==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C701614AAB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "690d5e46-8d44-1800-1326-2078ba621b7b",
+        "x-ms-content-crc64": "WPmMIkrDdLA=",
+        "x-ms-request-id": "d3b7b670-401e-004d-7baf-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-8e1a767f-9980-cc29-052e-df05cc827df7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fc24af5b0f6316afcc4d006c37705f7b-7b670e860d3e08eb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "99fb2682-74e9-5cb8-f731-ffe49e6bcf2d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C70132C769\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "f6mr5mShMSBolynmliRmBg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "99fb2682-74e9-5cb8-f731-ffe49e6bcf2d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "a00adbf5-901e-004e-70af-a3bf0a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "kgbK/eGWU6aiGbysKes/JiOBojC\u002BBDaIosSNEMw7JwcFoGuUU4f91F4uMj\u002BqhhkdXxm/pmbJbI7QQVscCELaZvK0poiAqtOcg87RkNH23hyqb7GyfIChPDTdxBEs4cscU8xM9d\u002BQnbRGIiOY99u82WM/cZmRJ\u002BpxE2pUoubBcKECtTwFqeg8GtL9bFldCERYIOqu7G8yiizh2\u002BF0PPvNhLKBlkKety96AlfHk7qREwsl\u002B4H7EoMx0CoQI84GyN3WL\u002Bim3HIBuWm7M\u002BoYa/ZxUMfWT0B50XEvT8YYjpNhczp58GPS6jeZI0IXQN6YGWQzn9IGMHmdXF52d4yr6SvVWcCwnnuTnmaPPSv9YpCSljVh5e7BWkPB3JMFXHKr7ToWQuce6HvpoAFrd/JNn/rN4\u002BBWSgQ8FP9878LnjUHz5E/w5x\u002BpdK66eETtVeNQczyYOHmSVKM12i7novi4AhK/eJKjXLjaI28ynNG/T74bK3yGTlXIYZCsuwzxwdG1AnUxLt1RrRaDvhQKX7jRdYtvy3Z8MrO99hYC9qGr6GGdfJlcjSDgyn5lApBAvgHX2kWBgfVbOM/CdDfHTrZ019WzbOIededqjwH3Fy8jfTcUKhtcKmZrQUPJmRnoGHvH8Cq6jVEeuWVdF/L0ZCGgnvcAsiSaGK1uRyufVNvOgXaFMCYEaO/m9XC2/hJ0dt0hKfsi6GZXLNh8TEYmf2SJj5V7bzP7mzUHGbyz5Bmb\u002BdBOfSvfq5kQLQNNhxypv3UMLG99\u002BQepJo7GG86po0i\u002B4VJ12AI5quT8akEwrhMZXVpHp7iqHgDJpFedGY/KZ4q7jqbJNOdz04KLgI7FeXh6rL10YvyPFMNSqzOrm5BUMgO3dB9tTyly09M1Hp1yBCrfImzRVQWNK3rid4izxzfyN02KDgVYDV2UAY4oWvYm36cJzHkjgtz\u002BKUili9egvwybQ\u002BdP5/UlhhQPPVN2ZdGDvJfgqvu\u002Bz7Rxi\u002BS8s4KG9EKCjBcO1viy40ZkE0WJh8R3Ic4/vxUQ3XQy3lsQadKSiEkQ9Ni6deWfLsa1Wbtv5wQgRJKzRjQtca\u002Bi3PecoXpz0ov8eJPrvazpoJFOW4S4w/dX8CRA3kIU44IpF5nuAo1MQYcwc29wNYflyqai3xUr6RgARLFVMvNI55UQwqYT\u002Bp0DAhr8iE\u002BH57qcWhSccgRt/S2A7r7c9g6T54vaYHLh0s8In9z7LmDIeF32uNffrHWQo8R4kgzfJwsLaKHErYZIu4hEk9Incc/Mt3Vg5j03tDsWSbytaEDCKXfR8MW/BMrWrf1PmhiiaTH1rNuXf0DN1LNmrWTKmlJIgmpbVoAJDLKriThA5xoidN\u002BKuLxkK6k3Aw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-49b8a06d-0d88-6fc8-bfd7-1a8156fde981",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-41eae661c3c424d431709c5a84d793e5-559d5d56d149231b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9e406651-3c76-86c5-e67d-d60a45620936",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "EtTxpgazWm3KwLH1PLaTSktNJO3Lkx4ZbFaO\u002BDuDCP5byyLbg592vE47N2KeEi/lfgSlS2UdFX\u002B22DqvJGIxRriymXCTt8es1mefj1y7elknqXk33ryZPbajJaplx5jrCvCq63m\u002BUcY8\u002BXX9foUi\u002Bl3gh3vo\u002Bmj7GVu58JIdRg/Ps4VrEY7gaFez\u002B\u002BRHm74wgCpMhEAcAxCIrtIdBWAzH7NlLssAt\u002BnP/x4jNP6Es32ciXBo0MHPsq914mK8w2P3gNwx4W3zMMhBfYUh\u002Bc4RBPpUgHvwy07xlnscitSGEjy7LLQiU9EPqVinJlI8rbngZN5nZ0LnBrWNP0vy16b0u2tIZswa7rEoRNYjSaT8tOjBOyb2Hqv60yb/lROGHdKys2vm9EftxnUtPiJrxL0QkIpiMJx//pzATpKmG1mdoicEcJY5FcCh1HSwyN\u002BIjg5o7gSIJOw2MrTOJqW0R6ocj5z7Z1Mn13rKwVwnzzW8N7\u002BEPS1VFX06zT7hau4a7I3JlDhDjSe6QRaJvWOPD2N/Eu/mMAl9xnoewJkVRm2Lr9TPXTr8eaqYyfsWy1caqr7bYlj/NLuDTM2\u002BJMyNpfup/Q6OwLEogphETWcNZ/sjAxbaOuQVjHsZTBFtPlXeCyMAbc1JjOoNst\u002B/uudUdeTSmyC1smsXk3GSdXSgu0NCZkFDDfkt2XcrzYcEVdGUxNYsmqM0KFi46Nlcthd2bPecfVSlEWjrpMGpiuXjEz6f/rCdcyCgDT7piiQg0CNftWGPaNh97rNuQfXii55z1dWbvbdm2PnX\u002B28Vu4ZDytSdSdSEU6tmIg/9LjIqvoGgdrVPhRNr\u002BNxouGxpZzIsK3YhRELJ74EqNZuoaarGrD3tdUXR80XAMlD3HJo\u002B/Lrd0QO7CHo/1oYzJVB4w48yoQwve/LtWjcxYBHy0tPm6zjgypimC6TCrp6\u002Bns71SG/AxHqOD4HH73bLiadoTASzTDkYl/j2i5VnbM1TLrxpPBiiMQ1YWNy3Gdsi24H8WmGaClGU3LF2yTnlJqKzdMC5YU2Pxhv2W/RdYX4d1LATaxJsuCNr1V9nK2fUczE6A6UaaHk0bZNGpK9cN3syWfWI0buQR7udToztJ5uzIufDI13YA2w23/5\u002BJRR0Dp7jNNFyS6F2qbzpfRntR0X4k4HHmRQeWlaIUvK8EiGnKEDtCfPJQNdFTHmh74ZTSJi5hZKSrHSKxdp76vivupeaQlTZAD1SL1KqgkyafGrQNQpaAoyPFHzLY0MYTlbelZLiBqwxeUhaZ1Y/6Con70hvqrTuVbcKCi7XDZz5OeH7zOy6uHa\u002BnrvB/5s2TytSo3T7qaOh70Db1/t\u002BWmurYC10Qxw\u002BbTfSsQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ahmKB9RelgG34N9c9h3\u002BZw==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C7016604E7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9e406651-3c76-86c5-e67d-d60a45620936",
+        "x-ms-content-crc64": "d\u002BXlPyiPw0I=",
+        "x-ms-request-id": "ec26227d-401e-005d-6daf-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-f3a07ed0-f6da-b921-4651-8822c7b5e1d1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b5454596baf3f010c87bd3e30654eeca-6fb3c46e3d6b2932-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "93f500a4-8267-c992-5117-71bb9f217f61",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "lDqmPWKUf4IJn0KPOUry7ZeOF/AmrqTsS4mjTCLCVQyIk30moIfhzG2kxev3bRpQEE97Tfj\u002BHeWWuvLY8DJgR0k1B6bMzE0QrEqCgem49d1vUzzTRgcTiXWYj\u002BaVCds7Q36hwWZzg0QCaqCufJv83sQUaZ31jABCIn0wNDxme6NuRj1qFzN2\u002B9D40dxnZQ3am7EhgJ8\u002BRrd9X57oQk4Hm\u002B/8PzVdkcaRnm7M/Lok2r1wVpiKRfoELwCG7beUjbiB8TbsaiXYfQrqkOExckn8WITheOy2fFX0\u002BA801qQP/BC1SwuEOHCXl9iOoLUY0r23iZQysxXLy3Tg93EWpKZl25TReyY9eCATSeAUJ9yg3CVRfEwQ3Ej76YCXo0H/gfMyKMUhR1aXehFzHmk0t6OXQBtLxCdZVf5L1pKmpdTfFMft4f4Xf5TOugI7nL3fxzLcAGMmtL3M2NLH1XHE8dQ9lAqhRtWlf8CGfAolHrlAbA5fyaVwuWAKIAkrUKkjCsgt/QizPYBcN4Cinzeyp7oZhmliZCcvzNuqliXMeS8XYnJB9yCxjS6OA5IlzhkoWHlOEslAwaWh/jEtCKZaj71QizzEcK\u002BZaPk602GUCf3Bgj6sfmdl16HNoPnvhISHNHPU1EPdZOfKtKnPBe1DDPQza4ZorhFW67Sa99C2quN1s5/twDW64x1X4sm9ldK0iZQFuxj\u002BH4ZifumPQmwWEwrFWlJOVky\u002BeIdoEMxHmFXh5m08se7LdpMZi0FMK6GxQM6/9zuAZTNHRkOQlg65GuaUrVv/2mIb\u002BuS\u002BNMsLckzmt9D\u002BiKAaYYA69GqrOuCEX3Bat35FsWVro/1WwTFoPNP2qt8\u002Bu5FGekvaxOb3cL8EOtVasLrOoAVrkuWjw6BP0reXtJABRqPeFD0yaux/czI9UoZbDYsYJwnZ0iiso7ari/IuYLwvAvQxe5x8nDUY7B\u002ByZXAZ88QrfoyGJ3N6MnCHh9/6UBN2DU\u002BSKpHvm4vUweYJ\u002BT1GkZcuA\u002BEvqduAtkgs9RRVHpwMPFgghskyPOIBsWWMcTkzQPVIy0wxR2N0EXNIw6Z2fqNK/b3lJQrN\u002B8b/Lvd180UP\u002BLUfDVJP2vT0rHRV6nk8ijPCQnR8TRvqetCFMhls/h0uOcrxV3FR\u002ByLI8XiVeBFNwqPEs7HRk6uZNJKByajbh65XJ7CuSzLCcUdRtFyjVQK/OG91qEpsXaYeVyPezzF67GnJPlBgnndxAUJqf95O9d6PwpE4Zt9k6skKkPMO46EV18fz2haxXpn4BKYHAd3H0GFETgygQYWJZVSHVQ6DYh6gVagWWxvI3mP3P2I5XOjrQ7\u002BRyZSVdJVCaXXCKgmKdaGHZ6w1sHRGfA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ZkXjYVyvEj1XxyVKslaoSQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C701647E7F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "93f500a4-8267-c992-5117-71bb9f217f61",
+        "x-ms-content-crc64": "5i6bQrRf5aM=",
+        "x-ms-request-id": "e34985fd-701e-0069-64af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-57c6cf26-e407-e26c-7055-1dc980016198",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b60b647cb6afe6e20c8ae09e1a29c48a-dd76eaa130a6db34-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3869ac59-e0e1-1fea-fc3e-d9b684f486a5",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "q97hekBETxafbcELDxQ1PSj3lqjC6sACQHvUAYNhnTbpP5KPVVhwx6kWtq0Sr/JxNOvWmKeyGsEe3jnEb06SPdCKItCBpufQhs/\u002BqzMS75GIY8yYiwSPNyTQcXcerFdahHndiI0i744DBRHXs26NC\u002B6oPAyB\u002BrLL\u002B\u002BursTRvstp3oye6NWcDZnQ\u002BlIXzt4O1QmWIdW9L2YnGEYyhdj5Zk1M3Xw9H09WGpdaYQ2Us2ENn9W7P5jxqLMqd8yTaYe825QAxvFhzbm\u002BPAtCZspYjmThJOoHPiqwXzDJFqd\u002Bxq0PnYV1k\u002Bxzr84f\u002BP\u002BRs0Xo0eVnrkSdtZltUGu8lLsWP3laNslA4v54cXUb60UrIqvu4ES\u002BGxhobefsCEOAsxsXCb2GO3x4p\u002B7q7zjPgc5UQjG/0bB2VCRc8cTlVNa6975eBOGHpOcvcjxV0y/fmOgVm8oRxOFmoLGZJUm3l08UM/d\u002BbXzszJlKkF9wHID4fVTYz7kMpTLc\u002B2Qv7n\u002Bdd97tPaM0YStvKMssyzCB8oAwoKvw3suWC4rEoXYYwOIZqRyAgt7hwBgtaabt394CWwTj/03XrJkXWzYUc8OxVmvpEx4UAXOhUtyPx3EkpCuswkZxNMGQRfyHbSuoyUxYeBc7BMzD6lmVQqhxR\u002BUn8rcOa615QCGmWM0djJBH\u002BImMM0td6aNe6Nvs3/IZIv4bX35wnl2i4zvxlKv/olnFTUYi4RSZygkXr37ViGAvjTXPBjEV114r7VATaFD3X0Z\u002BK5Kr9j3pfZVxWO7eyVbXxgtyMJwor3Xr\u002BvfAimG0IFA0W2DRg5b74YiboHpzSSP9P6JFgS6qUXwYw/tKKPc3vTiaqnH2BkJwek8XjQr/eLHXx0q/cp8ljgXgtMOfrbiRZ\u002Bc91KKuBzlj0QbfksR1HUtJdmWoeEqZdRhsEU2C1MyWgiUjvaAPJbwRW52URftBb5t4UjtW6O\u002BYoGOGPfXr3Pg6SRCfUV\u002BnOkyllxytBS8hLqGyCoaRP5k5hx1AiOvGKX6hXfzqpho/1RfqrVHS758wZRNQOdZ1qQl3Yc5CYrFk422eD6syNoiHdjVyppJHZpt\u002BECfUcfOkK7Tzc0BP/XJihc3gMOP3/i6KzMOhBwJ7L/8ywE6NjG19\u002BeP2QsNEN3TDDCDAYzG7hhH5TaUsBySydEdBGTkn1PlcZjr8Ab9rQpVK3frdusjJezo4lELIUfK7Q8p8Bxo/nzcrY/z2u4RWjgsP4Skt1L16d6H\u002B60C2lBBIQMHw7z97D0LDtlbL0sO15gY3uHDJjW8NAY94PLfycMvornbGYaLLlNXmah5mrqDiSQE\u002Bft\u002BjfrdW5\u002Bmz/s6O0UWK4yRI84RnaCOa4ydMplQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "TjVUx6YRXkPQG0k0y4swKA==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7016911C7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3869ac59-e0e1-1fea-fc3e-d9b684f486a5",
+        "x-ms-content-crc64": "4J9Df1V\u002BPo4=",
+        "x-ms-request-id": "d3b7b694-401e-004d-1daf-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-15cfddbb-93c0-c2a2-b530-3403dca06349",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-eb9ad89b7dbe3cefeb50c955e71935e9-90da25b9a02f0689-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "98b1238c-d0f9-9055-509d-de2f45aec40d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "1uU1NvPfJVZeNcSuASfjAY9lslk1tgZV56V9ImACq5QjZeHjnvOh2oAnjXc3zBAkDNpPCJSMSyDf4E9NYQP1XIowi5xFAGOcw9fYDiiOHRqVWRWFs6L/lxnBBL2jU3l8MTHtB0Fz3wx3skS9sz34UMM0twjub6joMPSCg/ul\u002BHBdXNz2oRbZInoJDgBdQuTcybT6bptxjsGJBNZN8FsQ0bnUX1dgAa6sW5WN5WGniu0PprpHq4rU7M0bbJw/jDEe\u002BD1GiOONfMcGThMG46lg4XroPUqhySYvAHKJRJQRbM9kbu0kYQIKginyQV12zgkkuosiV07mfS4WFohwAzcz9OFEoXS8PIB33rohr4jJuTJoZIoJ7hWAfvG\u002BDUp6mX/yvkx7MSyVaH4Lq3iUxc6mTV1VCJ\u002BtKgbLxCOC/S41/UQ7LvA7TYcF0/sL/UOc67gjF8DtJJHfRJRGr20JEmpQ1a0zWJbdagDVUDWjoizDL9hqX\u002BZuSNmzW\u002Bpc9Z0Z\u002B8CQuyiVaZIiRay/F9NcPKJog4CUn7KE4YzTgP2sgXViu1R0EuYDLcZFRxo5rjEGVx9H9HIdhVwNDNmbwuiVdsM3XVt\u002B5ym7ZFa6T1eYSzJbzSjeZI0DRTb4ZwYNaGvdsNFWAlDWh3D1i5AbYjYEdMCnQPTAtxE2Mxgkhn8jrvvr3Z6GQknhhUW46Nj95\u002BIA9PJFZid2HPnAH844sQHw0t2UMISXfjJ3xbuuB844OUw1I5KN3UjUdMClxiJ6qdNExxX7abZdaXbAzqBsxxQqh\u002BaCAo5vY/WUwLzE8rcQ/RzoakC5PNCV17oczQ6nZ62rez4796ZF1WQgZqj6mXe\u002Br9GEhF3UcUsW7SvTU5bm7FgOGXZ51AV1opTcmNUnmj5CXR09I\u002BNP1gnzJQp6cYHNOXlQ64AARNvLDuHI\u002BNh17lLtkPV5qcl1v0Jthq76\u002BjESDl9b16\u002B9QhlBcRQBh94xfja3jeCMVJCw2iw\u002Bk74s0ROvtel4GRejL07cNze1czdjOwh4Qm1RhrrPq/yCf69aFaAAUdH0uGQfFF6SsB1Y\u002Bmf02le2tI6mXi8vqW0aIa\u002BfgSGWtSFlboOjWC4OvtWddrCVjaVXpGESWfKixQ72BPOv8i77wUVFj2vUEltfmKBZkjO8hZMJSN3AhFsuw6l0rVQ7XsynobRrUP45gpEGssBSSTPbOX9fpapROz3pFsvCYGUHJDnUsvB\u002BUTWVz8VMudGb3Hp2mHPU27ghVWZ3gjkydyIr/46GfpdCXehKytblBYFrTjpRTMfyMkiBslyKBs/7YlijILpDFF3iMzuLihHiPFDlDDT/4CtaOcxFBcw6uFcYTmd9QeTGKDndbhiMZqc3ng==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "v9kgjqRmeQ48eUTMfsvPnw==",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7016B8258\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "98b1238c-d0f9-9055-509d-de2f45aec40d",
+        "x-ms-content-crc64": "4IVXu1Ywsn8=",
+        "x-ms-request-id": "a00adc47-901e-004e-3daf-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-f8fc0667-8aee-89ca-34d5-d832effeefbe",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-9e1d54f6c7c5256bac18ee15f3b945b3-a421171e440c2777-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "61298cf9-ed43-79ac-b5f7-4b440327ed54",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "5HI8qWX6ax7k\u002BiFyE87SJQ1nVS4TXX1R5lH4/dgqKkzGnaf0a445fKCGFaDaDxl6FMjwpzt6Z4f06sITAW5FutDVq3Ym3rl\u002BLtiNjUfdd9c3fekQOYIQTDUg/4HLJXoyQFvQBWOjUzYOcXlj7No/FnPr3IOFNYBNxV9ABt44swheW0zrDXJzlCmyAcgJrF9a4OkN4En2rQrbgj8DYk1X1b5wBZGOVAkBeEdZ0jS3QxgA5SX1K9O/Z61BEIoybzHcWysKmafOzIzfDGcBnNvWIz4nA3woYqrrsJ3jTEN\u002BzggVfXcIrapwMRiYFR5rvcrSa\u002BxLC2u0s/iBH\u002BgJ6oBJYT5f6x9kzXWUttJjj0yMf/LTEeBWMsOcYMl\u002Bh47CZkeYT7TfC9Grbp52t1SZUCSs9J/1Ntmg8i97wopV5kXn0k\u002BKy0CYrHMhKKJB4HpuAhCl0ZPvzDBt912EZElHVYhYj\u002BUEDoXkE0cr1A42XhG0DL96rxSy9wUfHdPiE0cq2tIa6FCVafSKwb5LxPgiNphL0FiJzKZzppfg5fGxAf8AAPo7HHbBH6LL7\u002B1WZzMM/eY7lkPvoA0rpkK4tIQC2cC\u002BS8P\u002B5hoiirG1vty5HT9k0\u002BcKdmq8EF/sD3UzCGodyBYsmBxwDhfLGAySOeIxcokCVOCd92NVATpjEdal74FGl/XFjIUj9MXQPl5eKdd9up3sMbOJgNGy15bhDPxAJiiKS6Hta\u002BYE32AbzbgF99di5lc5ub7NvBckE7TvQefJjxg10941j0\u002B36FFTbrMYreC\u002BfialB21qvI\u002BKyVgxFJ14UT2g0CP5LVYHgtFsek5jC2XUMMLBJIiqyhdOq8b2htOz2xx2d928xFHPnYSc/kJBJr3yXOTbty209gUMq4GQEfz9uJ8x7ZSIF2xw8oYDDcvUDYQIAynu2CTuwYHXsBnPPouInkWjDzgoakR3asSmsOg5N538iA3SD997QiwTsGdTobP6e2\u002BGMf5M35jld25fSBCYnXl80rZ\u002Bto9mKMwMFbrdJMkRqzV5swWesKh07ZhxG/obehLt1s79fMTfHwkxQMneB1KlTZzbH\u002Bl03SIOCcj39AzS8Jun7037FC9wmpP7bXDeluVFy85eQFooefmr73P75yv9X08uNhgEqjltaoVVeG\u002BxL3LjsSk9c69Af3ZUTyS7dLJo/g4gsGDNQSGU8dbV0gCK\u002Br8BGDYBv\u002Buf7behsFsUsfXT7HlhkX8SFm8HqYLZaqx1yVVlulx7Zz8jgMKpK5HGfz/gAuWHKWhA7wLG\u002BhVpxoMKLOYFr/eZV4U6PRC9aOreQSlC\u002BWjG7qDsJMtatWwpuro/nv\u002BqwNBIRqpfTOtYg4YX57nsJswaRD1FGQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "kgf5ikW7seS9Q1ohpZDfrA==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C7016FA06E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "61298cf9-ed43-79ac-b5f7-4b440327ed54",
+        "x-ms-content-crc64": "9Z7NIQmrnZM=",
+        "x-ms-request-id": "e3498648-701e-0069-28af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-79c58276-d42d-93c0-2c03-a1d6af6906d0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-46cd44f76311658baa8f46bf683919fa-63e54a345c47c31c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b835942e-6385-b5ca-3951-8218098b722e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vWaitZOhRELNszyT7iRawmWmRRwHCEY6ZwMFvC20OJMtGVzdm5CG6ef81GXU8GZYbyjO2RPdq7QgZ02Pm4gVGXqpZtTIfCbUIFw0CzTgZXecrEwE5V5/T26nvTRD9k1f5rrqK4mSkPMB\u002Bri2qJ\u002BAPwHV8\u002B48ETQcKRZlIL/ykCoP1SR59TrtChtYAuqlyafOJ34ybgJeItWGzgFzLHA0D2qOp9J7BknH5\u002BnT4w5JdmBul/hAvyInsLJO8yY4et2rJPOAFyLUUyA0aoYZiz/HPFihBJV3809HZvYgLBMij2wLKL4byF49mkTYDFSbDiVyh7bNlnZIMzGjObEstCYMEtsZDWOBq3T6ZGpQn\u002Bf6rFfQraVdVPj2w/SMd4\u002BtEeUey/p5gQHC8dtC0zIM95NKqIxZWweAr73jI0pu9DTkTFKEMtTtgSpWDrvKG4DG6sthQs4CU7benRs8lV22U/ynXYbfh8W/XSdiA0xLtpQ8HDl/DbJl4fmcppW4sOvMn7q\u002BIr365mIGoeSnoFBpkueHAHkkN0ZKQnuNQ\u002BEwB607lWOSjJPWQjbXeGvOvUGoMhSuMa9yqGh0dOBCbKOB1po3awrt1wVTsL5CTb7ae4Q65RDMgtb9ye36HRizlNaSVqLRl1I2ulsPWoDxL1upmfhcCIaStFTDOaId8rnsnxznsPccCOQxAyu1vSdWC5qSUYMfVotPAKFODV2wGMehIrtjCX9jjZATKgRb3fYsbS4Hi6E1zUiRmLBVzfuHgetjE5ts8gEaLsPyCyyH9CKqIZ8uqI0la1Ry0nHPDsCVjKgZ98lbwHss7V3eQsEcCaONq6xbWNldPahG\u002BiCPSyADXX\u002BDbfxYTmAkAbswRyiSVcjNQWMUOjPPu7khFcZanaE92uVCmZynNFxLNlYeLfZ/s6RXwgq87yJLtLFDNzmayWQZ821CT7wsJgwHyATcsY7DoWEiA9qXgOvD9\u002BTqZP0isWzxBDqJPWPoK5v9tSYdbgIjf5XYeMaKgnKCfljXQcIP5BeX6qxTOmT9Odc/msrEpojixuRnSTmmZ4HHBr4LEOrZ7dAPhYRWz0Qx2j7vSuiovdjQ9Xrdp5re8YIqjDOl8ijsZaz6tCAEi/egNm/6thyZH0nlOhtv\u002B0U1MZQBK0MQi\u002BgVAuU7rQm4y2mDPXEr4zplkWzqwLcNfWpmxIOLA2Czj6uH5bQ3XXE/LW\u002By7L3UCk1Zm5nWJsswCIV61emFLMgI0K7GpP6FLjP7qpJIW5Cskro1MmfG3GjgVtwvvYiHugCmqRwPDmVP021m23s46K30zUMvT/phQvNF5k4hVnCrc/CSorJ0nYRU5l76YAHtp24vO\u002B9FWGoFRWYoyScXLn38uw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "DOqaBhgc7uVZVsitDhH7Tg==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C70174CFCD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b835942e-6385-b5ca-3951-8218098b722e",
+        "x-ms-content-crc64": "br8r/bhQNb4=",
+        "x-ms-request-id": "a00adca6-901e-004e-17af-a3bf0a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-7961d4f2-6804-31a9-1245-e1eaba70d2b6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-51e0cc702e8112e3bc9212fef8252794-69a8ed510dd085f6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6f1698aa-34f1-cecf-c6f4-93968b232fc7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3/EagWUahYxcS0zTXDy34P6kmWICKDS8voZ9AWnehTZx6Tc9YnpVTQUY6a8zXGKdsbtoPFn1PLe8XsLfnYQjfsYWYXIFen6DT0td6T6EiGEj30\u002BtdkjcfK2AgAO3dq\u002BB9WrpHfvvmDc85O0Nl1J5ONZhu700dQh9OeXFhfp7zNmb3PPTmmtmM0YYcZFaz\u002BRaB0ctVrryTH9ibOMWKhM8wRgTcbtepZ1q\u002Boh2HAR2I2oAa32yTnUfqZB0cC6IUAkz2695Rl0p\u002B2Gqwlsxey977El5Fb\u002BVinOi9Mcr6jRu4ql\u002BQ0FU/NwM1m8cCIsZ7S1g\u002BITlDjpKnVE811KV/hEtO\u002BCyszjuJu9sbD9PeYLoiAeayvGvidNvNKbvGCWJd9he7syqZzr1cdKUeKL7\u002BiPPVE5L\u002BzMffbENQ3\u002BS/g3K4/Vn8Yu1PSHNpFkfGxExczmCIMTXPnulP3AanSS6Y3LFypWslAmYGRYtfVbZAGKg289FD95I8qR5wrEamp/8EkHmWVF7hN8v6gauqsElyz4OesJVdFOUfNfxM9JXfX92MGsV86YQJFfvFiXXmkjjVPZzCyDdp53tUd15ilEN12yHN3lVD9eY/VVqZV4uveKODt7b5HJfmYnNJ6HJl5oF4j\u002B4UGPPjUQf2g7KckE/vpT763xyMfL6J57viOg1z2a6ZIMfdWx\u002Bv4CZvApjlCZIjmgNzawdk7BMvijF3wVc6QunDw2\u002BIEknfCv72HXolpN3p/l/KAG6ndHS0rdEud97PdL\u002Bu4QYim4f5VGAIbo6ZCeVTTgL3cAK7XI8602R48JLgJuj6toOXx2LX0OvOXsXl26Prmynb18S9M4R3J8gjQKONKEel3pMhu4bgH19WrP2JFPfATRWoxA8kPUM/IN\u002BatFBIQTa\u002BQD0Qyh9jO/hlZkaGrdLQYzNN5GQ4QeEP4lrnRWrOzmuHCtT6r4M2BcgWvtc8uLLMilFc\u002BlzSRf5cAOeEu/aNllfa/6M\u002BFfNwV56b4cLJ02nn2rsZchQOtITWXq7bcYnRiSh/IbjPznSeLGK\u002BdmP7Ui193OF7dCQDzAreJ7cElSYUihjaSrGw2AwGu0WxUH5hGwxBXVSollTEe1WuMab9WZd8aewLIMe7zMSVNPjeknvMvQyqwzeRbDPD1g9cAqZlSWGudSZSFfoEhVBQE6FcJakZobSaElZfqz24R0q4X8oeL6uXMB1VemcSZj3nAViSp7BmAmExyzbLTsno2c6vjGWGMeQ1xTVLhGcNR\u002BwYuGmlJd\u002BaEh2pLCR0i6FTbKCYotnYIQ90nKJ7Gr46JINK8pZgQ7Qu1XpH3QW/gXlUOFeGdOUSQFdaMIk9HzefrwehKdkLMyjsqY2fUAPJw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Tx69mwicpRkZCxqaA3wRfw==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C70177196D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6f1698aa-34f1-cecf-c6f4-93968b232fc7",
+        "x-ms-content-crc64": "lrbSVQdXvFI=",
+        "x-ms-request-id": "e3498680-701e-0069-5eaf-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-5a8c7641-e9da-931b-4669-cbebe8f4d9ca",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-80e9accdcfb85004aefb65da1d22816c-b75e848e4add4ef0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "706e3873-0375-143c-12e9-edfe0fcd602d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "2AuhuPd6XYEjFbpnLF7LwU1B7rZR4FXk7V8LxZsvs1cG311ynlcvWA8heHPfZ5IZFgeu1130dve1vcqYb5jm82FjYE0AWSL2EZanL2jhBYbM8q6Tgdz5EWlmvOGNlul3O4QRewZFGL3luMXHTUaP1LdDzHzpU3KFaU7jmpxAaHutL/Pk0ImAhtnxrcgXMsQi1\u002BgqScpsjegRjBK3YX4gpU9KGR1TqgQtwkaj96WqbTaKwcO0FR\u002BxQKIL0kN3yCRb0Ah5zRmmzyzk/IeDyJVDZx/bLaC6bI8wmdh7R9jAtvohSCecMKAd4/KWzxiXLXgMyGskm5qEoGR4SDNAKodUI0aMYoBupjZ\u002BvkmuJJx2mGtgb39snBtfnafCI\u002Bhs3blqQqzSC8r3nSE0pdxR1XzHArDH37sI54YrLcXZrIJOEeGQQ\u002BHvpI2hadFdOPY\u002BDscr\u002BiE4pP39Ylslpt4EHvGe5pT7wJKa2F0iJnbpq6\u002BP7R/\u002BrrFhFWzjkuGGyf2unEvgvlFiQk00kCLEFX6HFLeslrm/Bm9APdEoGC2wFA5fc4kqCexeLarRyR2OnQDtW34q2jNE75bboIB/OSofg3sUZKH0XAvKTWgO7TxSsaDQOryvhjraGoTzT2ls3vOAskWiejhe\u002Bf9zX4zLNQJZie7gr/9tcP1AOkodAQ2hXm90jTv2rzdocUG8OyeuDuWBmsZ6iy70EkFIYT/uQffy0QEcVqfGYtm3eD29sDTVkitlm2dHJ9JAf3r5rk33eTBJymolkrg9ujfswxPxNmINcs8UiaaQqqou29YtzbSMwP4MdOXKsP9zJ\u002BAvWmS/T0gY7Dt94vCKuB\u002B/9rbhEO2DYAMU5cJ8Q8LQoWHFYVBGb4yNFOF4Dt0NgrvFCrlIkRfyrPpgqmmGnKh5rUGPxFfPeYYqU/sMClElBmIGtjkIhw9J0rVV5cUiB3c4/2Ccfr1k9pAzHj4c5qGoO6MGf\u002BZvcCYxRvKhepPACEuE1AvxiYilosCo1WnRLewTrKoiG4iRyI46ajjLwnv9chbymBGWt7EaYdwmx5u9YBkFjc3pnuzD8gt8tx5P2t9Eq2NT35TaffX4B7qrawDzfQofxTWuE9QpLqUGGQCTy4f94Rw3aoGEKxDX8ZYyGIcKiDkUMBSqlZePKbDv1GP1ZDwyrYnkvBOJm5ok1iE99xYe\u002B5HGf5pyUkuFqEDQlFas4oxZ/2r9JswmipV6hb91UTKa0dnSLuWiwFo9XxPSuAZEePOV5PerINTEn/QF\u002BM2MD1YONsN82bOmtz8PwMe4VNKONg3L4G067rEEDY/xnMiNsE\u002B9xIFDx54/7iy4nF8NDEshdsHAwS/p00gReMsktRp2gQ93\u002B5BQSw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "qtgrHLttiyCfNu/vDNvU4Q==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C7017851B7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "706e3873-0375-143c-12e9-edfe0fcd602d",
+        "x-ms-content-crc64": "1iqQGwgG29E=",
+        "x-ms-request-id": "d3b7b6e2-401e-004d-65af-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-1b4007cf-769d-0db9-d894-66e8f3d5d8bc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-cda6705972cde139d08c27072b2b9e3e-50f6a77053550833-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "532343e9-beb5-c551-d764-a6c9acc17c63",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "INPwOTFP0xs5EkEaT5YQutErUlI2PalR9sCByeDl9HC0IFYonxYaIJtwty1ANwJg8Yn\u002B\u002B7N7ueIqnkNxzQk6VB7RZS9A6Bq6EDK3xYZ7Eb6\u002BINhX5/i8OWdz/QHTqFKRNWMPb9HSIAluQ\u002BqAw/Ncro2Es60w42wlFCzHzOoZ52jgJZAibKLs6wDP6KMOO3V0Fk90TvWkYFH26VqlClMfVFyCoJ5iOkLrl8itYfvIF9i2U7abpZhyO8Q/LIJHR\u002BCsr5NHjJvXEdwMiLYt9/9WLdKC77edhK/DD2TaIw6/pFDnALFngIo830LZjhziRUTF6P6vxFgpDivkhHw3/e7OTORmRfZN7qxHRRB0xPWS4ckgFDoPD9/4vvKFg/wOBeFTC0E4fABNePlRaH5ItEo2UaOyFuizvj0EbYcEx2uwOUAuIbi0WmXJ05xAvqdhsAqnTzJYW\u002B75oEwEMw54SLCOoS4\u002BGpORgfY\u002B6ENLcgCVo718XHc5V95RNIFssCdWUIrssh15I5Z2Fs08GnKrrS1Lbo9Q/Os5VUlP7OUSJdHO55i4X8DjHIAnBUap/D1spoZTIEGYBlSfsl3TKTawZPD8bTLa805saFIPKfakj1gL40ZevgSQNuFDGaxjD/JKdqFVrY4KkrI45rjuiNxe\u002BiIEyEXvUqbsazdRl9qhCVhfxbJUTuLJAFGTJtdMoq0E5B6JXketWiT6aUFXufvYl91fjsMqCatAOsf0XCvOn8mJTLK7F6oRsmqNWuWgckZWuo/67BPp2tpySSN/uP74LMp4zW1IHX8yTtxYnK/Gn8iAnqGc1LO1oHHYSM6HkflslS0aJ6TZDZ0PyJ43kD4qq6lb/hpcXFcXwy38cNSxq73i7AeBq3cjp5AEjAwUfQ8zrZwkK5LeEDjWA2R33J3IXhzgVaQ2qAAxN1aKWM9LAkUeyMI3jH8qBNvOq6gTq8ryOy7vNChq/AWc8/M7U7hpigEeWRTbkdKdtlHIaPxXHoyLmB2hXM4ds8y9mpmL7rAjZSCm9FK2F6lbUX3XoZMIRNVnsLubyC4zAaVHHvY5EcihpQPcsSk51YBzRQpQRhI4tFXDJD70iJzxc/Osb/myIkC1NvyQK5OrLdo7J4Mk4rqTDmmhde2JrBxm6j42jWWHwCLJmxAVqIjCGPZjuGEZzJA4GGCPEa1SK4ngKUFVdZ91s2dgWkeqfmbg3lz2JvS7TB2u/XUE\u002BK51d2\u002BHNX5HbKNW7gX5uXJIjpr6rzJQWwWVJdwjp3gqcLu46uPXI0jnmHG5oDjuwZOrZW7aCkh8JRtq8RChI8UrLH1KQc6OcGpREhbAlrvNpmRJeEEJT2ZyPMXIbTE4RXWsjnO6pH/EHfQEiQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "9bG6Ly08p5M1nXiQ3JioPw==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C7017A9B5C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "532343e9-beb5-c551-d764-a6c9acc17c63",
+        "x-ms-content-crc64": "iaJnolNCMe4=",
+        "x-ms-request-id": "ec262320-401e-005d-04af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-fead5347-0ade-78b9-658b-3fb8e373381f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-056505892b852830f2b7faefe48e0984-e50d61797b313c1d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cb15e870-0daa-0378-f47a-bd0c7fcd6416",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C70135D43B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "EPJy/w/P53H98OKjNB0REg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "cb15e870-0daa-0378-f47a-bd0c7fcd6416",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "a00adcdf-901e-004e-4eaf-a3bf0a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "KOv1CI3smUM4hT/ileNWwCRSZPezW0V8JZXfAnUtzNnMHTw/tC51L3gVHuDNMBQkwewjwE3068ymeOL4DZbOC7hlFXimFgz13TR\u002BnT1lr/SAu0CICguM2DJvmTtLfSLhRxInaBucfavgLeMYdU2PQcnud1JWRQGt2DxFN3zRqV8RnVYqPUbY4z2UqNwnc2Pk31hxXQbQiwIReo/eV0YuD4SEB9f3ZQOCFZMUwZ0lhmTZYFckX0xZQBFUGcO3\u002Boz3ZplYo2yL7XpU7kdyvMlk6/QqBfbuCq83K8bGo0xAyxsHHVsEzeL4TXPdz3EE5oRH7y3PjfWVCFvpIHemxUotEyMsa55uYB4RMreDETs\u002BMkRBfrMfcT4lcRQAGqxrUYgor7tN2Hvm2Y8OvVo\u002BEvcgq\u002B0zZEaWDqLkBvqKbkVypuAuWmF/8FrJW6UkEbPj514d32\u002B\u002BN\u002BxBkaEZaNGBXGpKmxd6D7iWoLqTaQmhcv3uAR6bbI7VtG7z7MjAZoeISP862XWcaNimhz\u002B1K83jnx6kK2ey5e/cdOephyLv1ToyCiEKZ5iHUphG9eVOIIigD0ypHDsg1WIQXWWO8uG1trEFgiCr2DiFHNjObPAJjVNeCHfVRbn\u002BEjS/\u002Bgkz\u002BV\u002B3kD40SZ5o9DcUI/9iUmlxB9ASL\u002Blp4HD3BnDr7N4uUiN5Ftyy1EO09RRAwSK6nMDLTvM4IMl2TbDNPUMufAhY5dDb6TuNvzKMXTnVKR9OPGmwIJ7q9TJaAsgr5JYAhnkL59tR3rOEPY7Aq8KPoCSRfgHZfVxqbu\u002BegeZyYdqcjNfAyUFD/V22K\u002BIPKklvymKkmmWUJggcoXnrslzMEtyzIx/rztbiTYGjIlJ5W0OlL7eEzcd1CGbOoyjIWEsB6hgGWwYqg/uLwUzk8QO2okY1RYKlSEUUPhu5HSquGfU1ojg6c/88e6y7\u002BAx6kBdiGAHikxLIXKHT8R3rcWXQ3adXrk7Ley9G\u002BMrW6U84mq4EVgUpy4bibUWWZ4LhUQlG6xtkIuHIlpzRm5pI8nNSmlZv5xpgphEhdUEINBSsZKfAj/001HfMPL9oVy/smXrSRMwrcmru5kQKQ62fv2KHJTbzh2J1HsXfoqpa907hNNvGNvBHgPI80qm5KpDKLHxd4DL5\u002BBIYXSYGTM\u002B/k\u002B/1KA7R2YlyP6REtrW5u/Q0FHYu/RYc6DzJrtjKQTQifT65wwGC\u002BFPz66GNtEFdXqEy0TdZkZbY2T/SCCqwqP5wIjl2//jyshsiOhF1jjP6a1A2mG/8yOun4erBsPApQkOiHZII5l6pPx8cN1aEY0oM15zaehCPdFlOzh4OMAIr\u002BfjO03Gh8oXxjVhP35GUI32ftdlUTsgzEg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-3895eb30-abdc-08f6-b9ce-339a9dbd481e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-db7c19396b0b58cffc407e20ac0833e9-2f54983039fa48da-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c359ce1d-b1ac-dbb9-c1cd-1b07b8d2ced4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CcUDORjNoRQISBIC5IRaTQTGbz\u002BANmnQ5oztyShsl6PMebtX8ctwKZGmhReLScfUUDYdFqeYhdJbM1KL4NfrnLFuNWvIA1w5VUWu2bFSRJ3FGHnyToD8NPTp\u002B7145Em6u\u002BlmHBNbC03a48Fi6qshCe61xsdd\u002BU0wcQF23weewXD78x7H7CiKaQ0sGGu/mUpIx/LPwh6CXMGbNaoR5StGOyJQZ/aMWR3GK1y5MeHicNi3LRcUzv5ReJddLLZ9eITh5dxJbjJTu27VCZfCyCrfucTSWbcUMW0j/\u002B5fLyxmSbLX2EwFmQKlY3GoP8Vnjq9sfXPxqh7NzLRvJW9E9IxBbsDk6/De2iDCLfZFa/KnvHA\u002B8rG5dJ\u002BUCQuYlnOTYG/lZ9AFgqK/jqNTL3woiGHBx2n\u002BBgLaiPohUOLkRkOsL8yGXwQiojnOfmQNZkUia4Gq1s4JlFptCt7V5DLA2kdgpv\u002BvoShdnyUwMIedzSG1/uRgOnB1o5pyGVUlTL4HDaMcrcBFcspYTTap2WTTzz29IOVNX6DX6gJkPYfTN1NnKCLjgB9hb4waCO05y8k2n0oXaCvYuq0DRcK94DVChRXjQrBC704eW7BZM1eynR84Lp49vM4ojm503ztcpI9W14LYVokY86/7\u002BQ16foZWUaejhLGWBclGu7NCzRATwbchAlvV2keVIDvvQcLBrRDnHo2TuR/dwNK5kZvW1iae5zhVWHwrgXdgDmR2p8MGhQ2jWq6CgAeXREKIG0isvkkUUFqKa1STu50WM6u7ZhgPsgyNM3t3HGYwvhQ5o2Uus08aYVdpexm4D58Ra01c290qeWg8HovOnTPzWqxAWRg46H9boQXApjfy1STcZbAZ1OM2Dyr88ZTETMQjdSFsd7WH2YPNADrYadMxSUlm8jeD2YbJCkruO/brl1VBnTAVhl1uVYwsTNOpXaZXyqhKXVqMoJybom1rmJ6N4mjll8yiHMLs\u002BJ2rVo2yIKyjl3BNoDr7tfyUeuPwA7zun2lrxMbatK7lXmW84EkP6YLAxwEtP0Eu6eLPDqLf/PTgvbcjRlzmyeLCaELVPtSzhZBhLzy6wF8oPdrkC6UMBmFx3CKS66Im2v4fa9f/WasNHIkRfc24JvxY\u002BwmCAb09tWHgZGGxIJntO1Q9m1WHKOQu1u8b\u002BoiUuLUmOvCZpNhA4bV1H/VJXPvwI0J4eoqn0NIkUyvOIbrZS6usi\u002BaoVJZ7/LmfEgnv5HrzK9dFHD4rfmoddFCtcsD7nNNJndAVR8\u002Br/H3RCL7JNW\u002Bx2/XjlC9sgAx8it9Gzor4pHU1pUap3uMImR/AWXarVD7h/JfKFwij3RzDmb3vZS3z2GNIk5AoB/wS2voPrA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "1\u002Bwhr2oRd0p6XR\u002BLooQZRg==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C7017CE4F2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c359ce1d-b1ac-dbb9-c1cd-1b07b8d2ced4",
+        "x-ms-content-crc64": "Mm0Vf0X\u002Bt9o=",
+        "x-ms-request-id": "e34986c0-701e-0069-19af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-b21b166b-b72f-cb19-bc7e-81458232a070",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-42e168859809a20480e05f750a2b6499-808c05a44819108b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b0ef7a79-a073-5b69-22e3-d19b4e7abb92",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Jhk08s2BEmPArrj1mrg8DZMw9S3Ih07/WwCq19oBx/8gt\u002BzBxR3fpYNsdfKt3Fh1T2D\u002BlzO5fJ/KNJbM1juJv\u002Ba51OLMe0d2UVCpWxFcUn6nNYd6AjDLZztN9pGHEs5H47UL8wh2qNQYiEbjDyCNbuEXJaG0D7y27m2mf4S27z6BYnhcUV92MIyzYXrp51gbv4ivb\u002B0tktT4VAWazylPYpkHYqynMR2CofQVAa1CzAYVi7/8Bn9RVM\u002BkY/xZ22BjY//h4oWrc45rLc74GJEntof/hURpU1sZtQ7cA80gKcWUsZ2tYeqBaRcxkdmxWTw\u002Bfa11WVUc\u002BRCkxyx2zm/ASgQIZGbzeVScfRssOMKCaFzSnoYgq89vd7eNCZm\u002BCpuocEbVqPXVSgNY2Nw678FNIV/QpDDpoJ80mOyuZXC63nOAhMh7rb9m/FODx9LzNYj2P\u002Bc67WVrvs\u002BnoBAJJ\u002BSSnflouWv40nSgaajcZtjMQWNjtyaJgPENFcX41A2vXdVu8CrZinwd/W1zmoO9jlj32l6tpW\u002B\u002BCR0IWqOlAP1n8QzSbXWu87bmRrm4FuZtUIZtAfquAbdmsOcN0TDYd/1vC6l36iDiSOeoxl61BfM3mgodN/4DuO9UbL2OoSKGDs67SQo89mZlirgSBjtYsKr01TYmu0D/bFK5In1jVKfFIbiP\u002Bbzo\u002BqSjt6xG8LK0/LsSmsvrYFKOvNy3gtPoAjYQTeSCyLfuC9uRggSTuXugBSbBULnc2cBlAT3fMXfRu7R2NaPNMTMEJI/wWt5O\u002BwNhF3ytJrF8NHQjHMd6DtljwMZPHITY0tTzvSsq7H7iFwU5fhr6I5UC\u002BQAvqRRrihW1jJoY/95/iUSoumiGUkj1QQXCQJC/aJwxTCODqSi/hzMWdV/kyhgmuvTVUmksfKa4OWgPqEmE9SP957K7\u002B\u002BAc6DI1b9zoEHftnIWb6hYyBM98y2/AsN7pkX875uNla78UuGo39g3KzyjwIQzE6QoNyuLjPjBwXDdTTN5drCqUiDDGhzKs\u002Bw3CsvtGz4/RJah1LhsAgS2Oo1sy46oubCL\u002BXJnc/WHYYc/UIYs1Ko2ogSY2534OkwYDOOPWeRhjlEXYR3L19SdGnM1MK2ChWXnOimGD94Wk8MiS2MV\u002BAee2cY1FXOMasoz/8EqxwWimYd5pB\u002B\u002B235zANFaqYhxix5rllbrTW/yWtNfVhAc68i9g7HfmFPr4/5HwhSeMb1BvnSmvzCyt0wXh01IY4VuVhkInSnale7Kg7ZUp4tbVCUSGZufdiiYCsxlxBEGn3x41W/7kZCXZySF2D96Wg/AuDMkOkXt0t/wbJJddNHZx\u002BQ139IfY8aQfrJzFZ3pHbC8oQvh3mQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "if5JTSlXAmzsnJ3fapWKxg==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C7017F2E8C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b0ef7a79-a073-5b69-22e3-d19b4e7abb92",
+        "x-ms-content-crc64": "Vo3VnNhOws8=",
+        "x-ms-request-id": "d3b7b719-401e-004d-16af-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-fdba0f91-a05f-23ee-1137-61ce431f701b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-9bf5a060540911c930a08c0158c50819-811ef00e87838680-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3d8e8cef-1de3-5760-1883-c6f2e2d2b8ec",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "aVYbJO7k3q9QgdS4ZzTyfvlfv9Qz49UoZJEwCBphZHZNn77r3VOqacQRU4H0hyZHoiwMthJLXIWB8r9dtNaU7hxda8h2BqGltFUPIZBUM9xq6GXuVa5kAkM4auqTTbXufWRklxxe0ZuKZgG8Ozv1LL/i8stwpZlu\u002BWmFPZy3EmefIaMr8JzADBbKY\u002B6sp8YHQz0qsFvpfdfL9Z6z2ZP\u002B01SaHRmXyTwjIua1pUGqwlGifflfjGELtaTMYPr\u002BDDOCzJCaEYqtcHoAB451NNeVITNMEVuan0fyjmd1ymlCJRWyMtmxELDG9Qx/XoXTloHMNj/HsfvX6CxIp4MjN6URvuJ4wgL94xCChhtOGkDCH/flqJQpenQa20mtaWkto71nbp\u002BjW9R\u002BzlIuRSrfiM3rhoeLPY4R50RtXee5UHqnVONe56yhH8QjZ9pC\u002BzVJOlJ7wePhomUuVoZbNf3sxX7Xh/BHgaEgSmbDZ9a0zuwOJCOVPY\u002BXxbF9L5EmRerGNqFbanNEArmxWnZ8HjuPeYeaTBDaV4fuQME\u002ByVEP\u002BgV8/DA0WGR4yiJp4\u002BIZG6d27rUKi/jZ7N4abSqyBThnoWBw/yEKWyEiIoLucHSl1SQayNucBW8NoxBRGus6xsTpAkKCqByFbJOU52h16ntqdJcFlz1dypvwY1sRuEE151y\u002BBW0xIi0IlVxHBx4Gl7mU5qVUNS6HjDemkUXAdLNSX/8Mt\u002BUNOVFq/ALgFcN96syifNGb4LIuNng1ipDoRyCp9age\u002Bt/Thq1T6jgspnZ0Kad4Hvfhtn5N3oFs167AgrXhNx8aXu/szvUkR/Z5AZACwWDpbykpxz8p0RteZ67\u002BkmiDSm5WWcq3jFACvW6H09zwahZN1xKMt3Dg8Y3TjWdGJbSO9rYhq2eVMeLZJwrQof0/bfyYsLtV9pL\u002Bdmg95P7ou5e5\u002Bdwlzr\u002Bvt6Yws5BlD0\u002BQlCBqrnT5OQAjIzT\u002BWE3k8GxyFqggGZ896fgUJEMCmGYZrE/efgwjwL/cAauKsF9ZS8Ik8vmmb3qALcV75BS8IYrO5az9BXJfT1bpQxjzsziZu9mA3aVtczzVXVFGp9urIN8gu8uyXEVQxKKjvStijXmM4Sk7O0TkYXFvKKggGKh6PSM40/dt51\u002BTLxgCyrYRc9DXusWyb\u002BSbO1pZQzSdL6z6KH8IKbmCH/rKqAsr4pe7XrTXSV7iyM4\u002BnJidFKMr9QBsCKE2CEkXVJrL58fYcFnDneV/xeZNGF\u002BxyYwg5QpXnrILvtn1hVVqwPTDFuEGZiw/2Xe9qy8ZHu9ChT\u002B99m\u002BQdEgUzLF/zRiQFAXxigF\u002BqmNg4QuTmfOC8aDqsv8VrcqFM6KY8Zl6vwxeLZcqKA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "AHHjXvjHNLEPSJPjoAS9tw==",
+        "Date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "ETag": "\u00220x8DB71C70180DBFE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3d8e8cef-1de3-5760-1883-c6f2e2d2b8ec",
+        "x-ms-content-crc64": "1W1PqKi6oKc=",
+        "x-ms-request-id": "ec262365-401e-005d-3faf-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-a4a2a627-ef2c-ca7f-247e-a577e0910ef4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fe0312d0cf2c4c84887b60a0c9c7c9f3-d268a3cfb6744dae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c1ac3064-7dec-e9ae-7d08-8a035279868e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "ETag": "\u00220x8DB71C701386BEA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "xYl5dwqPKYVTT2bldrpCbQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c1ac3064-7dec-e9ae-7d08-8a035279868e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1b18-801e-0020-6caf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "F\u002Bnttz\u002BUyLmroG57KNaqMJvAyWc4bbDxSjLuUjZs7cVK9Dxl2nvTE3AAbJ8sk/Qaky4bzxADrKo4\u002B20NpnWCPrOoMDSaRFUf7bX3NwAQxbc\u002B074IUR21R0iSLd8OxW37fS7sg2LAgE/Y\u002B\u002BJaC3SqJza2z9K2euyW8\u002BnsBxd2ESdI/LrSJEFVflNvL1Y6WzvU6AWoWPabRANBVpB403g3Yuq7Eg\u002B51wP0YVF\u002BRkuWW5itFx8Szbgwrbe2kM2x3KraN81rf0grGhABs/alHP24q/v4yrxZJZQximVYA0c1Q4SnpA59K9tPgv0OEBnBipC6/uXSuBLtgBI4OfXi0xfIzG9y/njuOn8fqEi/SxV6cP/UngRiYotyuSP8RfHmba7mRUOpT4wYy8Nlsw/JLjX8vcn1DTUSZmnkAEVV8fWOOTuZ2AXS0CBzvNJA/K97qIrtAIco8F9409/ZxU9Gw9nO13nUL1UwKu2oglFi0Wm6aVe6Z/FuZUncIQUm\u002BAvRLPn5ciU2p3g0vdWaf20OFQJ1H1v3jFznX3Ew9w5QCTLh11ZYaV5Eg8Lehakc1ObbzgsCsNiv2aCcERK0Bq9q5LOjuKcXtayjMZyZGQayy4uKVCkDTlhZMf61u1dMj30SdKH2eRs\u002BxBhfX388Fr\u002Ba6kaGKbKGZ5ZbSYepYfpUV6EehqVkvFJwTI8Qo\u002B7ZHRo\u002BG9AQxWXLjAwLmi\u002BTlWMdCgfdHY8aNS70Ft0idcOngitsa0UqQ5E7U/qYWSEi3LYr85nn\u002B/\u002BLI\u002BahHK\u002BIqBdJZBgEJyke88Z2ocqVgtwN0jom94IqwIYr4UdeiCfis6vjTvUIHrSNDf/ScVk19qEKlEp0YbGVH6OR2Ebiv2ufk\u002B4fsTPmBLOFmemCV08t9uqmVPPcbVL5TS9RdkZuqk6UMt1rFURtI5CW78fHEsdUZOFbO2p4wyWcJWMElY1tFu\u002Bb7iVxwuCmOTFjRn2KMjto/BJkEm7jHG\u002B4z/DgaI4CKdnYLCSh46IAtQI5FHynEfMonJh7CAOAt9K2uPPwxdCiYB2ksQUWxhlwY11sqgfyEL39t8z1hiDVWHVS6yquEO8ylrRfAl/tEtV/C6SmFAzLw6c18g0Drdr8zlmQxNvuwVNtOhNTkg1dEKX2dXt7L0RohyeCeR3hLunZYjQGXE36kUpRONr4dzGZ2OJoDDhfgZ8UJz2za0c1iwsqeS/ZVrNY/OMwKvZqbw/26KA6eSGweuGU8TQPRyUCG63Ozv4BwIEvEBBULleoqrguvIKn\u002BhHqef5ORGV\u002BSLS\u002BLQ5JnKEQ9SgfC2kQXEyK7Ed84YqiWyCb5FQAsnscscdblgBJXw4WHcdah\u002B\u002Bo2R2yxFgdAWYqG9LtrQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-485e2ffd-5469-7579-bca1-29f55a71e892",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-cc1a45f1b958e18702a51d97110608e6-8721f0a68880120b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b28e8872-f626-68ff-25e4-00b8b1040e95",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "ETag": "\u00220x8DB71C701397D30\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "6Loso4e9L0f4Bzhr0PvVbA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b28e8872-f626-68ff-25e4-00b8b1040e95",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1bb6-801e-0020-6aaf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "w0jUMfMLNk7uIv6vYTF6LluxVsgNhKyElQYkVmaDzOWaombS/ry6rBbBVIsFqkCDSxzl2uGdtT\u002BcT5vt5\u002BDna1YYFL7KqDCf96qyTDAhfurFoAtJnfED/e0nNq4gzcU22eg17JaCuKPsRuM362kOetCxJ0bVns1kFRfRonKCfirke3JH7JJUQ\u002BdnXVcOyxGDGbvdb6V\u002BYTsa0NZ\u002BsBUxase5Um/3xo4\u002BXONebUF2VkoFTYm2pA\u002BEZRo2LBu81ZLRNvKQVXihjFItnxLCH/T6pHmMeWKMesW3NO1VwJlygYZRjTZO5gHRY8E3iQX9wkUlO4iiMFwvRbst2CCLTMu4uh2LcJK9rL54uhWhVPG/unKnL4UR0FEqIUd7IQ3hRRf1f87ocVGzaI/KKXVHjvDJbR6u5BxGpunLYU9KQoqwl3T9q9Ui10gg88f1Rqbc4pJXsbTuM2H6r9jkHA8CaCYEGpIASeMbppbVjfFVUGBD7n6885DWwWQTA/v9Pro5Hoqg8SwU3JmvOwodGaVwpV54oS6QRXWVLVgu7UbnHmjbnG5mtF8zLxLlDbeGuKi\u002Bo12dhJyMqNkVCsTT5e9TyB2iQnw3CfD/RHIbqzi9D3SwcEnoSpnLT/SUUKmaX0kjkUWa5HYshplsnT8qcfyhV/tPI3Wla32D1vKHorhGZOUo9xryIyv9hOmwe6xZod748/muSzvTfibHFg2DpOTgJjhaAXnirjTPUp\u002BM9O/QKjQUj66/mBmpVXj0KwwdeeAEz1V0/6BkFUXE3/icR4k29uzZbxQ1II4fsKwB7YIosdi/hySaXCuUsHlp\u002B7ggDQ3uvTQfRArLz6/HVU7zYyjCmy0g3cBknJnBRL6ayyXV/qOfEi9OCGzN87d10wfcoE1Rp1\u002BLADBMiiGaXgBLMQOJ8laqVFD4dJLAUukJ7siS5KNxSCTFSf1zUogOs6psgcK06\u002BGwMUv8WTPMyq1GQ5tZCHlc2ujfxKhZNwHI6sDoVNAnVAPn4bJXdO/w\u002BH9PLA/ttaowEKfZ1Cc5V/pKNG9y5HbcHu6YcSfHBGX57ssoCQry2jUWt0MpToDbroq4DUCAfRQJcg4gVUODaQxB4OZbEE3vV1k6XCwys9BuvMOdDvYleXC3H5b80YXxk043522agJ08yLbmRSHn1r89spiA5VoVHGd1pPC384XTSMje\u002B8ti1DwlYUY/PzNPz0nWvx/tca3zIcsGJNuthNUwEv1YCdvz2t5cWoQU1t00JtSn4DRm5tcb69n/XK9geNxxDiw29sVu4\u002BRBkBco3kvu0v4HBaShyiwmPR4B9H4u\u002B\u002BKoo8ew/TAOOP1PJFXA8gyOEYmxWXI4z0QAD7inbe5lEpU0gDuEPQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-26ddc0f5-d9e0-57ca-d4e2-d95f654298d3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d1185303666996243f55712ef1a417e0-35a91f01348f19c5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c990d0f4-d4eb-a267-70bb-503100280181",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "ETag": "\u00220x8DB71C7013DC253\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "xoa5ZPlFofBOhEK8TKvghg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c990d0f4-d4eb-a267-70bb-503100280181",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1c56-801e-0020-6aaf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "b3DTgrDtd2fLDukRwIty0QrTteJgpZF\u002BnimpbpX6DHGV8sQPZwGM5leRAZhnkxba10BoDj\u002BaQsreVeSHRAnR0QJ4fM7GYmoJR86LzqT5FgoTz5ZUkv0x\u002Bq/6MBEcBaJNvy\u002BV7xdHFHTWX8dxD3Mm5T/adHRyfT8ER4EezDJY7EIrPQ90Yyfzy7ohfTI1v\u002Bs81EvSQpEt20LwkKiVKUhCfnOFRdFksYIY56i6UP8Mz4eW4ffmhamx/WLMhNJ\u002BXaFy3/\u002B/sHkZ1yLIulvoc4pD48Eh/kdQW/jJ1EhvlyywmYkHSHH/TR8NfArVHstOyIrXiaEQXV5ZIYMH9tsxqj/1GCDR4SsYQ5aiE4I9ez0segu9lw6LoDsqrSbu\u002BFZD29HK3waqfedev0YLbUncHKZF2nzPcxMxanflpjQFKks/Xjiwcpw2gvwkX9jIgDLyTpB/qB3adGe\u002BmXWOxdazWZX6yw8RLKkKDlh/qxQ7aelF8lijhYEtZOrQ8dkmqLwmcQVDzbQi4CLndZnEW8lSgy\u002BLSNJ\u002BENQTzWYkQDrQ42acWTkP\u002BJw0IhI2vBDnaQkhfW6pm1/pqGExL/9N/qDnFpEzKAGPQ4uTViXAR1PDK2RdA8LMJkgGsrDY3sic5iRxTqV/tEAHkjriFUQ6KWANbQOb8PvdG/BJLHZRtmXC928BTvmuRHcjVXCI6RADzIhQy3DEAPUplDO0NYfJttzVHx7UONpmXiiMd5uKVTHfRWDtAOr0/fZ52LrF\u002BQ7vWp6Us8nyLpOu6W1IOIhanj8B1e8n3Lbx4SEnWmAgoGQZnR399aJn7RbMPxZ9rMVuHzl6xCQfx33no9KnytQyjUgJLppqXKidmujYWp2fdDRcuTsnpdw/\u002BtWgFVLPvyJCmrHNdH4qA8KQ3So7Rm3gSC6dSxCZC\u002BhsyTPFykdVzdrGlsDr0QC2MbZ4lseyA7Rov80kMnQRqY/JYatKZTh7OxBPda\u002Bs9HYu5hlaIHQgucV\u002BXAp5MZpltOwxInBVa8t9/Vu3Yo0Eu8pX9Uxat4gaqKjlzAktAQl16cHDe9IF2XpO3CMZaFY3eaBAIjtOC/1jFnnHb5/CT/tRQXjMQT/4URzRDNplAT9RrlNo7d7NJ97EX2VYPWnbi40nxyfdajdgR9AefP4i/hU5dsBMWWEdgxqaB\u002BHanxOy9oBNPTkYdEMbB6YNrqvfoWFPHsepjjErCkMNQ2NWhqi9bIV\u002B1cDbIQJ8MVK7D9RuumV/ioBLCWdPITP1CzDgxIH9UEIlYcyhc/3FLF3fb/punoj91vsncWIeLrSM5RXRnGzQvb6SSVmZ3haDhtwKcLE4h22o4\u002B2F1t/gBzIXFI7n9JDwDrI73FQvY/jkow=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-b4bb4a7c-ef14-d2b5-2d2c-e78ac68970b3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-144db4e37e046efeb44d02904d1a8ac3-0ed33dd0565a1417-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e1c3c1c8-4573-2baa-5ae5-637e49f56226",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "ETag": "\u00220x8DB71C7013F48B3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "MwWbdZ\u002BwR\u002B0VRPhigPgT\u002Bw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e1c3c1c8-4573-2baa-5ae5-637e49f56226",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1cff-801e-0020-7faf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "JoHJiJuRTBlh//2qGXl/9aAy9FrzdBXBLz/L13HCy1wqEQjhL1wIWDn5XANWtI\u002BvOYmqtOtXTrFsB1lbxnSnnjSgfwdwncZEKpsh\u002BRgRanuwG57oGBZx08JWdScDrJLEUb3PtTSIP5vDZolPNVWZW53eq6vWv4YdL6tEGSieQX4JXahaQrVGKNwCJbGNIZ1tvRmKJADn7ZI2sYaIQyVyJCUKRtitPxjol4PO05nVjw0O1lwOFBx\u002BIW8VI5AuveS2jwGMg9vEwH0AoYx9GBn4YSJ4emzJZA8IjCRplxuIudqeGEOYSAwySRbeDXOPAAlVHMFttkJ37Cvyg/a2WylieOiy3v/VYBgVRjFW61aceYsbE3pZGgKXJywYpcUVe\u002B7sfJWK3CIJf7ypWHARIAHVVgprm0euCF3lG7fTvbpT/8pCam7AEZxoEZO9sMKShQYqQk\u002B7quCmPnQ4pMFrNsICVVimz7aTFURtAoqz8FeaU5WwqHtrmFXqmyv6h23a/dvRu1tq7LZPlywKTahV800cnVAsuo1Hl7wCuzOKmY3XkgSv4TX8L2ffYBFOYEuslKje3ekcrkJNiiSfZzCCxf6fM7qjphEXIG7oTVl7\u002BDdxVieLrLujuuTCYVcQXMg3XJsTryyQCO2Wxrx7M2Ho0ZHtLREI9xlC\u002B3nW4UW6B8OmsfC\u002BaEkK4E069OX/KIaD2Y/FIy\u002B2LmSC0LSyuSan3L/41YJwKmhI4kzDzgMzQ9LzUwi29OSU74OMO5iVWCcnkhcmBlIEEq4mfUDi819hT4zhv2Yd8efaZOb\u002B4\u002B/Qs4olnDzrDT2A7kBZj3ejsvwjK\u002BwLs5jACaAvS6FrBS\u002B/Vcq2vFYidUFPYdAmxGJwNrLq27gCxf/xZZKcu8KcFOkRmjmt7fWlAbWqvFLImUU\u002BvxTvgSp2vJDKxVfEhrl/s0znFSkow0m9RNoCWAmsKMtNXvyurJK\u002Bmt2o4iie4Xr7KwgG4IQbFfvKMjxQc2SHHZyLdii90Qa5KHpMf\u002BAgHmNfBywApkdGMUgA43pVbiZ4IcSMEmpSPloCTLgJzpUaqhPZ8Gw4h3dURUTfve6LZLlT1F4clAz5DcnS/VqPPWOz5TlnfH26QJpNOMwlcoFsduf\u002Btfo3/hUG3\u002BOjZYkcxAjhLNe0JOc7mZTDzls/1JpIZodykIdoe\u002BcjYZ2aF9oRMXPEQ0apt1H/whxmcy\u002B5xgpJW/8BqTSAebDvkcNKoYK5sp3oe5FTnq81cs1qAgi3aZqSUbvbD4c/Q8qWuSWOtSGarMGS0Ut59b1PzDZmFnanOCgouFDG3qIWqTfGvOSJpr2s0FVGJZdPGFv\u002Bi0NQ2C1T7oH8ZfzQ080eeygUszjYxSV4uQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-20811296-e7b3-2414-6507-74867a19107a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b120cba14d2e11978ab9b0fb7250077c-8fc7a6daec6a7365-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3f687da1-2065-d80d-ef32-b0d1dc018d6c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "ETag": "\u00220x8DB71C7014366D2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "mVmLbC94ycpgiVt2UflDuw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3f687da1-2065-d80d-ef32-b0d1dc018d6c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1da7-801e-0020-15af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Yo1Bwdz9iCepbztlIyXFHdcf6DKNbmyMXNsLer\u002B2Vwo/anY45LfdSJg5aSGdO9GijkHtsSFBQPQhtGUA8Q5n8hcxJbmvjDkgQZ\u002BZUwRK7iAKaet\u002Byabp/imBFy9S3VaK0XYJbBUY8gEHzW\u002BBp\u002B3v1sVE9Ygi6SlxRyePLXQJzWNJDoKOQYIK8nbpdvw2Z1Y8kkFpDejNaOdNmCTuiMSN/f8LN5hqYZRDOgMSOHMtOuDQU5syoL97fKaaQahdG2mxXHj8Ki\u002B90TGsJtPkujB0H15EHjUpWl0/kLvy0B/r5R6ZYdv6MA\u002BwEoFphXnslsF2JSFKGf00hwIavZp0ygARwUC1S1lUee5Okwuzv9TkU/n5fKr\u002BocwgZdnZ4HN0O0iAWMQ4NktnIqwz\u002B4XygMctNmqhek5VEx90lOaAepl72lfDMmcPqxytkVr\u002By6VGLuQRrKkJ08H5K0Wkw6Fl56cStyEtL05gHYpN8\u002BjzV0d6LmYBbs3vcQaWyQciaud6SKqy6xOEGP6WsY4eu\u002BDYBtP9KpU7Y3jaI0YalmZGPbOj06o\u002BQGs09hVna70/0LUmvsIzJEBSP\u002BUx2MjMaYKYT3Pbe\u002Bg1mcVnyTSA0/e7m1KQ9NejEhlyUJPFDWijZ4yTzxtJY1XN8CX9y1sM0mztdTx2PHSq9TxaaCpVcIxcxGGn7ATccjf8wwSypUa\u002BZn4n15crLCsX6Nne7/oqd3\u002BZoAf5ZeVnEQMFeXlw\u002BE/2nAKsLZj0MJc2jwMq/YI90kuEGAU/xAGZv8aUJrOxp/CK6FP4fkrmpW9vwtXhPRSAyKYt699KttcBEm7SYArkhOcToBQvRVQBnnOV0AIruIGyE14MhLsRQDJ79mvbFERliz3tzZ3/UINSLE1stObV1VrsH0ys1wAsAl/hs07oJYouL0XEPerkssPbuldupItMpiAR7vT4ubM8wcs9HZw0aQbDPYSgEJhvCGyI0ByovV3UlQ0t1zeVNXaRh3seppUmplBRq2cGq5aIoeWIb\u002BiXlARuaYiPBpLPLQcOD4gcUWLXYirMVxL1zep2pTVRDcaO\u002BfN3sDwMl5\u002B9gn1f\u002BJsOa1CDsA2\u002Byz3xeJyeGWFdfSBBgBWUpaElysuKDtSUltROZznlzVy4zy62hTegbn0\u002BYARdHniFecWvXuZCM7xoXeLHT7End7DDiLDm3SBphFtNTK3PN3dcyO50Nm52dpxyTihV2R/MFulUmZXHn5ylRdqK9ecPmCVqaofDs0FBTBIUdI/3E6s8gDXEep3ilClRzvCU7IG0YrUC626XCWOoE0yDsyoMrTIuTXSxSx2Hh9VdceVQrGCRXxHa9Sg9pHfSG2dRX\u002BH\u002BRSC\u002BZZ4MAheXemOYOZh\u002BVw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-0f785509-34b5-067d-0a0b-f9b3f13f914a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0b5aeadede48b1075ca73ba89ed2794e-639e5b1b38bbb8f6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ccdc33fd-238c-d6c1-adc8-c6c15fb7d84f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "ETag": "\u00220x8DB71C70144ED32\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "q6oh4n1FhnXe53GQZ8eutQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ccdc33fd-238c-d6c1-adc8-c6c15fb7d84f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1e35-801e-0020-0faf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "9F8rxJJGwoRd\u002BkJ6xKRq31TDAGVtjuUTZ7N09Q8i5\u002BFEOqTabLnFHylt9h7vPkVNPh6La7bRu2Z5GF3e0sx0OhJhNon/kHKb/uA7/5fGIyltJrbxl3wqcn8\u002BYFRb501c\u002BLsMjge8Ta6r8G3VlbvOs/UzcKwVg6KVNsMKwC8ePxeT3gfbuZQisdgIRacOVNzDcK1eJ3agRnQZd1hDsox\u002BjbBWQre08vlgEb7TDT37huHnRlCBvxeg8peSwkI83v9Libj2uBIlD36z/ha4zTk3HfB2XGw8/M2ZtlAfIS\u002B2IzO/h4OEBc7PwTbSzcEB6CReW6VSxoKTD4zrXQLCBu1O/dri\u002BEW2shghp5o1ai4Ll80rwcaKZF2xLHj2mafLDLtJg9DnHu/eqKiMMB7nXaRd38Y0lkUmxJh8McvNvxhwVprf6\u002BddJHjeTBgd/TQ\u002Byc7TmLnhl3V2Ir44au0jEeiQG9qECHG9/7pNVkosCMdkPWf9\u002BSZfj74kaMkoJbqLujovjeFZusFcFZj\u002Bk0ArShn21CyFJhfBMYwbX5\u002BolNoAwpwP/HvmCoKmoOSOYPt9\u002BR6vMlGNBpMjblxUPlsitIG\u002B/tGkG06eD8mp34YzM9GQnWaB\u002BWKJcrwI7I4ekcwnhOtj0GEq2d3QESKH4ycM7zqLxKD1obseNIsVmy\u002B/f379glqa0GNvZsSIsOhAAo\u002BV/PxTk80sMuMwRJvVFT2tEJGkimHMcR/WG17bbPDT3jL8gJ8za\u002Buw0FB3aozHmlCH26BWm3guyYrdfXhvUcXyXWZp2JWdeqSl87kQVAeTD4ENU5FPfEK6zrcVVe5zQX\u002BKhQwlXsG76mD7sKe\u002BHXSCSm73Yv00o\u002BEjrgrdhyS1MrI5hc77bbC/UWkwU8ua\u002B7FCkwuAfN6CVuIrAq\u002B23WI8Rn71hZelht29NxGTA08ViLNZm/QYNLXUti/sz2oACHMH9A1MpXUZnAwuw0XN71OSFXr8XUJuIxHJIc5oubdyvC6diw5ByOM9P//n6nFvBsfcWbnwBKsxmdH7g4SmseNVvAYXL2NEUUyWvh5ChjmfWRoHjF/9griCbPI8RUVel44cki5rWNdjlwhtWUaM7hKYXClpniWEWDpOlMJxCAsHOCeQJvMLNABDpPRWkChx9n7fo\u002Bkb9PholzrzHcQU8o79ZSEf/McfjScoJvowLccR3J5DkWQh60MuJ465Fxc8LrFlWSoHUvm3wBbC8s39OGpy4kEl0GAq23rd8NU4ZXYQ7PhJytSdCYmljNFOX/h1Me8kRzTVFl1QO32wKmEjflqfsQbVtG2V1Ni3gESP3HyBZ77mFB5COtWa\u002BI9X7d8ngQ52rq3xoH2Bj3JbHpUZwV4BLsKjPA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-52c92672-77c1-9520-3597-4e0d7b2f5813",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-798f6609b01aaed71bee6f36fb5f3cd0-24d906071871224f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a8d39078-c024-a4df-7b60-51d79e1e5881",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "ETag": "\u00220x8DB71C70146E8BA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "E1Iz2jGYXTC8/5oHmxjCcw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a8d39078-c024-a4df-7b60-51d79e1e5881",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1ebd-801e-0020-06af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "zpDHQGWFq\u002BYbP4A3MFW/HIREpDlQNsFkwqNQimKPluSoMDOd\u002B2LX5JF3W/C7hK3oKNwKupDf3ZfPY37CNCCDjKmcjgAiISEibb\u002Bo2dvQqD31aGKGhNxTyFObzpjjFbBw885HH/Wtxga66EzRNwO8/rpBzMy\u002B/AjMSMashlKIPlcPOOUMiIlHR6Fby5uPgpFP3s/dokjksvfFe9YvAD\u002B0Mqn1wv4dsHYx\u002BYQqYjFtPMY0XaeCqpwOKobuRgyyGEdhp5nxmr\u002BSMi5ZrKjEuk/GWD4Q\u002BqOYMocN5pd4LmlpfuA9yLqXe6IGoip4KP7zSnA2KO3Ooh2jyXUS47MoGgPF7y3IhvGVLt2cCVh4HwmIGZwnQgZ7m9zCmv9FhJfu3ocnsznQK8N\u002BoPoQMZnFKqlsickXAdf9SVRRBezxT6pFrSrQUGvPuO7YqKELamlD/W9V2PrN192wKmnkfyXXjVBPy4Nu9Nk9nNHbPlg28d/qDgh8nHevd9ZNICYC6znIARtQu5/m1AiVFzwp8pmEeTmK\u002BnAdWvDZoFStIdSzO7GYEj095TVABDn/5oQ6hoU9yKbtePHIqqYqdhtKOLM04tyLkN9cR5MDSfU3HnNrnxrPcFgtxcPA0GeWE28Z9cuFygSor/Wl4YET6S77kIwzvtcBe8hbBxwYysB4xTQk6lQpslNvwu8kKY7WGtyUxD/bY1SYGHkCKcPnkOQ1LRtN7v/Z0d04w/zn3VI5hO1AhAaAnGLfjNHbJoiQhzIL7vxziSvduvNiop9YsDsnyaXWpwvetJC4bWIt/qpUqDvJ3O5VxvvCYskTHvrDh9uWs13juuAmLDpsuhvIr7xIDfpjjtRM0gKqE0RCy5aW9eWHl0pMce1boq\u002B06Avf\u002BbMNyhH/X/kGSeFbOaab5GGk1sU1QBhx\u002B5wMCOslmOn3yxqRNACFlpbsgU1p8TdHv71NEBFGqbmbnM9081YN4LD3Y26MCq9gHkAuSb7KBwlkxUgu2IjXsSFg9ZgxEKM/36GccY7JurUN7PHRF2D60JTFDy0N3wcoH7JMKxQXLw6c72odLZZ7mwqTIOuXBpnBZiQEawB1Mf\u002BZdFHbfI\u002Bg9r3jNCj23aP\u002BSnQjer8ckRkYi8XvE8MNJ71qg7lEnx578ykttNFxy4mBBSGMUrdAfeM4w/HJsOP51Q1qjFnquatVp4aV7t1Ipr88bg2igNQFKQbWDNsssUJGNN7DBj8vl0t1Nqoxq44F7x0yjULVV1Q5ZWJTFK3PKfZDT7r\u002BhJ\u002BADNbBLEop03140By\u002B\u002BiMAcNyJiqHc3IOepg207VzTBmt9sYFrFCoKD5Hl2kORES7SQ9/ddfn\u002BozBTI4Y8dOYhpMmxQUiilFuyfg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-71816c1c-6011-62fd-947b-15a8ee603225",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a01e3f9c706cd617ff5001958b84a3d0-c424b79dea832191-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cf48c1cc-2fe3-6a2a-1b53-baa297b99f7d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "ETag": "\u00220x8DB71C70149CE79\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "mpkg2drUciXHppjnpjRt3Q==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "cf48c1cc-2fe3-6a2a-1b53-baa297b99f7d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1f64-801e-0020-20af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "URjwo82aq8Q2et/P5jCugyr2fu6sLhMW8V2SO6OuOEDCOlF7ag\u002Bx4GMyysQtxPiy/PrLmvKQYSIE2rFvCHAgiEKfDavfMhgbRZ6LeWNO6Sxk4D6p4p1NMtgud5BdQdfzEkKCjrdN08nhr1VTBOe\u002BtfGECygxdqWlUdvTsLuHvgTGl2YhzFt1Fw11yDNH\u002Bi3wb8Gf2DavwZyc3TzbeiIOWvBRjGyBnemWD/MbvK5yXVeu4kH56OXOF9bKhe4emZ3qZm1C9m3Ab9LXCMlClAXuKn/lLZfhFHEKgnWWthf6d3VVMFVAL2bq7XJuIt8ci4LR21tvOWwFCVL7N3P3Kbi63ZFU7GSvrvoZ\u002B0AlcvKS7vfzxdu8iz4JUCYDRPfy8sS5tEVOyJ4eIi1gVj4s4JdfaUl8BGTd/VFSSpw9q2kDJgh7a76tRCZY1aOtXDUA3W\u002BPpNutdu5f27bz\u002B30B4HbEXDA1sHTYsiQjIy7AMKEcUm0trQeNVa8aG48IuUioVvQs6P8Fyi36t/G2ilK/n6sU1qgQ1DJvNgeAG5Tl0Pjce805k0ehF4hAMvYV18pdWnzk8\u002BKfmILCvbL4ha6ZFeb42g\u002BFhQtjc78gz6I8WV48IsAXAd0VPOJLd9aUqZLZpxwPHP272NVxgH8jf8jfhmNTu2LtgRQJ450sOg00zsktRiiFLDxhgUrrpoBd8rwaa/FzQe4v7CUIBjlfjp7HPLG29TifWlkm8joYAduTrPDgEs4cwY3b/loCfSYDAvKrJGnOp/2EehGYTE\u002BzF\u002BpKdFlIfnzPq3sj2vfenN0zI\u002B9HbN1xxQXzXJe9g3U\u002BJ\u002BdwuAjMuoN13HnuqswFpd0zZChfbKoN2K9TVSHlEScF5bIQbeTUZmlr0o9jgxo47ba5iR9M37s8Y\u002BBZeGRij8pS6MUZ9Tf5X/6/85kaqVSVGmdqLIcHuQb30woEe\u002B0ECUPEEZtUHvd\u002BwCohjOsiIbmLw13992NCSi6/IiEt9eMQu\u002BpWVpe5Qfxv62xd5i0a1LJQeLiPBxHfgsdslPvVUctGENABy8sh0oJhjQv35WMBpE5v3HwrgbTYdtPQTawAmZqgF9VcGQjnLqY1LXkG6JxjavCtZnVOGo8cKFX3UYXWYfNxVs6NpYtFiK3V9lM60o43beK7UjMkUvxGQPCz790hXsuGlJHO1cRkaN3HeSQ84VbGwOOiGg\u002B/TATRR2WakpjQs5eHtD38aJgdVupVXdjXCV6a7C/6f0S8xkeN/I1fytZF98WMtCwZylhLhMMlau8r\u002Bj0GAKVp1TRTy\u002B31b2sKvowTEGYSSlUygCLXrvqAl1xYYQJQWMow2yGROek/I1vsQcY3EVmIGa/o1H\u002BDkiY50jOQnA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-54142975-bd50-91b9-34e3-d91ee5708adb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-23d97e2f881a8ca85be8771af7dbad36-8f793e119a356dde-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "dc0af819-89d6-079e-1723-c69eca7b7ce9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "ETag": "\u00220x8DB71C7014CB43F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "pqEiHlimGB4tADUFQaNzMw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "dc0af819-89d6-079e-1723-c69eca7b7ce9",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de1fef-801e-0020-20af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "M0iGA89IU2iESq1J\u002Bldmta6GToOHYXUtJUSYnnzhIrynuQaKrY3NxRVR4Hc260ooqrVF1nhn5tHTWN2Lr7XroyjwokFR3AcguYhtNYH99zr6b/PGnEtEP9M0tlWvQRVgZjxPRUkI182tJB3v\u002BbBQ1WCjkT/BJAfdrGJuHCWycHhzDc9ErrLx8ZglGXcuVEYi5OD1DLDVn0E1cZnmmruo\u002B7SlfOzgCyetsqCnmwuPrlgbSzdEvGTHnW6ODzwZClbdfR3CiddZQtm5R1kQLQM1pcJBy0\u002BDYz5Q3d9\u002BUvzqlKhJyh3uzSWAwglei3QKt29qWGl52D4HWRrecqz42/Ddz7OwxmPmR9idwAhGJdjKRSVvE/mScLxpQnACD1p5h\u002BYYgbvBWvEMhBCR3Bc1wDRCFCyGicf2Sl72RoPy4zh9IzgiLaMcCOszYo/pAZOlM4E8wPst8v4fIjZcyxNtGqHYE7jeE5OQJgxBUiY4DEnLURIBtiM9TzE6AwttvzzXxkjtEe3bxiDuq5nu7J/Y5hXtkXkAa2N\u002Bm8SHpBCII2bPaYzdSvtb74vyEwqJTmORYhz1fy3D11rlb3UpUyIPZogyH4IT\u002BpwZkqHuDVhZ9E1g9kHzkqM5DJIy\u002BNqFMZxo462CVi7gfWeA2\u002B2M1MkCi3soyFzgG9Pk\u002BRPw4QLBk2AFhSqq1p0egHjac7e2rDfIMGxfXWk/iMfanl0b8JxlvkiNhk6fV7TdCkjjBqgcLkzbJ7CVYjb2xfxi0DhAA5DcdLRuKCboKNi3gVIgW4Ifvm8QP8jr0FwRlsFSPYd8nQa4B5LzrQUm8/7X3eHj1ml6QhLIL8PH8KNYXZFklutRO\u002BNMZ1PwLBBq6kzJE/N7LsBX1/p0s21C8Bfum1BzwVwThqH9l24WiRYBXkV3/tyw3C/RDb7x3Ih1CXc8AZDA9ijvto1SfZZRQU3jc1Qny/E7Pr4gobSdIqkYh4332YeFQGgdh0hOXl\u002BYgMxxDWkzTT6FAMPSn1RzUpPkOfYIWmfFXjPsCkOp7eBfiCHoLBQ/5TlPcdnEs6ATqTW0aSRojyZkq682RkP63BPjchcziyZ/pFO8ueiOAaqS2WAO9IO79vj7g4BlCZ72VJXF4EGI3x0ONcTQrNY91qkEo23i7OeQKHseOAilGZu1xmRTyCBpCflD/76\u002B6koiva3XYGYxE2itNLjFaqcVaRwpG\u002BVy6g2Jm5lzn\u002B0o0T0x/Hpazrg1hLP7pZNno59RLZWilc5ksNOfTsTMvXN7hWN7k20tu5tj9JYydkV5Ifj6IXJXhTxuzEynuoD0aMc/gB8w7BAxJHH6P6A4MjqNJi3M0psBI/8mDMchhgAbb4zP8/UlSDTnyP0AXQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-8596e5b2-20be-1139-2866-bd456278a6d4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-343f0c8c29726af32b99653b45450d93-61e21efe54e4eb92-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e88aacb-c2ae-cea7-e618-35a2527429f7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "ETag": "\u00220x8DB71C7014F99FD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "ia2bgasyedZfz/9TceBU\u002Bg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9e88aacb-c2ae-cea7-e618-35a2527429f7",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de2082-801e-0020-2aaf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "SQ\u002Becd7QFGg/RGjd\u002BOQKngDGuYnVLA9ta8hH9qS1mAU9U564X45\u002BdYfOWs2wtlpCi409lmeACxwAMQYWiB7Eiqxin6VGUT9yR0MBB9FCvLRuBGoWeAGevEiCuC2IZ\u002B1pCtAgTRa0/DlOyk4jfwRKvXRRqIOzrRKrxONcw5kR6eBVmPwBIm6duQgwyK2yej1EN/q5N79ptVy\u002BdYkzWDifPOFuzeYHSZsGs\u002B97guRl\u002BEqlGIyeV7Ig7OKgQq3laWHPkYvLQ6xXPe5fs4PQ7TN3WXw/jj\u002BsAOQuTuEEZgbtIUmOrPFYmbWdTdqdP6QuUP\u002BvKOkwpdshIpCnnfXLUtbncZI6QkFBHsDHoUBlD8FAAP7iVT4dvXtubIlhsfy/0vsEtc0S9A29bQkpaQOavBPOZpz36f2XyrQWy9W44G3EB89FYFn0LQvwJOc19FN31LB1kkpfx\u002Bj9bOoY\u002Byk4BY2cZWI0VFu62TmRB8QVYtZhn/ckQk0iZD/mSPRu2zLiuB9amI7xQ39Vu7gRzcAk5wkUt1sxE8I/eQAiTQxnS/4Gr0\u002Bku8lHb1x4z4eUEJd\u002BwmDqWiTWsKRdGh6Oz/Vy7m\u002B6Ch5xfyxAzEf/uUQ6q2lpo4usffHaMP6qR6CquaBmBeAY2QV4DUIzqY7c1/dfIm\u002B1JStqxnB\u002B4NofxzeMlRKnmLNjItFj8JZIedNj/VkGSiUw9ZR1/D9wmvkqWEYLphN7NT5E/ACdUTSVIkydGuKBGXwSXKB\u002BMZxz84jYOZdPPdK/58gawk4kk6Nf39ny038WqT/K\u002BEpz/AOh0Ah4xRicReV53TMaZ1Yt7cn8HlLDgCAIwZBYhUSITOrEePFGrM2Lw5r0ePVM/ELonAqBdt2x3k/obwOIRL\u002Bg8ZFIVe5k50H7cVu3zggqvMVNb\u002Bk6BtUNE5miXT3KAn7bU4dkA6dThLTJhgWC\u002BRBHvbI9OtTVZuq7O0FUwokEMG7d3HqAxrke\u002Bus0cYDQixmJWqCKjcipBe2cqchl/8ErxVWWpB2Vxvf5Hj/pofRq67AoymfoeaOlM9eN5BzwufspCawqOeb89JOpkW6IwGP4Mb0YPTRZQkux8HFFCOLaCGVEv5hIP7HKK9bTP\u002Bc1HXNzlLJf2HzG0MZgeEh0tuyxz4gIQwDLsPIMThFehQJkfNP\u002B0nQvezDpfu/R6MZoVXXqIXBeLNlyp\u002BTAUolqaErE\u002B/x1duR4glNYH8UR\u002Bscro/mcdGOSBU/6iyqPbiimfhakDezK896RcZ8cBg0TYK0clK6QzvPmMfWseuq56BQrsaCvbO3bYbAaCwLEdf9C5it8c9l5FbAivtv2HXjz14mL8VRsZPPAQDP\u002BdcPxIrz2aZS/PHQ6sZvwjA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-52972964-031b-5ec3-b3ef-3c2d86df7d24",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f98ae5f28199d838aed012e40f710187-205dc138ff04793c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "20d2af4a-def2-3c3a-0ab6-b133c4f16039",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "ETag": "\u00220x8DB71C701527FC3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "H5VFpSEAjsc5HmT0oDOdUg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "20d2af4a-def2-3c3a-0ab6-b133c4f16039",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de2125-801e-0020-3faf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "pnug7TCcH/\u002B04zSaFVBAuXvXRa5c78ZOj3joOEyTE4iAQZQ1\u002BwNcEvLkj1TymWPoQ/BaqfEO1ra1UV23s\u002BezINCrGtO8C714ezK8d2BxW/YV//RbOGmWcmrdf6qlpF8LMW6DR3\u002BPLDgy4S2/Ul9WQ/VnorPyWOdnFaho3osT09fTsEXx7hR3hdO7KFc71yALhzy1PQGrGNiGHDHWJ02tHw5W66EZZFXg8B3fNy\u002BQKz6HXVdPXpXWJ5hsatHjoF6GDglI5et\u002B8SLm1Ezky\u002BGp9vDzTsn2XsB4f8MIrfqD/VC\u002BWSgmSEVTCWw0aIlI8Vy3w3Tg71GUkLBIz2UndkQoY9f8JXK4gq2roEVdwfY3MI1nUemFog3/Ksl43njgK5IoDASyTMzp/kHGNU8LN866EJ/XvyVaosDJ/fuoQKM1ynSzNbXxhePBfVKnv2y99PL7vc3YCGxtzWlE6E/QQb2dkGvbVwIZyYu7FkHSs\u002BJTDAgIrYPWXMIHRWhLrZ2U8DyVCi4B4pzw4fRBHPIqmxmG8NxGx5M6xzSo0xKazRvuJyUFPai0UilsGMuOlEDQ3apOxb3ATimoWkP6WQ6JVhTYUvXMJV1x0p2y2a/IqzLz2PZnSwdeLdn8XOJlufka4sG2tkFKA7dM3fMfDnR54K4RBoAYIgoNeSUc0Ml6Cxikl/btEfXwqdU\u002BGm4UPx9kgnszVLJ4AsC3qTwcLjLu0tHaenZ\u002BjM\u002B5IF2r2Qec\u002BDoFt05NRrZlLJU1Nme503qiUEicOsSo5fWsejNVzCi5GrEBF3bjoIsadE7hSFVnAE3iCIi//711XdJYocyDEF9sfBu1t7wDv7C9gsV2x5ygRHrmcsSf\u002BhvzjLmkiv6/l2TudMw6skmQ30nYAX34/5U1uF1SnJ2bzIL/wisCXzSy/uphh1LQZpIwVpN6x/ie\u002B4wkb9KgbPvGU6dJOu8ejYAVJQOSlnhDZFLLIUYKIAWKYcae3u9iEpHvmzOqhiuiEsgTZaL0C2QT4Ap/1Eu0uzKiv9gpf6\u002BQsxNyo/tEmN0mKQ5997tillVhiv3k4j1FOt8ACMdSeZMZgrKPgWdpz0gtWas9N8R3PymDx/Sxq9DVLWkcRI8W07B7ZHQI0xTt\u002BLu1t4iSCAMbiciez7GeZ9bhuVT\u002BTYq4F4X6wdJPbmsUlc84\u002B/RIQyRmALrHeAP\u002B3P2eJxrA76ow/aACl0YxyxpciTriZmvimXUvmEzP8Z6C/OXUsUdRVKUkB/5URaveNTWgau7IG3WRvI2kkFZdYQsBgJtgXBrTCzSUvl5tjVPKUWMXL4ewueBwQ/W5rMNPxqbyU8QQfdgbzV66NF0WIy452j/zRjGEUce78BgkGV5xRfe4eg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-09f539f0-adca-5566-ef02-2ce900732fbc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-794a3e73d4073e596e094c4caf494356-d1a84f79ad6ac06e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a357c23b-09a2-6405-e149-d4c83f905b73",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:15 GMT",
+        "ETag": "\u00220x8DB71C70155B39A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "5D7CmQFOL6aUqTpgNz8dOQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a357c23b-09a2-6405-e149-d4c83f905b73",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de21d6-801e-0020-67af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "hFyAdG4B/VWNwPaz/0nuZl6p9KohbGhKz1tbQjiX\u002BF6ajOzpd0MMOJJkRckGriitlhv6dtLUsRfzNaUSproc9ciYGXNcBe8bnLsYvCaeRCEyrqwdnYGLxdrV9UGe\u002BpHXR08BbZS1UJAs39oWvPTwVfGD3/gO/1hHDFSYhhCtfaIqQHXWnNaNfV0b8L2mdAjm5J9QGhqYyUf3umE/HMqAf2E47Hx\u002BGrgb9mKb8g6aoJdMsqJwXWKHkXYt3\u002BJ0TWCSm3FcboiMZ8rnNCO4/dc4XBrJ82ooDyH\u002BsFoFUTrVpqkBCFadPjEPv0rXiSg/z5Oe9IPHq1n2aoxPXb4thhaQEY55t/WBmx3pujMgUIb5v\u002BDHZly3DftPCp3JTeFy4Tg0R3eZxReeHVll3vAl1hoGVp3dZiC52AOTKqxXt008dtj76wkOX/nJKEkDUS8KKTSDw/dElHsYem50BptrRmULKWgXKuoQ9/ajFD3WtobUiAB31PRW\u002BOFd4nGamlleXeHj9yjG8v9KcswAoIA9QcTnn32a83JxtTGGuUd4dlydRbZc8r5eDZYBLWEnVVhhIKGssvrbw2puckL3QDi30fxvYlrJ4E4GiZLnmcYRSV/ZJZmmzMNhwoJM7YB7Zs1dSVtluPL9lz9Spilo9CmjXSjjHhqfEAU4DaDXffPOiyLFiU9rrJFs245ZVCaa\u002Bc1YqJBYl0iyvjhVLapSJRpMhBoGo2rZOLGWd0KMRrzfnRTSftRjdfPZE8sXFX7nGrVzDM8LlFVjf3DewSAGJXd8dY\u002BVf6ZF6Q4nLJCewiIyr12NGTns1Am\u002Bb/9jhLTT0\u002B5Tmp/vUZsOLSLB42fFxLxOrBLDeQs9j6GF1g\u002Bn4mVZVFmhSieCQl3CfusXK/Ci\u002BapCFNeiEFriFgv\u002BaXuLZ0u9Z48OI3qVzGm0AfogJmSw491lZM2Nt0P\u002BvzQcg9niNhagWcNhlNUwrUhu7Q9fwe\u002BnToadJgJ9L7BLD2RFeEiQ0srjgM2gT08HNLeFH8o0nv5FdTVSRBAUIioTFYRx6jT/3RpEe0EiBv42lfFL9w/mFnBlAAMTPY66z12ijTnLlkqChkKv8CO9I242HK4eyCsaLf4TC\u002Bow7J\u002BMiqvjf3nFa/\u002BmyXHNNiZNqNyV3CHfmwcyiGA7t4pgUZqiImZ32aP1cbCueP\u002B5TfbYxmINmw9\u002BrO6ksPcZirR1RnfXKhTA1s85n2pwMSMIeDtpYvAnUraKJHV30ims3Of8OTGI4iLiF\u002B\u002BT1PykDXvLnDe8ryfDTfTBTAaeSQOljMODdPfyf5UYh0oAlH655Rb6qzbx8CzAOOw8xpYbRM7s7Uc4IZmE2Ryioyjcwrl2B2bwo53NtJyWwzsLtQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-bcb9043c-38d8-afc0-2138-d1cfe30b8a49",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-860aa8c2909251d7bcf8bcea206f522d-81f34e8cb94e94d2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "02f84515-bd99-2196-5f7c-2cd425cf9c55",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "ETag": "\u00220x8DB71C701590E7E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "EAeYHziICwUalfRWON\u002BgBg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "02f84515-bd99-2196-5f7c-2cd425cf9c55",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de225e-801e-0020-61af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "BON2M8a/LyugMR45q6JdXngkY6Km5WCtEj\u002BGonMtzLNkT5HfxNfu\u002Bs/Rokv1bIrfZh79rLasph\u002BDyCCGOY23cmRr1VwQfpmhNmnT1EIUt6a1pjtVMB/9t6hyW/y3Z8BBGjDmipYtzueEW3ZN2dLdbhB60ZJSYkFFbh2zniOd6c6okbkSLi0Ph9hT0NSor97WlOzrPZUu77fuoBx5ejDE53KnpUcYy0Djakq5/5Jsnb4/3Qk2sqw4eaICI44Qlg2ojuliAAqWvcmsCNJLdPAlgQNeOZwmjTTFbiulFqey0tQ8EXCoCpyzqCA/iqra7QWy3KGKslxxgQG0nJLf8aYh\u002BjX9D2J/fXdnqpB75gOK64Em8joFJx94y5Bu9G0K1Ld5HZB03N2iMl8qIwfL9Zr\u002BKbEQuf5sG9IVhETSEIgJXNbZAchyFg6jhMDa2wMXrdX2cMq8\u002BRu5DAK9XliZzyHWIMYx8fPRixOibDQ9kkDP/ddu3KC9TWO7H/XGtbe2CrSeBLs95rvhJOW3Go3me3rB7mGBKvOBGNJjdtH\u002BCtVb62GAn46EkRcbjbe6BjPV1KR6BcdWNd/AHevo2m/p4hoPXC4rZdzsPVxJZZ08xhKfjaEtgwUOBbaCv4GinLenMaqcqqkFqm7IjsdqDM9ChFbYSUzNvF8VAVd3qaZaSaGloTTynxxomuIzZfU9o/jmPzsqylNq2XVLh6lSjQHIbUUmxWqbUOU6cK5pmlZp111ekGlrMH9OOsi\u002BpxdyFQzhavivFt6NS\u002B9W8FmkAD8e4bBL8/yXXTzG2Iui3KjNx1qhiC9eusB/0UV6FT8lqTmIn8VnJiIQSg276T1T6m5GiCj/AngPwCfvzCK3HEj9oC9RGT3jZqA4kT0iotCDK\u002BbWNIwWJafAed6ed1r/WC3FvkgOAdAxYiKIx3E77B5WbKE74Oi75nuHkKBeRe5GODgPXeSIdCkVpdFqjl42hYzARwu5xHhFCdfNhnEw0h0zQY84K485zvd3JTsXUFccUQsTnf3ijXTAylMMu\u002B245dKzNk3P/Vn9hnkUQZ48Lrh/sDRlHDUfUbQad2E8LRMKvkBoYxoKTVSxFheEzkvWg5yajQq4UsidlOWYtIX4wFlmCoNd08qedGLgtAUemoJoRPTFoaAIUWt3y880cZnOuFW9HsTIeK/R\u002Bxin2J7Df/ljMG\u002BRMx\u002B5XbgX5gj7agLJEvuwYHu\u002Bn8xE86WHYHnNtEzV0UEqPYU2A8ELsZKn1pEV3saiEx59pJCjTUB5Mfw/STG8JZnBntR2eV26su45nBwUcoGzK6EtWCywhvBFvdHEzGdg67H4U0DxK5nBwvKiabAjZL96ix6QjsxsEBjkMbyL9eWG2Q=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-285598e9-9d82-b70a-c242-6218d7da5e3f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7efd4db96cfaa994aca94faeddc8b559-0d577c485eee7844-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f9b3eea0-5998-39d9-5e36-681da3812947",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "ETag": "\u00220x8DB71C7015A1FC4\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "239OWTG3euNTMEd5PSP7Vw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f9b3eea0-5998-39d9-5e36-681da3812947",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de22da-801e-0020-4eaf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "EkpASc9c5YtCKAz63DbNDBuQ/rhIoDjJHokiNjIC\u002BqQPZHirpT0JVYWQ2xm1BCo1yCzyjEFpD3ERdipGOa5YQC1o63i9IWfehqkzt8UfFBpe7W4FEG1iplQGmi4SwxvXN5vsTRixd6fEFAaYNlis8WIQ50w/Ui\u002B/BUUktoY5y8KOW38pMscBrHXHQPtnynD8WqjMAtzPl\u002BRrLUjTjcAgi0hDCdrYg7\u002BbDzrWeBI0WDrVKFzebcnmv8OavQV\u002BLR\u002B0p7WzI8CVI9fpMPKh\u002BB/SN9UN/mVkQR1/XUoWPsW6HOEbIdFcgDR5PwSF9TzWRMakx4YwcC\u002B5UGWXNMZ2fuURLhQRhtdOdraglL5g30zhqBiEcnY\u002BiauxYdBrxExuA8Afc8Yoxb7vVlHPj9xxWXEZtout8Qxu0qVoXyUG4rFqMZH9QGuFuOJZlRslb/rPQAdfUg7AwBG0sKAhv2WZ6HOfZV1LdBgFk/2oU1zxSWOqmR8dppCjqXF/SZDLZPh9wKynhQmchMvvWr4QGGy1wmY9diZFe0Hj/LzsyyuIOi4FK5KvScRZDhRULkzRk5AEyoYpje7RN0VqxIlNr7mgZh\u002BPCuzaBXii42gS8U31EWkr6ACkXqxAM/NNRIU6C15bs8ctQYijKsUNhqqFv0X4dbIgIse4/AdyT9f4jMDzaNcJtj6Fx9Dgh707ltgCunSuVc/TGumWo7e/uvKwq50EGh7SfAgHcq3iP5oJfGUvb5RiSjfxIE3tchOHxg3dL9wfN3y6MD5sp\u002BIh8NtPjCZSj0peTmBmE/nQ5An0gKygBA\u002B\u002B6kXodT9V9qNUzy9ynubsNDbCf\u002BF7uSOC6Uw1dyc1gevLkaLhaRoLCFe9EUTKXUUjCEt23YUtQjAiZYzzIH57H01Dpw1DC8obt3eJvqffuIsGEm/bv6RmnU9yvwSOF\u002BfZQfL2hrY43/yAWiUOpISIQq0A7A4PoGCp3Qm\u002B0UvGjZ\u002BPsHy16DHVzjJyW2R/WPnK6XxXjSvZyaGSTamteg6xus2FfvMH01p7Kx7cnET8KoUP8\u002BjPb/90tubaI5qIKFMkwaCW\u002BdkGwxUh3GIM/S1clSMjnYcl4kvNEMgMLK\u002B/8gPKt9ukZTCrCS/SrZOcZ7m5fY13ZIrM/t9VyOgR\u002BZZlYulfQkVRuDDzd5NXUzW4MakOU68iSI14/rn8TpxHmhCZbEupPSV0Z8VdhO33dKqpnZc/AqXnQxlc50OMVWqTq92DvefpDvSDmuvpxcSggYkOUrEFB5hqsigxTVXi5xJaydgPdLfDwI6ju2e5/X5Vu2a5fQO5jqNEGAu\u002BuMGeobLZj/vrkA3SSpIiYUwwsLWq3JHvKGkOoTs1ylusBQfNBRq04A=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-82f07fc0-c125-b84b-7945-e792db9771e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a62bbe86a2630869b8b6cefd72243dc7-84b707131bdf69cd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "37342ebb-a21b-b4bc-ec27-3f9670b4c8eb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "ETag": "\u00220x8DB71C7015BF443\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "m7I\u002Bo38mdwWC2tAuQkFfKQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "37342ebb-a21b-b4bc-ec27-3f9670b4c8eb",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de236b-801e-0020-4daf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "L655SMrtwLXFsSZFilVcMnvQRidxZpZANp4LDt229FXxK51WoGsVgMK0ZafB7uZAzyWYlg/sasgYOBIs4rHXD7zQU1\u002B3BpEPu8VkvQHuf0e4yj64HV5GBMDVPmdZ6J4R3FXr8ZqGicmTiNpJh63GKbnKdBdyH/FdiU6e4scpttMmU\u002BCsA46tMUF0JJWD/X0TDhWtjnOHnr1jjWdM6KYCatIHIjTNGiYrHUPW/fpc2ozRi9SyfCdfn7UiSHUmYUiacrrDfNpIRfPugXEvsaDDB7Pael3SUO2qp4J\u002BqtGwBbz7O4s/mV6yiEXgw/q2MO4UX0HCTObqyCLMGNRXypsiPny0NHYVg21VKPEY8Yzz83eUakuQ7rnVEHJpc4CJWr6pvoV9Aft3/9zTbCP10taV2CRdwl9QkU/D3iQErA/ty80ybjMHdvJ8HGpuvYGV4D2b05pcLJdeWSw1uSLXc1PM5qBWw2SjjWIy4ab14dPOLv7maNh1kZ810xQG0r3PpKgXotfgPx3Z90U4KUrxaXhYZ4oj8Qt6VlUBIO9PnLulYzz93T/87e/hDHCTPWdURGqcrWoyq7OdnUuB3x8tiluJksYO9Iw4XHmbQuWa5xntrNuFsu5Qc7iJX0D0eg3QtIEVCaqhRlDdZFHwlmnNA7YxlDNDqNdsOB8OhJRLROFry45jhd1uTGWLp06cYNxOu1yKwubajQupqNCKk8K7kh9whMvban3Yw0fOtwGIz9hDv8k3wYH6kT2CudwM47ijzxQuLNsQc1Hesf\u002BeDNUKIdj4R9T4hNGedvONWLChy9\u002BOKujsWaP9M0t3WA\u002BBW4Rod5gDFJzkqktDkLbnghugPeUgD\u002BHtHsc1\u002BhSIgSvBHBpuJeEYnbdDqoCdqMntFbAw1xopYUuje1nRzhmIXCkfgnObeV05h6Au3GVhUHb9R\u002BRjWKkQl7vOy6qHR86duk1XfSVWUpxT9k96\u002BoTmQSvj04c1JAN/Duq4zK2yskDSkSIXCtJQp/VID2FZlpw26Il\u002BpHNHaJVK1287noXvoEQPqGlizjdYkiyR7RWhJXdNgeQjNA3MiimMzTJjFAlwWG8dSu4z0xpSJRJHtXqAqLH37hygy2w3Qh1A1gAF9X0jIZSlhNuJGq7K0Q76hdWuCyWBaybsz4wC5gjQ8v0ZTTCUJJTm2yTWbdNu1vpePL1Iksvbg4pXNlEHo53SuCewsITeZmBAxzABqv1SfvmSpKpLiGAxPsmlPe1D3ziGA7WsvSZ2f9VcB8qb2tmMBLdXdP7zhzDGf3K7OCly/ej4eqdIpsHTHCTU7oCVlmTwGTg162o5knyF5T6zu0es6Qrio18yRF72hFjZH5ivMOgNyh7wPBJ\u002Bvg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-67ffe378-061e-9f39-f902-f996d6a7d847",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fd91d78b1f3b4323deb2f97557646c19-1d88c62fc14b4e4f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "746284e3-f24c-b92c-28c7-f059cb82cbbe",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "ETag": "\u00220x8DB71C7015E8BF3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "wVd/7loFJCw74\u002B3QaexWiA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "746284e3-f24c-b92c-28c7-f059cb82cbbe",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de23dd-801e-0020-2faf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "2j9mEmBy49W0VabwKLus\u002BGPkdgeAnXNl9vz3kzh99AgNSRb9q2tedUftCy15cbRsWH5PD462VDzMARtke0\u002BdN2Gd49\u002Blr0z4hgC/k5JF7IVHiju6LeV5VvTZMKlQ\u002Bfr4UNTL247Vx6kxV4iO98GqhxWWHfET4gp8JIzqy36jp4wFxkK\u002BeRD2ccKSiNVc6l4zLqmTutwJ5W3JT7YB6/wqjrD7iDF\u002B7A0En6sugVk0Hzkut53UD\u002B2v/ODU9Cla9YbGaPolYWIstEKcjxox2mQTlTB90jNfVX7CS4tQqfjjqqkkaBlfDr7XAgJaOH/SfiJ8wV753SNSZxJ7YxXW2wpJuOVxDHFLtIZxpdAxBBz\u002B8M1p0\u002BiZ6cyG0gEG46upASb4EYCaYXKwMQzXhzdSIWL2fHJIbAghr84Y6jlwRNDbyKSpOfKcZI9auKLbwWKVM7GeEGY4YJQe1mGxgnY4QOw7/L\u002BSqOhvWRjj7bNmRu5sgraI0TRqomcQi2KR6uEYIni1oMSiAovILrZNVXPguJBzRf\u002B/r2\u002B40VpXgh2F3m83y8o7sKYpyYArv6J\u002BHEz0L9PSHqXhWHMI/M5pS4BuQ1BHFYqppQfpSXt/lO/MObQNY1JJsr/JVnJXMrTXv37/vXxRNwfCSorL6NQqYcSDO8IaXOgtJJCRfb8XUXJTEor8f9dzewKtSxjHfcnqn/Su0/bxvWOW0pjrwLpHqvkYeNZKLeHsEMDAbBDPZqbGpt7LaX58YlUmZq0\u002Bh7pIZaAfrwXzoHESwcM1MFBSxmvyJBrcfEF6nBaBI8Y0rogFeAZwsLah0wZsuKi6RjEE1J9BTGOgbOlepBLucXyr3hI7L7hJ4ha1UVAUb8OYwFblfE8n8mIlZQwdEQujsmGJwdmVfxZ5uvGJjPsSjPwlxuS8CfQshOywFcqsLNAKEZ7uiq7qA0A/bMFdnWVmEtgP90sn56htXDzt5GlLzI4gfntcIwJNO8KjfZ0yz\u002BaGSQLxnDWF4ir1gS1x/B7X9J8zPB7qCu/WwruIhGkLOo1WZ5tmWjBZm5tRZqHU2z\u002Bky4j\u002B/5LHnD8TGtp5/V7A6kegG5WDcJlu2qGCmKROAud85LjgDDr6j8tbUz9W3549kXtZNMCpIFvvjyXxRAObxRjy/Ril390NpYzKJx1aGPsCRQco9M0n0sNd8X0VCUrHwI4mY\u002BGFl7KeTI4z3/k\u002BlHYq7v77ctBLyytUSO1g95xBAmaOM7UZfa1Viqg\u002B8/PKH10G6xpLzE2925e2ME/EPVTy8t2Sr2DBEHFRpegoDNg4iimQWQyB9TUY0VgdYkxekExTTAAVOG/8RNqp\u002BiZllc\u002B/fqYmNORHcP2ned4IpK0k8xWc1MDYIg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-630f92d9-081b-2823-4d9d-af3cb578dc2a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a9acc6896779082a96681536145d1a02-f3cc23614162942c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ecb2cc1f-5352-ec9e-1896-c039f322c952",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "ETag": "\u00220x8DB71C701614AAB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "XC0shTfd/4l/VG8UdNw1Jg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ecb2cc1f-5352-ec9e-1896-c039f322c952",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de245e-801e-0020-1caf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "aAvbA26\u002BkfOgLYQHEcnBDudcVGyhzhaXApfFon9FyX66uTPI5dSzkyegdART8/7qenp3iFLLupn1QwHX\u002BO5zWmQGTFeV\u002BCkSqMBEAVoRRA6Z2ygFzkAr7v6a0qHT3Jo4LBmgTaamVYFQZd\u002BRhrk\u002B4//yPR3Gbowj2l1Y\u002BiWIP8wmDNRBcfdn8oantGlhmmhFW\u002B\u002Bi4J58cr2MfXJJTVpbyCYSa3rk/XIIi0uXH7ojwUD1E5425V4tqZoWtPSFHqQrS\u002BtDTi/tYF59mlRT5VIDaLsxUzq7JOLH5cHgzkl9g22ma9PO4HIRCLNAuUsJ2sNHEks4U8pqbyYIe2ltDJIV/xbnrXl\u002BNYhIIEuHemuXvQr9mbv9RS\u002BiPPutxmUJo/shK7k0ISxJyN3D7zN/4vS7cb5eb3PWF7nnRXF\u002B0W8jP3xQZk\u002BxYpvdtNHdOVX8IlkG8lSmqjSHShMATdy7y/ZuoLC2LnylCQ8igLui\u002Bd5k6yIXd98afJRIyRw7sRS/IejabpmlRfTdYehFhCl45VA1m2K5pFQWVCQbbmVfalf6Yl7Tx4pEvqYuOhb21fdq0OPLBRWyBn2Twxp0idaOffeRSiHLpR3G8N28imo\u002BIH8ssZ6BlGRCR1zhPwRw0DXPoLwfZYrWnyrGBRU49nsTVaOaSNg4DOiSTgPF6WUZVSCn7OqtH7r1VhFzuo9PCVHgzepg1YddlpPUjBaHELXFra/0kAmRZjbopfLGxVFYQ0Wx5Rx7uH\u002BZSlZX2ZKjbUVbrQ3gWnhHT2e0dy\u002BVltFBe0nR1SuZSvUvW0WzOYyjRDesahdEeOjMapW0x0BPA7SEFV5J0pgawmMXsP8ylBXaEDP46Cu6/QJgBGqV5IK031eRLiMuWXKfkqizLMfpmdZ/2rYNVxuIyhhb6c4thN3gY9GnoWXxq7fBWFWDB9A6d2qUFQrMp4c8CWQL03CjcQ7K0sn2Qfhwji7/TP7FBMJHIHFjmG7SFLtJa5cA5thHHedHuTQHRDVyI4fczFuIdgShw7L\u002BQNif970OrNVgcKdWuC4XfkuOQNw78XXm9kdfwPWSXiIlSNwOp8F3\u002BZdgEbPghRQscPe5E4PVwk9juQF1ruzgzRGEMG9SCdeJFkdF29/BBnAzM1D92UufUIaNqu7AAUqrgEOiW1Wl2mcgL/w7j\u002BZvorKQQnqb4vTF5N/pxF/pyRX8mlucH6sbjVnp3alOZMCfHQc7ML7PD51P3HZ1uxUHN2XnP/WL04MHdLQhsgVKd4AfSaZXrZlWLIu\u002BTUI0pdJD4aZDZyTLFEqENLsJrVyYBGT2VnJur4nMkBJqzIZA0s7i3tFeBhBbUzVc03ndTX4vJUjdPk9f1DIcd9YRYUfERA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-f3a07ed0-f6da-b921-4651-8822c7b5e1d1",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6cbe878380f56421fbf6ee44c8a2082e-a8d690a58105f636-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fe3a4bd6-dfd0-716c-0bc6-d206a9aae48f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:16 GMT",
+        "ETag": "\u00220x8DB71C701647E7F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "ZkXjYVyvEj1XxyVKslaoSQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fe3a4bd6-dfd0-716c-0bc6-d206a9aae48f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de24fa-801e-0020-32af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "lDqmPWKUf4IJn0KPOUry7ZeOF/AmrqTsS4mjTCLCVQyIk30moIfhzG2kxev3bRpQEE97Tfj\u002BHeWWuvLY8DJgR0k1B6bMzE0QrEqCgem49d1vUzzTRgcTiXWYj\u002BaVCds7Q36hwWZzg0QCaqCufJv83sQUaZ31jABCIn0wNDxme6NuRj1qFzN2\u002B9D40dxnZQ3am7EhgJ8\u002BRrd9X57oQk4Hm\u002B/8PzVdkcaRnm7M/Lok2r1wVpiKRfoELwCG7beUjbiB8TbsaiXYfQrqkOExckn8WITheOy2fFX0\u002BA801qQP/BC1SwuEOHCXl9iOoLUY0r23iZQysxXLy3Tg93EWpKZl25TReyY9eCATSeAUJ9yg3CVRfEwQ3Ej76YCXo0H/gfMyKMUhR1aXehFzHmk0t6OXQBtLxCdZVf5L1pKmpdTfFMft4f4Xf5TOugI7nL3fxzLcAGMmtL3M2NLH1XHE8dQ9lAqhRtWlf8CGfAolHrlAbA5fyaVwuWAKIAkrUKkjCsgt/QizPYBcN4Cinzeyp7oZhmliZCcvzNuqliXMeS8XYnJB9yCxjS6OA5IlzhkoWHlOEslAwaWh/jEtCKZaj71QizzEcK\u002BZaPk602GUCf3Bgj6sfmdl16HNoPnvhISHNHPU1EPdZOfKtKnPBe1DDPQza4ZorhFW67Sa99C2quN1s5/twDW64x1X4sm9ldK0iZQFuxj\u002BH4ZifumPQmwWEwrFWlJOVky\u002BeIdoEMxHmFXh5m08se7LdpMZi0FMK6GxQM6/9zuAZTNHRkOQlg65GuaUrVv/2mIb\u002BuS\u002BNMsLckzmt9D\u002BiKAaYYA69GqrOuCEX3Bat35FsWVro/1WwTFoPNP2qt8\u002Bu5FGekvaxOb3cL8EOtVasLrOoAVrkuWjw6BP0reXtJABRqPeFD0yaux/czI9UoZbDYsYJwnZ0iiso7ari/IuYLwvAvQxe5x8nDUY7B\u002ByZXAZ88QrfoyGJ3N6MnCHh9/6UBN2DU\u002BSKpHvm4vUweYJ\u002BT1GkZcuA\u002BEvqduAtkgs9RRVHpwMPFgghskyPOIBsWWMcTkzQPVIy0wxR2N0EXNIw6Z2fqNK/b3lJQrN\u002B8b/Lvd180UP\u002BLUfDVJP2vT0rHRV6nk8ijPCQnR8TRvqetCFMhls/h0uOcrxV3FR\u002ByLI8XiVeBFNwqPEs7HRk6uZNJKByajbh65XJ7CuSzLCcUdRtFyjVQK/OG91qEpsXaYeVyPezzF67GnJPlBgnndxAUJqf95O9d6PwpE4Zt9k6skKkPMO46EV18fz2haxXpn4BKYHAd3H0GFETgygQYWJZVSHVQ6DYh6gVagWWxvI3mP3P2I5XOjrQ7\u002BRyZSVdJVCaXXCKgmKdaGHZ6w1sHRGfA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-49b8a06d-0d88-6fc8-bfd7-1a8156fde981",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0e9ec21dfb0f5758e1aa82a7963896f7-f062b87e07e24148-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a76248f9-cae7-cd82-5ad5-0ecf4aced0f7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "ETag": "\u00220x8DB71C7016604E7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "ahmKB9RelgG34N9c9h3\u002BZw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a76248f9-cae7-cd82-5ad5-0ecf4aced0f7",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de259e-801e-0020-46af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "EtTxpgazWm3KwLH1PLaTSktNJO3Lkx4ZbFaO\u002BDuDCP5byyLbg592vE47N2KeEi/lfgSlS2UdFX\u002B22DqvJGIxRriymXCTt8es1mefj1y7elknqXk33ryZPbajJaplx5jrCvCq63m\u002BUcY8\u002BXX9foUi\u002Bl3gh3vo\u002Bmj7GVu58JIdRg/Ps4VrEY7gaFez\u002B\u002BRHm74wgCpMhEAcAxCIrtIdBWAzH7NlLssAt\u002BnP/x4jNP6Es32ciXBo0MHPsq914mK8w2P3gNwx4W3zMMhBfYUh\u002Bc4RBPpUgHvwy07xlnscitSGEjy7LLQiU9EPqVinJlI8rbngZN5nZ0LnBrWNP0vy16b0u2tIZswa7rEoRNYjSaT8tOjBOyb2Hqv60yb/lROGHdKys2vm9EftxnUtPiJrxL0QkIpiMJx//pzATpKmG1mdoicEcJY5FcCh1HSwyN\u002BIjg5o7gSIJOw2MrTOJqW0R6ocj5z7Z1Mn13rKwVwnzzW8N7\u002BEPS1VFX06zT7hau4a7I3JlDhDjSe6QRaJvWOPD2N/Eu/mMAl9xnoewJkVRm2Lr9TPXTr8eaqYyfsWy1caqr7bYlj/NLuDTM2\u002BJMyNpfup/Q6OwLEogphETWcNZ/sjAxbaOuQVjHsZTBFtPlXeCyMAbc1JjOoNst\u002B/uudUdeTSmyC1smsXk3GSdXSgu0NCZkFDDfkt2XcrzYcEVdGUxNYsmqM0KFi46Nlcthd2bPecfVSlEWjrpMGpiuXjEz6f/rCdcyCgDT7piiQg0CNftWGPaNh97rNuQfXii55z1dWbvbdm2PnX\u002B28Vu4ZDytSdSdSEU6tmIg/9LjIqvoGgdrVPhRNr\u002BNxouGxpZzIsK3YhRELJ74EqNZuoaarGrD3tdUXR80XAMlD3HJo\u002B/Lrd0QO7CHo/1oYzJVB4w48yoQwve/LtWjcxYBHy0tPm6zjgypimC6TCrp6\u002Bns71SG/AxHqOD4HH73bLiadoTASzTDkYl/j2i5VnbM1TLrxpPBiiMQ1YWNy3Gdsi24H8WmGaClGU3LF2yTnlJqKzdMC5YU2Pxhv2W/RdYX4d1LATaxJsuCNr1V9nK2fUczE6A6UaaHk0bZNGpK9cN3syWfWI0buQR7udToztJ5uzIufDI13YA2w23/5\u002BJRR0Dp7jNNFyS6F2qbzpfRntR0X4k4HHmRQeWlaIUvK8EiGnKEDtCfPJQNdFTHmh74ZTSJi5hZKSrHSKxdp76vivupeaQlTZAD1SL1KqgkyafGrQNQpaAoyPFHzLY0MYTlbelZLiBqwxeUhaZ1Y/6Con70hvqrTuVbcKCi7XDZz5OeH7zOy6uHa\u002BnrvB/5s2TytSo3T7qaOh70Db1/t\u002BWmurYC10Qxw\u002BbTfSsQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-57c6cf26-e407-e26c-7055-1dc980016198",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-666408383ff2ce218ce114f9f0d78b8d-8a41c2e2242f80b4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "610d426a-3c47-0aa7-8d2b-fa93c73eb728",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "ETag": "\u00220x8DB71C7016911C7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "TjVUx6YRXkPQG0k0y4swKA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "610d426a-3c47-0aa7-8d2b-fa93c73eb728",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de25f2-801e-0020-0faf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "q97hekBETxafbcELDxQ1PSj3lqjC6sACQHvUAYNhnTbpP5KPVVhwx6kWtq0Sr/JxNOvWmKeyGsEe3jnEb06SPdCKItCBpufQhs/\u002BqzMS75GIY8yYiwSPNyTQcXcerFdahHndiI0i744DBRHXs26NC\u002B6oPAyB\u002BrLL\u002B\u002BursTRvstp3oye6NWcDZnQ\u002BlIXzt4O1QmWIdW9L2YnGEYyhdj5Zk1M3Xw9H09WGpdaYQ2Us2ENn9W7P5jxqLMqd8yTaYe825QAxvFhzbm\u002BPAtCZspYjmThJOoHPiqwXzDJFqd\u002Bxq0PnYV1k\u002Bxzr84f\u002BP\u002BRs0Xo0eVnrkSdtZltUGu8lLsWP3laNslA4v54cXUb60UrIqvu4ES\u002BGxhobefsCEOAsxsXCb2GO3x4p\u002B7q7zjPgc5UQjG/0bB2VCRc8cTlVNa6975eBOGHpOcvcjxV0y/fmOgVm8oRxOFmoLGZJUm3l08UM/d\u002BbXzszJlKkF9wHID4fVTYz7kMpTLc\u002B2Qv7n\u002Bdd97tPaM0YStvKMssyzCB8oAwoKvw3suWC4rEoXYYwOIZqRyAgt7hwBgtaabt394CWwTj/03XrJkXWzYUc8OxVmvpEx4UAXOhUtyPx3EkpCuswkZxNMGQRfyHbSuoyUxYeBc7BMzD6lmVQqhxR\u002BUn8rcOa615QCGmWM0djJBH\u002BImMM0td6aNe6Nvs3/IZIv4bX35wnl2i4zvxlKv/olnFTUYi4RSZygkXr37ViGAvjTXPBjEV114r7VATaFD3X0Z\u002BK5Kr9j3pfZVxWO7eyVbXxgtyMJwor3Xr\u002BvfAimG0IFA0W2DRg5b74YiboHpzSSP9P6JFgS6qUXwYw/tKKPc3vTiaqnH2BkJwek8XjQr/eLHXx0q/cp8ljgXgtMOfrbiRZ\u002Bc91KKuBzlj0QbfksR1HUtJdmWoeEqZdRhsEU2C1MyWgiUjvaAPJbwRW52URftBb5t4UjtW6O\u002BYoGOGPfXr3Pg6SRCfUV\u002BnOkyllxytBS8hLqGyCoaRP5k5hx1AiOvGKX6hXfzqpho/1RfqrVHS758wZRNQOdZ1qQl3Yc5CYrFk422eD6syNoiHdjVyppJHZpt\u002BECfUcfOkK7Tzc0BP/XJihc3gMOP3/i6KzMOhBwJ7L/8ywE6NjG19\u002BeP2QsNEN3TDDCDAYzG7hhH5TaUsBySydEdBGTkn1PlcZjr8Ab9rQpVK3frdusjJezo4lELIUfK7Q8p8Bxo/nzcrY/z2u4RWjgsP4Skt1L16d6H\u002B60C2lBBIQMHw7z97D0LDtlbL0sO15gY3uHDJjW8NAY94PLfycMvornbGYaLLlNXmah5mrqDiSQE\u002Bft\u002BjfrdW5\u002Bmz/s6O0UWK4yRI84RnaCOa4ydMplQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-15cfddbb-93c0-c2a2-b530-3403dca06349",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e5a13b869c468ecd9424486d226d28cd-033d56b948312f14-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0865f4f4-6fc1-69af-8cce-f3644e7a37fe",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "ETag": "\u00220x8DB71C7016B8258\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "v9kgjqRmeQ48eUTMfsvPnw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0865f4f4-6fc1-69af-8cce-f3644e7a37fe",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de26ca-801e-0020-4baf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "1uU1NvPfJVZeNcSuASfjAY9lslk1tgZV56V9ImACq5QjZeHjnvOh2oAnjXc3zBAkDNpPCJSMSyDf4E9NYQP1XIowi5xFAGOcw9fYDiiOHRqVWRWFs6L/lxnBBL2jU3l8MTHtB0Fz3wx3skS9sz34UMM0twjub6joMPSCg/ul\u002BHBdXNz2oRbZInoJDgBdQuTcybT6bptxjsGJBNZN8FsQ0bnUX1dgAa6sW5WN5WGniu0PprpHq4rU7M0bbJw/jDEe\u002BD1GiOONfMcGThMG46lg4XroPUqhySYvAHKJRJQRbM9kbu0kYQIKginyQV12zgkkuosiV07mfS4WFohwAzcz9OFEoXS8PIB33rohr4jJuTJoZIoJ7hWAfvG\u002BDUp6mX/yvkx7MSyVaH4Lq3iUxc6mTV1VCJ\u002BtKgbLxCOC/S41/UQ7LvA7TYcF0/sL/UOc67gjF8DtJJHfRJRGr20JEmpQ1a0zWJbdagDVUDWjoizDL9hqX\u002BZuSNmzW\u002Bpc9Z0Z\u002B8CQuyiVaZIiRay/F9NcPKJog4CUn7KE4YzTgP2sgXViu1R0EuYDLcZFRxo5rjEGVx9H9HIdhVwNDNmbwuiVdsM3XVt\u002B5ym7ZFa6T1eYSzJbzSjeZI0DRTb4ZwYNaGvdsNFWAlDWh3D1i5AbYjYEdMCnQPTAtxE2Mxgkhn8jrvvr3Z6GQknhhUW46Nj95\u002BIA9PJFZid2HPnAH844sQHw0t2UMISXfjJ3xbuuB844OUw1I5KN3UjUdMClxiJ6qdNExxX7abZdaXbAzqBsxxQqh\u002BaCAo5vY/WUwLzE8rcQ/RzoakC5PNCV17oczQ6nZ62rez4796ZF1WQgZqj6mXe\u002Br9GEhF3UcUsW7SvTU5bm7FgOGXZ51AV1opTcmNUnmj5CXR09I\u002BNP1gnzJQp6cYHNOXlQ64AARNvLDuHI\u002BNh17lLtkPV5qcl1v0Jthq76\u002BjESDl9b16\u002B9QhlBcRQBh94xfja3jeCMVJCw2iw\u002Bk74s0ROvtel4GRejL07cNze1czdjOwh4Qm1RhrrPq/yCf69aFaAAUdH0uGQfFF6SsB1Y\u002Bmf02le2tI6mXi8vqW0aIa\u002BfgSGWtSFlboOjWC4OvtWddrCVjaVXpGESWfKixQ72BPOv8i77wUVFj2vUEltfmKBZkjO8hZMJSN3AhFsuw6l0rVQ7XsynobRrUP45gpEGssBSSTPbOX9fpapROz3pFsvCYGUHJDnUsvB\u002BUTWVz8VMudGb3Hp2mHPU27ghVWZ3gjkydyIr/46GfpdCXehKytblBYFrTjpRTMfyMkiBslyKBs/7YlijILpDFF3iMzuLihHiPFDlDDT/4CtaOcxFBcw6uFcYTmd9QeTGKDndbhiMZqc3ng=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-f8fc0667-8aee-89ca-34d5-d832effeefbe",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d2eec5cf580ab002a292c1636c1d80b8-926bb869d5967fca-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d39f45f2-afd9-f967-a4b7-cf49e79c61bf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "ETag": "\u00220x8DB71C7016FA06E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "kgf5ikW7seS9Q1ohpZDfrA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d39f45f2-afd9-f967-a4b7-cf49e79c61bf",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de2754-801e-0020-4eaf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "5HI8qWX6ax7k\u002BiFyE87SJQ1nVS4TXX1R5lH4/dgqKkzGnaf0a445fKCGFaDaDxl6FMjwpzt6Z4f06sITAW5FutDVq3Ym3rl\u002BLtiNjUfdd9c3fekQOYIQTDUg/4HLJXoyQFvQBWOjUzYOcXlj7No/FnPr3IOFNYBNxV9ABt44swheW0zrDXJzlCmyAcgJrF9a4OkN4En2rQrbgj8DYk1X1b5wBZGOVAkBeEdZ0jS3QxgA5SX1K9O/Z61BEIoybzHcWysKmafOzIzfDGcBnNvWIz4nA3woYqrrsJ3jTEN\u002BzggVfXcIrapwMRiYFR5rvcrSa\u002BxLC2u0s/iBH\u002BgJ6oBJYT5f6x9kzXWUttJjj0yMf/LTEeBWMsOcYMl\u002Bh47CZkeYT7TfC9Grbp52t1SZUCSs9J/1Ntmg8i97wopV5kXn0k\u002BKy0CYrHMhKKJB4HpuAhCl0ZPvzDBt912EZElHVYhYj\u002BUEDoXkE0cr1A42XhG0DL96rxSy9wUfHdPiE0cq2tIa6FCVafSKwb5LxPgiNphL0FiJzKZzppfg5fGxAf8AAPo7HHbBH6LL7\u002B1WZzMM/eY7lkPvoA0rpkK4tIQC2cC\u002BS8P\u002B5hoiirG1vty5HT9k0\u002BcKdmq8EF/sD3UzCGodyBYsmBxwDhfLGAySOeIxcokCVOCd92NVATpjEdal74FGl/XFjIUj9MXQPl5eKdd9up3sMbOJgNGy15bhDPxAJiiKS6Hta\u002BYE32AbzbgF99di5lc5ub7NvBckE7TvQefJjxg10941j0\u002B36FFTbrMYreC\u002BfialB21qvI\u002BKyVgxFJ14UT2g0CP5LVYHgtFsek5jC2XUMMLBJIiqyhdOq8b2htOz2xx2d928xFHPnYSc/kJBJr3yXOTbty209gUMq4GQEfz9uJ8x7ZSIF2xw8oYDDcvUDYQIAynu2CTuwYHXsBnPPouInkWjDzgoakR3asSmsOg5N538iA3SD997QiwTsGdTobP6e2\u002BGMf5M35jld25fSBCYnXl80rZ\u002Bto9mKMwMFbrdJMkRqzV5swWesKh07ZhxG/obehLt1s79fMTfHwkxQMneB1KlTZzbH\u002Bl03SIOCcj39AzS8Jun7037FC9wmpP7bXDeluVFy85eQFooefmr73P75yv9X08uNhgEqjltaoVVeG\u002BxL3LjsSk9c69Af3ZUTyS7dLJo/g4gsGDNQSGU8dbV0gCK\u002Br8BGDYBv\u002Buf7behsFsUsfXT7HlhkX8SFm8HqYLZaqx1yVVlulx7Zz8jgMKpK5HGfz/gAuWHKWhA7wLG\u002BhVpxoMKLOYFr/eZV4U6PRC9aOreQSlC\u002BWjG7qDsJMtatWwpuro/nv\u002BqwNBIRqpfTOtYg4YX57nsJswaRD1FGQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-79c58276-d42d-93c0-2c03-a1d6af6906d0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1319bd992cfd13ca378ebf9c863e4567-86bf9c89908929af-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "09725186-64db-d225-7834-9cccb5b8a8a4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "ETag": "\u00220x8DB71C70174CFCD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "DOqaBhgc7uVZVsitDhH7Tg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "09725186-64db-d225-7834-9cccb5b8a8a4",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de27d4-801e-0020-46af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "vWaitZOhRELNszyT7iRawmWmRRwHCEY6ZwMFvC20OJMtGVzdm5CG6ef81GXU8GZYbyjO2RPdq7QgZ02Pm4gVGXqpZtTIfCbUIFw0CzTgZXecrEwE5V5/T26nvTRD9k1f5rrqK4mSkPMB\u002Bri2qJ\u002BAPwHV8\u002B48ETQcKRZlIL/ykCoP1SR59TrtChtYAuqlyafOJ34ybgJeItWGzgFzLHA0D2qOp9J7BknH5\u002BnT4w5JdmBul/hAvyInsLJO8yY4et2rJPOAFyLUUyA0aoYZiz/HPFihBJV3809HZvYgLBMij2wLKL4byF49mkTYDFSbDiVyh7bNlnZIMzGjObEstCYMEtsZDWOBq3T6ZGpQn\u002Bf6rFfQraVdVPj2w/SMd4\u002BtEeUey/p5gQHC8dtC0zIM95NKqIxZWweAr73jI0pu9DTkTFKEMtTtgSpWDrvKG4DG6sthQs4CU7benRs8lV22U/ynXYbfh8W/XSdiA0xLtpQ8HDl/DbJl4fmcppW4sOvMn7q\u002BIr365mIGoeSnoFBpkueHAHkkN0ZKQnuNQ\u002BEwB607lWOSjJPWQjbXeGvOvUGoMhSuMa9yqGh0dOBCbKOB1po3awrt1wVTsL5CTb7ae4Q65RDMgtb9ye36HRizlNaSVqLRl1I2ulsPWoDxL1upmfhcCIaStFTDOaId8rnsnxznsPccCOQxAyu1vSdWC5qSUYMfVotPAKFODV2wGMehIrtjCX9jjZATKgRb3fYsbS4Hi6E1zUiRmLBVzfuHgetjE5ts8gEaLsPyCyyH9CKqIZ8uqI0la1Ry0nHPDsCVjKgZ98lbwHss7V3eQsEcCaONq6xbWNldPahG\u002BiCPSyADXX\u002BDbfxYTmAkAbswRyiSVcjNQWMUOjPPu7khFcZanaE92uVCmZynNFxLNlYeLfZ/s6RXwgq87yJLtLFDNzmayWQZ821CT7wsJgwHyATcsY7DoWEiA9qXgOvD9\u002BTqZP0isWzxBDqJPWPoK5v9tSYdbgIjf5XYeMaKgnKCfljXQcIP5BeX6qxTOmT9Odc/msrEpojixuRnSTmmZ4HHBr4LEOrZ7dAPhYRWz0Qx2j7vSuiovdjQ9Xrdp5re8YIqjDOl8ijsZaz6tCAEi/egNm/6thyZH0nlOhtv\u002B0U1MZQBK0MQi\u002BgVAuU7rQm4y2mDPXEr4zplkWzqwLcNfWpmxIOLA2Czj6uH5bQ3XXE/LW\u002By7L3UCk1Zm5nWJsswCIV61emFLMgI0K7GpP6FLjP7qpJIW5Cskro1MmfG3GjgVtwvvYiHugCmqRwPDmVP021m23s46K30zUMvT/phQvNF5k4hVnCrc/CSorJ0nYRU5l76YAHtp24vO\u002B9FWGoFRWYoyScXLn38uw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-7961d4f2-6804-31a9-1245-e1eaba70d2b6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-34eb9211e4cbf5b600009e985868d189-5bbbe4a165e99c7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "95c23b1f-5829-c6e4-475a-6a895b64b939",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:17 GMT",
+        "ETag": "\u00220x8DB71C70177196D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "Tx69mwicpRkZCxqaA3wRfw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "95c23b1f-5829-c6e4-475a-6a895b64b939",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de2845-801e-0020-2eaf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3/EagWUahYxcS0zTXDy34P6kmWICKDS8voZ9AWnehTZx6Tc9YnpVTQUY6a8zXGKdsbtoPFn1PLe8XsLfnYQjfsYWYXIFen6DT0td6T6EiGEj30\u002BtdkjcfK2AgAO3dq\u002BB9WrpHfvvmDc85O0Nl1J5ONZhu700dQh9OeXFhfp7zNmb3PPTmmtmM0YYcZFaz\u002BRaB0ctVrryTH9ibOMWKhM8wRgTcbtepZ1q\u002Boh2HAR2I2oAa32yTnUfqZB0cC6IUAkz2695Rl0p\u002B2Gqwlsxey977El5Fb\u002BVinOi9Mcr6jRu4ql\u002BQ0FU/NwM1m8cCIsZ7S1g\u002BITlDjpKnVE811KV/hEtO\u002BCyszjuJu9sbD9PeYLoiAeayvGvidNvNKbvGCWJd9he7syqZzr1cdKUeKL7\u002BiPPVE5L\u002BzMffbENQ3\u002BS/g3K4/Vn8Yu1PSHNpFkfGxExczmCIMTXPnulP3AanSS6Y3LFypWslAmYGRYtfVbZAGKg289FD95I8qR5wrEamp/8EkHmWVF7hN8v6gauqsElyz4OesJVdFOUfNfxM9JXfX92MGsV86YQJFfvFiXXmkjjVPZzCyDdp53tUd15ilEN12yHN3lVD9eY/VVqZV4uveKODt7b5HJfmYnNJ6HJl5oF4j\u002B4UGPPjUQf2g7KckE/vpT763xyMfL6J57viOg1z2a6ZIMfdWx\u002Bv4CZvApjlCZIjmgNzawdk7BMvijF3wVc6QunDw2\u002BIEknfCv72HXolpN3p/l/KAG6ndHS0rdEud97PdL\u002Bu4QYim4f5VGAIbo6ZCeVTTgL3cAK7XI8602R48JLgJuj6toOXx2LX0OvOXsXl26Prmynb18S9M4R3J8gjQKONKEel3pMhu4bgH19WrP2JFPfATRWoxA8kPUM/IN\u002BatFBIQTa\u002BQD0Qyh9jO/hlZkaGrdLQYzNN5GQ4QeEP4lrnRWrOzmuHCtT6r4M2BcgWvtc8uLLMilFc\u002BlzSRf5cAOeEu/aNllfa/6M\u002BFfNwV56b4cLJ02nn2rsZchQOtITWXq7bcYnRiSh/IbjPznSeLGK\u002BdmP7Ui193OF7dCQDzAreJ7cElSYUihjaSrGw2AwGu0WxUH5hGwxBXVSollTEe1WuMab9WZd8aewLIMe7zMSVNPjeknvMvQyqwzeRbDPD1g9cAqZlSWGudSZSFfoEhVBQE6FcJakZobSaElZfqz24R0q4X8oeL6uXMB1VemcSZj3nAViSp7BmAmExyzbLTsno2c6vjGWGMeQ1xTVLhGcNR\u002BwYuGmlJd\u002BaEh2pLCR0i6FTbKCYotnYIQ90nKJ7Gr46JINK8pZgQ7Qu1XpH3QW/gXlUOFeGdOUSQFdaMIk9HzefrwehKdkLMyjsqY2fUAPJw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-5a8c7641-e9da-931b-4669-cbebe8f4d9ca",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-075d139f38c3a78fd00fd7c725ccead0-4aee350593701d7a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7aacc382-12f5-a37b-83f3-1e70f95b9eb0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C7017851B7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "qtgrHLttiyCfNu/vDNvU4Q==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7aacc382-12f5-a37b-83f3-1e70f95b9eb0",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de28e9-801e-0020-3aaf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "2AuhuPd6XYEjFbpnLF7LwU1B7rZR4FXk7V8LxZsvs1cG311ynlcvWA8heHPfZ5IZFgeu1130dve1vcqYb5jm82FjYE0AWSL2EZanL2jhBYbM8q6Tgdz5EWlmvOGNlul3O4QRewZFGL3luMXHTUaP1LdDzHzpU3KFaU7jmpxAaHutL/Pk0ImAhtnxrcgXMsQi1\u002BgqScpsjegRjBK3YX4gpU9KGR1TqgQtwkaj96WqbTaKwcO0FR\u002BxQKIL0kN3yCRb0Ah5zRmmzyzk/IeDyJVDZx/bLaC6bI8wmdh7R9jAtvohSCecMKAd4/KWzxiXLXgMyGskm5qEoGR4SDNAKodUI0aMYoBupjZ\u002BvkmuJJx2mGtgb39snBtfnafCI\u002Bhs3blqQqzSC8r3nSE0pdxR1XzHArDH37sI54YrLcXZrIJOEeGQQ\u002BHvpI2hadFdOPY\u002BDscr\u002BiE4pP39Ylslpt4EHvGe5pT7wJKa2F0iJnbpq6\u002BP7R/\u002BrrFhFWzjkuGGyf2unEvgvlFiQk00kCLEFX6HFLeslrm/Bm9APdEoGC2wFA5fc4kqCexeLarRyR2OnQDtW34q2jNE75bboIB/OSofg3sUZKH0XAvKTWgO7TxSsaDQOryvhjraGoTzT2ls3vOAskWiejhe\u002Bf9zX4zLNQJZie7gr/9tcP1AOkodAQ2hXm90jTv2rzdocUG8OyeuDuWBmsZ6iy70EkFIYT/uQffy0QEcVqfGYtm3eD29sDTVkitlm2dHJ9JAf3r5rk33eTBJymolkrg9ujfswxPxNmINcs8UiaaQqqou29YtzbSMwP4MdOXKsP9zJ\u002BAvWmS/T0gY7Dt94vCKuB\u002B/9rbhEO2DYAMU5cJ8Q8LQoWHFYVBGb4yNFOF4Dt0NgrvFCrlIkRfyrPpgqmmGnKh5rUGPxFfPeYYqU/sMClElBmIGtjkIhw9J0rVV5cUiB3c4/2Ccfr1k9pAzHj4c5qGoO6MGf\u002BZvcCYxRvKhepPACEuE1AvxiYilosCo1WnRLewTrKoiG4iRyI46ajjLwnv9chbymBGWt7EaYdwmx5u9YBkFjc3pnuzD8gt8tx5P2t9Eq2NT35TaffX4B7qrawDzfQofxTWuE9QpLqUGGQCTy4f94Rw3aoGEKxDX8ZYyGIcKiDkUMBSqlZePKbDv1GP1ZDwyrYnkvBOJm5ok1iE99xYe\u002B5HGf5pyUkuFqEDQlFas4oxZ/2r9JswmipV6hb91UTKa0dnSLuWiwFo9XxPSuAZEePOV5PerINTEn/QF\u002BM2MD1YONsN82bOmtz8PwMe4VNKONg3L4G067rEEDY/xnMiNsE\u002B9xIFDx54/7iy4nF8NDEshdsHAwS/p00gReMsktRp2gQ93\u002B5BQSw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-1b4007cf-769d-0db9-d894-66e8f3d5d8bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-891862ad0f4c2c3cad599701972a249a-468f43f018f949e4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9706f66f-3fb7-1b43-a7c5-5c1e13592811",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C7017A9B5C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "9bG6Ly08p5M1nXiQ3JioPw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9706f66f-3fb7-1b43-a7c5-5c1e13592811",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de296e-801e-0020-31af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "INPwOTFP0xs5EkEaT5YQutErUlI2PalR9sCByeDl9HC0IFYonxYaIJtwty1ANwJg8Yn\u002B\u002B7N7ueIqnkNxzQk6VB7RZS9A6Bq6EDK3xYZ7Eb6\u002BINhX5/i8OWdz/QHTqFKRNWMPb9HSIAluQ\u002BqAw/Ncro2Es60w42wlFCzHzOoZ52jgJZAibKLs6wDP6KMOO3V0Fk90TvWkYFH26VqlClMfVFyCoJ5iOkLrl8itYfvIF9i2U7abpZhyO8Q/LIJHR\u002BCsr5NHjJvXEdwMiLYt9/9WLdKC77edhK/DD2TaIw6/pFDnALFngIo830LZjhziRUTF6P6vxFgpDivkhHw3/e7OTORmRfZN7qxHRRB0xPWS4ckgFDoPD9/4vvKFg/wOBeFTC0E4fABNePlRaH5ItEo2UaOyFuizvj0EbYcEx2uwOUAuIbi0WmXJ05xAvqdhsAqnTzJYW\u002B75oEwEMw54SLCOoS4\u002BGpORgfY\u002B6ENLcgCVo718XHc5V95RNIFssCdWUIrssh15I5Z2Fs08GnKrrS1Lbo9Q/Os5VUlP7OUSJdHO55i4X8DjHIAnBUap/D1spoZTIEGYBlSfsl3TKTawZPD8bTLa805saFIPKfakj1gL40ZevgSQNuFDGaxjD/JKdqFVrY4KkrI45rjuiNxe\u002BiIEyEXvUqbsazdRl9qhCVhfxbJUTuLJAFGTJtdMoq0E5B6JXketWiT6aUFXufvYl91fjsMqCatAOsf0XCvOn8mJTLK7F6oRsmqNWuWgckZWuo/67BPp2tpySSN/uP74LMp4zW1IHX8yTtxYnK/Gn8iAnqGc1LO1oHHYSM6HkflslS0aJ6TZDZ0PyJ43kD4qq6lb/hpcXFcXwy38cNSxq73i7AeBq3cjp5AEjAwUfQ8zrZwkK5LeEDjWA2R33J3IXhzgVaQ2qAAxN1aKWM9LAkUeyMI3jH8qBNvOq6gTq8ryOy7vNChq/AWc8/M7U7hpigEeWRTbkdKdtlHIaPxXHoyLmB2hXM4ds8y9mpmL7rAjZSCm9FK2F6lbUX3XoZMIRNVnsLubyC4zAaVHHvY5EcihpQPcsSk51YBzRQpQRhI4tFXDJD70iJzxc/Osb/myIkC1NvyQK5OrLdo7J4Mk4rqTDmmhde2JrBxm6j42jWWHwCLJmxAVqIjCGPZjuGEZzJA4GGCPEa1SK4ngKUFVdZ91s2dgWkeqfmbg3lz2JvS7TB2u/XUE\u002BK51d2\u002BHNX5HbKNW7gX5uXJIjpr6rzJQWwWVJdwjp3gqcLu46uPXI0jnmHG5oDjuwZOrZW7aCkh8JRtq8RChI8UrLH1KQc6OcGpREhbAlrvNpmRJeEEJT2ZyPMXIbTE4RXWsjnO6pH/EHfQEiQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-3895eb30-abdc-08f6-b9ce-339a9dbd481e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6e76c086b761f21a0dcb2c90a4ac782e-935568780a7a10da-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0300f8b0-0654-37f8-64b9-1ed575a8d918",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C7017CE4F2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "1\u002Bwhr2oRd0p6XR\u002BLooQZRg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0300f8b0-0654-37f8-64b9-1ed575a8d918",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de29e0-801e-0020-19af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "CcUDORjNoRQISBIC5IRaTQTGbz\u002BANmnQ5oztyShsl6PMebtX8ctwKZGmhReLScfUUDYdFqeYhdJbM1KL4NfrnLFuNWvIA1w5VUWu2bFSRJ3FGHnyToD8NPTp\u002B7145Em6u\u002BlmHBNbC03a48Fi6qshCe61xsdd\u002BU0wcQF23weewXD78x7H7CiKaQ0sGGu/mUpIx/LPwh6CXMGbNaoR5StGOyJQZ/aMWR3GK1y5MeHicNi3LRcUzv5ReJddLLZ9eITh5dxJbjJTu27VCZfCyCrfucTSWbcUMW0j/\u002B5fLyxmSbLX2EwFmQKlY3GoP8Vnjq9sfXPxqh7NzLRvJW9E9IxBbsDk6/De2iDCLfZFa/KnvHA\u002B8rG5dJ\u002BUCQuYlnOTYG/lZ9AFgqK/jqNTL3woiGHBx2n\u002BBgLaiPohUOLkRkOsL8yGXwQiojnOfmQNZkUia4Gq1s4JlFptCt7V5DLA2kdgpv\u002BvoShdnyUwMIedzSG1/uRgOnB1o5pyGVUlTL4HDaMcrcBFcspYTTap2WTTzz29IOVNX6DX6gJkPYfTN1NnKCLjgB9hb4waCO05y8k2n0oXaCvYuq0DRcK94DVChRXjQrBC704eW7BZM1eynR84Lp49vM4ojm503ztcpI9W14LYVokY86/7\u002BQ16foZWUaejhLGWBclGu7NCzRATwbchAlvV2keVIDvvQcLBrRDnHo2TuR/dwNK5kZvW1iae5zhVWHwrgXdgDmR2p8MGhQ2jWq6CgAeXREKIG0isvkkUUFqKa1STu50WM6u7ZhgPsgyNM3t3HGYwvhQ5o2Uus08aYVdpexm4D58Ra01c290qeWg8HovOnTPzWqxAWRg46H9boQXApjfy1STcZbAZ1OM2Dyr88ZTETMQjdSFsd7WH2YPNADrYadMxSUlm8jeD2YbJCkruO/brl1VBnTAVhl1uVYwsTNOpXaZXyqhKXVqMoJybom1rmJ6N4mjll8yiHMLs\u002BJ2rVo2yIKyjl3BNoDr7tfyUeuPwA7zun2lrxMbatK7lXmW84EkP6YLAxwEtP0Eu6eLPDqLf/PTgvbcjRlzmyeLCaELVPtSzhZBhLzy6wF8oPdrkC6UMBmFx3CKS66Im2v4fa9f/WasNHIkRfc24JvxY\u002BwmCAb09tWHgZGGxIJntO1Q9m1WHKOQu1u8b\u002BoiUuLUmOvCZpNhA4bV1H/VJXPvwI0J4eoqn0NIkUyvOIbrZS6usi\u002BaoVJZ7/LmfEgnv5HrzK9dFHD4rfmoddFCtcsD7nNNJndAVR8\u002Br/H3RCL7JNW\u002Bx2/XjlC9sgAx8it9Gzor4pHU1pUap3uMImR/AWXarVD7h/JfKFwij3RzDmb3vZS3z2GNIk5AoB/wS2voPrA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-b21b166b-b72f-cb19-bc7e-81458232a070",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f7e28cbfac38b9369353db2e6d56a2d2-c60e22711ed3117e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b6d1184-2558-d2bd-4cfd-779407033b53",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C7017F2E8C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "if5JTSlXAmzsnJ3fapWKxg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1b6d1184-2558-d2bd-4cfd-779407033b53",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de2a6a-801e-0020-13af-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Jhk08s2BEmPArrj1mrg8DZMw9S3Ih07/WwCq19oBx/8gt\u002BzBxR3fpYNsdfKt3Fh1T2D\u002BlzO5fJ/KNJbM1juJv\u002Ba51OLMe0d2UVCpWxFcUn6nNYd6AjDLZztN9pGHEs5H47UL8wh2qNQYiEbjDyCNbuEXJaG0D7y27m2mf4S27z6BYnhcUV92MIyzYXrp51gbv4ivb\u002B0tktT4VAWazylPYpkHYqynMR2CofQVAa1CzAYVi7/8Bn9RVM\u002BkY/xZ22BjY//h4oWrc45rLc74GJEntof/hURpU1sZtQ7cA80gKcWUsZ2tYeqBaRcxkdmxWTw\u002Bfa11WVUc\u002BRCkxyx2zm/ASgQIZGbzeVScfRssOMKCaFzSnoYgq89vd7eNCZm\u002BCpuocEbVqPXVSgNY2Nw678FNIV/QpDDpoJ80mOyuZXC63nOAhMh7rb9m/FODx9LzNYj2P\u002Bc67WVrvs\u002BnoBAJJ\u002BSSnflouWv40nSgaajcZtjMQWNjtyaJgPENFcX41A2vXdVu8CrZinwd/W1zmoO9jlj32l6tpW\u002B\u002BCR0IWqOlAP1n8QzSbXWu87bmRrm4FuZtUIZtAfquAbdmsOcN0TDYd/1vC6l36iDiSOeoxl61BfM3mgodN/4DuO9UbL2OoSKGDs67SQo89mZlirgSBjtYsKr01TYmu0D/bFK5In1jVKfFIbiP\u002Bbzo\u002BqSjt6xG8LK0/LsSmsvrYFKOvNy3gtPoAjYQTeSCyLfuC9uRggSTuXugBSbBULnc2cBlAT3fMXfRu7R2NaPNMTMEJI/wWt5O\u002BwNhF3ytJrF8NHQjHMd6DtljwMZPHITY0tTzvSsq7H7iFwU5fhr6I5UC\u002BQAvqRRrihW1jJoY/95/iUSoumiGUkj1QQXCQJC/aJwxTCODqSi/hzMWdV/kyhgmuvTVUmksfKa4OWgPqEmE9SP957K7\u002B\u002BAc6DI1b9zoEHftnIWb6hYyBM98y2/AsN7pkX875uNla78UuGo39g3KzyjwIQzE6QoNyuLjPjBwXDdTTN5drCqUiDDGhzKs\u002Bw3CsvtGz4/RJah1LhsAgS2Oo1sy46oubCL\u002BXJnc/WHYYc/UIYs1Ko2ogSY2534OkwYDOOPWeRhjlEXYR3L19SdGnM1MK2ChWXnOimGD94Wk8MiS2MV\u002BAee2cY1FXOMasoz/8EqxwWimYd5pB\u002B\u002B235zANFaqYhxix5rllbrTW/yWtNfVhAc68i9g7HfmFPr4/5HwhSeMb1BvnSmvzCyt0wXh01IY4VuVhkInSnale7Kg7ZUp4tbVCUSGZufdiiYCsxlxBEGn3x41W/7kZCXZySF2D96Wg/AuDMkOkXt0t/wbJJddNHZx\u002BQ139IfY8aQfrJzFZ3pHbC8oQvh3mQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c/test-blob-fdba0f91-a05f-23ee-1137-61ce431f701b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-52a4b080d1ecac98bd0e2d90afa426f9-ad73b4dc4d06386c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "63514088-be3b-52bf-5805-d106ee434318",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C70180DBFE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "AHHjXvjHNLEPSJPjoAS9tw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "63514088-be3b-52bf-5805-d106ee434318",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:14 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "f1de2aee-801e-0020-0baf-a3ea25000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "aVYbJO7k3q9QgdS4ZzTyfvlfv9Qz49UoZJEwCBphZHZNn77r3VOqacQRU4H0hyZHoiwMthJLXIWB8r9dtNaU7hxda8h2BqGltFUPIZBUM9xq6GXuVa5kAkM4auqTTbXufWRklxxe0ZuKZgG8Ozv1LL/i8stwpZlu\u002BWmFPZy3EmefIaMr8JzADBbKY\u002B6sp8YHQz0qsFvpfdfL9Z6z2ZP\u002B01SaHRmXyTwjIua1pUGqwlGifflfjGELtaTMYPr\u002BDDOCzJCaEYqtcHoAB451NNeVITNMEVuan0fyjmd1ymlCJRWyMtmxELDG9Qx/XoXTloHMNj/HsfvX6CxIp4MjN6URvuJ4wgL94xCChhtOGkDCH/flqJQpenQa20mtaWkto71nbp\u002BjW9R\u002BzlIuRSrfiM3rhoeLPY4R50RtXee5UHqnVONe56yhH8QjZ9pC\u002BzVJOlJ7wePhomUuVoZbNf3sxX7Xh/BHgaEgSmbDZ9a0zuwOJCOVPY\u002BXxbF9L5EmRerGNqFbanNEArmxWnZ8HjuPeYeaTBDaV4fuQME\u002ByVEP\u002BgV8/DA0WGR4yiJp4\u002BIZG6d27rUKi/jZ7N4abSqyBThnoWBw/yEKWyEiIoLucHSl1SQayNucBW8NoxBRGus6xsTpAkKCqByFbJOU52h16ntqdJcFlz1dypvwY1sRuEE151y\u002BBW0xIi0IlVxHBx4Gl7mU5qVUNS6HjDemkUXAdLNSX/8Mt\u002BUNOVFq/ALgFcN96syifNGb4LIuNng1ipDoRyCp9age\u002Bt/Thq1T6jgspnZ0Kad4Hvfhtn5N3oFs167AgrXhNx8aXu/szvUkR/Z5AZACwWDpbykpxz8p0RteZ67\u002BkmiDSm5WWcq3jFACvW6H09zwahZN1xKMt3Dg8Y3TjWdGJbSO9rYhq2eVMeLZJwrQof0/bfyYsLtV9pL\u002Bdmg95P7ou5e5\u002Bdwlzr\u002Bvt6Yws5BlD0\u002BQlCBqrnT5OQAjIzT\u002BWE3k8GxyFqggGZ896fgUJEMCmGYZrE/efgwjwL/cAauKsF9ZS8Ik8vmmb3qALcV75BS8IYrO5az9BXJfT1bpQxjzsziZu9mA3aVtczzVXVFGp9urIN8gu8uyXEVQxKKjvStijXmM4Sk7O0TkYXFvKKggGKh6PSM40/dt51\u002BTLxgCyrYRc9DXusWyb\u002BSbO1pZQzSdL6z6KH8IKbmCH/rKqAsr4pe7XrTXSV7iyM4\u002BnJidFKMr9QBsCKE2CEkXVJrL58fYcFnDneV/xeZNGF\u002BxyYwg5QpXnrILvtn1hVVqwPTDFuEGZiw/2Xe9qy8ZHu9ChT\u002B99m\u002BQdEgUzLF/zRiQFAXxigF\u002BqmNg4QuTmfOC8aDqsv8VrcqFM6KY8Zl6vwxeLZcqKA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-65121ca6-ef6a-a027-8035-d4538ae74f5c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2317adfbf1ce35c7e652ac158f385912-ab0f89306a29fe62-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c60b01fd-d8b2-2718-308a-7bec513f5cdd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c60b01fd-d8b2-2718-308a-7bec513f5cdd",
+        "x-ms-request-id": "f1de2b2a-801e-0020-41af-a3ea25000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1611397855",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,1024,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,1024,30).json
@@ -1,0 +1,535 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-9e6374d2d06df9524a2d0a4cf16046b9-8ac604ba21dc8f8d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6491feb2-3093-5f2c-bd65-ab941b18fbdc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EBF77D5F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6491feb2-3093-5f2c-bd65-ab941b18fbdc",
+        "x-ms-request-id": "68289452-501e-009a-60b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-04df53f9-402d-185b-22ca-d5d7012a9b90",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-df7a992f6f8fb1b0410a0c96215b0637-4e292ffe86033f99-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7b3ee73c-aabb-37fa-1a98-1f0f71d244c4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "oIbaqmF1FH9f4OyvkpRdkYBtuH9YsovzuIZMW4jo23AhtUemIte/lYOdxU8PSdoHxTBSDcra1e365vHaKLn2dwV7jd1Nt2\u002BprSL8u\u002B075G\u002BrRZVYlc2lRt9Zqzvl5W3Jpk1Kk7v9uQ3AqWCn3hr/vwGBLuMjnuE31kf98wszw8i1MhSf8VGzrouHl\u002Bxt/mjEWuw5Y7eKpghrErx0AMYCjeWX8qsFYM2wzYBXmwb1ytfeOJkf\u002Bl8RKowMM96UP63EhQoG1Qy8vvoeiZU2MwoBdkjllccs4pOGhscf\u002BSzvG47SkhX87vTLIXmfAXDJ2veBCr2Vr6nmmKN3f05EncXNLm0HZKD1BYhUGXNNjeEivazPnu9vWWzk6/pyhW6lh4S00dIDwXVXiwQ0QZU1mQrBVMKhdP7WXtUAInilgoAZrpLumLsPH/s3eBLqOhjWrlLwsTCrAxKG3nP9Ap78sQmEG5IDRgBOsjXHavzs6yS8KnQltdFQbap/aLpIERxcOsYJZR6F02dSof765JkWmvJOQNgq1vs4NK3ng95FBqAYazA14oUFNlcM0xTSVYkRac7H\u002BdFEMWPL0DFwnk\u002BJDJpe4nlp4bdsSQqBHgPnZd4k1hoPfgzP1DnMahFUlJgHgsZ5dHMQqIgWW7DGwxNg42tSTMc1eY6Ojg0/nHelGLRxeZs8bfBrFC6R\u002BCNbCBAmbIamAUjR0gk46\u002BZl0AsRcUL8VEp3I3Z75ziZo4BrMoX9GTDw/xZsoKaSBIEJBkQigIfgX7PGrkgQKhoQNy\u002BIzLhgaLfaIHIskLOj5R/0ceDzdiL5i9PSNmro4NT8W2h3CTfJqZ2NR18UtM4AI8koG7g5HMEMj0HljjJM8kCdLzRKLNvoK8hCZi7D5NcE0hOgv8Qcwj\u002Bnanr14xtrQFUfd4SatffuQPDw9rWTSapq4bwfrDN7gW30o8Fg80es1ybYo2xTahwcsX/TK8uKEyHQiwJfTJQio/YWpRE1jkyoQx\u002BOuqY9F3efAvqzqFWhao\u002BgkGdFTYqStv92PMQL5iMyKues\u002B1l7knOKv0mZbvugdTqBlf7lY/aV/AOmxtqykxzWgX1u9W82JP30u45A\u002BEgD1seJiVAlTcfxF/5V1MuZ2Cstw\u002B1\u002BMX/LS3AA8KhoVAS7o/ATKArLsTO1fN5w4VAyW\u002BJiEzVahKRHvj7gJFwficL6mjDbha8hYRG5yLWhWmofzpXFBUHPYB5Ly2rL643XlvMbdkYfVtUzQLEkobvvpmPUwFXGWoOBKzkSj7lFVnaD4jLBheQjAHfAkcSPq79iXCUG9io3EDxvmksNDccc7uo7oL6JLSB\u002BscDeBsi\u002B8X96rzKTPl9MS9L2UeqZFfKvpKPaVA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "dA9cw/op3fNME6vEL42bNA==",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EC00BB77\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7b3ee73c-aabb-37fa-1a98-1f0f71d244c4",
+        "x-ms-content-crc64": "itpoQlt0mY0=",
+        "x-ms-request-id": "68289492-501e-009a-1eb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-86ed3b5e-6e60-ddc5-7669-29e64066db23",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-df457f72b4faddf0b96c57a21e43fa07-35e28a5b2fdc3046-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "33c1cc5b-ba81-beed-1043-5aef9ca10d9e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "lIivi\u002B5U7JLcNuSczS5iJOSddXjVBI\u002B2GeHxx4KgQc6ClBsb805ltRRGUs6jqZwrqE/LC1YaiJD5\u002BXENYyQQO/QWGjkSRjCWN79kjrLAE3BFxR8z1TZ4ZwuKIvrcWFLwNhbajI9jGGIeNdSWtvndOOYAx50F3Wa9nbIthyM1ud5tdFib5Ybh4qy9FJ9h4bERrekU25C161mwHO/cNZA\u002B6Hv1KUGhQVNfH\u002BXwR8jGXLsBG9o6Id1OuIn/68iXBKwcfywkbLhvcGuWtLyrxKOQ6sAz2xm2BMedp3G4olaKyBo51Micou8Dkatvo2whovPlbgAIYymSZXpkhsVGts4UC\u002ByhcvDb9EfRL0puR2BbfAR\u002B0jNWgmXxpm5NNxsqvNrdWpeAfzADCnq4NzPeJB4aCQrAyOObvomGr8yBjb0spnNvkOzI2vzUesi5nUoxEoFPMi0RafP2QpwO\u002BdBkgXy8jJDAb5MyUi8O7E0b4iE\u002BVZ1KMVqQGj1/eE5PuuErcPlL/BC6caPuHeD\u002BAn2m22B7z6MyGVAiLHJTQPdF4pdN4ntU0OURhOP6XBR5khi/2Zzu1Oo9\u002BVaoKc\u002BeZzCrqDpIsCABUQp6aku/OL07qJpZk2daVw6tD\u002Bklq6cVchyzTrPZMOH3vYiSc2qffcCYbYA1RNPJUVEsm6A23KVjZPcuDOoJYXe4YtbfyOOjDZIpjD4m4C5I6v1hrZVAwOHjLg5zcHHVjwsJfOH96ohuiI0ODU9mPITI5SLsqLTid6H0/JnUMJ0gU/0zHWNMS/908yQHMrKRfPGKq4pO6eZWJgVACO7umljw7bpSMx8ge5oid7SP2kXuY3\u002BoSYQS0mkW3PZeDEIRhlnLF0T4P0nSaS/wK3Eyxky/UaVuRlDT3RtQPFYowm5XEfFbxMMB9iM21uBUIqb45Baqn7qcokAI9zkopwPzqabAmBqA1gKIvVuBOHBwfrp0WFdAfiO0u26wUsyJ2E4gQiw5lIqLdw0TIeFfGmrQmHh/s0\u002BrsyqDDN2sz4Q2/uQMYfVDN\u002Bow6eBKLFxBVKAD4LpTCiX/dY8BtYet36iJ3CL9Url0jGGNTspuYYbOQbg8qO7J4/S/DetlQYFjgwk3wE85RAHmjlRYxbxakBQJM3TOcDa6v/kuPUXND0vfKsrANqA2lPy2VRqacR43ZXzXXA4NlRPTfQFWCwe8GX8JeJvxmVl00p53FxocH07a9tjI9rI80pS37bie34n1\u002BjyakfiDRssiY4lvln34tl6yfBQv8yPMzKYGOqyh1fIVgh3egY5WV7AMppIpzDwXvjZa7GN1xQcZzcRRfQwfgY6WWhNfGjXQXCRjIkyQo/9q7nt1RumPn7wWxbPJBNqk7Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "GPlwcFfH3eU2TwPlwuqtog==",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EC03EF52\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "33c1cc5b-ba81-beed-1043-5aef9ca10d9e",
+        "x-ms-content-crc64": "k57MB6eplOk=",
+        "x-ms-request-id": "64d69f82-401e-00a9-7fb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-50ad18e2-08d5-7147-a278-42c95b555e92",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-595db944cf706586080cde1c3f24bef6-bd564d07cce9c20d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a4b425e5-1010-2a43-4c8d-aa5f92e31ca8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "xeeOkak7pQe6V0lVgQdYSr41KIsQjUI21nS8WlCNGVw8iQMdSxND6V\u002BLt9FuT4CDNvRSbZH9GTikV7o1f0u3LD7tGPcDO/\u002Br8j4shdVwyIb0OCNbOqvKPm/LePNYDmoU04qTgTaIf/v1p3tT0ZNiNI80QUYnW/GSItqHN8ILUuTUF7JK3UZPa7knZpMwd23baERkJM0k7HiZAF5cAEc56VSXf7nhGFZI5NWM//ReYatsq89\u002Bpi4Wryo5sdzo8mpx7nw\u002Bmfez\u002BlDuHD/3l\u002B2DOp\u002By8FR4ukMmgM\u002BPp2d5YPFrGxB4H8izubF/kIruHxg9tnY9NQIV\u002BDM5GBgoJFLodLtOjHvcCxrW/zaj\u002BSq4N2C3UfHwOyruVSLcPgevi5RflhvOoJOcYapbZzbLcv8JgeC4cdJg\u002BDiRXzZY/80TJ3OiQ2IP6ZfNGvBGlNT0I\u002BIj07wn9xnC/p7iPUFcQ2HdSD/CKS6d\u002BZhI61bhGWNknDxUNSsQ7DBa30XELKtWcNeOaUyUMvm0htkk3gzD4OU7fqAFCA02zVsPaErp2M3s8np\u002BUrAWz2pCn69R6w0klv5gia4KUWjKWJvwhcmuyq0MN\u002BuRRI40JK81wmhd5OFN69FLiU8e4aEStPoUJUqhk9QCRLQiklFwK2T/1Y7/bHO6opn3YkFd7lVKf4\u002BUIP5llC6UW6AtK1l/213qHwwSE0iGWoOwqTCTpFZe1xPC2wtmmUFfaxHTjHZAd4fjcs5JN2tHDsV7tOr9AbZJz1RFvQBShIXLsqg3ss4McDGprzKHFJ\u002Bnes1F6\u002BVWYmpaibwi\u002BrqHke5IfoXDD1v3b0S5VFGEwrq1nkMyDZmgdVA93CgR6XZ3Ih5DPpYa42pyTnuhnA0Y1scCbVx2VINVqAg0hTMy5YXOQTEzQIMkmrrYwL4d/9hCJQZgD3wZAM2a7paN5V03P2j201rc5JVE3dKhnpTFN6kw8WAt0tYJtEFjmVLslrVcoIFWJyt\u002BZkBwHDGqeGI51bbtXfP9CmyR7R8ZeEtDV0ccRf0TbhB9sYsfvLWlXzvfKsSb/zjBX5YUxDkMZO30LMTqjTNkJmalb6to3U227I7jOk6Hp1gOW\u002BVn/qrWcE2dKo/xu9EIegRd9pCMWYFIXdirKSqfbYVs2zFN/Ce7zv5ey7O\u002BxTG82r9JKbHIgQFkH6HSK0Yi/b0Khd\u002Bfu33coieRLY7Nipim709rVkPUo1kv6N2G6aO3PM31sz9RHB5BbYeKN1RzlpQJKzz3t6d6NeGGb9OgVriD2fHA2NZYVNIwKei7SmwFvFFIfb1nwIUmen1ey6xLoRfOBl1isr6\u002BsNZpxo2\u002Bvut1gLOBV9j6HBhrml1Y\u002Bogm5YfR7EMOog==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "bk1N8ZOtOmJ0cNlUpJH0\u002BQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC079847\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a4b425e5-1010-2a43-4c8d-aa5f92e31ca8",
+        "x-ms-content-crc64": "7xT84O4SrYM=",
+        "x-ms-request-id": "16e8be60-e01e-007b-7fb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-e0361bca-752b-8a7c-8e02-8dc31774d8bb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-13c1945f75e86aa8d288b813d8214d59-e58687937191e29c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "77091806-68ed-238d-aed8-31167ee1bd32",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "PtPpRfcYYGW2TUPhBe3Sp2bdqu7NDBQeH3MyocYQPS0bPZMYWsmr8TIkFZi6F/J66eqCbU7bfTK/yiWD5b6fpRAVxshZuU2cMri7qPZ7ZAeBuLjcjtDeP8BhWY\u002BjKAtzhW\u002BIpFEqIDCc5juVH9Q7RGYeAS0GwxdAN4YH\u002BGC\u002B\u002BAmtSCOH8sC1V5eIP6eUSCDrJRQphSbdbcJXSG3LIifP3e0x6NextFKmaKmWfoNvq\u002B5lG9NLlXPiz9phL6pS6jVvuGK6Y2BJOnHCgxx9R\u002B8\u002B55x/ZQZUg0h6Thj8UISnU350JsUhtUiNHOFhiRJWZYfrIkcN04QuGzQZQBRITOntGi\u002BdCCEpHTJU8Ukk8/o1I\u002BiQEC48mX/6RQuRB3QzRc/4dG7iuV1mwgQVueI6Cic65B0stzu7sIGwosIWlxa9IKx5LH\u002BLU2qLKk4qJuCdwDvjVyNXB42TPMPtMhaaUCrtWJg1wN2orpGzoI3tkYmgEuKHMkDzZRkf5u\u002B7nSBT8dkkPM5HZ/9dOqiRpGb/pqs5TR8zEh3p\u002BvJ\u002BFtru7BBwX6\u002BzyFS7WKrjKveXYcGzHz9DglABIN68OkHbyFEkb06YIUW2S91WfvR0T\u002BglUZgxy/ebqmq/bz7R944S349Zv7qp/0B7/NNh7ANcjNH1luipqf1aicTj2LIG5VRPRJ5kG5AtfFJYtc8jOb1mYuJt22GlaTWS/jb2xieOdRZ/Eahl\u002BHFAxxqWUPQtN08GfHXPmAnyqtpo0RxaN7UrykC4pCcVAWpxLBRGDxlBZcfm70mxvtwNjGfO/CdU5pBka4WzdJIn8XsLXWz1q5vAJ2tVc0hseQtjqxfARgVCHUWE4qOUjfA0vv3OpmFwF\u002BDMDdS7/nNH\u002BPJ5UMl7Zqt1yD8mccn3LJl7ILRKndKq85M39Dgwhx7SPOmxGj0nuVdSWN4iSaYW1OE7QN6\u002B/Vofz1w1RHJyRUAgVDXfRhFbVGdc90XziKrtICBX9EdAFD6PkUvh8nXl4BKdAfVxN47P3\u002Bx2YQUVK0eyRyNSGlH54ED2ULTGemHydxcyVoa0fOmSiBRbybI4eWUDLqpRk8XBpCC1eubZCGWKhOru49XA/co6wJI8nheNvdZOwku3oORRcLJl/wICuH\u002Bv0ETISpaQQzHfF9IzhQUJJ70Qi0Ua0uQGnXIjWv7IOAcSjc3SxXM/vn8a2IkRHeusXNhF8i05lf5gwa0kbegzFt7LIfg3N2JK0M3G//pa9H\u002BHdv4mg0ba2PfPcgPFG1CW5sGqRfzydCV2\u002ByFgc5UDBcwtnPbqDZKY8EgAaMRehLR8MBk5sK\u002BClAHYsIgkeWViy2w2l35aq9kuEVW08gxgF3Zs5EJ8ylUdqwj0EQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Ymi/N2cdQwFFrD2afkXWfA==",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EC0A2FF6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "77091806-68ed-238d-aed8-31167ee1bd32",
+        "x-ms-content-crc64": "S3IbVHS2fYQ=",
+        "x-ms-request-id": "69fcc46a-201e-0029-67b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-e9f4b1ee-4b7d-55bb-f37b-e3e72cfc8120",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-bb059f92af669336ba1f1ab1582eb13c-31cd20d3a2122a6e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7959b606-a4d9-38ba-4687-5afd0240b3aa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Wc6i9XiYEreVIuYBFxjsdmWafCSd3tFUbwjvijbCvjy/tsPcZv6ZxPi84cC2mkAP/7\u002B76sLmAXv9TYVwqIeA02OqQmBUEBBnALcr4PwRndXH4Ip3BtR52LVI3xh5KRtwPA1cDFjguu\u002BvVOkLuyB\u002B7K\u002BwqMj9CcyPMGqqDDH47debu6TvtZF95yWax7Hrbh2VyfNoyIBTcjNBzNzuNa6\u002Bt2YRb/98jzceM8GiY0EapMFMFUM\u002BjyRXSElwrei1jrF33BBL2f8dGDm8SpW\u002BsA/xJigaoR9qgCdBuia2C\u002BFOaKQQK4cwz8rCLv0JgUWPmJg6f4e/m\u002B2SDFvoCR7ZZw1XbeHxroWHwVZdWHIiYP7isiKOfIxaj823fR4rSMas6MfwshRjnekTsr4wYUJ6cKtdBlb7S\u002BuA/d0TOjBmXHiQsW\u002BrMa7pfhQ4e8nOKS6KPA1yzkFwsJ3bb7Q3UGO4rFZFoK/Tzz78c4dBwtAhstOviP0i9I02IAHRz8L6si6xgM5ziIl\u002Bt2zPdVq6Lu3Nurzgh8dmlrjIDn\u002BuAQB7AsBZkEIBrSlKMdGRU34yfPETBBUFGSpmSukWq3oKz7ZsVHOaYZ6qzAySllb21EI5lZGNmvzqdeiV8kVY6wKvQGEaJP8LmBtTaTgJcoPUcHWn3BbofDW5gd6KBG9YUeEJ41b127BDLvx2OjHE4QNlwYHPsQ7sxsMsYKIhgZSs\u002BhdX/48s35TFY64ZckED9KDaJELtiZ/SHR2SyXoNIq1nykAZbeJ0OeHsCU5g0lOCKGwCRlxSvnF4hOFxmRYZt0ABsagB6oe\u002BZutgAH9RckvJEKEOCtxQFQvPoOkAAp/L01ENXiCrgD3kRN9x8b7xJxGWqIh1Cq1ksJycMkmdvWRLlS0tQxMqHZBjKcb83yRM3XnXaVoWVsikqK2ED03zR4Z7JVyRw\u002BP9bIr4EeHmaNF3T1XPxlQJNT5kiJtmpg5Cb\u002BI/gLnIuxmW2f3PHUTnvkDcDL/4I4EycfAdLDtIl8Z8tqH\u002Bp\u002BcYr5Q7OexXOhf5fcpbiZlPSUxhDA/Jq4/eTkI3U2ej6BZYxF0rveqU2zfYI65x7A0sLGxVnZrXTgQEXeuqH\u002BevVpWzAsU8JIxizDHY8IfgbWE0Cib7Tkt8gHVZJmD\u002B6rtPKcwZvepI8Ajf89Bp/158JO\u002BJdRXAswhJN4FQ4/4sY\u002BF1iMa6x6927BoeG1p7EoEW3AJwdXWmj3XEz4Zo9wwKs4/u83aXwVxAEon6opitziQAOQb7vO1szvlR9vcoDvQNE2jLjB4KfxulMGLrrOzdFgFiaL4FDvehgSR9RsplFwSV7I8v4kIF9rnrVouLgSINc\u002BD2xqU2CAVxKQr5jDlQPw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Vs2z7wjUjD4OQQRNjxgJtQ==",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EC0AF334\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7959b606-a4d9-38ba-4687-5afd0240b3aa",
+        "x-ms-content-crc64": "6xdJ3\u002Bilx/s=",
+        "x-ms-request-id": "64d69fa0-401e-00a9-1ab0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-251c970b-fb30-6df8-9c22-c2d27a835a2e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4bca3c867206aee171dc94795f5e7944-87b6c310289a4c05-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c810c436-4387-c459-ce35-1be8d870ae8e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AnDS6m9QXl/kir64NwtpgJsXcy0rY6/FrDdpMzHuTQYTCfccZ2bQyP/229Pwe4ZRCIR\u002BoPjp1Z7ADD035yst9jy3pS4TTBg0RqsuNIjc1TGwFyqtb6wNKTRZXFsomeDTyeSWONVYPrxrSVpNu6EW4zYLhs8BgIeQqnz5uvC9C63KWmujRp1cV9luQSVSwG6TQnklHBIR0khdBY5YX4PLrT2tgmA1c5yYry72kj5hPukNZnd3mO\u002BauYgiRUAPA/hVopPnpD4OXc/cjG3jGj8K\u002B8ekS/gMVBVOEsnXEy1ciKw2oO\u002Bqepmq/winmwuBt55JGEp5arf/SE5\u002BmJJ0NkmigAPBrXlPX4Au\u002BUzwZLgJzVsqjvvj4h30NligLOIHNsm\u002BBRoIwAkk\u002BbjJSnFrD\u002BSWdMs2SqdOv53mzXYhrjOeJ8ODMV\u002BdAQxSBZVCGZisiCdzCrcX0Oshb0Z9IfKSA0uFKiOt6N6F\u002BHO\u002B5EQSDKUFOUVPrqN7h1bYYcEZIN8ZvwJKvO90/59I7hJEWOunD2OgeOitQlWnCqLM1YccbNiTpCVByFC2kDmlBr\u002BRNy5rMFFdeKf2bHytorJMpyoYLII6sLTGZUcT6ueuCDuVFtJ0YaQ1vvMwnDiolCWdaekPjdo9VoZ6pcsJSo3ASGNAF4zf2EaF4m2OChN8HdEidYH\u002BnnthWL9M\u002BbzZK3RlcFTUaHyZvpGiiaptr0xy/of559UMwano37/Mk96JrLb5KJm/p7VVibfvWxXQ86hz2fs030SeWa6q7Ii8zCuyGN3zdIays1bSpF4eHGWUF\u002BwXWbnjVcxyWs/rFLssmLyLPUM43X4iwCakYTvlgDxIFtScpXNxzsMQgBq3x56bpguikt8iXDpt9ZmTP/ORjdmTov7mkPNJGW9/J1xkavmICbsvQ\u002B5cJrqaL7DZ3o7PfvNAJCWftBYYWHhvozTdCIqgCjY3YkrrNntETGBDbzvgr6lpI0bU6FSlFup17YOFvSYlOdNYmBuoVe2pW2i11ek9j/OLc\u002BVDyyLhkUxfdUn4vo85HTVnhxeNwM1YK4zs8EEAOF2P\u002BklB4m2xdgbPSeCksJ3Ze7ez1Qfc/rIX66CW9aELXz3raMRF9zvHthEQvXfts3rvE3SJTGJWs/uWKvbNG4FlxOqiuEfYk4N87B/2y0A7KTcmpuIsgRLalbXIrs1E\u002BpuQq/iNSvozFn/wDGBCX\u002Bi7WwG/pnSeOELYyCOSEOS2N/GEZh9Hrd488pBiO3WxlzXMDVPMhVMm8XO2tYLXoQWbOtRvvvnIc60igrTkPPzNJjDtxQOQ6rKdXXSskfhcZFGKxgGgQtk7BJmmqgKfQrR26I5R6dsCClAh0WCFG\u002BK1xR5iWg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "0iT/7y\u002BBNjXu20kLndcqJw==",
+        "Date": "Tue, 20 Jun 2023 19:52:46 GMT",
+        "ETag": "\u00220x8DB71C7EC0C2B7B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c810c436-4387-c459-ce35-1be8d870ae8e",
+        "x-ms-content-crc64": "UgkTYFMeors=",
+        "x-ms-request-id": "682894f2-501e-009a-75b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-04df53f9-402d-185b-22ca-d5d7012a9b90",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1aa5babe064511d616bf13d4f5e0737c-ee9096496e9ca25b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3dc6f357-eb2f-7122-92cf-303c099afa3b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC00BB77\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "dA9cw/op3fNME6vEL42bNA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3dc6f357-eb2f-7122-92cf-303c099afa3b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "682895ab-501e-009a-20b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "oIbaqmF1FH9f4OyvkpRdkYBtuH9YsovzuIZMW4jo23AhtUemIte/lYOdxU8PSdoHxTBSDcra1e365vHaKLn2dwV7jd1Nt2\u002BprSL8u\u002B075G\u002BrRZVYlc2lRt9Zqzvl5W3Jpk1Kk7v9uQ3AqWCn3hr/vwGBLuMjnuE31kf98wszw8i1MhSf8VGzrouHl\u002Bxt/mjEWuw5Y7eKpghrErx0AMYCjeWX8qsFYM2wzYBXmwb1ytfeOJkf\u002Bl8RKowMM96UP63EhQoG1Qy8vvoeiZU2MwoBdkjllccs4pOGhscf\u002BSzvG47SkhX87vTLIXmfAXDJ2veBCr2Vr6nmmKN3f05EncXNLm0HZKD1BYhUGXNNjeEivazPnu9vWWzk6/pyhW6lh4S00dIDwXVXiwQ0QZU1mQrBVMKhdP7WXtUAInilgoAZrpLumLsPH/s3eBLqOhjWrlLwsTCrAxKG3nP9Ap78sQmEG5IDRgBOsjXHavzs6yS8KnQltdFQbap/aLpIERxcOsYJZR6F02dSof765JkWmvJOQNgq1vs4NK3ng95FBqAYazA14oUFNlcM0xTSVYkRac7H\u002BdFEMWPL0DFwnk\u002BJDJpe4nlp4bdsSQqBHgPnZd4k1hoPfgzP1DnMahFUlJgHgsZ5dHMQqIgWW7DGwxNg42tSTMc1eY6Ojg0/nHelGLRxeZs8bfBrFC6R\u002BCNbCBAmbIamAUjR0gk46\u002BZl0AsRcUL8VEp3I3Z75ziZo4BrMoX9GTDw/xZsoKaSBIEJBkQigIfgX7PGrkgQKhoQNy\u002BIzLhgaLfaIHIskLOj5R/0ceDzdiL5i9PSNmro4NT8W2h3CTfJqZ2NR18UtM4AI8koG7g5HMEMj0HljjJM8kCdLzRKLNvoK8hCZi7D5NcE0hOgv8Qcwj\u002Bnanr14xtrQFUfd4SatffuQPDw9rWTSapq4bwfrDN7gW30o8Fg80es1ybYo2xTahwcsX/TK8uKEyHQiwJfTJQio/YWpRE1jkyoQx\u002BOuqY9F3efAvqzqFWhao\u002BgkGdFTYqStv92PMQL5iMyKues\u002B1l7knOKv0mZbvugdTqBlf7lY/aV/AOmxtqykxzWgX1u9W82JP30u45A\u002BEgD1seJiVAlTcfxF/5V1MuZ2Cstw\u002B1\u002BMX/LS3AA8KhoVAS7o/ATKArLsTO1fN5w4VAyW\u002BJiEzVahKRHvj7gJFwficL6mjDbha8hYRG5yLWhWmofzpXFBUHPYB5Ly2rL643XlvMbdkYfVtUzQLEkobvvpmPUwFXGWoOBKzkSj7lFVnaD4jLBheQjAHfAkcSPq79iXCUG9io3EDxvmksNDccc7uo7oL6JLSB\u002BscDeBsi\u002B8X96rzKTPl9MS9L2UeqZFfKvpKPaVA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-86ed3b5e-6e60-ddc5-7669-29e64066db23",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b85ef492d0aba255e95221144f6c2b36-4f093ebe401dbcc9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e591c44c-70a9-e25e-4c78-73e472bed897",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC03EF52\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "GPlwcFfH3eU2TwPlwuqtog==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e591c44c-70a9-e25e-4c78-73e472bed897",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828965a-501e-009a-47b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "lIivi\u002B5U7JLcNuSczS5iJOSddXjVBI\u002B2GeHxx4KgQc6ClBsb805ltRRGUs6jqZwrqE/LC1YaiJD5\u002BXENYyQQO/QWGjkSRjCWN79kjrLAE3BFxR8z1TZ4ZwuKIvrcWFLwNhbajI9jGGIeNdSWtvndOOYAx50F3Wa9nbIthyM1ud5tdFib5Ybh4qy9FJ9h4bERrekU25C161mwHO/cNZA\u002B6Hv1KUGhQVNfH\u002BXwR8jGXLsBG9o6Id1OuIn/68iXBKwcfywkbLhvcGuWtLyrxKOQ6sAz2xm2BMedp3G4olaKyBo51Micou8Dkatvo2whovPlbgAIYymSZXpkhsVGts4UC\u002ByhcvDb9EfRL0puR2BbfAR\u002B0jNWgmXxpm5NNxsqvNrdWpeAfzADCnq4NzPeJB4aCQrAyOObvomGr8yBjb0spnNvkOzI2vzUesi5nUoxEoFPMi0RafP2QpwO\u002BdBkgXy8jJDAb5MyUi8O7E0b4iE\u002BVZ1KMVqQGj1/eE5PuuErcPlL/BC6caPuHeD\u002BAn2m22B7z6MyGVAiLHJTQPdF4pdN4ntU0OURhOP6XBR5khi/2Zzu1Oo9\u002BVaoKc\u002BeZzCrqDpIsCABUQp6aku/OL07qJpZk2daVw6tD\u002Bklq6cVchyzTrPZMOH3vYiSc2qffcCYbYA1RNPJUVEsm6A23KVjZPcuDOoJYXe4YtbfyOOjDZIpjD4m4C5I6v1hrZVAwOHjLg5zcHHVjwsJfOH96ohuiI0ODU9mPITI5SLsqLTid6H0/JnUMJ0gU/0zHWNMS/908yQHMrKRfPGKq4pO6eZWJgVACO7umljw7bpSMx8ge5oid7SP2kXuY3\u002BoSYQS0mkW3PZeDEIRhlnLF0T4P0nSaS/wK3Eyxky/UaVuRlDT3RtQPFYowm5XEfFbxMMB9iM21uBUIqb45Baqn7qcokAI9zkopwPzqabAmBqA1gKIvVuBOHBwfrp0WFdAfiO0u26wUsyJ2E4gQiw5lIqLdw0TIeFfGmrQmHh/s0\u002BrsyqDDN2sz4Q2/uQMYfVDN\u002Bow6eBKLFxBVKAD4LpTCiX/dY8BtYet36iJ3CL9Url0jGGNTspuYYbOQbg8qO7J4/S/DetlQYFjgwk3wE85RAHmjlRYxbxakBQJM3TOcDa6v/kuPUXND0vfKsrANqA2lPy2VRqacR43ZXzXXA4NlRPTfQFWCwe8GX8JeJvxmVl00p53FxocH07a9tjI9rI80pS37bie34n1\u002BjyakfiDRssiY4lvln34tl6yfBQv8yPMzKYGOqyh1fIVgh3egY5WV7AMppIpzDwXvjZa7GN1xQcZzcRRfQwfgY6WWhNfGjXQXCRjIkyQo/9q7nt1RumPn7wWxbPJBNqk7Q=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-50ad18e2-08d5-7147-a278-42c95b555e92",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b9207c56c70d0369cab3b90b5426834e-bb30f1b0ffb70456-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "44f0b007-1409-3991-baba-938db5cf200b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC079847\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "bk1N8ZOtOmJ0cNlUpJH0\u002BQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "44f0b007-1409-3991-baba-938db5cf200b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828970b-501e-009a-69b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "xeeOkak7pQe6V0lVgQdYSr41KIsQjUI21nS8WlCNGVw8iQMdSxND6V\u002BLt9FuT4CDNvRSbZH9GTikV7o1f0u3LD7tGPcDO/\u002Br8j4shdVwyIb0OCNbOqvKPm/LePNYDmoU04qTgTaIf/v1p3tT0ZNiNI80QUYnW/GSItqHN8ILUuTUF7JK3UZPa7knZpMwd23baERkJM0k7HiZAF5cAEc56VSXf7nhGFZI5NWM//ReYatsq89\u002Bpi4Wryo5sdzo8mpx7nw\u002Bmfez\u002BlDuHD/3l\u002B2DOp\u002By8FR4ukMmgM\u002BPp2d5YPFrGxB4H8izubF/kIruHxg9tnY9NQIV\u002BDM5GBgoJFLodLtOjHvcCxrW/zaj\u002BSq4N2C3UfHwOyruVSLcPgevi5RflhvOoJOcYapbZzbLcv8JgeC4cdJg\u002BDiRXzZY/80TJ3OiQ2IP6ZfNGvBGlNT0I\u002BIj07wn9xnC/p7iPUFcQ2HdSD/CKS6d\u002BZhI61bhGWNknDxUNSsQ7DBa30XELKtWcNeOaUyUMvm0htkk3gzD4OU7fqAFCA02zVsPaErp2M3s8np\u002BUrAWz2pCn69R6w0klv5gia4KUWjKWJvwhcmuyq0MN\u002BuRRI40JK81wmhd5OFN69FLiU8e4aEStPoUJUqhk9QCRLQiklFwK2T/1Y7/bHO6opn3YkFd7lVKf4\u002BUIP5llC6UW6AtK1l/213qHwwSE0iGWoOwqTCTpFZe1xPC2wtmmUFfaxHTjHZAd4fjcs5JN2tHDsV7tOr9AbZJz1RFvQBShIXLsqg3ss4McDGprzKHFJ\u002Bnes1F6\u002BVWYmpaibwi\u002BrqHke5IfoXDD1v3b0S5VFGEwrq1nkMyDZmgdVA93CgR6XZ3Ih5DPpYa42pyTnuhnA0Y1scCbVx2VINVqAg0hTMy5YXOQTEzQIMkmrrYwL4d/9hCJQZgD3wZAM2a7paN5V03P2j201rc5JVE3dKhnpTFN6kw8WAt0tYJtEFjmVLslrVcoIFWJyt\u002BZkBwHDGqeGI51bbtXfP9CmyR7R8ZeEtDV0ccRf0TbhB9sYsfvLWlXzvfKsSb/zjBX5YUxDkMZO30LMTqjTNkJmalb6to3U227I7jOk6Hp1gOW\u002BVn/qrWcE2dKo/xu9EIegRd9pCMWYFIXdirKSqfbYVs2zFN/Ce7zv5ey7O\u002BxTG82r9JKbHIgQFkH6HSK0Yi/b0Khd\u002Bfu33coieRLY7Nipim709rVkPUo1kv6N2G6aO3PM31sz9RHB5BbYeKN1RzlpQJKzz3t6d6NeGGb9OgVriD2fHA2NZYVNIwKei7SmwFvFFIfb1nwIUmen1ey6xLoRfOBl1isr6\u002BsNZpxo2\u002Bvut1gLOBV9j6HBhrml1Y\u002Bogm5YfR7EMOog=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-e0361bca-752b-8a7c-8e02-8dc31774d8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ff9df9085b0c8f44b8d6b2a37056e813-b6e84f8de4c521fc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "c2ddb97b-93ce-778d-019d-27f776c47770",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC0A2FF6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "Ymi/N2cdQwFFrD2afkXWfA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c2ddb97b-93ce-778d-019d-27f776c47770",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "682897d4-501e-009a-2eb0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "PtPpRfcYYGW2TUPhBe3Sp2bdqu7NDBQeH3MyocYQPS0bPZMYWsmr8TIkFZi6F/J66eqCbU7bfTK/yiWD5b6fpRAVxshZuU2cMri7qPZ7ZAeBuLjcjtDeP8BhWY\u002BjKAtzhW\u002BIpFEqIDCc5juVH9Q7RGYeAS0GwxdAN4YH\u002BGC\u002B\u002BAmtSCOH8sC1V5eIP6eUSCDrJRQphSbdbcJXSG3LIifP3e0x6NextFKmaKmWfoNvq\u002B5lG9NLlXPiz9phL6pS6jVvuGK6Y2BJOnHCgxx9R\u002B8\u002B55x/ZQZUg0h6Thj8UISnU350JsUhtUiNHOFhiRJWZYfrIkcN04QuGzQZQBRITOntGi\u002BdCCEpHTJU8Ukk8/o1I\u002BiQEC48mX/6RQuRB3QzRc/4dG7iuV1mwgQVueI6Cic65B0stzu7sIGwosIWlxa9IKx5LH\u002BLU2qLKk4qJuCdwDvjVyNXB42TPMPtMhaaUCrtWJg1wN2orpGzoI3tkYmgEuKHMkDzZRkf5u\u002B7nSBT8dkkPM5HZ/9dOqiRpGb/pqs5TR8zEh3p\u002BvJ\u002BFtru7BBwX6\u002BzyFS7WKrjKveXYcGzHz9DglABIN68OkHbyFEkb06YIUW2S91WfvR0T\u002BglUZgxy/ebqmq/bz7R944S349Zv7qp/0B7/NNh7ANcjNH1luipqf1aicTj2LIG5VRPRJ5kG5AtfFJYtc8jOb1mYuJt22GlaTWS/jb2xieOdRZ/Eahl\u002BHFAxxqWUPQtN08GfHXPmAnyqtpo0RxaN7UrykC4pCcVAWpxLBRGDxlBZcfm70mxvtwNjGfO/CdU5pBka4WzdJIn8XsLXWz1q5vAJ2tVc0hseQtjqxfARgVCHUWE4qOUjfA0vv3OpmFwF\u002BDMDdS7/nNH\u002BPJ5UMl7Zqt1yD8mccn3LJl7ILRKndKq85M39Dgwhx7SPOmxGj0nuVdSWN4iSaYW1OE7QN6\u002B/Vofz1w1RHJyRUAgVDXfRhFbVGdc90XziKrtICBX9EdAFD6PkUvh8nXl4BKdAfVxN47P3\u002Bx2YQUVK0eyRyNSGlH54ED2ULTGemHydxcyVoa0fOmSiBRbybI4eWUDLqpRk8XBpCC1eubZCGWKhOru49XA/co6wJI8nheNvdZOwku3oORRcLJl/wICuH\u002Bv0ETISpaQQzHfF9IzhQUJJ70Qi0Ua0uQGnXIjWv7IOAcSjc3SxXM/vn8a2IkRHeusXNhF8i05lf5gwa0kbegzFt7LIfg3N2JK0M3G//pa9H\u002BHdv4mg0ba2PfPcgPFG1CW5sGqRfzydCV2\u002ByFgc5UDBcwtnPbqDZKY8EgAaMRehLR8MBk5sK\u002BClAHYsIgkeWViy2w2l35aq9kuEVW08gxgF3Zs5EJ8ylUdqwj0EQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-e9f4b1ee-4b7d-55bb-f37b-e3e72cfc8120",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ddce63277d4b074efd82bbe6d891efdf-4ef1fc5f3bf9aaae-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fc11682c-5ef1-c23d-71fc-e063bdd5ccae",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC0AF334\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "Vs2z7wjUjD4OQQRNjxgJtQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fc11682c-5ef1-c23d-71fc-e063bdd5ccae",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828989a-501e-009a-64b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Wc6i9XiYEreVIuYBFxjsdmWafCSd3tFUbwjvijbCvjy/tsPcZv6ZxPi84cC2mkAP/7\u002B76sLmAXv9TYVwqIeA02OqQmBUEBBnALcr4PwRndXH4Ip3BtR52LVI3xh5KRtwPA1cDFjguu\u002BvVOkLuyB\u002B7K\u002BwqMj9CcyPMGqqDDH47debu6TvtZF95yWax7Hrbh2VyfNoyIBTcjNBzNzuNa6\u002Bt2YRb/98jzceM8GiY0EapMFMFUM\u002BjyRXSElwrei1jrF33BBL2f8dGDm8SpW\u002BsA/xJigaoR9qgCdBuia2C\u002BFOaKQQK4cwz8rCLv0JgUWPmJg6f4e/m\u002B2SDFvoCR7ZZw1XbeHxroWHwVZdWHIiYP7isiKOfIxaj823fR4rSMas6MfwshRjnekTsr4wYUJ6cKtdBlb7S\u002BuA/d0TOjBmXHiQsW\u002BrMa7pfhQ4e8nOKS6KPA1yzkFwsJ3bb7Q3UGO4rFZFoK/Tzz78c4dBwtAhstOviP0i9I02IAHRz8L6si6xgM5ziIl\u002Bt2zPdVq6Lu3Nurzgh8dmlrjIDn\u002BuAQB7AsBZkEIBrSlKMdGRU34yfPETBBUFGSpmSukWq3oKz7ZsVHOaYZ6qzAySllb21EI5lZGNmvzqdeiV8kVY6wKvQGEaJP8LmBtTaTgJcoPUcHWn3BbofDW5gd6KBG9YUeEJ41b127BDLvx2OjHE4QNlwYHPsQ7sxsMsYKIhgZSs\u002BhdX/48s35TFY64ZckED9KDaJELtiZ/SHR2SyXoNIq1nykAZbeJ0OeHsCU5g0lOCKGwCRlxSvnF4hOFxmRYZt0ABsagB6oe\u002BZutgAH9RckvJEKEOCtxQFQvPoOkAAp/L01ENXiCrgD3kRN9x8b7xJxGWqIh1Cq1ksJycMkmdvWRLlS0tQxMqHZBjKcb83yRM3XnXaVoWVsikqK2ED03zR4Z7JVyRw\u002BP9bIr4EeHmaNF3T1XPxlQJNT5kiJtmpg5Cb\u002BI/gLnIuxmW2f3PHUTnvkDcDL/4I4EycfAdLDtIl8Z8tqH\u002Bp\u002BcYr5Q7OexXOhf5fcpbiZlPSUxhDA/Jq4/eTkI3U2ej6BZYxF0rveqU2zfYI65x7A0sLGxVnZrXTgQEXeuqH\u002BevVpWzAsU8JIxizDHY8IfgbWE0Cib7Tkt8gHVZJmD\u002B6rtPKcwZvepI8Ajf89Bp/158JO\u002BJdRXAswhJN4FQ4/4sY\u002BF1iMa6x6927BoeG1p7EoEW3AJwdXWmj3XEz4Zo9wwKs4/u83aXwVxAEon6opitziQAOQb7vO1szvlR9vcoDvQNE2jLjB4KfxulMGLrrOzdFgFiaL4FDvehgSR9RsplFwSV7I8v4kIF9rnrVouLgSINc\u002BD2xqU2CAVxKQr5jDlQPw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359/test-blob-251c970b-fb30-6df8-9c22-c2d27a835a2e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-da86765e3cdfbd3078aeb9e6734f9721-48c0129978a2bcd9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0dcaca60-7bb2-b47e-2ce7-e4b03a56630e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "ETag": "\u00220x8DB71C7EC0C2B7B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "0iT/7y\u002BBNjXu20kLndcqJw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0dcaca60-7bb2-b47e-2ce7-e4b03a56630e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "6828994c-501e-009a-01b0-a30f5b000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "AnDS6m9QXl/kir64NwtpgJsXcy0rY6/FrDdpMzHuTQYTCfccZ2bQyP/229Pwe4ZRCIR\u002BoPjp1Z7ADD035yst9jy3pS4TTBg0RqsuNIjc1TGwFyqtb6wNKTRZXFsomeDTyeSWONVYPrxrSVpNu6EW4zYLhs8BgIeQqnz5uvC9C63KWmujRp1cV9luQSVSwG6TQnklHBIR0khdBY5YX4PLrT2tgmA1c5yYry72kj5hPukNZnd3mO\u002BauYgiRUAPA/hVopPnpD4OXc/cjG3jGj8K\u002B8ekS/gMVBVOEsnXEy1ciKw2oO\u002Bqepmq/winmwuBt55JGEp5arf/SE5\u002BmJJ0NkmigAPBrXlPX4Au\u002BUzwZLgJzVsqjvvj4h30NligLOIHNsm\u002BBRoIwAkk\u002BbjJSnFrD\u002BSWdMs2SqdOv53mzXYhrjOeJ8ODMV\u002BdAQxSBZVCGZisiCdzCrcX0Oshb0Z9IfKSA0uFKiOt6N6F\u002BHO\u002B5EQSDKUFOUVPrqN7h1bYYcEZIN8ZvwJKvO90/59I7hJEWOunD2OgeOitQlWnCqLM1YccbNiTpCVByFC2kDmlBr\u002BRNy5rMFFdeKf2bHytorJMpyoYLII6sLTGZUcT6ueuCDuVFtJ0YaQ1vvMwnDiolCWdaekPjdo9VoZ6pcsJSo3ASGNAF4zf2EaF4m2OChN8HdEidYH\u002BnnthWL9M\u002BbzZK3RlcFTUaHyZvpGiiaptr0xy/of559UMwano37/Mk96JrLb5KJm/p7VVibfvWxXQ86hz2fs030SeWa6q7Ii8zCuyGN3zdIays1bSpF4eHGWUF\u002BwXWbnjVcxyWs/rFLssmLyLPUM43X4iwCakYTvlgDxIFtScpXNxzsMQgBq3x56bpguikt8iXDpt9ZmTP/ORjdmTov7mkPNJGW9/J1xkavmICbsvQ\u002B5cJrqaL7DZ3o7PfvNAJCWftBYYWHhvozTdCIqgCjY3YkrrNntETGBDbzvgr6lpI0bU6FSlFup17YOFvSYlOdNYmBuoVe2pW2i11ek9j/OLc\u002BVDyyLhkUxfdUn4vo85HTVnhxeNwM1YK4zs8EEAOF2P\u002BklB4m2xdgbPSeCksJ3Ze7ez1Qfc/rIX66CW9aELXz3raMRF9zvHthEQvXfts3rvE3SJTGJWs/uWKvbNG4FlxOqiuEfYk4N87B/2y0A7KTcmpuIsgRLalbXIrs1E\u002BpuQq/iNSvozFn/wDGBCX\u002Bi7WwG/pnSeOELYyCOSEOS2N/GEZh9Hrd488pBiO3WxlzXMDVPMhVMm8XO2tYLXoQWbOtRvvvnIc60igrTkPPzNJjDtxQOQ6rKdXXSskfhcZFGKxgGgQtk7BJmmqgKfQrR26I5R6dsCClAh0WCFG\u002BK1xR5iWg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-11c01c04-f6b6-3fd1-446a-afa084f1d359?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-57b71e2c1a1ff3a06dfaece78ea38268-6fecc4b1833e90fe-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f303faf3-be0a-70fc-b8ae-66cb53cc26a9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:47 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f303faf3-be0a-70fc-b8ae-66cb53cc26a9",
+        "x-ms-request-id": "68289994-501e-009a-36b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1486248461",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,1024,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,1024,30)Async.json
@@ -1,0 +1,535 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-c3e06986b185cd89c03cf06f3a56a257-4fe535d675002fc7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "56662145-388a-fb44-11cd-405c10bf974f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C70060F002\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "56662145-388a-fb44-11cd-405c10bf974f",
+        "x-ms-request-id": "e3497f4e-701e-0069-6faf-a3a8ce000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-658f07d6-f854-ee36-9998-6d76eeb51783",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b08c3b27c9958218cb91dc6b7bf88a94-b10f2f673124396b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "dbe9c6a6-3815-0fd3-bf33-7583f906ac59",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "X0beDoOCG0f3275IH4eYEWHPN6QB/mt86gZXI9oZZPvonEl5I6LgBeB4Ii/XiiSshINKB/sIKGDaYiN9Kvhs3nfDX4I\u002BHu2\u002B7zLDids8pF/hq55XzlwA33TonsF\u002BY9roC0S3FCqibWWVixfJRZ\u002BFnr3Em39ZFQ8aw4AOVn8sQIxY2n2WhJA0Pz05wUJENprUYgAEusdaj/U1nFGqkxflaUuLcGoh7xosj1xCIFTN1YzlOfN/J4bE/UuIYOc/iqslU1j3ucYws3Lm1ytrGG\u002BhaMfExVojZkHFx3MemY4y7QWwHMz81RzGtYaBmVBbWeXc5vggesVRAewWMfJTEhnks\u002BoluvuipZKq/hDTos3xam2NQbKVEXM/Xxrf5aQqc6NsnOVlNZ7qOkFmdnu1fV8fJceExdBmTqF35lvgwr/ugItsZwXoizXPowdxL5v3iuG7v7/cpq3SBk5D7k5CCXeBd/XvSBZZN5qRtCLI9R4Gf1t6JQMAEdrdmmC3pJzmjZqQ77imB0LKYoglSvGLChEvPW/zyOR0gWUbEq61oZL9qyeHOAVmYHcYr8J62sfoUo9Ph2ct88S1HG5SivWUFcD1J5/JA9EMyd332hgh\u002BaaeMr8eZhkr0Lhi0RuWFNWChJoChLMnHk6\u002BQ76KNRirlCLHs1c1dq6mylfmZzG1dbUHdVZ\u002BHnTzdhNxYCJboJqgtj35zmB9TA7rXLpbQbccCM0Jg8DCLXWt1DxDxBaMSyq8RrD0vKZUiSlIk8K6mDVcVFdUUR3Z3YnHS/ojOoj3XxCPnvoHKEsmtfmXepmz8zwH52\u002B\u002BN/kN4mgmLXGsME\u002BhUDSxKvk6VCwMLZwjQmPwE1e\u002BHFIYOScXgruS4PvaeoSq9iplAchCzJJCsQpc6aAENhkZ7hP8iBYMmac9qHMxMrMXeEw5ihKPe0/A1YgdupgbjarhwIxxrm0TWGcgBSQeEX9WRXBTyqsGinLDO7KO798OIhvJT3EmpsreJjKqbnYrosQIxnUox8L/2zYZrXK7hWiIEeIIVcENMJ6mdaR5XBz8mJnthSlp5lpYynQ7DflXI6DJIVyTIk0D\u002B5bXgVIdhX4ZHRXZzf8/HyuIsItM0SKlTlIErzrAaHVM6YqTkmUIO0T2Iu/jflWgigIxC3LBtylzMTL/GdZEWbWfjON1q4zFf3VGVq8zwdD9YyU3j10CijJhIGAyCCFtscg6RPFxK951a4v9e2B5P3BiArWwDMpXnQKxE4ssk3ZT2KTm\u002BX3ejDdGwSTRBQ/S5\u002BDw0AZrvaX\u002B4qbvvxdTSdgUqaK7kkbyg3Z\u002Bakqmhpfz3iurO8Jw5xv/5xbW78wf83hLvFttFlWZ/kyQ7VJaWFsO/OHsqA4VpA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "hGpsK8/ofqI2FLcgKX\u002B7EQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C7006CAE3F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dbe9c6a6-3815-0fd3-bf33-7583f906ac59",
+        "x-ms-content-crc64": "Y/Z\u002BnpuyRUk=",
+        "x-ms-request-id": "e3497f9f-701e-0069-31af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-b1e22245-7d1f-7cf4-3294-5875d62285b0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-9e17a98eafb8caaed329a85f8c56474d-c9a5c6117714f86c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a1571667-220c-9534-5ac2-4b7084d04a2c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "1hE8duD5yaWPusfz6jNLaTYYmedaqmnit\u002BaP24j\u002BkdJ2GRWW0Z7EyLwWG3VTob4qLGgjsaOebSuoWr/5au4dkCj1fNEetJiYVNAqRI/zjhYnZa4f2\u002BAv16vp7Xbfyl7O\u002BYtMXiTtC3fQi13ScymctMup0gQ//bVIxqUlNMchuYlyXEoDpzDxOlk3T1CCXGOCTDirNvdZjvvVBJd/x9awrtLTYBfemA2bt5irCK5lxWlBo\u002BiOdoKRGM5PLqOYcnKCh6B9rvxMpLMrD35froVNcD4uPSTuIThPQUdIj2pqA0QlKIEN5xZt9f40Y2cEMmlIAb1kajVOk2VoLm20AxVIwAs6OYYEQIknwEclur7RSg/dAI2tBpkO15QbpLipufHp66JbyfjjQ8A0PKrtKdmml\u002BNd1gOHm7pyK2Lx6JzQfgZWO84cdYEW\u002BrzMeMnvIa26dQzUS\u002BPuYk/n6J6W8VskY76jl\u002B0LiiFiR9tGuiPxgwq0N3OP/DIjZ9l\u002BNI3jgAhhqBULS4rArurqcQQHqKcs9mST4brnlGeLfy8TjVWUf8bT5RIO5Td/9IiIpIotHL8yUT4oT59OeROtf8xarCGVVvI\u002BM8KUHhAsFOwxXvDcXmNw4TwXay8nhWv/YGVrJUdn806X7\u002Bj8nTIt\u002BzuyHBsi0SFo6cvkferDFq5Xlb6rwe6lyWqiRW56c0QJ6m/0dWhQ3I9EAzt8gnZj1Ng6pQdzgTpMDFKwgIuy7XaH25J7zqFFBrkvZr2yKEf0P3CWQM08lWg1p2gVn1sDkRXF9afj5wU29J9ORBt8muQLvEEbHKyoSkUqRic5MGZeK9Wo7TOfEFdqX0wu7lFNuA2DCuMZ6HRoHathuaHe/MM48BhF1Kyxa6zqsLxgeVz03I0ZtSWDRENgQNCHPVa1i2KI9v44CONg0p43Lzi3CKNPbd0UxUeetKvV5JTcKS5VNCRZ14JdvNSpuOOHTBQLqDcsONB5ocYb6kJSYyNPhKlw4foUXjAh8bAIagxjFmiXyTtcsPBd25NdPuxAC1mwWjQ6F2oZ90oGC0cfcTe5t9PZupnn8tS4EgVnth9E4OZXVw/YKf/9ftLwVaSoPWpco4YYZlC/yWdfgQRlskAqwiphyBkn4Y3U3DzG9pwvENWaCxKZK3qVl46neKj7l8ySxpJ6R3VRNML4RIkT\u002BdLKMHEvyqctkZevyzCKgGnl2URwNDAKtMhgSdZQoebwgp683Ec3zM0lZDT7yntExrRZE2pFosWhwHyozoHQ3PCwv0mSzqMhrQ13S8/7DulNG4Mh9457q9/ZGxvLj/1MVIhESgsxsvcRN2VdzVf1pbKSWrP9ruRhNBRquLOHVR4QK/dHt8TeG2iLEA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "VqIbmksMEZ1\u002BmOsIPr\u002BeIg==",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C70071DD99\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a1571667-220c-9534-5ac2-4b7084d04a2c",
+        "x-ms-content-crc64": "JyMWImz1Cmk=",
+        "x-ms-request-id": "d3b7b17e-401e-004d-7caf-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-a775632b-0abe-4df2-ea77-bdf2cbce0d5b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-edb6f91d545688d7b767d4d8bbb17d03-88cee59ac494e9fa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e21b3c7f-0bae-074c-b03c-fc0bed81f034",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "9sb5RIniRk2hX67u7rM/S3KeJDgWNuLVPR4b6sbdUqTUrudUbkaH3eLROyg1h3uF9P7bBn6q/8DkJAdrxluGxA0JGUDL6twrF0dWRPu6oLWilfXIAUsmKq4ncEo/GxaGS3caK207ugohr\u002B82U7rFKoRRyTBlvcLC4\u002B\u002BRpHmS7Pswz/mDn3VHZtvrp1Jb79bzYkbF7VLlIY20WEd\u002BqRWQjsPzBYTBQYoOCmJVehVwZvQZnkEzzP6pS65rz0cuyb3GWhiOaOlRMiG7t\u002BPwkKZ4RPJSZAvTXcLESbrWVXFD4EGljyD94f0KyGwgdxUbuboH84tU22Sx8v1Wyh4ue9yveNaiSwGGe2L0R5yfs\u002BWsqZAAzmHm7gXc85wjphff3E2Pcf8/eW64gXgoYJPIEj8XqiCOLqx7yInQxldkY9RLFWtPD0LmbTAiR03pvo1yE\u002BFdDPz2UK2gFKh1brMWUx2j3UsneQL9MD3wa\u002BZekQr8XrJ2B1fYVMS9rvuacf59C/MvReFCSprfYNu\u002BBeXHQoKdeQ8AoEzGy4iGasoGY74\u002Bc1/zLkwpuRQYl6Z7GU7f9mx5/PjufGunaXpYu\u002BDP2P0dgJKF1BM1c7/75wmlS7E5p3NejWbGT/b0TMXS0P0zSb6pXpm8WSJYQ4k485RiAR3IHxNscEqXVjGbkYhOY6LBx55K/O0YfE5RBkrdjVthkkqnCbHqx9lzEgdnIMeaCd/mdiv2FwUwsKLFG2kAusnVOf89plrx1wDF1unlsFyGtv1r9hYwa3pFdlgOJatvc1g9kubIXWKF9Z8rMUAbSwBGPmVslMOypc6E9zAB4rFUVWORpx11vlma5QF2BDk6KitXyOdGA96Ui\u002B0YQ2UygxLt1tvdiaPj0H8L0q/BO6CUSs0EqRrKDlKE/BwwXXv0Z2LviS5eXaCIdPdnOjEv009Mg/mYLdn4IseJWIyGs3MEF2pM0rJyNuwsfDUiY9MhVCnN49mBWzqI92Zm1AQUAcGDYiPG4wGc2UwMbLCk1b/0aARjuc\u002BZgrswxNtMDGLoF3tznwCwWnEnMAmNde\u002BJ4yGmcWv/sEfy6eBnlh4mUM3qI1Q1MDa/Qw6TO4nFDAzLp\u002BC5pZr26Gc0gbUgSMNSAd88o1KbU7Pr5y5dbHW9LN3TnO89bKsy8zrsAK6Bn/tKQDmqiGm6MFMtzr1smHvyd1XXTKzUFZQzCq8XrlIEakgyEyw7EqN0GGubEJ7uxVq/\u002BolZqVJPdSukd365o4EAKWR0OoVPtmSxYzRAOQX2RERUWLTJqsD2454BlpolunTqmuY6eYvVb0MkqEUdDjwlrjI5ZEvNN36jflbnTSDKi6m/Vp4eu8u4f\u002BhwpAJ72NRh2\u002Bdo6w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "8qaSI9X2E1NnLQXhhk9UFw==",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C700744E3E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e21b3c7f-0bae-074c-b03c-fc0bed81f034",
+        "x-ms-content-crc64": "MAr9twQUvp0=",
+        "x-ms-request-id": "e3497fd9-701e-0069-64af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-ee16bcb6-e6dd-582f-1312-33bfa0c01876",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-093d4ea30dc5de2aa9de3ba0ee2e1f6f-cfedc0f94ae9ff63-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "48f06a63-67b5-cd7d-9333-535179987f52",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nQfyZ4DlY1yTfCimgoVyOGKgU5Y5O7Yk0ISQxk1J5d56G8TU9ABqb8W/z\u002BtvVbJpr\u002Br4fEjIfmJQzpf8VZwPSpZJK2bBnUNhNePQeWvLtXvSJhZjUWmWsp1hgyZpbhopsIVUJSlLqBGml0dk9wT2hBkbKi6GrPgss3nJXxod98fJp8nmd49Shn4EvLoiMbqYa/8NTUPsogOMJ3KvgUj3iZ\u002BAm1A7Dw2JyaSvgfA\u002BCoK/MfQaD6qD3QTGWk8dowQ1DTIaopVpXVvyhISfPCETTR3w71BU3Hn0/L5MdLW9bCafenS9I2fsVdOZKIsm5KDisgwyLbOz4TC5JqXXHeilNRhd/8GtVim1A5l9u7TuzhgdacKpij5y65lDBP3BFTjr9PNzyOTfNVzifSoaNiZ8yleNubQm\u002B6rZ6xMoalIr8\u002B1hksbAewYzPjRmxg0UWLVzxjmmM1yExPhJmd3QtssJtok8uaRfu09QWnuAwDWdxJJetaMYhb\u002BR3M3Od\u002BEpYodoXA\u002BD2J8QFAvqVdngBATCrNRKcgEo8THKq9zXkERtJ/fzF2QlGezzTaGYLi/msNjIDMsM3vCFQGreuS3COYPGfS3h7eygnZLoVyRgj8MB5PoDDoR5YEkHbdb5R1\u002B/MBMd0bACBMPsKG44JIfMJbCn3NUyvyv/TRzk2n8WplUyKSYQQ74S/983F\u002BUVQDzCO0glUWqKjHHoHYSUHSpE1YEZBftgu\u002BHyld31\u002B6dF6gzgIp428FTqqJy0JyU5feK18kFk\u002BztAYX9mMryNlJHJozN4tPqLDeUsLl1frJO8uRf7QAhm4e7Rn8Efz72YXRMK64TywMnnKeVcN83d4bXrqnmlklOJY8FEpxQ5bD0nlNFJVMAPyfhNFBciCqkh870MMyVE8svAgYfCrRm1rb2nNKP8lI303OCAWH48ZlkYI7RXLTgY4qEGidI5TBzemGZZe9UGJF8vGFZEw5pMgxsuqollXoCFj1EB9Qq7upDEosAX4uqDEf5UJxTh0x8HuQW3CqKSeTnm1OuDBS9UdF3GfyHaNaAwqpiKEDZro7wy\u002BjwFA7DuMiiGMA7/AAzPALK3G1P9LINkhl8JB2gDejEvUAryTnCt2E34VASSMaqLug\u002BDtIhoNM25oH1Q5Cq/grbdz68B3bFBCkIFBdd\u002B0lW0fk1Zf8aoxhw9Oa7zXPQjONFOtWH7itxdQapFYi/2Os4nnGbdZgPvNAiTxKQDTq5O4swFMB3zufRw\u002Bz0cY2PsRv7gy7\u002BORdHOXoBZaMU4WvP894Bi8AmwNOJybWvF09Gkpn2mI4LuwJ37N9GcmlEuN6BKH2vjilb0L5fcG9dlCYqvtMFHkjZxDjfjZ7g3FJmRQzXLew==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "hLqCqXo4hLxgyyUPUwIzQw==",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C70077A91F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "48f06a63-67b5-cd7d-9333-535179987f52",
+        "x-ms-content-crc64": "tJZ\u002BNJF\u002B3wk=",
+        "x-ms-request-id": "d3b7b1a8-401e-004d-24af-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-8b4bbd13-6f40-3bc5-2f94-c6a8c002b063",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-3472843aa9ec501e4fb17465e92bb36b-e8950415b863710f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "83a8f7e0-a890-3d7f-54d7-3c705b5978d8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "j\u002BeladkRNAAinbwb/kvYopqN1krzpSDgQob8kh3SivAmswJckGGioTDA\u002BYn02ezGzCL6oHCi8\u002BrGxCdSFaLiUBPM9EtJexI56zUZMquX7GmaNsb71\u002BqAg78Xlss5T4yO3qh1KOWhfVAQwLU7icA\u002BLti\u002BuN7b53goS3CLMeVG/5uoi1QDIcSE\u002BLl26hY1Rfr/2Wfze5eusvYvTdx0FkxqysEZkv1sOwwTOb8kZf1i8wV1i1d\u002BU4MD\u002Btld09TnD\u002BJtCyBVG7L9kp5a30LYiU35zVnW/4r07HY9FpgjD2c4LCrct1ndDNhSd/m4I3NBK3GMZAV7EBBYeB\u002BpGAUa2YM2IrIX\u002B9HzHMCAhIeQPMgC\u002B\u002Bonl6pivRwZgz45M/TTOJ52gQHAKS\u002BfmEhE\u002BoyIxzxXphwa80LY1GWW/XeTuujMrUvpGrrGQdG7iP9iHcKPkbwC4o3XuEVbna2cKSy3DN5feExAn62CkGRKX2pDdreiB2y7kdhb9PQGjX0MKhelA3sgAqV1TvEOf1EojVnaGCf2\u002BSK/\u002B3sGBINYOhIwdWZMpVvuInMRLLh7rBGGMmeaK3RWFjD15gcAGv4hHRPf3grq2\u002Bf\u002B6/az5MxpRE9pf9EcvQ\u002Bd2l82V79T7gd18A\u002Blm80HnFd/nD99ojJji6G4lpssBF8EQQSqtIMoqv3vPvO9xKiBYuJ6nCHPHzcs0swdm1dsSeywoFrJXOfUV/FCjmQ\u002Bpsb5NzS4smc\u002BNCHNfuG3Cg\u002Bmg/UHDSNOtwX7pkUvjZHT7iwFJGMis5aEcWw4\u002B94GHE3inAtuN5miqn8uvQwiDqeQ\u002BY\u002B1seasg89egpu3Frwn9In4TfCFZLaTYnnj8/WKYWLFpwJOUGtmNRk7ELX965TDB8iCKsG2C5TZIU5syI/Z0yA48m\u002B52KMekRfXSVQBlXflIOwtBzehDpttdS8c\u002Bm2JYj2UxfklCi4kZJmq3sFA2IzXh6ijrMvpluPTS2N0ApapTucXbc9\u002BwBa9CKOd9y/ZLZ2iRHPF5rVxqi8VUb7Lr2ICAJDaKWu8WceS5aQoTJ\u002Bz\u002BR7G0r0j5GcypcKgaW5X8lhBm/ef/wMx5eurMwEQSV6PYVigBN2k3hsoqIOoHPBYOvJM5rCnFPkalOzSd7FmIVxjEAcVt\u002B16nLzcdld/icn7U/gOxGKt6ExehXDx0mZpwYYnRAvoQoIE0Ur0y52imgsi1yS4WFz5tii7tzF9iMpVcrXQWES\u002BEhB1CfMYuRyvvOtkz/pCsWkpLY7iLYtRhkiAnlno0ULGY8QUQk5p4fwMDPtGGLnPE8BLpyq13OWEJIKqmBrDxuqpnmw2LW4awEyR1iGQCm6PsIuYnSoXEIffjx3MvkniSUUQnXpNmQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "t20RoczXrPo9fOIHFN1Z7w==",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C7007B0404\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "83a8f7e0-a890-3d7f-54d7-3c705b5978d8",
+        "x-ms-content-crc64": "t5L286vS2Mg=",
+        "x-ms-request-id": "e349800a-701e-0069-14af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-1abffc87-960b-44d2-331c-94acd633ac29",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-9618062fa3e0a0bd705f6cd7c89cc386-93b1eef8127f103b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "8270b278-fcf0-d9c2-2142-12d852cb7537",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "wJGN5FaeUU4BAq\u002BM239t80IXpUZsQznsgRuaA7ejYlMeHE8M7GhCRwHi5Nt1eeh0rSHY0OjkvXxXoWM7A02WXqBbbr8wYAba1F5FiV9edwcyJVWWy5FqOl7StUsEBkOzS4Y6GQooREwa/fuKnzMd\u002BCpcCN74AJIO8DRgXau71s4bkT7ZJF39CuAJfM2W4JsrtbwgqP1lu0vzKynWyOagXictbg31RNTNXv797oTFeA\u002BYNajvmi7Qttbz5fgzJkH5aB2laXGONnDoU0n\u002BZ8zGLbIZPZI\u002BscP5XLg2AV7bmTi8A4ZmIA\u002BeCv43Bkfl0U4KLLhFGuivu7ZZrAy5VzQSDLoQQWRFYA2jezOTBqt8FItpLNWmln9PDUjQDHMD5LPKJfqM1I/qxMuqop61G7QL3JeBTytfbHY7wDQcdVOZoJZ/yeGw8D/7f2cJ\u002B/PgmvGTxC/cgZWIarmDURNbzk93EQEINVLSWuxXhdDDVXCCWyZCiLAkvR4B914oLZ4roLAYkerx2GSfwGpDhPvFxRVIAPbtGEWeU1PjBj7zqS1NK\u002BUfqsOFkIPBosdG4TkiPDJJ4CyoPodqej6WDtEmrBc89VgWpRpRwnBzK3Z\u002BV3IawMoLqskBpe1etDCF7oKxm/awCevgDJYX\u002BB27NRIQ7CLLfE0GGgFNO09qt/Dqy9PuwZB/zU6GObQ087KrRW/aTsgNunI0q4D0Ys6bdlWlLSxKzXSBkB7URUKZ0iZPofXgj2ko3BFhuRUQi2p/6sNejsaFYXf7WL2pOXUvmtlZpcHYu\u002BbsfFAb6RRecQWzVFp/OkNgyT9\u002B5Derf6KcMR48tuWppy/dchF1anhjnee39eUasGCV\u002BduBWteuQP2tfrf1IrofCqwrocgy6l/HGkZP84m9gYC\u002Bp70KKE1XLjEUx\u002BvAbXssmOs47w\u002BXYg57uj\u002BQX0x08P03Nnr9FOFf03KWHiJzBqzLI1udhJJxJkSujm0Nxs/koNfuiTcAL4MJ2BucAUTsCLSSxTvx1mtrxRA2ToZ0Ug2jsn5LhXx1y/TYk6x21SX/wYa5ewGT88lrg8MnyeD9lYYO\u002BE/GoYI3HPpHGEK/9PDqNo3/utYLEL604AG4TgEU2/4lZ9zWOSADgV8HS9qHq47SPJNT/dqwA\u002BiQEcGBfs35Mz1Emo0UE/1s\u002Bzh3BMTkLTRy5RJtwd0jdWT0RidfggORDhecQxEBvimW5gKiOP4jrOSMDpi7i3JgICQpH83VDHg15fasR\u002BkjcSfp19ragTxl0JpD03Nq1oKlPCLs2J5bwNqJbFIId2T6aJ1x0rOYhZ/nw08zkjkEyw9zBwrHN5mIjRcAURXpXFk1SGrW\u002BATPDbeDBBRPKC6ghKFDlQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "j8uksDhCpy1/POACoIlvFQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C7007F221B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8270b278-fcf0-d9c2-2142-12d852cb7537",
+        "x-ms-content-crc64": "5mG2DzervEs=",
+        "x-ms-request-id": "d3b7b1d7-401e-004d-4daf-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-658f07d6-f854-ee36-9998-6d76eeb51783",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-542533c71339b301765bf8b6a1f66613-17132b47fef7c822-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a9f85c48-f5e8-6de7-b73c-8b4be07b8161",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C7006CAE3F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "hGpsK8/ofqI2FLcgKX\u002B7EQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a9f85c48-f5e8-6de7-b73c-8b4be07b8161",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d3b7b20b-401e-004d-7caf-a35e6e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "X0beDoOCG0f3275IH4eYEWHPN6QB/mt86gZXI9oZZPvonEl5I6LgBeB4Ii/XiiSshINKB/sIKGDaYiN9Kvhs3nfDX4I\u002BHu2\u002B7zLDids8pF/hq55XzlwA33TonsF\u002BY9roC0S3FCqibWWVixfJRZ\u002BFnr3Em39ZFQ8aw4AOVn8sQIxY2n2WhJA0Pz05wUJENprUYgAEusdaj/U1nFGqkxflaUuLcGoh7xosj1xCIFTN1YzlOfN/J4bE/UuIYOc/iqslU1j3ucYws3Lm1ytrGG\u002BhaMfExVojZkHFx3MemY4y7QWwHMz81RzGtYaBmVBbWeXc5vggesVRAewWMfJTEhnks\u002BoluvuipZKq/hDTos3xam2NQbKVEXM/Xxrf5aQqc6NsnOVlNZ7qOkFmdnu1fV8fJceExdBmTqF35lvgwr/ugItsZwXoizXPowdxL5v3iuG7v7/cpq3SBk5D7k5CCXeBd/XvSBZZN5qRtCLI9R4Gf1t6JQMAEdrdmmC3pJzmjZqQ77imB0LKYoglSvGLChEvPW/zyOR0gWUbEq61oZL9qyeHOAVmYHcYr8J62sfoUo9Ph2ct88S1HG5SivWUFcD1J5/JA9EMyd332hgh\u002BaaeMr8eZhkr0Lhi0RuWFNWChJoChLMnHk6\u002BQ76KNRirlCLHs1c1dq6mylfmZzG1dbUHdVZ\u002BHnTzdhNxYCJboJqgtj35zmB9TA7rXLpbQbccCM0Jg8DCLXWt1DxDxBaMSyq8RrD0vKZUiSlIk8K6mDVcVFdUUR3Z3YnHS/ojOoj3XxCPnvoHKEsmtfmXepmz8zwH52\u002B\u002BN/kN4mgmLXGsME\u002BhUDSxKvk6VCwMLZwjQmPwE1e\u002BHFIYOScXgruS4PvaeoSq9iplAchCzJJCsQpc6aAENhkZ7hP8iBYMmac9qHMxMrMXeEw5ihKPe0/A1YgdupgbjarhwIxxrm0TWGcgBSQeEX9WRXBTyqsGinLDO7KO798OIhvJT3EmpsreJjKqbnYrosQIxnUox8L/2zYZrXK7hWiIEeIIVcENMJ6mdaR5XBz8mJnthSlp5lpYynQ7DflXI6DJIVyTIk0D\u002B5bXgVIdhX4ZHRXZzf8/HyuIsItM0SKlTlIErzrAaHVM6YqTkmUIO0T2Iu/jflWgigIxC3LBtylzMTL/GdZEWbWfjON1q4zFf3VGVq8zwdD9YyU3j10CijJhIGAyCCFtscg6RPFxK951a4v9e2B5P3BiArWwDMpXnQKxE4ssk3ZT2KTm\u002BX3ejDdGwSTRBQ/S5\u002BDw0AZrvaX\u002B4qbvvxdTSdgUqaK7kkbyg3Z\u002Bakqmhpfz3iurO8Jw5xv/5xbW78wf83hLvFttFlWZ/kyQ7VJaWFsO/OHsqA4VpA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-b1e22245-7d1f-7cf4-3294-5875d62285b0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-84b423837838492c024b4d5af2011f6b-673d249306dbb0ea-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f59076fa-cbd3-bc4e-b1ec-0c6083c70b26",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C70071DD99\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "VqIbmksMEZ1\u002BmOsIPr\u002BeIg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f59076fa-cbd3-bc4e-b1ec-0c6083c70b26",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d3b7b29c-401e-004d-02af-a35e6e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "1hE8duD5yaWPusfz6jNLaTYYmedaqmnit\u002BaP24j\u002BkdJ2GRWW0Z7EyLwWG3VTob4qLGgjsaOebSuoWr/5au4dkCj1fNEetJiYVNAqRI/zjhYnZa4f2\u002BAv16vp7Xbfyl7O\u002BYtMXiTtC3fQi13ScymctMup0gQ//bVIxqUlNMchuYlyXEoDpzDxOlk3T1CCXGOCTDirNvdZjvvVBJd/x9awrtLTYBfemA2bt5irCK5lxWlBo\u002BiOdoKRGM5PLqOYcnKCh6B9rvxMpLMrD35froVNcD4uPSTuIThPQUdIj2pqA0QlKIEN5xZt9f40Y2cEMmlIAb1kajVOk2VoLm20AxVIwAs6OYYEQIknwEclur7RSg/dAI2tBpkO15QbpLipufHp66JbyfjjQ8A0PKrtKdmml\u002BNd1gOHm7pyK2Lx6JzQfgZWO84cdYEW\u002BrzMeMnvIa26dQzUS\u002BPuYk/n6J6W8VskY76jl\u002B0LiiFiR9tGuiPxgwq0N3OP/DIjZ9l\u002BNI3jgAhhqBULS4rArurqcQQHqKcs9mST4brnlGeLfy8TjVWUf8bT5RIO5Td/9IiIpIotHL8yUT4oT59OeROtf8xarCGVVvI\u002BM8KUHhAsFOwxXvDcXmNw4TwXay8nhWv/YGVrJUdn806X7\u002Bj8nTIt\u002BzuyHBsi0SFo6cvkferDFq5Xlb6rwe6lyWqiRW56c0QJ6m/0dWhQ3I9EAzt8gnZj1Ng6pQdzgTpMDFKwgIuy7XaH25J7zqFFBrkvZr2yKEf0P3CWQM08lWg1p2gVn1sDkRXF9afj5wU29J9ORBt8muQLvEEbHKyoSkUqRic5MGZeK9Wo7TOfEFdqX0wu7lFNuA2DCuMZ6HRoHathuaHe/MM48BhF1Kyxa6zqsLxgeVz03I0ZtSWDRENgQNCHPVa1i2KI9v44CONg0p43Lzi3CKNPbd0UxUeetKvV5JTcKS5VNCRZ14JdvNSpuOOHTBQLqDcsONB5ocYb6kJSYyNPhKlw4foUXjAh8bAIagxjFmiXyTtcsPBd25NdPuxAC1mwWjQ6F2oZ90oGC0cfcTe5t9PZupnn8tS4EgVnth9E4OZXVw/YKf/9ftLwVaSoPWpco4YYZlC/yWdfgQRlskAqwiphyBkn4Y3U3DzG9pwvENWaCxKZK3qVl46neKj7l8ySxpJ6R3VRNML4RIkT\u002BdLKMHEvyqctkZevyzCKgGnl2URwNDAKtMhgSdZQoebwgp683Ec3zM0lZDT7yntExrRZE2pFosWhwHyozoHQ3PCwv0mSzqMhrQ13S8/7DulNG4Mh9457q9/ZGxvLj/1MVIhESgsxsvcRN2VdzVf1pbKSWrP9ruRhNBRquLOHVR4QK/dHt8TeG2iLEA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-a775632b-0abe-4df2-ea77-bdf2cbce0d5b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-49961986ed3a19302de4694f1b6acc5c-c8df7ddda3eab453-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "69515e54-8ceb-df8d-311d-ab71bde2e6d8",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C700744E3E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "8qaSI9X2E1NnLQXhhk9UFw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "69515e54-8ceb-df8d-311d-ab71bde2e6d8",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d3b7b31d-401e-004d-75af-a35e6e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "9sb5RIniRk2hX67u7rM/S3KeJDgWNuLVPR4b6sbdUqTUrudUbkaH3eLROyg1h3uF9P7bBn6q/8DkJAdrxluGxA0JGUDL6twrF0dWRPu6oLWilfXIAUsmKq4ncEo/GxaGS3caK207ugohr\u002B82U7rFKoRRyTBlvcLC4\u002B\u002BRpHmS7Pswz/mDn3VHZtvrp1Jb79bzYkbF7VLlIY20WEd\u002BqRWQjsPzBYTBQYoOCmJVehVwZvQZnkEzzP6pS65rz0cuyb3GWhiOaOlRMiG7t\u002BPwkKZ4RPJSZAvTXcLESbrWVXFD4EGljyD94f0KyGwgdxUbuboH84tU22Sx8v1Wyh4ue9yveNaiSwGGe2L0R5yfs\u002BWsqZAAzmHm7gXc85wjphff3E2Pcf8/eW64gXgoYJPIEj8XqiCOLqx7yInQxldkY9RLFWtPD0LmbTAiR03pvo1yE\u002BFdDPz2UK2gFKh1brMWUx2j3UsneQL9MD3wa\u002BZekQr8XrJ2B1fYVMS9rvuacf59C/MvReFCSprfYNu\u002BBeXHQoKdeQ8AoEzGy4iGasoGY74\u002Bc1/zLkwpuRQYl6Z7GU7f9mx5/PjufGunaXpYu\u002BDP2P0dgJKF1BM1c7/75wmlS7E5p3NejWbGT/b0TMXS0P0zSb6pXpm8WSJYQ4k485RiAR3IHxNscEqXVjGbkYhOY6LBx55K/O0YfE5RBkrdjVthkkqnCbHqx9lzEgdnIMeaCd/mdiv2FwUwsKLFG2kAusnVOf89plrx1wDF1unlsFyGtv1r9hYwa3pFdlgOJatvc1g9kubIXWKF9Z8rMUAbSwBGPmVslMOypc6E9zAB4rFUVWORpx11vlma5QF2BDk6KitXyOdGA96Ui\u002B0YQ2UygxLt1tvdiaPj0H8L0q/BO6CUSs0EqRrKDlKE/BwwXXv0Z2LviS5eXaCIdPdnOjEv009Mg/mYLdn4IseJWIyGs3MEF2pM0rJyNuwsfDUiY9MhVCnN49mBWzqI92Zm1AQUAcGDYiPG4wGc2UwMbLCk1b/0aARjuc\u002BZgrswxNtMDGLoF3tznwCwWnEnMAmNde\u002BJ4yGmcWv/sEfy6eBnlh4mUM3qI1Q1MDa/Qw6TO4nFDAzLp\u002BC5pZr26Gc0gbUgSMNSAd88o1KbU7Pr5y5dbHW9LN3TnO89bKsy8zrsAK6Bn/tKQDmqiGm6MFMtzr1smHvyd1XXTKzUFZQzCq8XrlIEakgyEyw7EqN0GGubEJ7uxVq/\u002BolZqVJPdSukd365o4EAKWR0OoVPtmSxYzRAOQX2RERUWLTJqsD2454BlpolunTqmuY6eYvVb0MkqEUdDjwlrjI5ZEvNN36jflbnTSDKi6m/Vp4eu8u4f\u002BhwpAJ72NRh2\u002Bdo6w=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-ee16bcb6-e6dd-582f-1312-33bfa0c01876",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-dd581463eedb1b1a33a7579163375472-a07a986249296bc0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "250ca626-a176-c63b-65e6-40fc3fcbc037",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:11 GMT",
+        "ETag": "\u00220x8DB71C70077A91F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "hLqCqXo4hLxgyyUPUwIzQw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "250ca626-a176-c63b-65e6-40fc3fcbc037",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d3b7b3a7-401e-004d-7aaf-a35e6e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "nQfyZ4DlY1yTfCimgoVyOGKgU5Y5O7Yk0ISQxk1J5d56G8TU9ABqb8W/z\u002BtvVbJpr\u002Br4fEjIfmJQzpf8VZwPSpZJK2bBnUNhNePQeWvLtXvSJhZjUWmWsp1hgyZpbhopsIVUJSlLqBGml0dk9wT2hBkbKi6GrPgss3nJXxod98fJp8nmd49Shn4EvLoiMbqYa/8NTUPsogOMJ3KvgUj3iZ\u002BAm1A7Dw2JyaSvgfA\u002BCoK/MfQaD6qD3QTGWk8dowQ1DTIaopVpXVvyhISfPCETTR3w71BU3Hn0/L5MdLW9bCafenS9I2fsVdOZKIsm5KDisgwyLbOz4TC5JqXXHeilNRhd/8GtVim1A5l9u7TuzhgdacKpij5y65lDBP3BFTjr9PNzyOTfNVzifSoaNiZ8yleNubQm\u002B6rZ6xMoalIr8\u002B1hksbAewYzPjRmxg0UWLVzxjmmM1yExPhJmd3QtssJtok8uaRfu09QWnuAwDWdxJJetaMYhb\u002BR3M3Od\u002BEpYodoXA\u002BD2J8QFAvqVdngBATCrNRKcgEo8THKq9zXkERtJ/fzF2QlGezzTaGYLi/msNjIDMsM3vCFQGreuS3COYPGfS3h7eygnZLoVyRgj8MB5PoDDoR5YEkHbdb5R1\u002B/MBMd0bACBMPsKG44JIfMJbCn3NUyvyv/TRzk2n8WplUyKSYQQ74S/983F\u002BUVQDzCO0glUWqKjHHoHYSUHSpE1YEZBftgu\u002BHyld31\u002B6dF6gzgIp428FTqqJy0JyU5feK18kFk\u002BztAYX9mMryNlJHJozN4tPqLDeUsLl1frJO8uRf7QAhm4e7Rn8Efz72YXRMK64TywMnnKeVcN83d4bXrqnmlklOJY8FEpxQ5bD0nlNFJVMAPyfhNFBciCqkh870MMyVE8svAgYfCrRm1rb2nNKP8lI303OCAWH48ZlkYI7RXLTgY4qEGidI5TBzemGZZe9UGJF8vGFZEw5pMgxsuqollXoCFj1EB9Qq7upDEosAX4uqDEf5UJxTh0x8HuQW3CqKSeTnm1OuDBS9UdF3GfyHaNaAwqpiKEDZro7wy\u002BjwFA7DuMiiGMA7/AAzPALK3G1P9LINkhl8JB2gDejEvUAryTnCt2E34VASSMaqLug\u002BDtIhoNM25oH1Q5Cq/grbdz68B3bFBCkIFBdd\u002B0lW0fk1Zf8aoxhw9Oa7zXPQjONFOtWH7itxdQapFYi/2Os4nnGbdZgPvNAiTxKQDTq5O4swFMB3zufRw\u002Bz0cY2PsRv7gy7\u002BORdHOXoBZaMU4WvP894Bi8AmwNOJybWvF09Gkpn2mI4LuwJ37N9GcmlEuN6BKH2vjilb0L5fcG9dlCYqvtMFHkjZxDjfjZ7g3FJmRQzXLew=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-8b4bbd13-6f40-3bc5-2f94-c6a8c002b063",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1822a4b36d62dc02f35d7c6d21dc34c2-2e2b77678d842db0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "164bc677-c0d5-d661-7d03-4ea53515d06e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7007B0404\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "t20RoczXrPo9fOIHFN1Z7w==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "164bc677-c0d5-d661-7d03-4ea53515d06e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d3b7b415-401e-004d-63af-a35e6e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "j\u002BeladkRNAAinbwb/kvYopqN1krzpSDgQob8kh3SivAmswJckGGioTDA\u002BYn02ezGzCL6oHCi8\u002BrGxCdSFaLiUBPM9EtJexI56zUZMquX7GmaNsb71\u002BqAg78Xlss5T4yO3qh1KOWhfVAQwLU7icA\u002BLti\u002BuN7b53goS3CLMeVG/5uoi1QDIcSE\u002BLl26hY1Rfr/2Wfze5eusvYvTdx0FkxqysEZkv1sOwwTOb8kZf1i8wV1i1d\u002BU4MD\u002Btld09TnD\u002BJtCyBVG7L9kp5a30LYiU35zVnW/4r07HY9FpgjD2c4LCrct1ndDNhSd/m4I3NBK3GMZAV7EBBYeB\u002BpGAUa2YM2IrIX\u002B9HzHMCAhIeQPMgC\u002B\u002Bonl6pivRwZgz45M/TTOJ52gQHAKS\u002BfmEhE\u002BoyIxzxXphwa80LY1GWW/XeTuujMrUvpGrrGQdG7iP9iHcKPkbwC4o3XuEVbna2cKSy3DN5feExAn62CkGRKX2pDdreiB2y7kdhb9PQGjX0MKhelA3sgAqV1TvEOf1EojVnaGCf2\u002BSK/\u002B3sGBINYOhIwdWZMpVvuInMRLLh7rBGGMmeaK3RWFjD15gcAGv4hHRPf3grq2\u002Bf\u002B6/az5MxpRE9pf9EcvQ\u002Bd2l82V79T7gd18A\u002Blm80HnFd/nD99ojJji6G4lpssBF8EQQSqtIMoqv3vPvO9xKiBYuJ6nCHPHzcs0swdm1dsSeywoFrJXOfUV/FCjmQ\u002Bpsb5NzS4smc\u002BNCHNfuG3Cg\u002Bmg/UHDSNOtwX7pkUvjZHT7iwFJGMis5aEcWw4\u002B94GHE3inAtuN5miqn8uvQwiDqeQ\u002BY\u002B1seasg89egpu3Frwn9In4TfCFZLaTYnnj8/WKYWLFpwJOUGtmNRk7ELX965TDB8iCKsG2C5TZIU5syI/Z0yA48m\u002B52KMekRfXSVQBlXflIOwtBzehDpttdS8c\u002Bm2JYj2UxfklCi4kZJmq3sFA2IzXh6ijrMvpluPTS2N0ApapTucXbc9\u002BwBa9CKOd9y/ZLZ2iRHPF5rVxqi8VUb7Lr2ICAJDaKWu8WceS5aQoTJ\u002Bz\u002BR7G0r0j5GcypcKgaW5X8lhBm/ef/wMx5eurMwEQSV6PYVigBN2k3hsoqIOoHPBYOvJM5rCnFPkalOzSd7FmIVxjEAcVt\u002B16nLzcdld/icn7U/gOxGKt6ExehXDx0mZpwYYnRAvoQoIE0Ur0y52imgsi1yS4WFz5tii7tzF9iMpVcrXQWES\u002BEhB1CfMYuRyvvOtkz/pCsWkpLY7iLYtRhkiAnlno0ULGY8QUQk5p4fwMDPtGGLnPE8BLpyq13OWEJIKqmBrDxuqpnmw2LW4awEyR1iGQCm6PsIuYnSoXEIffjx3MvkniSUUQnXpNmQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f/test-blob-1abffc87-960b-44d2-331c-94acd633ac29",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c97c7ba7668fbcfc66a565af3e688529-87596a6171079034-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7885f9c8-a980-e761-cf15-defdc334a736",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "ETag": "\u00220x8DB71C7007F221B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "j8uksDhCpy1/POACoIlvFQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7885f9c8-a980-e761-cf15-defdc334a736",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d3b7b4b8-401e-004d-78af-a35e6e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "wJGN5FaeUU4BAq\u002BM239t80IXpUZsQznsgRuaA7ejYlMeHE8M7GhCRwHi5Nt1eeh0rSHY0OjkvXxXoWM7A02WXqBbbr8wYAba1F5FiV9edwcyJVWWy5FqOl7StUsEBkOzS4Y6GQooREwa/fuKnzMd\u002BCpcCN74AJIO8DRgXau71s4bkT7ZJF39CuAJfM2W4JsrtbwgqP1lu0vzKynWyOagXictbg31RNTNXv797oTFeA\u002BYNajvmi7Qttbz5fgzJkH5aB2laXGONnDoU0n\u002BZ8zGLbIZPZI\u002BscP5XLg2AV7bmTi8A4ZmIA\u002BeCv43Bkfl0U4KLLhFGuivu7ZZrAy5VzQSDLoQQWRFYA2jezOTBqt8FItpLNWmln9PDUjQDHMD5LPKJfqM1I/qxMuqop61G7QL3JeBTytfbHY7wDQcdVOZoJZ/yeGw8D/7f2cJ\u002B/PgmvGTxC/cgZWIarmDURNbzk93EQEINVLSWuxXhdDDVXCCWyZCiLAkvR4B914oLZ4roLAYkerx2GSfwGpDhPvFxRVIAPbtGEWeU1PjBj7zqS1NK\u002BUfqsOFkIPBosdG4TkiPDJJ4CyoPodqej6WDtEmrBc89VgWpRpRwnBzK3Z\u002BV3IawMoLqskBpe1etDCF7oKxm/awCevgDJYX\u002BB27NRIQ7CLLfE0GGgFNO09qt/Dqy9PuwZB/zU6GObQ087KrRW/aTsgNunI0q4D0Ys6bdlWlLSxKzXSBkB7URUKZ0iZPofXgj2ko3BFhuRUQi2p/6sNejsaFYXf7WL2pOXUvmtlZpcHYu\u002BbsfFAb6RRecQWzVFp/OkNgyT9\u002B5Derf6KcMR48tuWppy/dchF1anhjnee39eUasGCV\u002BduBWteuQP2tfrf1IrofCqwrocgy6l/HGkZP84m9gYC\u002Bp70KKE1XLjEUx\u002BvAbXssmOs47w\u002BXYg57uj\u002BQX0x08P03Nnr9FOFf03KWHiJzBqzLI1udhJJxJkSujm0Nxs/koNfuiTcAL4MJ2BucAUTsCLSSxTvx1mtrxRA2ToZ0Ug2jsn5LhXx1y/TYk6x21SX/wYa5ewGT88lrg8MnyeD9lYYO\u002BE/GoYI3HPpHGEK/9PDqNo3/utYLEL604AG4TgEU2/4lZ9zWOSADgV8HS9qHq47SPJNT/dqwA\u002BiQEcGBfs35Mz1Emo0UE/1s\u002Bzh3BMTkLTRy5RJtwd0jdWT0RidfggORDhecQxEBvimW5gKiOP4jrOSMDpi7i3JgICQpH83VDHg15fasR\u002BkjcSfp19ragTxl0JpD03Nq1oKlPCLs2J5bwNqJbFIId2T6aJ1x0rOYhZ/nw08zkjkEyw9zBwrHN5mIjRcAURXpXFk1SGrW\u002BATPDbeDBBRPKC6ghKFDlQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-dc2e1705-a138-c601-d1b4-6927d286d37f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-161574131332d0a162f1d5e51c153bf5-b30991461d22aec6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3cdc31ee-578f-a8ed-42b6-c0e76be55098",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3cdc31ee-578f-a8ed-42b6-c0e76be55098",
+        "x-ms-request-id": "d3b7b4ed-401e-004d-27af-a35e6e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1609624756",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,2048,30).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,2048,30).json
@@ -1,0 +1,535 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-7418c171c0bc8c3f82d2cea5b949af7a-6dfe4d64eef3e707-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "677998d8-61c7-d3bc-d242-08e6cb529563",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F0027844\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "677998d8-61c7-d3bc-d242-08e6cb529563",
+        "x-ms-request-id": "69fcde6e-201e-0029-35b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-7854d8b7-ad2f-bc09-95fc-7fd7273550b9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-6b99cd6774f05573016c96c467027714-befae2e07a764729-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fc5eeb57-e541-121c-8c1e-f9bce44422be",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "8T4NYtvjrgtL8ZOYQ5YfxC3ucMESlZ7M3L0HV7BzaWy1sS5YQTgqqtgDsw5NwW1Gy83M/GcWFlyfQYYd21db2Igm45Fnx4L0w8boDuKQfxtQwYvip2wEnpvSuACyDc6BqNqFJ97b3gRK1zmhLQd6D8JrzBnLeDEbIUT2lQ\u002BBQrX3Z2YHClg9dOKHl88zY3GUV6k\u002BR0C1tS\u002BpagWZ5Un0yJWDqcahcwRqLlg2ROBh577SYj1lQ/t0QbE2XaBTo4\u002BZks46sLmr8\u002BOk1Bjof3FPR4JGx4MLjoWZDmcUahVkF4vJnbIRJzcFJ25ZwW7ijMJA5hUdDNsLjQNJoKFRlojOQL2NH\u002BK/PSBKQJ8Uss0WtoKl1IP/RgqvvQ\u002Bux4aWs5Dmi4GxVW3ggaj108s899s1M\u002BkerMIEzvmz3mHSEHWas40OLiZMZGEUxFPaCnI\u002BcsY0eJScdwbO4b2H/nYLDnAzWh8\u002BLcm06c6ICuhvKcOGdGubnZfh/TyGQExoxGbrCLbip7BTAEX9f4/GFG0eX7f5AYkKcHDYUV3jt\u002Bx8SyRnnAExjIITM3Qlnh0IGunOZ\u002BCUbsPc4JhFCVVTb0hYgDNqX3ds7dI15s0V5NJS0DdzFVAM6N1girto7IMswMMszR7qnrtxYnoNXoj1x/zF8jke31r3TJdWCdS8AwFPCSYJ6Be0aDJ8ArLV/olUa8O/ovlJDuBpNICGk5TntF55vlVh7N/kEYoHodynIk0NAZ4R/WAHBftFoLSXLdWdlU1UW0A0837k2pFuQmwEwRIyeJH11rf9cbhZG0sqTeO1aQyOU8YN2Q4fLCLPmcOPQd6hZLVDqL\u002BWVuqI2tgzuYytudlfdW5LJZ\u002BD1amULtj1ytltiekuccFN\u002BPzbhP427HOVIt/pL8xvVT4WwNIWASgRkxD\u002BxjCjfkgXEnxyb6CgTek1/gz5C5oM/TOqGLHuN/fUyvHtNyZD8qOX0R1Q/eWddXPo4AIcGId18cj8\u002BWaWKNqEnqWvsxXD8QxoYjl8uwBNDKM\u002BBlb0uLFpd0VdRvk8AKlDy19A7sJdJe72s7ZO\u002BTXIr\u002BzDWCKEkOX0RTvPZqoTLGGQOfCgDR3h4OFn/gT6G34PlJcMeaeGvzt5S6mGjr5E4oZUvb9FKKLO4nhBHJHh\u002BSm8v9ITBrO6Cnq0J8F0WlIiIxx9pl2\u002Bymz1PZYvRKKqmFJ/ys/sMdvTmrNFkQHhWocmHvh1Y1PL/vVmHcgci8XXCo5u9JCDNvJAqguqeThrFOMPCSaqNTX\u002BtMzZhhMStw7ubodycmX3o\u002BgGNbhHIYS8\u002BwnlDYKeLdRZb0DDqa/fLfP8uwqx\u002BKJ\u002BF2Y9pP98t5JHHYsJLaqMUEGyGAIlM/k4JgfFSmZ5CgJnZ/UcYIjV3bitfIsk1f9IcGvJ/\u002BCfWONsBX34tmwszRKJoca0cO\u002B43TtJd7duFFAIfNr7sAshxw4SsFsL3SZLga94mzM5lP98ESKlVuEs/vAs7zmSMB0HZ9q3osCTrAAU/fYH9Xkczujaf57pfHEt5bFq3u3suVCScTNZgvI/6GUhkFjqJAh3ECFRuLF\u002BHutoibwOKM4SKESldYNFwkz2mpY5x\u002BsZQsCp887LmwCeE1NI8fg1McCWDmgTRa\u002BEMk3UWx0bRVb/T0f8ZTUAR41EBmIw/dFUwWnWoriDBf0RJMGA9j/jg838SKGxOcuLlsfbzz5NVDR7gJq0RaOee0lJ6kF0f1BNYYKUNLQwooidSgvwqDa\u002BxNCMBXWlLj4qXcxXZ06KFxd3jW68uB\u002BASt0RFvqXrdMTiyZx53napzJEatbn2Ds6EjP0eRrIAguwC7qYkxhEkq/5RNwnGS\u002BenOY8d01JmHKi1wPHozS5S4gawNu\u002BQhMa/9cm7pNeEvkDVtwzjIq\u002BZnNI9bwUfO97P/lUDFhT31rSIXd2IqreQ8QKw01Yhb79XFpodkxXBoPnq66aCgagsHaBYWoSR0TJabL3CbmiIrk6Vq/\u002B62kNexv0jnf7RDi\u002BaRPW1iRU6xQVnwyaYPzJRYj0X7RWosQMdOVOHbnMzSV5OJ\u002Bmy0yV5mua6EtdchseK0nuBuSEZ8dOyWI/Bc1bSdHmISdcI3k8X3lJvLl4rwHKL/Jw3cdA9dDYVwLpVuCeP596dlDzwgfPsqZrOqsO1RlgdNXb6msKpixWhMt3UgmYq30Z/jmw123qoCsg1LolyYLoieELw1Q0b88knD08WGCd048t9Nbfr51n8EpA6tFyMLtJjsgnjego5Y5qjDowrkjLggEq99WrCNpEo9IK84X9smuC8smXdUWnBQ5IdSNiN0IBdGfQRznlnobu4\u002BoVHvIIbNnOrrx\u002BMwy7gvLGYpK34WuPCH4eLWoynFNDqJJbkeYcPwhJlImGg0BaFMRGHzvzNwF\u002BhRZz6T9vmxFoO4t6YPEMqiOJbk3iCYQ9xBim7HwXT3GR3AvPqVXJ2fh3HUi14LTTOXUYasi0nHyRNSUnya\u002BVUOwZ6YPlPADNwJRUa\u002Bs8iORk0rIH/\u002BWo3ECPPXQwoRBI4s1bnPcw7v10Sqk0XzCQVaxBwvb9jVEHcAxDVf6MnR6DC4ke4OvsNOS1k7U7dHwQ/\u002BjH7t8aS1R8VCvq7Zj\u002B6KyKsVSncXTBVI4SSPqby/yPM1YWxa8/aMA0oozAAUdLtqsIscIoaI10BplQBwNa4IkvW7lC6CL9SkiTcs/nAFJHx5FPkxo5ZsrIob4V72G82sEDkaaNCM6ICmZ6lPY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "R4BJFGRaQLMxKyh9Xn1Ldw==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F00DBC8C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fc5eeb57-e541-121c-8c1e-f9bce44422be",
+        "x-ms-content-crc64": "7sRQFKaXsX4=",
+        "x-ms-request-id": "69fcdec3-201e-0029-7fb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-c2aa129d-b5e7-db81-e348-3fb9d89503ef",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-016f94b4d11613e3fe60bd4ea8a1f55d-53b0de8141a8376b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b4301906-f3c6-4a31-a4ea-4ca3a98fb961",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "6Fvn1pgN5G\u002Brur7Cxoi0v9HUChW5zeYgS891lJyyno2IJCIKk71esKiVm06CrkTEujUiGnAwqhp1x4vImE/T\u002BRwwOqJmqSwUdlltIzKXnpyLsdlmj4MdV3kHlMwylRhYwqEyUXShXREJDqQWw4fo3ijvPed1bWmYE\u002BIoXhRf4uBBFGGQZUwn6VPIXIHeBpPyH7ajQlgx4lQ4mT6ReP/8qizD1a4lV3nbx1OTrRHnugxONj5evJ\u002BIEDIMWMsOlXBUzLJVGzHkzMg9x3oEnTVDUN8xQkLAnu2MOsV8Gf6tzTLjP\u002BBfkp/aaWl2IPUlhHL9yQjs3VIulC3EyeBraLPJj/pIIV5U471AVtnZSX33Z7VSf1D2we/ftaqzmsm\u002BbgG2rZD73GMUqOVKq4Z5VEqvzWEqGOhi0s4KaWyzoUn0gefXI5zt/IpSPtZrrBVpZWBgA81nk1UYU9rC8XP3YAebViqeojGuwtHX2NoS9ya5oAQLU517jO6Rvs/BKwoXWt7Oz1Xry8IusUD8kLt7Blu0CVBv6wxpH8k8DONh7JfGwH37QyfQzdVB3KFdf/wyFrh0DSK6qG7RZa\u002BMr77fzcWpNdA9f8M04zt7LQ9rDJ/NCfYr7d51DBcPKt53RB4WYQ/btEos9Zb1PyrmP3pfZlgPvqXItN/nMym4LlXkvJ4cZMv/j1hVoRRfNa2zjs2dr8OFZ4V4Tq0v9IAgc8ZAEIOLytquX9f/uh2RaH4yM6VcGn6SX1QYoxYe0JrYNS1NHyUpJ8Ty70/sha1o5\u002BUv/cDaxFhHrrEvcibEkI88J4XwRElYCAzhaSsupdmmsLwx7tPa/XDUBXB0\u002BrWdLl/Ar14oeKOb1vS0\u002BVstGAjYiMJqkqG8YioUGz7Z5A5XRDrMbvZ7fTgZlhjeJgQUp\u002BxnnHHyM5u9BE0zFFxkwfLlXbUgYaoSXAuJUPyJ3Twm/3RRcUicZBCeDmqpR2nbtNQl\u002BchO9EZCVT9maeKeNCYRDRToEk\u002BqSPmkgVI/aRWhrZsoY\u002BRz1wstDxwINvot/9lDmDlV86KEe7DPqnLzAuspxLtHdtFCnTYIugMyoRL\u002BdoF4/NHcTLr5o\u002Bc0oyyZOg0x33E/5okIAfoCTDifUdqd0TPwegYaTHgATdLpDfkKb4D1AcGgv5D4cPrW2v\u002BCWlINltL5qL8HFpL5Ppi2HvQA\u002BN23qVAY/RGj\u002BAkLQ3J5fvOA3HcnEcbB7uovp4D3QVIG1uIiyrAC9ZjAVbC1\u002B9MggMCkNkF82eYW9rtl6VaRq7a3BW2PVrNDfefeZrsVC/IXDifAUgoQif37C9T0nAxCL6r5/fVlkSkNYbhannIrAOrITtou0Fispnxwk0reTuHbmzcRHA39sX39s/FRtuuK0AvpLE4xE15RTVd59f3eLhPXfwI7GuTdy5xdMR1nWvCR5cM/9SKSqYjYv862hLt/H4TeejboT7UmDGCx0\u002BJA6fNm5w85njnxRNV6YloWJkfg3hGZid\u002B5qJYOGenB4NWlmNXaT5ysRYBL7DVhbuxbD\u002BUZ0fXRp2AUrT95K4VQMGT/1MqEPNeqNJiQTZypWDqpsgkDpw/g1PB1xaJdMxr7\u002B7zRYZki1tMObpxdQFnDalQEz3h7TIhUHwDZD3Y0TQF\u002BlFLf2Pegh9w19Tlzg5SXsVtOWGOhf640fUKZSMdc2SGa3qsG45JdZEicRldP4JtsQl0b5vSe3RWjq1q1Bj4U2RsX2KTokM3I8PMbBDlX5ZymLQZpQfMs/AGWYjg3qF4Jh208Nwj2g7GPUvUAgtjbTMa\u002BDtg3qpcn69ujUi2VkUiVEX3MGq2Tr6pV2u79K3kouhVxeJmF0tzVFEssUzGD\u002BsCsanFbDzIYKl8u4tCoKb9iepcYIxmvED\u002Bg9wZhZ1x50d8uUcAIzavjWU06V\u002B8MLOqMytiZa9an/VoyuxgstsMDtRDwetj/Wa3sNMrLdLlPlMob1ZyD32YJhlNm1RKTt6KKN6HfG7ESjHArrDYM3Img4idNEOAnf9Wq5/SFmYSbWXwnQD0XcHgZCUkrVzMv/KnKxfLqRabBYrfMNTO9jfPskFK65ZtMiXKuNAeX\u002ByiieutKutORsBTWZd6FSztFW3tVPsfgdRcOfjuAPBGfKmePKrpIctIfW98\u002B5H\u002B9xj42adiLQrxgwQTTPDyYEHMCNzt29SCA/OmpNePnoZGXULf9SdM4E\u002BiqL2i1dDWWh0psO61ERtAdtmzu4gzZeB9zPOyEmsegyiNTzMa3yoe0E66Ye2bkUwnn4JNmSTHb0bZJQjhJEe2Dy3GJ8XoKZevlOs5dQPy5juninbkzOYDyd/oPbohOawHAFbD0W2GP3HungQ9ifpG6j7NPZnQzT5Hxlnp/\u002BvZjls/NnCpMxDOHUsA\u002BjLhxkPlpVd/U/wSNjcYeA8TnEOKEROo/leFmbcqAyBOz9cPZfwaAFaQXjpfLPw9kLsFvn0LduUfOMfsYAucUVDbw2ZcCRYO\u002BZvo9bbVSdFXRAj8JESjQ1jt7Ck4KaBK9Ajpg2mZ4Yeg9sDhIn0ySe72lRgCnC0MOIANchzo1s/7ngGt68ZrvWKBXy2DwiDbv6I6QZCERFfb3UrljHNquB/w6YB7hF4oitu5gUEDiHpfMbJ6rpE/c1Wt0g57gjDzFqMNjtSgXDdEEbq0zscS2FDQilq88AmOtXYqzbJTrQiqxmqd8fmhvtV/MpzahqSSnvm5qvfWNiaZgtlidZKE9GCuDgRY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "BCneIIQuc3JIKOVZSiRnHA==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F010C95C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b4301906-f3c6-4a31-a4ea-4ca3a98fb961",
+        "x-ms-content-crc64": "wAWx1JJwNww=",
+        "x-ms-request-id": "993db1a3-d01e-0002-42b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-f22ec61a-1dfe-2234-1e95-8efd7edd0af2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4d4e585cee2a20c33514bbd96967c4bc-76cc0d08c43fb9d8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c6197b67-0d5e-99df-7d0c-059f5412d5ab",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "gYQ0JBABG8gQ0VC\u002Bj44KHScNioTYnQoUPRpLNKqjN1jyF5enTl0FGh3OvOKQkd/MIe6NWIEpTeR5H\u002Bf2tucdbJn4y3j3Y87KB3BnCeEohKs7fhK7Ft/XycmzLS91D2Q2sFBJl8Zm1b4fwlERwkQDUZs8uzjUYlW5IQKvRDWfVPcLMVmQ3\u002B3k1alUnFOOxgeFsNyUOVQsYU76j3XEtpGIf25ZBZDqcnKuV\u002BaPf8UBK1v6KpRZCxuj388Llk93IB4XzBzlNcF2mj1p5eJunOGI\u002BGMayYv9LnRTtSXA39siNjfHd7OpHPaahJBW7yU5NEPugp3rXFaSGp2nkn\u002BbtbtiRq6qpyUu3txtf0X7pj9OGoDi0lw\u002BNtrgNFwVAYl2/s7V9Kh2jo0dv6TAftwRlnNeWXj\u002BueJeIxDUynLJGNxT9oF2JrKW14zzxBK4fbj9z53ot6gReETsdtCYocMbVKfHbYhbmnDByIHsC/XQpqZY1/vU4GE0QX48irDi/TbI13Br8A8vojQtJ\u002B4nJWxPHM8pQMrHR3NGkiwKHhDA3stLIzSEZLWWKDXHprhyDRwR7W7guLxrAI/8JV3jJYMkbUkj2wI4yrcakhiVAKC604UP\u002BDGh4CUO4CKkhz9XswKxojlvTjEa2CK3xSaj1QDuQVHY0yxRgowjFfvfk0J3wt8W411nS4VT9SAO6hr/agoitUbuf9/VYCCsTDk1OkTfPwNGjfGih/bLhN4MQphyI6rxvd78iUMAQYM9uv9MHbrbLqoWud0Yfy1PIvoAyB2IOiiORHxm47bARktuZc33f2cjMRPtW2rM2D6wrGZJ/3hmtYDWvdg9dUv0VnKSqhpgWKOS3JcJmt69wms\u002BtTZPdkfSB7BNIMGO5bzI\u002BAX4Oi4jUFTCtiLhXRqhGfts/78VpN8rv6JqEzfiBPfaQKLZxYc9GmXhjcAk8aqVqwbFIeb9s1QlzHuLuTwc4LIrBhx4yFRzL\u002BRZMxcfB8731GcxHOIQ3Y1Os/gMsWEpxa0O\u002BeqOHeKyUfIBpIA8BsWtk\u002BXU68PPGimOKhVcZ32DL25qEA3jabeFfsvwDjkNEa0yXx58VNnpP97BAPPNVup0fnQR0vW3ySouT2z43gvvgBhnKQhfB9uUgNEvImnDtyjgfJDF\u002Bz\u002B3epbzTgRs8WHS0X/bZSziFXaYfVEkiKbBaphEF2J7KoXZr69xbLnXKI9wXVHp6FH8/mYZLH7tk/LvMeNsKNn\u002BVqb5AbZ9cKm9wVTBsypU14JGRxj7Yf4G6xu8gjrWawC1cQar7\u002Babf469XGspLODHmllhJeDBA/Wn8xaawO1v51ZUC0Ikqeibq8iJPgST3b479OfgdEUg9G0QA/zPAL6gTnUV1SCdo/FxxXoXN8TxFBZYXssGjnIQNBbUE6XrzKoK6fCOfQeenlD1b6/KCL2pH\u002B7md6Lymr8DBKAJyJBMhfnQDU7UYpcOucB6EB/DRStZK/O2BVQHF04wi3lnlNXAqem1\u002Bvtv1b1X2L3id4qgQL50sJ2clYClyPX/o9YdpiXqumY1DUsw6VY2Xi2WJZ/EkEu68uM3IxRoEDEFcDHmOTGX970jajJzRMZHZjZTDqNWOhOLY7NCspZSzPwaKnkkTyT7/i7ioCUYR64c8L3dFQKOrzUeWtZ9VUQn0Z02WBlNIhYRWA90c5ntcxwEJcLYdLf6jHtEBvROfanpu8\u002BH4e6Vz86mzL3yGTubMea5eC\u002BCTl3mO8ydCBwhw9pmirjKZZEub1bzMaj6CHJAqdUOlQR5Z2xyoaYh\u002BMaxhQjii46C0MtViwnZjhy06zNaXV9HEy3V7SNMV8TrDXaQQayfGHzkvdgKuAr6oNlQvbZzxppnanHbDJ5rNngGaX2TSUxvFdO2dp\u002BGPVoj201J\u002B5kOeEbbKNc7xAveeIZgA0\u002BMZ1aM4ajjvVD74S0WtzFQITre\u002BPE3tyB1M1HH1/0YJjkLl3P2vBrxK7r14EepJA3ajVdMgQtdVLA2F61XG\u002BVT4rv0Cx\u002B9WmQg7cw2QtbYzA9E7EqlzKUurUPDv6VtmQ/Vof6MtRntHTLyK5M\u002BJhLZXUueEy\u002BbrhUVxV3c\u002BZq/slO9YKDYTBf1Vs4XsqER74Yx6mFaz4bgOvPpdu\u002B8ESSYM3g/gcZxARE0qLxgg/tzBNbWqw84ZOPN3Sat7tUnOEWqf38o0W7Av\u002BhQJSbJf7b4dXIY5mYUX86VcqSfxBI7DHB3tQR7SzJnFesm6D68A11vtXljD1LflR\u002Bwk17KIfvWFBm2UcqxfCo/sNF67neP2G9HLw6Z2P0dmB/ly7fTnfTvT9MlBrGSvThPJF6BZKeoILvvg/HsPDwcmLmqzLFyaxPdi56jatG9tHHWSrOfnDR4PKr84xoCAhOWCW346PGH3LhKpNkIBbXpMs9/FvGIfPuFMpAGdYf42oiLDGFjxcuATm37VPhacDf1ErFLg\u002BwhDYxycrZggWYxUclQfPhUhW0D/seEjSgCKsFZEGPWrVebaf7V8VIVIM0HyQIvCvM\u002BoIxDSIQlnX9kb0j0B3ADWqRytBL5f5Qb7d76fMQl0yDOGnDWk2XSdsx/cIEKIRlcA29evFXgRSH4KFumKiC7PpsnJewALMc/nz1Geg4SEcvFnXlUxxbL7dVO3moKLEurwzLl4vwsXNanHh0XmsoS5RaP4I2nZ3eFXDcWsU5cNXLxmrfbLC7PmECirKj5s1MKO/hUeku\u002BBFu7YIXEFaqIS\u002BmqJf8=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "Ss9nYo6AQ5H/wLOqLMMeew==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F01201AE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c6197b67-0d5e-99df-7d0c-059f5412d5ab",
+        "x-ms-content-crc64": "Jjz/DxniJmE=",
+        "x-ms-request-id": "146c19e6-a01e-0055-64b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-245228d0-fdfa-31b4-270d-8826cfe32841",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-31caa36867255b42ff4235f96aa8701f-39c19438a4930fea-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2f7d308c-448d-95e8-5867-2e1fe08ec1a6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "PU39CQxFtrRsLJuFiEy0zrGPBO4gquteEwnfscEI29IbjakhUtrzs9kI89rCNfeR09Wfl39v5pNhnvUCZQTyY1HJavqjk3vWm1EUF7YRnN4STt7raURSrKcVv7Tk8E3VFY\u002BI\u002Bcr87T9ZyPsuWs/dUAIX8BclB/oNdr1TjdTH8aoDPwEmiKITFWGfkqBII1LYOG6yzf82rw6Ve4IMqV9rktZQKhrOtsdfA9u1hnRZxFJre1VlFSSrzY/ykQ0gBmwBMwDJ9/g3CoKnU8okgCmaO7YwoS0KBnyypV2K2yW6PvxutFJ0j81ZNHHSvsFahk1mWFVW8GU\u002B9i2DF1GbrC5d7BTNtsvWJavp1my8OEi6WB8QJIPPZE6XL74l8Xh7vodCddGtjNCBjzKpbRn4gr7kyL4yi4iqjYjFNYYNsTQzbRflecN2DctPjpVRJvc0nq3/QCi5STP/mOdJ51dJc979df8CEwj7brrz4vzzWWeRkJfZDnAMeSTk5eHbLSV0Bhu2U7D3MoukBNJtxWY2DD9/uFbAb2Vt8fzaHS0nH0CVf9zhPAW3mV4LNAmenrO\u002BrtmiW3XOtJa1SWG0HRVdfeWR2EaJVdA5yB74tDtczlNIHG9UhcPLxstGK/KjAntJrrckDcVtNFgJaJNW1v9bWXoOawCmCfghxRJ6QyrdlsWirwWDN8GN2ugWShwwde/L6tF3lJd6o6S\u002BAkez8vAuLNLNsyf51yK5gZAYj7/b8VAir1lYZQEuJwxhxTV52ej46B5KY8HI0RKvvhMGYhPl4xH3kUOW1cbQnosamBLsQKeoIKagkI6OWt1GqKftKMX4e\u002BEjgUilYRJXesQ2rTgAwn1rXUFtRFKDaTdlUCwe4nXFIh0wyL5fA7\u002BUSRbJWKykRuYpgsuDizePoBgRQBHlOJdPcIsbz/m/DFqC2Ps7uhGKwAlG9WCqQZbloCilTsOtrhB/eechiHfsanVwAbI7VOYHhn8HnkM2pC70NS7RGb6X1Crru0ApaTeSWovrOUDkqkxBnsdDpg/MSNS5LFNIGlC32SyHT5im3hxIdES4S2vtEIvij3v2VC4bH3NrbzzkSkA6NGAUXFqzm8Cr\u002BjHLE/xpzBzHZorVwIX9bDAlOm7fZCoEfhcL2bMwLvS6S1n8UAt3AqMgHOO1ZHPaFu8qjmFRy5YHxpXkXvJolziWGnUrARwlrjjLv0dGThmkMMLEBp\u002BTaX/C9Yl2kqSwt4WrH0r\u002BrhXTBeAohQtPwHh7QC0wpJGYArD1aQuTrhuUGwjCmy/PpoGs8QG\u002BauRzczQR\u002BlF2fxPzEhyZCEUJQFbElGoDjCVIrJqshLKQ2ZjMgfXXgrTKHpv0zogSNZ07orGq\u002BtZ6cOYOyE22yftgYzmEzYZPMr2h\u002BnbODr2cNnb8cOIB5d/BUhEOyLpnE1SglGtPjmgX7G/zCf9gq2EpcpHWulgYXn1Zwnp0QGoDOuchLnpSTacO5YRyDtzfYaev5VYokFn7hzbt9cztoqsF784YPn3n1yTqyNTUplCheWHTxFsT26qNJaZDZFfbIEPZbB4NxyIqyA4xPceEJ\u002BHlS3trGt1P8hMkihjWo3LMD6iR\u002BjkxlLI\u002BqfxN4Z7iCf7FXhjbcAZliXoL6DwJUySbZS4f8iyntLfJLHDhAhB1QYEaEUVZ8Z\u002BiLHC/Jat2NFbXsXxwwxbRHqlhEkOVhIdplaa770LfQXSOfca7544LUvcaCVGUBX5qSPOc995bDKfpVZAFukUT\u002BG8I4UZPFTYaVr9Le3o21ZAoUKZPQkmVM3Ae0pL\u002BBpiyBhHhiyQ4GjO8gqEeEJAss3//3GqexLUlcq7VMEOkG1AnmHVpVEps8DVzksCodiLg8h4S/yktE0Fbuxh2YurvGGZQ93cbw181k\u002Bw1KzL0ffuL9T4kkhsm\u002BoUzDZgx9Y1Lg3lZWH\u002BrxC6/3Gs9\u002BOgOZz4d622ry4ZKKf3y6LXGBJ1e6ai5miR83zAQZbWw6QGcJKZaEwofoLjzDi6Cudx5\u002BdfO3g5AVcwZoAs9m2XQmkD7VcMOa/CSP0nvxov2\u002BiZUlmve4QryXM7ZQHP/4gVSInTuhmQYao3mPJ/FUI9BI6bl6AT58bk1CPj0NSt9k1xEnaMXCHPCOyve\u002BKVqLQw/mB3MGvkAWDC6uH5rJDViaKhDgbPrKRozI6zZG/kTytvstZwNsHhiQ0RzXU/1Vhf1fI/8J6xZU28CmfdNJj02pu2if2\u002BZVLgw4D1ueMzLPcyU455pF6MvkmEtCxeBFR0GPLZhUteoXCjXzEZv6tqiN1squEOezY9Kc\u002BwNbEmgrssgaDwVaev17Id2kktcwKiGitO7VlzZZ28nFt/qm\u002B/eNh17ToGejc1wNcy7KDpE7bNDhuJ15VduRgDN7lILClGXl1st4XEm6PwFSyGQHj804ygsphQNaVHGDAiB0J57ZCp6I5DeFgxBHZ3lcJk23SjAmAsp32M8ii4KZ9RopRheiuf2FfquVcwc6ol3J/m3jy/gwDeTUYTHPpli1K832HeFh\u002BWyQMcuEkM/DfTaxGI1UteliOTgyzhiL9dhTIAc5BIR8aATBE9nsq70VESQ7Hk2LILYkk\u002BTpLytUBHwzMXCIijiyNPCIU2IPtY263b00kJdKh/\u002BRFLCfk3kZrQ\u002BduXoMTEbrSSmdAs0UFR5XLhFuH7PkqKmw97WIEqF3buZSsfxTblF2CQdtrYUyfT9SSGUn602b\u002BRCQm5TRYzaIJZPmwY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "srApVOZZeGAYNml1ZmglWg==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F010C95C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2f7d308c-448d-95e8-5867-2e1fe08ec1a6",
+        "x-ms-content-crc64": "Z\u002BNzhbOJ4h4=",
+        "x-ms-request-id": "6828b44f-501e-009a-31b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-bd89cebc-6539-015a-5678-94e76e4fe4ff",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-1f2b98226a334ee2644ba012cb3924ad-32275a81f6499c44-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2e3bfe04-f276-4f03-afec-e67569b59668",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CLonM5VbIMypCoKWGWG/T45T9gQ/bLoDcf\u002Bh7NXc4Ak1MkIugvJquBbsPrXGtutZDjwakBVwFpwAJMKWuTP3zCp5YOcekcyc6T7uUi0EPLoTR96YwVDzxBymLV4v0/7i9XGLTVYEO31wfqbXgsNu\u002B\u002BcHg3FVXgrahZzKd2NtbBY/C127ee9kDgxgKEOpHEJZNzF3KE\u002BMjZdnsce5OcMZAhKQmHZls4L3o3Rl9DXHMWlacT8x9kPGsn7GVMgoqtRIRyYwGIPL84Svf4XaJ5hhn4BeX8iE5wzOyeX4n165z/ifHK0Plhjlj366gna\u002B7IrlZLRIyUsMxF8ZYU\u002Bd01Mm9bCMOgvrUQhnedBKyWWVD91bEjqqcQask1dO9jTJR7sqlIzFMbF/\u002BhOr4FB7wvv5g1JyQsEYe4Oq4KeznVvTnjEUHzTY0N0r2xcn/pC2MNBbVHLiVwT6ERgIG1EKzF2310IeZ6LHILN0Rmep8X3z9K/WV0jp8UcsGQ0b0LSMIQ\u002B6byZOl8kulDO\u002BbhCdUSCaFSahM3QUzub68U2Vq1D/5yRY74FXpFzmqMIVKoI2j8jsgLqN6u2apaE/VKZ7mOnjv4brRWKfQ3HKu4ux/6Nkw2KFqCqWcf02vUngF0\u002B2ag/ZMmv8S0lmTT1Jwy5i6aX925FE9vC/TU2JtIcYvyshE1F72M03aHgYHlrsTK3O1NSj4jy\u002BcnMeGeUdcpbCTo0RJ6/c5hDYxXIYK9eW0gCfuuCzdNzuYqHeXb7oGfXiVdDM2yX\u002B8e3DyxzJpkabiEfkfbi1D9mwIsQN/olS76t9NtUGyfbaocjy76jAJbxbQtR3A5w8LEb3G7lh8PNkcdtwTG9wlL9QCtzwwyAx8P0Hsry02\u002BwPQAmPD609ebHVjX3MT9hN6q0VJvm/TGkmxSq7WT03r5bvYQtm4YQREpArGjWiZKEkuscOnrTyUPSgaEmCgh9znt7n3O7N5wkpBBNolDE0hGGJlp92KBHh/RAWxng6jpBwuHxXuoezV9K\u002B5ZqgirvDa\u002BTo\u002BeuA/XXNBd/dtiGQ7nWD99y03cna1j/Mt0N2QHNVU1qUUpWk8LsHirSn1qGxLfclHZLfDo4bDSOss0UxVsVsh2LG/Jvf3gchrVMUMv\u002BeG4lMUCPgdkTMeURy\u002BDx11jPvO04\u002B6jFbRT6KvWE6BtsjDpi75AWhixEe\u002BoNWbebLq9cgJPexXzBY8AvlVrjjkXJpT\u002BqjuvEtTq88IPCtBdhXvxKKGuHkca5oYvP6uzVZOmgR7R78J/Hl8tZHdD8/q\u002BszjpamWHeQhN07Olf9M5J64\u002BWInBe5WpcgpCcLnfxuKbYIxi2es\u002BHwgGhAwO2Z6L9DzJFatw/TeTP/hbRPhefhzRGg9Wxl3C8DlxuveZqqhrxox9BqFHGnNE36ni0tofuAXvPb\u002BfNS3u9hVh/zJP\u002BZVf735r0Wdrmf\u002BcAfaz4C1fYgLhqmzo3IFunhCb1Rsw9NYEkvNbo\u002Baug6PAAyM3KxX4Ep0/Xl8oZxL9DTNW37TUWx0gr005884cQybJKNleJ3L6k8KOAZaG7CvgbpajR7Pu66gWFnvIzh7fExsoX045ntWwXDvyVkl2mbMhWZUnaPti2k0hSBD3IdWjru6LXoztps\u002Bw8vuH/IVur3zIp3SJp6ovxYUBGFbEySpWTqdq\u002B0s2Q6LFdnYP6u23wqikPophKgdEW5kH3J54/CnBIb3uA6QxgmPBtDEkH9qnWUW\u002BEJqv9RSgJp\u002ByLmcUXHpcPsk/yc70cqwmn3XGEEu\u002BUINIutufISyZTe0Ef1P8vVe219ERd4\u002BGua3uiWWu2gZT893jy5GuvR2clovh7/NIKdIeDzhqnOjzwfE9sKe26mPWsIuGGPHGGCrDdNEDpNmqll\u002BDkMrd\u002BWbk4AmQYQx15awYCz93whDgV/cdpxgH8B0ngxpII1mY\u002BMcUoTjoJbceTZ8k65mqMtROozjTsFJe3O/seN3iLbJSjxJoUxDn\u002BDI//1l44wSDjVBGCYAQtUh0xcRJC6zZPB/s0myHMd\u002BzZqsGo7D41fnbWOuNrCQyMcnZ851cnuyFZsM5nACoDFtwgqLVChGHe//abaLBS4/7qqCivU5CZse\u002BgTz9zzn5M1yQHRmBXSeoQnetgiFJtCszTeFQBV8dLivbFojUiby10TpWMS52ek2I\u002BmrGpNSmdM0RunFYmT4Ncv7tpkae08jK56Dm44L8zNOT1wrkVnlHNJG7wt87bUgMSL4/iMQG6iah\u002B70zv5FKFP2ttLIjGSx1lnG04wDpj4po6qrUzTQfnPzkQlq8E3UAca3hnaiF6T\u002BBufJCUfcVuGwy2tTmZVe5nie1PtbRuYMMpGFTB/Hh0vFrUwNBzTr1zonuiUigGhxWJ/9wwKpooABvRa2VsrBqUPfTixJUd8Dsz3BM4yBKXIpVDN/yYQJXAqLy0nedYAvZdDhAzJ758aAulAE6K7zQJOkTMKXQd\u002B/ljHhvUZVZX19kY373\u002BZ/7Wxs/w9zxLObmIr2eei9WCQxYW0AmiqAK1TSx1bhN6CtZJ\u002BWaoKQS9F\u002BBiT7nyuUgDmpir55P1MBrJP6YT1c\u002BmDqCNVJJy1hoNWbglQFxIxpfgcdN60iNCVMVL3uliqUIUuD0VYWC5jMB\u002Bmo3bz/O\u002BfHUOM2P4Lzh9Sv/NJvcsqrB2EIQfM2E3KuES\u002BDeVaoTRjV50VHniGI0EmBZg6GnJUe/dYbtvo00T2wR\u002B6TMA5\u002BB6\u002B5mY=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "voPjgqkhsupwlMoT\u002Bymg4g==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F01276D7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2e3bfe04-f276-4f03-afec-e67569b59668",
+        "x-ms-content-crc64": "eRJ9GyBcleo=",
+        "x-ms-request-id": "16e8d68b-e01e-007b-7bb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-60bd8ff9-5e06-80bb-dd87-a45126845d06",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-a84fc720295ced28c90271d57efe0f7f-1e6d9d34d292b627-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "569b26f9-a6d6-1934-a775-7098b6bb2d0e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ATNZeoRYHlxZzNeA7A16ezQMJWZps3DdIi1xQjKA6OIuS/brZWvh1vYxSzEmRbrGORNqxEQshU7CfFdX5twq2OP0UaEWjxbIK09vOGg/tt1yqwgeFiSeAsWoKOkUiu8ZBnJNMvMZr6n9oZn0vE3lg8V65DvUDMG/Vk/bbmYttKBgVTH18YTpWfteIHWKqUV4wqUjmqWzRfqwjtukPUFC0O34lGcb75FBkYo/detMNa0JYqvBCRn6rA82RWOoRBy6HFCHkRTeXNIT4gkbdNAPY1kum9uWgcfT/ehX5KoumExuhVmbxaOYKgXZrSYQ3zc/J\u002BEKeahAJJqItJMrh3co5Um8rO53dJ61lnHVvNOgwh6wF73IJB\u002BjLWG\u002BEhAPbKONsMfcVDJJyLNDVOM3a2fH6PF1em\u002B6X8EqGH\u002BMuWGNpinNRwsLw27rZ08KhdA8bML69yofmvIz01EGsjyzvA5Rta65aiNbuySDiRMfr9nx7qy8kcI3bgs3mXS6BRExN6pAuNAiggKenzsFmxDeEyN4FcSQ9itMGUeigtCvoLYTUVFp3/cIzmupHvKGMtL7WIVQQe9NoUF/856Jf/8y7v6F8kq\u002BdTQsb0ZY5tg4xud0pipKXl/Gxa8Q6etYf09rdy/zAD\u002BHPONRJNKo9btoRi22FNnV55CfviyarYtJ1PD37G6pRcWo7GpG\u002BTqMHtDzqKO\u002BoWp2lY\u002BfU0IT7Y5XCE/hsAhNvwFnDiduj\u002B5VEqBbpgXoijOFgVbeCvGDlP/b7/Drq23HpumhVpJCBwahSkGit0aJb30cXC\u002BybrQQ5Hook5/9aWcykwAbRjSgQ3pPPb\u002Bv4d25UX9zzk4\u002BFTc0kXIYGnNno\u002BDZbyNFbSlJexi0YzH0YAKcbkEfipsY837I57TBiCgG6Jnf1XG5dONWKlI2irIFPzBve6sxRxhEwXykfIZ0h/PwrXqXFYqR4/peyV9I4mnMwqeDUQx81KCBmxT1FPdc4aJfRdw3biqm3pix0324\u002B94S2Lnf8Dbmc9jaFnp2m84CAee96ZyNlVR93XJ0ywEjyJ814zw9ffBseNIDXVewL0LJrtKW\u002BxFChUJlYRPDcajXt07aQLiSxYP2UHHKiTj9za0wqhwujMyN81352BvdqQYqLKUI1e\u002BKN\u002BlPn6qgePsKaJRlk8eLqCqCTUxbme1nGadqn12S9Pe\u002BpnMy3\u002B0h7Hth7nCGeBU/noN7hoeiL57854UDNtied3Ocp\u002B1TWMk8YGHR\u002Bap84KGRKgDZFm1wG3bVNvdnHrWiwnb86dAo7Ea6PyYm0TXzfwbkcQvXxWEGLIt2fiLR1EKrLjYzgPbQaD66H9dHSUpB4bfxg6yqyv0V9b1Fsm4j6Grje6L/wP4QFAjNHaWJv\u002BJANZxr4FGVAGM4HYs5irbQljZtY86oQSC44G\u002Bk3K1YjDXaBX3RuAgYTno/xqJz1olS/IduHFwTmPN8sv/i8SO14JFVXoU4/90uVBRUaXt\u002BRArlUeAm6W/Zxm2KVQYJNl1WieYQHncDGf2pQMdHvy94/W31/J9Dj/Yhe5gYrqrXJR23/t\u002BUbSaS4TfifKmokQc9EleYEzm9Evnv76Lf62tT0hupkMBP45BHYxpnYRJNeeqR2pxTPhHk\u002BezmpX6DsvbMjqqO/gBG7i7GULAeVbDnonW4ThDPAJMJxZbUaT4Sw7Akm9JnvnvpSuttjO5gxaQ7/gIIy2Pl/Y4XhDhqcYXws43/\u002Brrdf\u002BP5zgQlYnSlqADymWo7CvdMPp5EUDpDf9lmfNhgYMrqXX8fDvxfwJsacts4d9gbtamVs7sbmS\u002Bptk8qvuWbREg1CDvqHPv77X4DKt1eCwcAS8cvy60OzsRQdletNAG1fi6TAm\u002BcMJmumsU9GG5RSqtHKnMebHiaJjl2maWjTbh8TauvywiYYxougDDn0bVW/yusZQqNlxK1\u002BNs1JpbzCkwNwcvCoX\u002Bjr8ZZ8OtHslWDIJp69\u002Bit77aZ\u002BtIsYj2DO3bk2hDqk12sCbVEM6cnbUaGsQb8eRJjYNEUKaesdk2J1rV1Y9hFmYw8ze4zabsPco2MprA3h8FjgHo\u002B1Wq2/5Jnu13ysgltQRh5v6skMPYWBbcZINCdUU7zEeJeB8Mihc1by65dHMCDHmSXvccWPk\u002BDJ9CynN/CymkO/6AmDjlVVjndyGRIuej3lgFrBZSH3NKS29/zcOjumQFFTh0fXBAqQmaOOHbrO23nuwbdVsTVhyLNkzNaYeZQ7y9jA2vK1znxQMIt\u002BaNcp59xC7TiEEM8cMb7Ucnc0OCAPUlHhzgCHOPN7BUBqI5\u002BceyT6FYybt7rJpOkz4ZwFHDirbtaFSBnbu/RFCQtOsc3fODcSOiKTs5rW2ClXkxdXdelH/rSJFzLK3lmYFm5vuzLbFKmk8yHV17s77q/whCic7dNhxvNZFiDER1uI\u002B11sZx02fH5t8oLHcec5jWiDGloxO2ibDbQ/gf6IoGuGTRxdz0dS\u002BgfqLztQmlTMH4j4QWzBV8A0kVmo9vp/5VIXASTKm73hMCASBswtSnNfc2I10B8\u002BxPUcaX3t6cMNqknpOVlvwYQK1xEM7xEzx0bmCYOYCdUy2Hxv7jJAM0ZcxJxCRBDZ73GeKvjOMdWj6KI2x6B/tWB0tmEdABORyqOKsCq08YM1zFoSOh8cJOami8WQCSvmHQ87zY3v/O9eDCAVQ0GrLzbewPtGLXtBWJG6tnRNwYG35JLbeOQ1Rg9q8\u002B3\u002BxuFk\u002B4=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "u0gJ59GchlPxzA4VHnSW1A==",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F0136105\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "569b26f9-a6d6-1934-a775-7098b6bb2d0e",
+        "x-ms-content-crc64": "iUGlOZRpmRE=",
+        "x-ms-request-id": "64d6b4d7-401e-00a9-27b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-245228d0-fdfa-31b4-270d-8826cfe32841",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-96b6a1c01cb2b65dc2d9950b14409341-75a5b1f6d856e8c7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "437bd252-401a-8291-14a2-e68a5630148e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F010C95C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "srApVOZZeGAYNml1ZmglWg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "437bd252-401a-8291-14a2-e68a5630148e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6b539-401e-00a9-02b0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "PU39CQxFtrRsLJuFiEy0zrGPBO4gquteEwnfscEI29IbjakhUtrzs9kI89rCNfeR09Wfl39v5pNhnvUCZQTyY1HJavqjk3vWm1EUF7YRnN4STt7raURSrKcVv7Tk8E3VFY\u002BI\u002Bcr87T9ZyPsuWs/dUAIX8BclB/oNdr1TjdTH8aoDPwEmiKITFWGfkqBII1LYOG6yzf82rw6Ve4IMqV9rktZQKhrOtsdfA9u1hnRZxFJre1VlFSSrzY/ykQ0gBmwBMwDJ9/g3CoKnU8okgCmaO7YwoS0KBnyypV2K2yW6PvxutFJ0j81ZNHHSvsFahk1mWFVW8GU\u002B9i2DF1GbrC5d7BTNtsvWJavp1my8OEi6WB8QJIPPZE6XL74l8Xh7vodCddGtjNCBjzKpbRn4gr7kyL4yi4iqjYjFNYYNsTQzbRflecN2DctPjpVRJvc0nq3/QCi5STP/mOdJ51dJc979df8CEwj7brrz4vzzWWeRkJfZDnAMeSTk5eHbLSV0Bhu2U7D3MoukBNJtxWY2DD9/uFbAb2Vt8fzaHS0nH0CVf9zhPAW3mV4LNAmenrO\u002BrtmiW3XOtJa1SWG0HRVdfeWR2EaJVdA5yB74tDtczlNIHG9UhcPLxstGK/KjAntJrrckDcVtNFgJaJNW1v9bWXoOawCmCfghxRJ6QyrdlsWirwWDN8GN2ugWShwwde/L6tF3lJd6o6S\u002BAkez8vAuLNLNsyf51yK5gZAYj7/b8VAir1lYZQEuJwxhxTV52ej46B5KY8HI0RKvvhMGYhPl4xH3kUOW1cbQnosamBLsQKeoIKagkI6OWt1GqKftKMX4e\u002BEjgUilYRJXesQ2rTgAwn1rXUFtRFKDaTdlUCwe4nXFIh0wyL5fA7\u002BUSRbJWKykRuYpgsuDizePoBgRQBHlOJdPcIsbz/m/DFqC2Ps7uhGKwAlG9WCqQZbloCilTsOtrhB/eechiHfsanVwAbI7VOYHhn8HnkM2pC70NS7RGb6X1Crru0ApaTeSWovrOUDkqkxBnsdDpg/MSNS5LFNIGlC32SyHT5im3hxIdES4S2vtEIvij3v2VC4bH3NrbzzkSkA6NGAUXFqzm8Cr\u002BjHLE/xpzBzHZorVwIX9bDAlOm7fZCoEfhcL2bMwLvS6S1n8UAt3AqMgHOO1ZHPaFu8qjmFRy5YHxpXkXvJolziWGnUrARwlrjjLv0dGThmkMMLEBp\u002BTaX/C9Yl2kqSwt4WrH0r\u002BrhXTBeAohQtPwHh7QC0wpJGYArD1aQuTrhuUGwjCmy/PpoGs8QG\u002BauRzczQR\u002BlF2fxPzEhyZCEUJQFbElGoDjCVIrJqshLKQ2ZjMgfXXgrTKHpv0zogSNZ07orGq\u002BtZ6cOYOyE22yftgYzmEzYZPMr2h\u002BnbODr2cNnb8cOIB5d/BUhEOyLpnE1SglGtPjmgX7G/zCf9gq2EpcpHWulgYXn1Zwnp0QGoDOuchLnpSTacO5YRyDtzfYaev5VYokFn7hzbt9cztoqsF784YPn3n1yTqyNTUplCheWHTxFsT26qNJaZDZFfbIEPZbB4NxyIqyA4xPceEJ\u002BHlS3trGt1P8hMkihjWo3LMD6iR\u002BjkxlLI\u002BqfxN4Z7iCf7FXhjbcAZliXoL6DwJUySbZS4f8iyntLfJLHDhAhB1QYEaEUVZ8Z\u002BiLHC/Jat2NFbXsXxwwxbRHqlhEkOVhIdplaa770LfQXSOfca7544LUvcaCVGUBX5qSPOc995bDKfpVZAFukUT\u002BG8I4UZPFTYaVr9Le3o21ZAoUKZPQkmVM3Ae0pL\u002BBpiyBhHhiyQ4GjO8gqEeEJAss3//3GqexLUlcq7VMEOkG1AnmHVpVEps8DVzksCodiLg8h4S/yktE0Fbuxh2YurvGGZQ93cbw181k\u002Bw1KzL0ffuL9T4kkhsm\u002BoUzDZgx9Y1Lg3lZWH\u002BrxC6/3Gs9\u002BOgOZz4d622ry4ZKKf3y6LXGBJ1e6ai5miR83zAQZbWw6QGcJKZaEwofoLjzDi6Cudx5\u002BdfO3g5AVcwZoAs9m2XQmkD7VcMOa/CSP0nvxov2\u002BiZUlmve4QryXM7ZQHP/4gVSInTuhmQYao3mPJ/FUI9BI6bl6AT58bk1CPj0NSt9k1xEnaMXCHPCOyve\u002BKVqLQw/mB3MGvkAWDC6uH5rJDViaKhDgbPrKRozI6zZG/kTytvstZwNsHhiQ0RzXU/1Vhf1fI/8J6xZU28CmfdNJj02pu2if2\u002BZVLgw4D1ueMzLPcyU455pF6MvkmEtCxeBFR0GPLZhUteoXCjXzEZv6tqiN1squEOezY9Kc\u002BwNbEmgrssgaDwVaev17Id2kktcwKiGitO7VlzZZ28nFt/qm\u002B/eNh17ToGejc1wNcy7KDpE7bNDhuJ15VduRgDN7lILClGXl1st4XEm6PwFSyGQHj804ygsphQNaVHGDAiB0J57ZCp6I5DeFgxBHZ3lcJk23SjAmAsp32M8ii4KZ9RopRheiuf2FfquVcwc6ol3J/m3jy/gwDeTUYTHPpli1K832HeFh\u002BWyQMcuEkM/DfTaxGI1UteliOTgyzhiL9dhTIAc5BIR8aATBE9nsq70VESQ7Hk2LILYkk\u002BTpLytUBHwzMXCIijiyNPCIU2IPtY263b00kJdKh/\u002BRFLCfk3kZrQ\u002BduXoMTEbrSSmdAs0UFR5XLhFuH7PkqKmw97WIEqF3buZSsfxTblF2CQdtrYUyfT9SSGUn602b\u002BRCQm5TRYzaIJZPmwY="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-7854d8b7-ad2f-bc09-95fc-7fd7273550b9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-adf19d8a35193d7d4ac89777f4208a25-a4e07eae3d3391ed-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e346d7fa-ea3f-6df3-3e1d-a10a9e53e603",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F00DBC8C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "R4BJFGRaQLMxKyh9Xn1Ldw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e346d7fa-ea3f-6df3-3e1d-a10a9e53e603",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6b5aa-401e-00a9-69b0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "8T4NYtvjrgtL8ZOYQ5YfxC3ucMESlZ7M3L0HV7BzaWy1sS5YQTgqqtgDsw5NwW1Gy83M/GcWFlyfQYYd21db2Igm45Fnx4L0w8boDuKQfxtQwYvip2wEnpvSuACyDc6BqNqFJ97b3gRK1zmhLQd6D8JrzBnLeDEbIUT2lQ\u002BBQrX3Z2YHClg9dOKHl88zY3GUV6k\u002BR0C1tS\u002BpagWZ5Un0yJWDqcahcwRqLlg2ROBh577SYj1lQ/t0QbE2XaBTo4\u002BZks46sLmr8\u002BOk1Bjof3FPR4JGx4MLjoWZDmcUahVkF4vJnbIRJzcFJ25ZwW7ijMJA5hUdDNsLjQNJoKFRlojOQL2NH\u002BK/PSBKQJ8Uss0WtoKl1IP/RgqvvQ\u002Bux4aWs5Dmi4GxVW3ggaj108s899s1M\u002BkerMIEzvmz3mHSEHWas40OLiZMZGEUxFPaCnI\u002BcsY0eJScdwbO4b2H/nYLDnAzWh8\u002BLcm06c6ICuhvKcOGdGubnZfh/TyGQExoxGbrCLbip7BTAEX9f4/GFG0eX7f5AYkKcHDYUV3jt\u002Bx8SyRnnAExjIITM3Qlnh0IGunOZ\u002BCUbsPc4JhFCVVTb0hYgDNqX3ds7dI15s0V5NJS0DdzFVAM6N1girto7IMswMMszR7qnrtxYnoNXoj1x/zF8jke31r3TJdWCdS8AwFPCSYJ6Be0aDJ8ArLV/olUa8O/ovlJDuBpNICGk5TntF55vlVh7N/kEYoHodynIk0NAZ4R/WAHBftFoLSXLdWdlU1UW0A0837k2pFuQmwEwRIyeJH11rf9cbhZG0sqTeO1aQyOU8YN2Q4fLCLPmcOPQd6hZLVDqL\u002BWVuqI2tgzuYytudlfdW5LJZ\u002BD1amULtj1ytltiekuccFN\u002BPzbhP427HOVIt/pL8xvVT4WwNIWASgRkxD\u002BxjCjfkgXEnxyb6CgTek1/gz5C5oM/TOqGLHuN/fUyvHtNyZD8qOX0R1Q/eWddXPo4AIcGId18cj8\u002BWaWKNqEnqWvsxXD8QxoYjl8uwBNDKM\u002BBlb0uLFpd0VdRvk8AKlDy19A7sJdJe72s7ZO\u002BTXIr\u002BzDWCKEkOX0RTvPZqoTLGGQOfCgDR3h4OFn/gT6G34PlJcMeaeGvzt5S6mGjr5E4oZUvb9FKKLO4nhBHJHh\u002BSm8v9ITBrO6Cnq0J8F0WlIiIxx9pl2\u002Bymz1PZYvRKKqmFJ/ys/sMdvTmrNFkQHhWocmHvh1Y1PL/vVmHcgci8XXCo5u9JCDNvJAqguqeThrFOMPCSaqNTX\u002BtMzZhhMStw7ubodycmX3o\u002BgGNbhHIYS8\u002BwnlDYKeLdRZb0DDqa/fLfP8uwqx\u002BKJ\u002BF2Y9pP98t5JHHYsJLaqMUEGyGAIlM/k4JgfFSmZ5CgJnZ/UcYIjV3bitfIsk1f9IcGvJ/\u002BCfWONsBX34tmwszRKJoca0cO\u002B43TtJd7duFFAIfNr7sAshxw4SsFsL3SZLga94mzM5lP98ESKlVuEs/vAs7zmSMB0HZ9q3osCTrAAU/fYH9Xkczujaf57pfHEt5bFq3u3suVCScTNZgvI/6GUhkFjqJAh3ECFRuLF\u002BHutoibwOKM4SKESldYNFwkz2mpY5x\u002BsZQsCp887LmwCeE1NI8fg1McCWDmgTRa\u002BEMk3UWx0bRVb/T0f8ZTUAR41EBmIw/dFUwWnWoriDBf0RJMGA9j/jg838SKGxOcuLlsfbzz5NVDR7gJq0RaOee0lJ6kF0f1BNYYKUNLQwooidSgvwqDa\u002BxNCMBXWlLj4qXcxXZ06KFxd3jW68uB\u002BASt0RFvqXrdMTiyZx53napzJEatbn2Ds6EjP0eRrIAguwC7qYkxhEkq/5RNwnGS\u002BenOY8d01JmHKi1wPHozS5S4gawNu\u002BQhMa/9cm7pNeEvkDVtwzjIq\u002BZnNI9bwUfO97P/lUDFhT31rSIXd2IqreQ8QKw01Yhb79XFpodkxXBoPnq66aCgagsHaBYWoSR0TJabL3CbmiIrk6Vq/\u002B62kNexv0jnf7RDi\u002BaRPW1iRU6xQVnwyaYPzJRYj0X7RWosQMdOVOHbnMzSV5OJ\u002Bmy0yV5mua6EtdchseK0nuBuSEZ8dOyWI/Bc1bSdHmISdcI3k8X3lJvLl4rwHKL/Jw3cdA9dDYVwLpVuCeP596dlDzwgfPsqZrOqsO1RlgdNXb6msKpixWhMt3UgmYq30Z/jmw123qoCsg1LolyYLoieELw1Q0b88knD08WGCd048t9Nbfr51n8EpA6tFyMLtJjsgnjego5Y5qjDowrkjLggEq99WrCNpEo9IK84X9smuC8smXdUWnBQ5IdSNiN0IBdGfQRznlnobu4\u002BoVHvIIbNnOrrx\u002BMwy7gvLGYpK34WuPCH4eLWoynFNDqJJbkeYcPwhJlImGg0BaFMRGHzvzNwF\u002BhRZz6T9vmxFoO4t6YPEMqiOJbk3iCYQ9xBim7HwXT3GR3AvPqVXJ2fh3HUi14LTTOXUYasi0nHyRNSUnya\u002BVUOwZ6YPlPADNwJRUa\u002Bs8iORk0rIH/\u002BWo3ECPPXQwoRBI4s1bnPcw7v10Sqk0XzCQVaxBwvb9jVEHcAxDVf6MnR6DC4ke4OvsNOS1k7U7dHwQ/\u002BjH7t8aS1R8VCvq7Zj\u002B6KyKsVSncXTBVI4SSPqby/yPM1YWxa8/aMA0oozAAUdLtqsIscIoaI10BplQBwNa4IkvW7lC6CL9SkiTcs/nAFJHx5FPkxo5ZsrIob4V72G82sEDkaaNCM6ICmZ6lPY="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-c2aa129d-b5e7-db81-e348-3fb9d89503ef",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-16c9af72a51447f7b756ab5214dd144c-8dace1f9e51aba9c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7e8f2979-30ea-6a4e-00fe-c45a415cd6f4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:53 GMT",
+        "ETag": "\u00220x8DB71C7F010C95C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "BCneIIQuc3JIKOVZSiRnHA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7e8f2979-30ea-6a4e-00fe-c45a415cd6f4",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6b64e-401e-00a9-80b0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "6Fvn1pgN5G\u002Brur7Cxoi0v9HUChW5zeYgS891lJyyno2IJCIKk71esKiVm06CrkTEujUiGnAwqhp1x4vImE/T\u002BRwwOqJmqSwUdlltIzKXnpyLsdlmj4MdV3kHlMwylRhYwqEyUXShXREJDqQWw4fo3ijvPed1bWmYE\u002BIoXhRf4uBBFGGQZUwn6VPIXIHeBpPyH7ajQlgx4lQ4mT6ReP/8qizD1a4lV3nbx1OTrRHnugxONj5evJ\u002BIEDIMWMsOlXBUzLJVGzHkzMg9x3oEnTVDUN8xQkLAnu2MOsV8Gf6tzTLjP\u002BBfkp/aaWl2IPUlhHL9yQjs3VIulC3EyeBraLPJj/pIIV5U471AVtnZSX33Z7VSf1D2we/ftaqzmsm\u002BbgG2rZD73GMUqOVKq4Z5VEqvzWEqGOhi0s4KaWyzoUn0gefXI5zt/IpSPtZrrBVpZWBgA81nk1UYU9rC8XP3YAebViqeojGuwtHX2NoS9ya5oAQLU517jO6Rvs/BKwoXWt7Oz1Xry8IusUD8kLt7Blu0CVBv6wxpH8k8DONh7JfGwH37QyfQzdVB3KFdf/wyFrh0DSK6qG7RZa\u002BMr77fzcWpNdA9f8M04zt7LQ9rDJ/NCfYr7d51DBcPKt53RB4WYQ/btEos9Zb1PyrmP3pfZlgPvqXItN/nMym4LlXkvJ4cZMv/j1hVoRRfNa2zjs2dr8OFZ4V4Tq0v9IAgc8ZAEIOLytquX9f/uh2RaH4yM6VcGn6SX1QYoxYe0JrYNS1NHyUpJ8Ty70/sha1o5\u002BUv/cDaxFhHrrEvcibEkI88J4XwRElYCAzhaSsupdmmsLwx7tPa/XDUBXB0\u002BrWdLl/Ar14oeKOb1vS0\u002BVstGAjYiMJqkqG8YioUGz7Z5A5XRDrMbvZ7fTgZlhjeJgQUp\u002BxnnHHyM5u9BE0zFFxkwfLlXbUgYaoSXAuJUPyJ3Twm/3RRcUicZBCeDmqpR2nbtNQl\u002BchO9EZCVT9maeKeNCYRDRToEk\u002BqSPmkgVI/aRWhrZsoY\u002BRz1wstDxwINvot/9lDmDlV86KEe7DPqnLzAuspxLtHdtFCnTYIugMyoRL\u002BdoF4/NHcTLr5o\u002Bc0oyyZOg0x33E/5okIAfoCTDifUdqd0TPwegYaTHgATdLpDfkKb4D1AcGgv5D4cPrW2v\u002BCWlINltL5qL8HFpL5Ppi2HvQA\u002BN23qVAY/RGj\u002BAkLQ3J5fvOA3HcnEcbB7uovp4D3QVIG1uIiyrAC9ZjAVbC1\u002B9MggMCkNkF82eYW9rtl6VaRq7a3BW2PVrNDfefeZrsVC/IXDifAUgoQif37C9T0nAxCL6r5/fVlkSkNYbhannIrAOrITtou0Fispnxwk0reTuHbmzcRHA39sX39s/FRtuuK0AvpLE4xE15RTVd59f3eLhPXfwI7GuTdy5xdMR1nWvCR5cM/9SKSqYjYv862hLt/H4TeejboT7UmDGCx0\u002BJA6fNm5w85njnxRNV6YloWJkfg3hGZid\u002B5qJYOGenB4NWlmNXaT5ysRYBL7DVhbuxbD\u002BUZ0fXRp2AUrT95K4VQMGT/1MqEPNeqNJiQTZypWDqpsgkDpw/g1PB1xaJdMxr7\u002B7zRYZki1tMObpxdQFnDalQEz3h7TIhUHwDZD3Y0TQF\u002BlFLf2Pegh9w19Tlzg5SXsVtOWGOhf640fUKZSMdc2SGa3qsG45JdZEicRldP4JtsQl0b5vSe3RWjq1q1Bj4U2RsX2KTokM3I8PMbBDlX5ZymLQZpQfMs/AGWYjg3qF4Jh208Nwj2g7GPUvUAgtjbTMa\u002BDtg3qpcn69ujUi2VkUiVEX3MGq2Tr6pV2u79K3kouhVxeJmF0tzVFEssUzGD\u002BsCsanFbDzIYKl8u4tCoKb9iepcYIxmvED\u002Bg9wZhZ1x50d8uUcAIzavjWU06V\u002B8MLOqMytiZa9an/VoyuxgstsMDtRDwetj/Wa3sNMrLdLlPlMob1ZyD32YJhlNm1RKTt6KKN6HfG7ESjHArrDYM3Img4idNEOAnf9Wq5/SFmYSbWXwnQD0XcHgZCUkrVzMv/KnKxfLqRabBYrfMNTO9jfPskFK65ZtMiXKuNAeX\u002ByiieutKutORsBTWZd6FSztFW3tVPsfgdRcOfjuAPBGfKmePKrpIctIfW98\u002B5H\u002B9xj42adiLQrxgwQTTPDyYEHMCNzt29SCA/OmpNePnoZGXULf9SdM4E\u002BiqL2i1dDWWh0psO61ERtAdtmzu4gzZeB9zPOyEmsegyiNTzMa3yoe0E66Ye2bkUwnn4JNmSTHb0bZJQjhJEe2Dy3GJ8XoKZevlOs5dQPy5juninbkzOYDyd/oPbohOawHAFbD0W2GP3HungQ9ifpG6j7NPZnQzT5Hxlnp/\u002BvZjls/NnCpMxDOHUsA\u002BjLhxkPlpVd/U/wSNjcYeA8TnEOKEROo/leFmbcqAyBOz9cPZfwaAFaQXjpfLPw9kLsFvn0LduUfOMfsYAucUVDbw2ZcCRYO\u002BZvo9bbVSdFXRAj8JESjQ1jt7Ck4KaBK9Ajpg2mZ4Yeg9sDhIn0ySe72lRgCnC0MOIANchzo1s/7ngGt68ZrvWKBXy2DwiDbv6I6QZCERFfb3UrljHNquB/w6YB7hF4oitu5gUEDiHpfMbJ6rpE/c1Wt0g57gjDzFqMNjtSgXDdEEbq0zscS2FDQilq88AmOtXYqzbJTrQiqxmqd8fmhvtV/MpzahqSSnvm5qvfWNiaZgtlidZKE9GCuDgRY="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-f22ec61a-1dfe-2234-1e95-8efd7edd0af2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-df8258f906677c0f07103f8fd67020af-bdcc2004a9fd52d1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7591ce5c-67c3-2c19-0733-fc7fb3c62c0e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "ETag": "\u00220x8DB71C7F01201AE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "Ss9nYo6AQ5H/wLOqLMMeew==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7591ce5c-67c3-2c19-0733-fc7fb3c62c0e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6b6db-401e-00a9-7fb0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "gYQ0JBABG8gQ0VC\u002Bj44KHScNioTYnQoUPRpLNKqjN1jyF5enTl0FGh3OvOKQkd/MIe6NWIEpTeR5H\u002Bf2tucdbJn4y3j3Y87KB3BnCeEohKs7fhK7Ft/XycmzLS91D2Q2sFBJl8Zm1b4fwlERwkQDUZs8uzjUYlW5IQKvRDWfVPcLMVmQ3\u002B3k1alUnFOOxgeFsNyUOVQsYU76j3XEtpGIf25ZBZDqcnKuV\u002BaPf8UBK1v6KpRZCxuj388Llk93IB4XzBzlNcF2mj1p5eJunOGI\u002BGMayYv9LnRTtSXA39siNjfHd7OpHPaahJBW7yU5NEPugp3rXFaSGp2nkn\u002BbtbtiRq6qpyUu3txtf0X7pj9OGoDi0lw\u002BNtrgNFwVAYl2/s7V9Kh2jo0dv6TAftwRlnNeWXj\u002BueJeIxDUynLJGNxT9oF2JrKW14zzxBK4fbj9z53ot6gReETsdtCYocMbVKfHbYhbmnDByIHsC/XQpqZY1/vU4GE0QX48irDi/TbI13Br8A8vojQtJ\u002B4nJWxPHM8pQMrHR3NGkiwKHhDA3stLIzSEZLWWKDXHprhyDRwR7W7guLxrAI/8JV3jJYMkbUkj2wI4yrcakhiVAKC604UP\u002BDGh4CUO4CKkhz9XswKxojlvTjEa2CK3xSaj1QDuQVHY0yxRgowjFfvfk0J3wt8W411nS4VT9SAO6hr/agoitUbuf9/VYCCsTDk1OkTfPwNGjfGih/bLhN4MQphyI6rxvd78iUMAQYM9uv9MHbrbLqoWud0Yfy1PIvoAyB2IOiiORHxm47bARktuZc33f2cjMRPtW2rM2D6wrGZJ/3hmtYDWvdg9dUv0VnKSqhpgWKOS3JcJmt69wms\u002BtTZPdkfSB7BNIMGO5bzI\u002BAX4Oi4jUFTCtiLhXRqhGfts/78VpN8rv6JqEzfiBPfaQKLZxYc9GmXhjcAk8aqVqwbFIeb9s1QlzHuLuTwc4LIrBhx4yFRzL\u002BRZMxcfB8731GcxHOIQ3Y1Os/gMsWEpxa0O\u002BeqOHeKyUfIBpIA8BsWtk\u002BXU68PPGimOKhVcZ32DL25qEA3jabeFfsvwDjkNEa0yXx58VNnpP97BAPPNVup0fnQR0vW3ySouT2z43gvvgBhnKQhfB9uUgNEvImnDtyjgfJDF\u002Bz\u002B3epbzTgRs8WHS0X/bZSziFXaYfVEkiKbBaphEF2J7KoXZr69xbLnXKI9wXVHp6FH8/mYZLH7tk/LvMeNsKNn\u002BVqb5AbZ9cKm9wVTBsypU14JGRxj7Yf4G6xu8gjrWawC1cQar7\u002Babf469XGspLODHmllhJeDBA/Wn8xaawO1v51ZUC0Ikqeibq8iJPgST3b479OfgdEUg9G0QA/zPAL6gTnUV1SCdo/FxxXoXN8TxFBZYXssGjnIQNBbUE6XrzKoK6fCOfQeenlD1b6/KCL2pH\u002B7md6Lymr8DBKAJyJBMhfnQDU7UYpcOucB6EB/DRStZK/O2BVQHF04wi3lnlNXAqem1\u002Bvtv1b1X2L3id4qgQL50sJ2clYClyPX/o9YdpiXqumY1DUsw6VY2Xi2WJZ/EkEu68uM3IxRoEDEFcDHmOTGX970jajJzRMZHZjZTDqNWOhOLY7NCspZSzPwaKnkkTyT7/i7ioCUYR64c8L3dFQKOrzUeWtZ9VUQn0Z02WBlNIhYRWA90c5ntcxwEJcLYdLf6jHtEBvROfanpu8\u002BH4e6Vz86mzL3yGTubMea5eC\u002BCTl3mO8ydCBwhw9pmirjKZZEub1bzMaj6CHJAqdUOlQR5Z2xyoaYh\u002BMaxhQjii46C0MtViwnZjhy06zNaXV9HEy3V7SNMV8TrDXaQQayfGHzkvdgKuAr6oNlQvbZzxppnanHbDJ5rNngGaX2TSUxvFdO2dp\u002BGPVoj201J\u002B5kOeEbbKNc7xAveeIZgA0\u002BMZ1aM4ajjvVD74S0WtzFQITre\u002BPE3tyB1M1HH1/0YJjkLl3P2vBrxK7r14EepJA3ajVdMgQtdVLA2F61XG\u002BVT4rv0Cx\u002B9WmQg7cw2QtbYzA9E7EqlzKUurUPDv6VtmQ/Vof6MtRntHTLyK5M\u002BJhLZXUueEy\u002BbrhUVxV3c\u002BZq/slO9YKDYTBf1Vs4XsqER74Yx6mFaz4bgOvPpdu\u002B8ESSYM3g/gcZxARE0qLxgg/tzBNbWqw84ZOPN3Sat7tUnOEWqf38o0W7Av\u002BhQJSbJf7b4dXIY5mYUX86VcqSfxBI7DHB3tQR7SzJnFesm6D68A11vtXljD1LflR\u002Bwk17KIfvWFBm2UcqxfCo/sNF67neP2G9HLw6Z2P0dmB/ly7fTnfTvT9MlBrGSvThPJF6BZKeoILvvg/HsPDwcmLmqzLFyaxPdi56jatG9tHHWSrOfnDR4PKr84xoCAhOWCW346PGH3LhKpNkIBbXpMs9/FvGIfPuFMpAGdYf42oiLDGFjxcuATm37VPhacDf1ErFLg\u002BwhDYxycrZggWYxUclQfPhUhW0D/seEjSgCKsFZEGPWrVebaf7V8VIVIM0HyQIvCvM\u002BoIxDSIQlnX9kb0j0B3ADWqRytBL5f5Qb7d76fMQl0yDOGnDWk2XSdsx/cIEKIRlcA29evFXgRSH4KFumKiC7PpsnJewALMc/nz1Geg4SEcvFnXlUxxbL7dVO3moKLEurwzLl4vwsXNanHh0XmsoS5RaP4I2nZ3eFXDcWsU5cNXLxmrfbLC7PmECirKj5s1MKO/hUeku\u002BBFu7YIXEFaqIS\u002BmqJf8="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-bd89cebc-6539-015a-5678-94e76e4fe4ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-391138f54549d8b27be0a1bdcf5e1511-2b13339ddb05673f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "73fdb1b0-61cb-1030-04dc-636e2fbfcff1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "ETag": "\u00220x8DB71C7F01276D7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "voPjgqkhsupwlMoT\u002Bymg4g==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "73fdb1b0-61cb-1030-04dc-636e2fbfcff1",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6b77c-401e-00a9-13b0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "CLonM5VbIMypCoKWGWG/T45T9gQ/bLoDcf\u002Bh7NXc4Ak1MkIugvJquBbsPrXGtutZDjwakBVwFpwAJMKWuTP3zCp5YOcekcyc6T7uUi0EPLoTR96YwVDzxBymLV4v0/7i9XGLTVYEO31wfqbXgsNu\u002B\u002BcHg3FVXgrahZzKd2NtbBY/C127ee9kDgxgKEOpHEJZNzF3KE\u002BMjZdnsce5OcMZAhKQmHZls4L3o3Rl9DXHMWlacT8x9kPGsn7GVMgoqtRIRyYwGIPL84Svf4XaJ5hhn4BeX8iE5wzOyeX4n165z/ifHK0Plhjlj366gna\u002B7IrlZLRIyUsMxF8ZYU\u002Bd01Mm9bCMOgvrUQhnedBKyWWVD91bEjqqcQask1dO9jTJR7sqlIzFMbF/\u002BhOr4FB7wvv5g1JyQsEYe4Oq4KeznVvTnjEUHzTY0N0r2xcn/pC2MNBbVHLiVwT6ERgIG1EKzF2310IeZ6LHILN0Rmep8X3z9K/WV0jp8UcsGQ0b0LSMIQ\u002B6byZOl8kulDO\u002BbhCdUSCaFSahM3QUzub68U2Vq1D/5yRY74FXpFzmqMIVKoI2j8jsgLqN6u2apaE/VKZ7mOnjv4brRWKfQ3HKu4ux/6Nkw2KFqCqWcf02vUngF0\u002B2ag/ZMmv8S0lmTT1Jwy5i6aX925FE9vC/TU2JtIcYvyshE1F72M03aHgYHlrsTK3O1NSj4jy\u002BcnMeGeUdcpbCTo0RJ6/c5hDYxXIYK9eW0gCfuuCzdNzuYqHeXb7oGfXiVdDM2yX\u002B8e3DyxzJpkabiEfkfbi1D9mwIsQN/olS76t9NtUGyfbaocjy76jAJbxbQtR3A5w8LEb3G7lh8PNkcdtwTG9wlL9QCtzwwyAx8P0Hsry02\u002BwPQAmPD609ebHVjX3MT9hN6q0VJvm/TGkmxSq7WT03r5bvYQtm4YQREpArGjWiZKEkuscOnrTyUPSgaEmCgh9znt7n3O7N5wkpBBNolDE0hGGJlp92KBHh/RAWxng6jpBwuHxXuoezV9K\u002B5ZqgirvDa\u002BTo\u002BeuA/XXNBd/dtiGQ7nWD99y03cna1j/Mt0N2QHNVU1qUUpWk8LsHirSn1qGxLfclHZLfDo4bDSOss0UxVsVsh2LG/Jvf3gchrVMUMv\u002BeG4lMUCPgdkTMeURy\u002BDx11jPvO04\u002B6jFbRT6KvWE6BtsjDpi75AWhixEe\u002BoNWbebLq9cgJPexXzBY8AvlVrjjkXJpT\u002BqjuvEtTq88IPCtBdhXvxKKGuHkca5oYvP6uzVZOmgR7R78J/Hl8tZHdD8/q\u002BszjpamWHeQhN07Olf9M5J64\u002BWInBe5WpcgpCcLnfxuKbYIxi2es\u002BHwgGhAwO2Z6L9DzJFatw/TeTP/hbRPhefhzRGg9Wxl3C8DlxuveZqqhrxox9BqFHGnNE36ni0tofuAXvPb\u002BfNS3u9hVh/zJP\u002BZVf735r0Wdrmf\u002BcAfaz4C1fYgLhqmzo3IFunhCb1Rsw9NYEkvNbo\u002Baug6PAAyM3KxX4Ep0/Xl8oZxL9DTNW37TUWx0gr005884cQybJKNleJ3L6k8KOAZaG7CvgbpajR7Pu66gWFnvIzh7fExsoX045ntWwXDvyVkl2mbMhWZUnaPti2k0hSBD3IdWjru6LXoztps\u002Bw8vuH/IVur3zIp3SJp6ovxYUBGFbEySpWTqdq\u002B0s2Q6LFdnYP6u23wqikPophKgdEW5kH3J54/CnBIb3uA6QxgmPBtDEkH9qnWUW\u002BEJqv9RSgJp\u002ByLmcUXHpcPsk/yc70cqwmn3XGEEu\u002BUINIutufISyZTe0Ef1P8vVe219ERd4\u002BGua3uiWWu2gZT893jy5GuvR2clovh7/NIKdIeDzhqnOjzwfE9sKe26mPWsIuGGPHGGCrDdNEDpNmqll\u002BDkMrd\u002BWbk4AmQYQx15awYCz93whDgV/cdpxgH8B0ngxpII1mY\u002BMcUoTjoJbceTZ8k65mqMtROozjTsFJe3O/seN3iLbJSjxJoUxDn\u002BDI//1l44wSDjVBGCYAQtUh0xcRJC6zZPB/s0myHMd\u002BzZqsGo7D41fnbWOuNrCQyMcnZ851cnuyFZsM5nACoDFtwgqLVChGHe//abaLBS4/7qqCivU5CZse\u002BgTz9zzn5M1yQHRmBXSeoQnetgiFJtCszTeFQBV8dLivbFojUiby10TpWMS52ek2I\u002BmrGpNSmdM0RunFYmT4Ncv7tpkae08jK56Dm44L8zNOT1wrkVnlHNJG7wt87bUgMSL4/iMQG6iah\u002B70zv5FKFP2ttLIjGSx1lnG04wDpj4po6qrUzTQfnPzkQlq8E3UAca3hnaiF6T\u002BBufJCUfcVuGwy2tTmZVe5nie1PtbRuYMMpGFTB/Hh0vFrUwNBzTr1zonuiUigGhxWJ/9wwKpooABvRa2VsrBqUPfTixJUd8Dsz3BM4yBKXIpVDN/yYQJXAqLy0nedYAvZdDhAzJ758aAulAE6K7zQJOkTMKXQd\u002B/ljHhvUZVZX19kY373\u002BZ/7Wxs/w9zxLObmIr2eei9WCQxYW0AmiqAK1TSx1bhN6CtZJ\u002BWaoKQS9F\u002BBiT7nyuUgDmpir55P1MBrJP6YT1c\u002BmDqCNVJJy1hoNWbglQFxIxpfgcdN60iNCVMVL3uliqUIUuD0VYWC5jMB\u002Bmo3bz/O\u002BfHUOM2P4Lzh9Sv/NJvcsqrB2EIQfM2E3KuES\u002BDeVaoTRjV50VHniGI0EmBZg6GnJUe/dYbtvo00T2wR\u002B6TMA5\u002BB6\u002B5mY="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1/test-blob-60bd8ff9-5e06-80bb-dd87-a45126845d06",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-033655d567409fdb5e23fada80a5e0c7-56eab813cd8296c4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "01cf34b9-b9c8-cf43-d434-fc47f2c21d2b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "ETag": "\u00220x8DB71C7F0136105\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "u0gJ59GchlPxzA4VHnSW1A==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "01cf34b9-b9c8-cf43-d434-fc47f2c21d2b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6b82d-401e-00a9-3eb0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "ATNZeoRYHlxZzNeA7A16ezQMJWZps3DdIi1xQjKA6OIuS/brZWvh1vYxSzEmRbrGORNqxEQshU7CfFdX5twq2OP0UaEWjxbIK09vOGg/tt1yqwgeFiSeAsWoKOkUiu8ZBnJNMvMZr6n9oZn0vE3lg8V65DvUDMG/Vk/bbmYttKBgVTH18YTpWfteIHWKqUV4wqUjmqWzRfqwjtukPUFC0O34lGcb75FBkYo/detMNa0JYqvBCRn6rA82RWOoRBy6HFCHkRTeXNIT4gkbdNAPY1kum9uWgcfT/ehX5KoumExuhVmbxaOYKgXZrSYQ3zc/J\u002BEKeahAJJqItJMrh3co5Um8rO53dJ61lnHVvNOgwh6wF73IJB\u002BjLWG\u002BEhAPbKONsMfcVDJJyLNDVOM3a2fH6PF1em\u002B6X8EqGH\u002BMuWGNpinNRwsLw27rZ08KhdA8bML69yofmvIz01EGsjyzvA5Rta65aiNbuySDiRMfr9nx7qy8kcI3bgs3mXS6BRExN6pAuNAiggKenzsFmxDeEyN4FcSQ9itMGUeigtCvoLYTUVFp3/cIzmupHvKGMtL7WIVQQe9NoUF/856Jf/8y7v6F8kq\u002BdTQsb0ZY5tg4xud0pipKXl/Gxa8Q6etYf09rdy/zAD\u002BHPONRJNKo9btoRi22FNnV55CfviyarYtJ1PD37G6pRcWo7GpG\u002BTqMHtDzqKO\u002BoWp2lY\u002BfU0IT7Y5XCE/hsAhNvwFnDiduj\u002B5VEqBbpgXoijOFgVbeCvGDlP/b7/Drq23HpumhVpJCBwahSkGit0aJb30cXC\u002BybrQQ5Hook5/9aWcykwAbRjSgQ3pPPb\u002Bv4d25UX9zzk4\u002BFTc0kXIYGnNno\u002BDZbyNFbSlJexi0YzH0YAKcbkEfipsY837I57TBiCgG6Jnf1XG5dONWKlI2irIFPzBve6sxRxhEwXykfIZ0h/PwrXqXFYqR4/peyV9I4mnMwqeDUQx81KCBmxT1FPdc4aJfRdw3biqm3pix0324\u002B94S2Lnf8Dbmc9jaFnp2m84CAee96ZyNlVR93XJ0ywEjyJ814zw9ffBseNIDXVewL0LJrtKW\u002BxFChUJlYRPDcajXt07aQLiSxYP2UHHKiTj9za0wqhwujMyN81352BvdqQYqLKUI1e\u002BKN\u002BlPn6qgePsKaJRlk8eLqCqCTUxbme1nGadqn12S9Pe\u002BpnMy3\u002B0h7Hth7nCGeBU/noN7hoeiL57854UDNtied3Ocp\u002B1TWMk8YGHR\u002Bap84KGRKgDZFm1wG3bVNvdnHrWiwnb86dAo7Ea6PyYm0TXzfwbkcQvXxWEGLIt2fiLR1EKrLjYzgPbQaD66H9dHSUpB4bfxg6yqyv0V9b1Fsm4j6Grje6L/wP4QFAjNHaWJv\u002BJANZxr4FGVAGM4HYs5irbQljZtY86oQSC44G\u002Bk3K1YjDXaBX3RuAgYTno/xqJz1olS/IduHFwTmPN8sv/i8SO14JFVXoU4/90uVBRUaXt\u002BRArlUeAm6W/Zxm2KVQYJNl1WieYQHncDGf2pQMdHvy94/W31/J9Dj/Yhe5gYrqrXJR23/t\u002BUbSaS4TfifKmokQc9EleYEzm9Evnv76Lf62tT0hupkMBP45BHYxpnYRJNeeqR2pxTPhHk\u002BezmpX6DsvbMjqqO/gBG7i7GULAeVbDnonW4ThDPAJMJxZbUaT4Sw7Akm9JnvnvpSuttjO5gxaQ7/gIIy2Pl/Y4XhDhqcYXws43/\u002Brrdf\u002BP5zgQlYnSlqADymWo7CvdMPp5EUDpDf9lmfNhgYMrqXX8fDvxfwJsacts4d9gbtamVs7sbmS\u002Bptk8qvuWbREg1CDvqHPv77X4DKt1eCwcAS8cvy60OzsRQdletNAG1fi6TAm\u002BcMJmumsU9GG5RSqtHKnMebHiaJjl2maWjTbh8TauvywiYYxougDDn0bVW/yusZQqNlxK1\u002BNs1JpbzCkwNwcvCoX\u002Bjr8ZZ8OtHslWDIJp69\u002Bit77aZ\u002BtIsYj2DO3bk2hDqk12sCbVEM6cnbUaGsQb8eRJjYNEUKaesdk2J1rV1Y9hFmYw8ze4zabsPco2MprA3h8FjgHo\u002B1Wq2/5Jnu13ysgltQRh5v6skMPYWBbcZINCdUU7zEeJeB8Mihc1by65dHMCDHmSXvccWPk\u002BDJ9CynN/CymkO/6AmDjlVVjndyGRIuej3lgFrBZSH3NKS29/zcOjumQFFTh0fXBAqQmaOOHbrO23nuwbdVsTVhyLNkzNaYeZQ7y9jA2vK1znxQMIt\u002BaNcp59xC7TiEEM8cMb7Ucnc0OCAPUlHhzgCHOPN7BUBqI5\u002BceyT6FYybt7rJpOkz4ZwFHDirbtaFSBnbu/RFCQtOsc3fODcSOiKTs5rW2ClXkxdXdelH/rSJFzLK3lmYFm5vuzLbFKmk8yHV17s77q/whCic7dNhxvNZFiDER1uI\u002B11sZx02fH5t8oLHcec5jWiDGloxO2ibDbQ/gf6IoGuGTRxdz0dS\u002BgfqLztQmlTMH4j4QWzBV8A0kVmo9vp/5VIXASTKm73hMCASBswtSnNfc2I10B8\u002BxPUcaX3t6cMNqknpOVlvwYQK1xEM7xEzx0bmCYOYCdUy2Hxv7jJAM0ZcxJxCRBDZ73GeKvjOMdWj6KI2x6B/tWB0tmEdABORyqOKsCq08YM1zFoSOh8cJOami8WQCSvmHQ87zY3v/O9eDCAVQ0GrLzbewPtGLXtBWJG6tnRNwYG35JLbeOQ1Rg9q8\u002B3\u002BxuFk\u002B4="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-952a4360-455a-135d-7b90-552c10a814d1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-aab8827612d9608e06cc84debbc3cf7f-3a4935308a6502db-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fbb57268-cdef-f228-2638-15be4fa714db",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fbb57268-cdef-f228-2638-15be4fa714db",
+        "x-ms-request-id": "64d6b84e-401e-00a9-5eb0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1587505679",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,2048,30)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToBlockBlob_SmallMultiple(6,2048,30)Async.json
@@ -1,0 +1,535 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-8a86c68483ae9a6aeaeb455d04c2ce9c-5801d3beebc951fe-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "318afc9e-0e7f-4b88-a5e0-889b6408762b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C704C7ACE2\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "318afc9e-0e7f-4b88-a5e0-889b6408762b",
+        "x-ms-request-id": "ec263d8a-401e-005d-36af-a39b06000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-79fafa7c-e8bc-a6dd-b735-eb8043435467",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-d0a81438a7c2974334d5af2266cbbb18-67cd6d6b1ba18de8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4ad48928-f4aa-f2b6-4ddb-c7c8230d6023",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ErvQoutMenqqMt/HqaHolDot\u002B6yp6c0e\u002B1agby0wuljdgwaODCRiFqRDEK4y8sASxscrttrc4CnusaeUrAtMeXiG6iaaWocVyuUIZtkf7AiWjalmBAN\u002BAKLdoFt9zmmY95Y1qwiad2s/Fuv11HpQz8We/h9i5nV1COmDvbosmPx7cG5C6UD//BU9Ju4YiSwojdCW3s9KNREhwKMfFrqxE33ueWQLDeWEngIJJb\u002BGXH\u002B9Wi/plbksMTpcICmd4OVbixJxKQ/HHIDrEUDNQBBRm2MjYbuLyH7DwUcpruy8574crpmtFTNv9T6v/oR5X/EqC4XFeX4pz8OUrWfInm2TLiqBsZJ2pIUwtGx93Mr5SmJW/6Nm9m0/8t7WGWfLplfQG89a965es2YAlcQSrPP5mmMEcZ7JLDi8Qr6zn4sdZQ0UrMD6n1K090s9ZmCoLUbr3X4ExjS4Bu\u002BWnbXvqxTb4jC3/f8z/voQUHpTjMXXExV3yMEMGZ7YXKXQYwKdxEw3YYQw8S9Gt9\u002BD83a6ZXopv4mfd\u002BNSzsmR3qFaYpr4c4suGypBpiLlMRDiiSUnHvYrp6R4/U1p5ZO7nxON7FREin/rjElP6BhnuUbSb0Wjab\u002BqLrv1gHY\u002BxTaXhgcOV0W7nv6lPJGt3L\u002BMEUMGlnVOFzVT472ZTgoJrccTt2EQWGEAFtFG/S0t/VL8aG4yNy7BSW7SunSHIk/zm47KmiRdfLjhBYCkBxoHJuVrneab13aZUW7zPZ3tefOCUmGeY2Mtnuy1UDGtHUFUy5SPHIVpV8QYMUi1aj8a9IyMIbS4acKBPf755YZE6zQsn3IJXl1uGPudhTEbeDSsm1ykIPuNm2LRDd6Hb3I900UTiMvNEZYvHgi5G\u002BORZsXJTEoqn8o5nwMQN1B\u002B56mJX7LrB\u002B9p34nFdQLy1H9\u002BQKYYvSInEzN72unHvdpFsDZfMLwxpV7WYG3BZCrHR8qEkfaqZSqHYUt\u002BcC0FoiKvgMXMkqPDTZtIQl21Za4Js5IeQivjm0oM2M5wszQw0L1KEuRl\u002B7QmwUNbYiPN0fuddLyb5l/2y\u002BR6v7rVUppmF3GfalPJpLje\u002BIHoiDknPwbS0z53lepeU0YA6jv5UW6p9UuxLWao088EvO7eDkOrUoC0An9b7oGHQRcMybp85KYSP5PudhGfKv9vctn8gEQDVZe7RE7vTQbJKuxPmwoViNdHy8\u002BvvNxvFdiA7HuoisDSCHQiwJ9XI/KMJEskT470WeoBtLV1VJi6TC92bmCLIZ8rfJKW88c38KfdI5eRSsVJi5ORptYLXbTbZ3Rw4LWRAQKs\u002BNL7XmUiycMNmDAAKQFpLePN\u002BnvIIB/euotTxw/xSyGU5FHyTSwtbt0S/cWD2j1yBrPSxAeH49izHaPazwG0HEwOa0Swdt\u002B2n4udtiJaWuBO4MBbH4caDQF5Py\u002BJU5/bXuF4dG74wpDTGyR76i22WMPDi\u002B9BWPzF9F5DNjavLEzswldA4eVxVR0whwRiniLTw\u002BZsxsevmQXls4AQtYtZI\u002B/YjyfVdXfeUTbREdD4YlY7b3NPQ2aEPChSWy1kYaCR1mQUiQ77/U1vjXSR3og17VEq1EUXCeCIU1L/gxpJee\u002BVPzps49hHQHEm4LXx816gHG3cOo1becyDjDa8\u002B3oyJhSE\u002B55NyAp44pPT8Skql2D0XmasbD5iOsVu6Faii0X387mhbPe/UlRjZFf5iIijWfXWx5wThrnVIsHY39\u002Bz1ldO2/5viCpoNAwSSAjmaLE9yo9hzMOo5G3/y0o253N0sI0Aq62KM9HLbZKQAT2x7rkPmxRQUQqTpvaRcLzfMk2YnZd65rwEs5a\u002Bll4wF\u002BMvTt2QJktfJF\u002BDbAW2\u002BcMU6ztF\u002BGOlNgj8C\u002Bd9krqrYo4TYSHfTgsBOXg493q3TrrTqasj6x5/iRfVlBtk4ZGk1wl2opeiNJwvQ7/qbT\u002BNRbwtqugPiHdvk9gJCrrwnVfnlB9wQKsiMXQO86hflBvYR05eNjeplE\u002BSBg\u002B\u002BmCrhP6ZnA9kgHQQRCnlzAJTPEP\u002B8McNrkWYgPf/P3jmcZJhKLbQB95BCuClKTSy9NZO6wvYPAWdnda0/R8XZUD7KdabgKdPgzRhueniZIUQ6YghrFRtDjGIx47cHwrDLaWjqf9eF3QvA2vXdoYfuzVRoBeS9bTsjhuhDrkYb2AtnoxAQrqFttIT9qzolZeraQxVin7zMDvssx/nuQi/FpAHqdv533R6z\u002B1BfwMIA/SH\u002BaWswuTlOm5UV5OeofnJVNwY4O\u002B/rY2X2r6NrbE05LMnX8NjDlevIm9ppYvk3C33eCYi8x8ExEgUFOQqV4i5H27gd0I2ZkaEacKAVgQFsvqMmjWPFfGQIpt3TvlvhMrisIoZBGjvvRXfmoVYhHJADmXpmblXLgV9TFSmvxdNFOT7naF97KqRoN0jr3tsN5opMzyThesNj4aAn7QURP3\u002BkoGcYOrMxiG7W/TcN36ODRi6eY/auZL56g4e\u002BVDyeVvfIRz1z9avXG0e2C32MVgH8o6fWctyJ9TypnbcrcjMxN6Y/RJhmEFCDx0ev\u002BFlB7iyFwbGVx\u002BQbP1IAylf0q6gThNPWTRJplpJWU6qU2vzjZ6\u002BKpbCCnG/CIwRFZUb5jhyem3SFa6EaHCsePnQ5hmVVHWKoagX4kOhjEykNIzBMXcSO9j6IXfwOb4mFZF37iZ2e8EjjUSQXpguLIlh4DPj60eGvq5AnzL9mmvo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "SCoA04cYMEQXSv11PJyj3w==",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C704D72AF9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4ad48928-f4aa-f2b6-4ddb-c7c8230d6023",
+        "x-ms-content-crc64": "8wEvn3NxoHc=",
+        "x-ms-request-id": "ec263e0f-401e-005d-31af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-88a7891c-6d93-03bf-5bf4-cdf51a37fde3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-16d0b2663726e0aea035cab6ee4fd9b4-56305a111c943571-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "95fbffe8-549d-9578-a005-9bbeac8d8bf5",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "yL3q28nBn1KRwnBCvzsgWZusWAWhIfO1DJwzmM9DDFcdPmxWaIpaRN1LDGF6F24AFWg0o0qoXabJNM4tjQeDTbYYJYHPyvAQUhQnVRSSOvQtMoNnD2kNdOHFjDO7LbbWx7\u002BrYfHtMEt3I1E1gAeRNvna/1qEHD5NC7GfCj28VSReUI5V59gDQAI47\u002BsY1/TaM1Y64S1bUquAXVZATSYNus0s1y95PE8g1r9YTCxTNDO8xdbngnT2Av7i1YmCw/LbKjQd6wDEYPcGGQpuAgZ\u002BLSkjg4dQJjhZNdQxlmbGnhLMfSH4NUkz\u002BGTe4GhphwD4ZKdgX0BrigT8xLUrk8qQQHv3ooTkhvjg74oickXP763UODG/ZT7SYfMd/HGTCGWaTaDtceV7FN6vgG\u002B1SBi\u002BLNQIVlqZ0do8JUGRxoqGTecliCSl4n7IWSRTD\u002BXPHRjaXs\u002BdirEKAHvFsEyk6U1UKDOIj8DzGUlVP/02RsH1bQcptmi66cI1G4eo3zExI2/W/ueyRo1X5kSGR0u007q6z0NEezLlmj9xUnQ4SzoXIxuNYEfaQyZ50dAjM6J2gUfN7hDu7ag88WSnQfQZH5sKbyMvJ3Nz34wdyqpiwWac\u002BtEta1wpKTZzUG7iMgIxYLE0GcR/R1nUWQ\u002BD0CL\u002B2jD\u002BC0Yj7LQ\u002B4EXsvNYEkKyJ62n4LqihHbJ3WBFNplgUdHY\u002B5Ce7DnT99Th\u002BkouDz8li\u002BeW4BquHXO6Uq5Oi8Trt2EdgxayFztz1\u002BjhvI4on9IlH66xyW27Ktog5J2PhWwT9kLlDIwkd3SsJwwtyFzljbbcJWgaOe33ZlQ4kS6d5E580cZLR49B/Kg2BaZhjWJ9O1rmr1wD9bxU8ao36\u002BZGEj69rPaWmkonmijD4DBHkdj1v1XXtzTyfNwJ8lHhDhTF8/dno9xr5qEQvxE3QBWIEV/RQiiQblsFyzAajKv0RowX\u002BfA84/H4jdiwxvQnvzzGfeDyE8voMYGYXdSsTVX1GHiBI0YhTy1t1LRT36dm4g/3UBLLAjLAK8RupIIZSDyGv657op/2pS6zhDsXmFXeNX/IuPlDLhZJwPd9tqqvVIh3zSP460Nz/K7gF333qJNyjG8GTJNHQ42UMeGoeO6EBDOuo8815Uo4WLxKXxqYUhRgDyY7qQf5LImSYLlhy4fAXBNKSQjEOKskyffW\u002BOB2\u002B9/JRGnETFsrtXNBo4CM2pE0igMHUgkPn9J/Et8QJjepH2jZlIMZ\u002BA\u002B0IpOVhpUql\u002B9mnnLdb6nWvaSbSTl8G48/lIQbs0YOHo33Uy91dhk5UH7zrYvAz6\u002B/Btrafq7SOAsEVe4RDuCpVH/g5hx6XUePYfS\u002BiGoHfsjUWKxrM6PfJRckcSArJEGaSlUL3\u002BWTRKmXTxy2E7Oc/NshOLY0PiTcAcEJVewjYDmzIEIU\u002B57jRRQC1\u002BSDKRFni3BFCe\u002BPZggwL94kie69c\u002BrnAu9thAU8PfeiMWo8WNivocp73lpOJ7415Mu8vr8lRWP9nCYl9gNrCMv37TCh89cBdOQgQZWMlN8xO6M5f4M0eOgGQri2ia/LENWSVjqJk/D0v0nbAQfObQdG9L5gLYlIv3BEn60aTu80WSy//kKkp6euRMA1XXfkN9G1b5TtZuNIRZbGQPRD3nBeoqvXDnLEok0atejJE2H4YGvbZN9WSvJNd7Sr4mKvamZT2r7MDSVi7M1H0rD2gzY0yeCIaHmVBFe1iZq6GMPua0uGeTSjLFdCeHQOEnRBWvCCcxSCIwHsutZnGoeKqNQNWWtlbAn9lZmNRewFhvXjdC6qO6WrbEhJmb5iPBXPu8\u002Bj/LUM2\u002BrmgN169NkR5zfgh6ZU4HEuZekjH9ZPn1mHvY4gZYY80phHw7bILHtvN7KGfbRvettecZrP7bgQluWH9zdO8YGto7EKDRy\u002BZjVxs\u002BQjxR2hFEK2wfPrcOTcMyzRQDlAHEYw1N4HZWm6oA9hWjnX7M3H5t70lC\u002BNxjLIKd3z6SH8LZeh8vBDnbLY\u002BCHghhavCEJfCV1eT4gWoxKrOzuPyrbtZSymNf3dhEkoG5gNqTwYHSGbkOPAoeILi0/dlGJ3TS1q9yDqBNZEfYUUMjPsBPXWkx4V8DXTKMdKmqquA\u002B/msM5qorYbMhRPUxderHOuH4JaBwVEYVj3l85dn24rmnmVLX1hgWJDu10Fyp0idHhTmH8kV/zqolN1dw7nvZKqI7iZxX7ySJogFkukQpa71R9SCgLvB0Z8qo8p7A5XX/3KW6bkhLL9YU/hBD2xQmO8uZ3vlbeTvxx2HRrzyFyPyLZN3ebv10xsVKizCf8Ey2gvbTZsa8ZGOpyKcmeUDZTzVTuHZ2R8zOZNf0EO3LEdbVGywF8qH2DwB6dGZWDk1EsTw7THfWQDspxMHuiFO1nvaQEV5Uk5yTnal1/BNmeBZKb5\u002Bxj8WfPprxG\u002B2fx0ashJWvhj0vL92fZ\u002B6OYIQng0zrpBj0A88xMNKDo3evM5YiyTd99vIZW3\u002BB0mgW0N4WiZhg9GMtuICGflUqq4yl8HQYq1dMqcya0kjZcjGnGmA0bNnfTn9y9RC293hc7q\u002By3CHz/iVGid\u002BLheIaVEZO32Q1Nj7yxqI05bYG1fJUfeOZJlYP8xw67eL6E4hdGKDKKBfUJ/iwwBV/vxivP/QtN0f\u002BQS3wfuxIOkhb\u002BLMZ14zVfK3agBYrKGYA0HQDi63uzNwAXtey2ekrjC2wFQeiZadLmcNGUrcx00=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "0TsT7hXen1Jpa22rAAC3xw==",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C704DDB9B0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "95fbffe8-549d-9578-a005-9bbeac8d8bf5",
+        "x-ms-content-crc64": "SrShgdj\u002B00E=",
+        "x-ms-request-id": "ec263e4a-401e-005d-61af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-6a1fa4e2-fc0d-336f-ac00-d05e823ebf18",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-3df42646e4a4932a9c559bffb0c9b9c7-df366cf39c069b30-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "24dfdb24-ca12-e986-5858-298b18e72d44",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "6uQAHllOCQHVBs\u002BRIKpXar163G\u002BdcudcEv3fWcBUM9jjIlBpSIMWW/lRfo9VA/LLoILnuATG8Hf8owxcb69BgdP3rf5a7SE6Y4F1TPRYBg4KE7k9bHrUHTLYbKR2uexJEPy8XlX0cbJgrVWCUKSDpJ39Ulv2AxVZIpDLgYF8w6qVLDv3nKe4FaEH3b8lUcyOVMcHeWeQUwznYjzFKPAx4\u002Bmr7SRojAj1RT267yZWM9DDPSy5dUpDBNkvDzlr8\u002Byx1vnVemOoJci\u002BEjMp1mTmkS9rAevDd26fZ\u002BlLOHzPiVJQCBktgLlsGxdj\u002BmIWGS50SX4J//EB7V6KNhJ6Xe1M74jh2c1LuBB1/\u002BbTX30LiE661u/9xYpgTxq6okqm8b4qFwvaNT9gKZBukwAKLo3hf67DwIb9Tin\u002BgIqykBbFzw0nqEhyMVMOWaxfjzGKVSCN2SKc4zE3Lcnh27S1rpl5qMTy44ZFbk5atGbanr73dCtpJbbzKevc8Ht\u002BkFWfWKsT5eZtl3KaR2rUQS7KXY4K6maJTIjihX/YFfILx974u1u7x7jYity4zt5MH\u002Bi9EpPsc6buFQwiMF9nlIKAj4CM3IXSD5XVMl\u002BK0H6qlmaWGwJfHlM4CaVPmJZYcPZaNz5dwEJi6wP9FkBGZEWNeJr50Hl/IHEsU9Pfgnb/fMJpL5k/TNUjNC//YggS8qRgwR/8X5992hfNMGxvg2iM/pl\u002B3DSrTivE1ZxJf75oGmEufsBXAh0i7FWBchxotLDGcmNulBVvtHP0N4kDM1pYZBYLQASoNft8XPDfKtsPWyHrggxa\u002BoZLv8lNYsuTHrj6KQ0FXXOrHj1o8jclj4qX5NtoF7FN/WqQwIE7W9Iv6D035QDOCf6tP2PP8gdOJS8\u002BtX7wKwcGrCujdZ3ycMNqOAr67qqJydvcutdNfgtjQZpS/KVUP7w2MDnVK5Nhu8\u002BfZLr9VDeFteuiE3AvuS0gPzQCoHQdFvlNxL1wtJ5He/8IrRlRZe1jzEe6sStMBncLtetfXhpbgk7AsI96FABMW5dxJgsUz9pGn9MsYmTNAb1FZf\u002Bz5x3krSvKkLVd6LhGblaT2t9s9uURGL5HLh/q86/SNK8BmHN6jHnfST8k6bcb5vQNOSbd2W4Zos9enX4M4JwGi7QIRNXiGU1mja2m7C8HK0cq3LqI9FtA6PakG\u002B/60mmiHV4CEqEeKiDYd0vBcrWfV3E34QPifZZYx1zfPv1ea7pEBM/RBBilC7GZsH0Pf3VABMR\u002Bw/Blv5/HqkpFP\u002BwiegyRfG7mzlJYkdZSSM0YSEjnnjo44KfJ3kQvCVrNYMzFdjVxfgIGWjVxJTIaEnfRr2ECXqCx6ppkyJ0qtsX4ijAJjNGXpspF4EQExrp1rszMXVr4ygIrE4ybDbZk3KNweZoBEYWlOgiXvX1crSPf7hnRXVlq/78u3XlF/JkU4ASgk00gc51GJyNRYQ2Fz2Vpux6ck35KBnra0zMMYD1ugt14uxrWv3t8izU1GZ2yqA4T20B7eE2GVo3TRaBqOcfl4t8wDBNLk/yjIAdIFOzcKCok\u002BIT98wqP8mWMAnnaElFuTza\u002Bgpz6yEhD2FhFPUGg9h12RUFC6O/UoBmuvpCCyA612cS1HaWNKTA8uRuySrUj7AtcZMwQLGdH6eGCTAm3wQ9JkGN86tl36BsRBS/TIlZkitKEJmNBpa1dbjTDC90mhfgMaLpRpgEy5Hyw/yY4dMaLHsE3MpurCOq2H3yltNw\u002B6oA2x7qbE\u002BPQUkHnkKWHJfltN\u002B0b71JcYGDPm4eEjTCfchSlAawM8ArdZuBZxHdFL/mCN3zvIvsu2WdazHhcS8QRRx2Q4SRNYEfiPYhxA5zoimuOAlWzsE8ZdydFsiOSgRobR3xZtE7VNdc0DeVzvNbKcUIMzUlvXZfOd2n8B64jT7ttVbwfjtUduM1\u002Bf6JqprtQekDhhrPRrOnliz3k2C0pEb0pBWYaq\u002BNs7hV88d70Y9Cuq4xtQskHnKnSOgKYOOCfVG7lQKBUNs9ddZeeVLsL8CdsNiyhu87zIWm9SHDg1LU03ZxwDiMvWXW9EM0yaEftxkrbKwKz/Zmf8h43lu5efKDhaXcemuEEPd235KsBwbghz4EmBKmzgd8C0RwE98KGXpMsUP/Pzixo1\u002B4k\u002BxnunTBlFsZtN3j3LuiXG8nE/0UaMYUX1XG5UgFUvi26joXGFDPrn\u002BH7GCYbNSEWN7Jio9epCsqT1si/q8PFGHlKPJ9i0QeV2GBjHxhf/KBPoxpO8hpWEYS6Mz5rLPMdNQCs0PiCs2arzcp3ReqyM9kobwipdyZf9CoaqJ7IKaxsRekYsyunze\u002B0oiRP3suZCP9kQ7zqdL7ZTdzNZwvI4qMeCgABmoCugKIZ9dQBDxVfgJ\u002BeZOXvgtArPmVO2Wbj7MCBMdTLmG1\u002BtcMa0H7p1z3HbuZrKX69L4cv1lsaX6Y8NgkUgN5Bk\u002BgxH64i1LFRQmYnh2p/d8JBwwJMm8ISY1Yc3pp11Fdfhdr\u002BOQnPm1rW3ZT089c7vL5G0r3b9PgmH7tYBvUW3G0PxwKQgT25ciendb4uHXB/4CLbLgGZhJDi2BpNd5VkvwEm5SvVqzuBjWCVNH869wFL2CXTOq1sdUNxrakja/uSQ7W8BzhFqTTnWqGgBE8RqOAYAp5vkIRTum/nY/6RXiFlAvHJffDJBi7x7OAMy3HzXwTJCmlcI7IwaU3JXUY1Vfx/OwFeSCs=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "4R/gKaOgGVv9noM6IXXySQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704E02A55\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "24dfdb24-ca12-e986-5858-298b18e72d44",
+        "x-ms-content-crc64": "fl6oHATuMEQ=",
+        "x-ms-request-id": "f1de2e21-801e-0020-73af-a3ea25000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-6fca66a0-90ce-5c13-faca-3c3413526523",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-a7981e9fec039c4be1a644a9654e0bbb-d947d59c32bf7fd0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e46f9417-5d4d-b396-c7da-8436b3004aeb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "CN8\u002BmBOi/6nou5fjjY9wlBbY2btt7KQOjCNezGlBO42oxjIhILAYTE9ShsIMwbhfjF/tIe6YShw6MAzvRDNAp38KOsZcT3RmwIxrGmXiActq/z8JUxmeEHwW5vCkKAgcEt9CAobyAj3qh2FhLS\u002B2WC5BhUXzNlNlaypKRmiEwpeETgiGn/9EePwCHsy4PONMYI3BY6PCKdyM3JdcqLvUZsTJ3d4nMLgu/A1I8BeGrS5H/ebawl/0wSUs\u002BcJo6M9ALrgI718EJS/Vk2aVeTjEBS9oFKrV\u002BaNl1Bu5\u002Bzb1xhM9CMJffr7PQ9e2BS/4XkfsZ/STANMkajQUohpDSir538xTWHF1ZIZxmdHTH/N0bXbTzJNCYsY/GJ2OS9yji/itvSZipAbWdwNtImYCUUtBoDWjcH2Xt3wGEz/U5xmqzQ3ZJWLMEchv/VWQ1EBfPcZRTKqm/xt6FgWqXJHHAY/pwlRYKCzpdI5sNHIoBuI8p9Z4g5puA83yXg9cIrU3qPzFphHrBhSaaNgcOsupUQ8jbbW6Tn71er6HZsocjFHZNYx1Y2DQUaDB3RrCUskBSQwAObQAfFl\u002B0CtTY6BKftuGQwQ/M\u002B6vUhwU\u002BHBjMij1hR29HFOc2bky95I0fe0Ad18/Ow/FwhYdUOeY64PoGp0DXd2DjGGH6mpLDDtcetQvFIERI/cZL8MGn8tsBO01St31MR8Pfev\u002Bt1GkerbawdYSadcC1/am6S4afOyVG\u002BV8FcJeZkm0H5aVE2umdLUMLN31WZsWM3LmT0fx9AH\u002BaJxrKGT0fFuMXklAbMSK/3V4Dk8PoMFKZuJPdxcCwiqVl6rPOkxRGK\u002BCaftR1cauXE/Seeax78jaIcGCpARDiZsfqtUZu8UoJvWgjDbG\u002BZAboBvIMElD5Kfi9BiKznOqPt9gMSrxlaCJqVLxEWKRFCgwZwTpe1lR28YtNsasnViB9U1XZcdmKQp6Pob2UtNFUODwWWdvwcOFDlZjw17a3Az6bxsVOa5gyj35bjzTWonz6Oblu0PwETOJ0lZxAmasn2F6/OK3LxYxkI8qdVKHsrTNcNt49SHICl3oi2dX78jWTc7aWF6mPLjPsyu0xZzhAh\u002Bio5GKM6pAsfKEz6Su2qDHUyiDrFlWJjQjqUH1E0XBBohItUs2TBkkmadrIm0TINmK7XFzXVbGTH1dZ4ppS52twsgcZiRUkAcOXxKy6gTGD4hoaibTTqgxgWnO2OWPu04Jvl\u002Bk97m0NVxpZP5DFGF4l1gCAeB32XQf6uW7hrgif6TDqCulIhfOszXJaemq7m0HVkGMjLpukeXrhA3U\u002Ba\u002BkR\u002BVaf2s203RAM02rrW\u002BKdfx3sy93lfLpVRdFuZ0K\u002BrqFJSIEUG4B0YLMS1lsw\u002BR2YA8RXEV/LbLycCpU8BnXNjmTJYdNhiSOdeKtqkmZfZEyz1mN\u002BZ10BfhwEd9DreFp9RUg2J1cKNnrgudj0oJoWfKZISDAST2cHyCP3XVESscBQ7Q0eaTz1aZ/ona1ETJ1B7jtqovAqKvXg7l9zUtkpjgfYY7NM\u002BBNpUx5QafH5g3tGdW9V6A8QJsIXPXrdgdbGvw\u002Blq\u002Bkp9PXnwU/R2cEEJ2rkLR2p06X4yHzxdfqYi5EHiaqiE9eSXEB5bib/PgzBExXP\u002BZT5HOuprONsOL87D3W\u002BylBWYdNTUdCdMGV/OYov8CKkyJI8Tmy/OKc0JiPBPh7xADP8qrECvKfEW\u002BxGKnMZPAhcVkajQrvj12lsH2us3DJGjfmWc0Wxogwqd/JAOQ40GunbZKeYDb24GJMH1l08F3/6P1y5gsjC6vR6uQqJo54bOASB0XdK7oA73lqyaYvvLmCyRjnxupfhGLnzXVSzLnU1LJ4YekXIr1CcfaSuEEEoS4rqFx2kab2soLj9l1EriK/lvX0tlrPaqdbpFXzzcsg4itHJyRdXkMMgq9mNCtf/cLT0iFMEOvUWz20GuxQA\u002BW2whMx/Yb\u002BYTix5zOraTZ7\u002B6eSH/qp1NFAcszmqENXvH/Jr3EXLQA81XHpmim3KfIHOR5EvuTrDO5C8Yq6GLn0Wiq04bnEY86nVkmJwDmoiEnZ3m8kEv6a3aKC1Tt1gb239ED\u002BA0c4QtVQnWeaYky0mWlB4DlK0EcsGgMWQo2SMdWM0cv5qYUBoJyZ03SWAHtWzTvSM6CEbST40ehDIgBHvmuSDpCAu/DkPz\u002BdsPzSlhmIv3RRv/00CGOmANecvn6bURUJBPLr1RJL7vRh5r0oJTvPu2KM9f5tXgUs2boYR4HBAV7myZEnnepiBtEJ0yGmftubzQIbD1sWm6bsvvtXM6Zzn\u002BVeQVuqpx54Ke8tZIrkhlvffHp\u002BpfIC0C7rO97uC9MrljM8Rzx/8SXjo\u002BVs6TYbCDegd7Yr9PrzW3Etvmw/iR4cAs5XqD4eYIpVmwIMluf30DKnTpQc/6E5SOzLUTO5pBnHT\u002Bdow2D4gRYr1ln358SKNe45mDuJAAIsHl9SUw5Xm/bpREcAjwzSrsx98ClIQWEnQRxFgAzdPU/kO6UApi4H1DpiDaJ9iqXhZuluDA/Y5Nz9KhHyEhvqCwb3G1Nn0QeedRzu5TS/qrd2YxkibzFADFfIA3wcFcEfdwGchm9SeZXi0Jby6v6oPoBae64CyJzUtw/7n86LgWBaz20yIiNIJOmEQJ6bTSFZH8T8wZoSHa9kx85fVtrGVk42mBqQdhtcElfFfoj\u002BOWnton8Jj8DFR7K\u002BzVpV6M4=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "kW56WCq76B4fP4eh/evADg==",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C704E225DA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e46f9417-5d4d-b396-c7da-8436b3004aeb",
+        "x-ms-content-crc64": "iz3EONTPMS8=",
+        "x-ms-request-id": "e3499d55-701e-0069-01af-a3a8ce000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-6d69ab2a-20d0-3000-3d87-d58a4193306d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-f34da8f39b73955432cd9914ba21eb2c-50d643f8ea270814-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d099341b-66ad-03e3-7e62-55493ac45bfb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "/DujlmOQipJ8TN4NdyOIfbcqmzPfAbrO7J3FEmjVDzRA9M\u002BEwgSX6\u002BiZDhurfvgPYOxUddscU/uA1anFy3gqpjyqzYJTA7qzkrBLRvKeIm6ltrJ8gJlYI6HUBO1a0SBvb2jfAbF1u1wxoeIr0Q0I4bM7IBTGrSWiUangf/7NWMGP29aKvyC9L/pVSt62LFKUzCI5H7ALqcFCPK8HlTxdZEkhm/U2fSKSfvEacGJH7CVWTLLckzkQhDEVSIJxtZm99\u002BaVlZBcXU4Ap6G/8Dle\u002B1CKsUiJgdEQEBfEITSfIclXXHh8sVaU\u002Be5k2\u002BuXUZT4tk0y5wNRM3YUhIR5mDwZYIbYZ5PA4kn59bdaJaXleL6Cy2rnbDrFBigCZyzRG2CxSntlv\u002BoAN9MEOPFL9g7QLwzF9szRMvRMEmBqvnocJ9pWqNoqgLjUgpSW4jNIeRAaMTggDCST4BiGGa2KlXhZ5xEX9U40pq9T8XM4Ok/AA5lQUI1C/Bu1wsjBo2YLSu0bPfoiMITB5YqJzBqwW6XIxhUUOUTrFuv1YjKGcgJISKeGHf1UndIUjmoCuS8BBGci\u002BN1Q9xCoLycPLc5SOnOIQINzKT2odChC/6rZ6F279F3KY3kl91GW3u3VRXAEwlT3enisjdopeoS0DfdlzkfJUzhwh9f5Ykkx3EtQ0i\u002B4PjxW4m7kD2aCoOn1celZMA\u002BmDPE4kzp8/hgverCP2ahV/M\u002B7DuzY5ETR7ufuA/Bf2Ks7qsY9gKsB2eNWtZS288dAn3UaniEjzSetZqVTjvonz6IEUy7iGHskuTQIgi\u002BvG/ofrWR7RTmJGN2ejxkFrUvpL\u002BXysZ\u002BYXof59eXsG0r4/kqqM\u002BGWq4poejtRQ4liHgvpH1NJvGpbh07cgU9UnP2SpZDPW3lqUoNbiTZkRxr\u002Bl9fZA/v3r0LgTqySuSk7FN4\u002Bvp34ksKRf8zP7TI09j8z3up3epkBm/ZO7wzN15laH3VYJYh8BgQUSIMvJ8EPq1htXts/w5pEPSOnqaO2xKgydc693NC3ttflYzIV0XM0P0O0X3i9GlzaE\u002Bhk1VxhXoPb/LLzUc\u002BHtqgDWWBoLmuwcmpgAWQvdVpx48joUuF7hASuOtTAQe1zLanQucD7cuV8tGLxAFwfrIdXgW4Gn2PGiNVbufSX7zF87NS6X7uZdnDja55\u002BiYOnj41Nab9/bY1GCTHrn7nw5cQxdRSIZEzLvQv\u002BIzTFR/5RtCpmSYZx/X9GdFWJrta38oXaTRRvHypAgau0gUlZgMEzmeuOiZw9v3eVQe/3QQ81RzCu6/rp4pT/JcjavHw17POTVhTqKGnpnI2c2d07ST\u002BcfzoZq5XHSbdXj2TUYwP7X1X7Y\u002Br6Sx7HxU9sTQi3xNyIPj1CG0Feyw1dkpkFFTiKoXmIP\u002BVUoTQbUuVGW/uuoMuHSyTFuUQTnZfdnbiFwrAW4quPLoT2M50JJslbF3ARr/LNfckUxOc1dKFNdwN7lY81MHlPHnFGkRiGvJJ6t4Yny\u002B7FuEXmAR3EWbriqLuajZE5Jef3wZCBhuuwjQhVu7wbJqwVtt1KTi5bi8W2ZOld7C4AQJKfLwldQzFZNnMUb539xoIPhNa079e4mzbKyiICU6HZVHsqfPait3Os8Ri7RhwnuZ1nTmdYTFG75pPTkngOV\u002BLSOxoi0kqLbM1jCP2\u002B/VQZoxGFmwQ5gQcqb5VizyT6nZo16AsBBOZT2\u002BKa9ERT/Ok/ue9nibvdmLkT\u002BGO0KJypaGpjiBRJF54qMb8in4zD1nKrIxU0kxTeV1BS7gyDn7NF8IzZ73TV9aJRPFf8u/gsTyHwCASHdNRWhTDD9imRppIM3a4A6eb\u002B1i1z41e84pxXJp7rk5auvXy3g2pDEv94v5XF791KK2Y68TLWFJB9maKUbNCKphP7XSAySGV8u8Mu\u002BiTB9vK/Dfo3sKJk16nrOunHrqYv7hiCypG9F\u002BIBvjVuqBlsvKOw1V7VUvZwl4Z2Rg57tA0d/wwLPixgAvUXNvJs9S\u002BPf31GF9lHWZsiETILRtDUhQkoUKkNYH12T9JovhwEBKFX58eQNZwz1qVx6Sz5VLskQ7HoRKWFgR4Az8cG3pp/Hg2RtF8JQ1Bs9XkDnHdQffoXQ3tqG7/70WWpkGXVLPcL8csfaJ9cG/9ge08rguWmr1LM75ofFAJNleP5YLLql8iC\u002BKqsMRRauih7CqBw0E6AAuETCDxc693I0dK8Y7pNdeOGqYk6\u002Bn49cTRyowli3cWUeF7R14\u002BLJQzN419BnldtLpS86SfERgdj1ZYI6kfTZvQNJ\u002Bpce55T\u002B4N9bRce\u002B9PdBXV1pfOdzzJWbQL5gzvE\u002BXxqNHZtELL2ae6jR9jwRNnDKuXSXsEBb1i3BQ2bWndHuHOatMdccPTCfjsE\u002BohaZikoNlhW8pq7aMQetQulWg52W49kVY8SZrrwEN\u002BF/HXPXZ7kcyQe8cbZ30sCPbroHSMtjZ749RGZFc\u002BeZeG6NWxPTlhswOfqV2rJi3ZEDygAB/O8WG7X12eNSl1UgIvkHqrfs\u002B9hfFw8QzUzL2maVQWmnV3u/tz9d3fw3naJldfe5W3MZVw5nouWfxU4o6f\u002B8vRYreIt9R/N4Tt3cJ7ls61eVUr8zvCpbf7SV3/HxNTP8uuCMOf0sO9N/4MgwS7tsctn2k5dASQDrkDjW52gBR1nqH6yY4LFaqRars9tiavQ5aazX\u002BqGcvDHfoKnEFVRrflmuRmwOk5JoXA=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ydfogoXG6kKwTCNoDNtZCQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:18 GMT",
+        "ETag": "\u00220x8DB71C704E225DA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d099341b-66ad-03e3-7e62-55493ac45bfb",
+        "x-ms-content-crc64": "JVdgLkw/fzg=",
+        "x-ms-request-id": "d3b7c731-401e-004d-10af-a35e6e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-9e9d7d05-ea24-2e5a-3b35-c1cf4fa2adfe",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-dfb7bf084b27ee74e1b2ed89d9104011-1158c49bd1767929-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a6327154-7654-6ead-9e37-e15261986890",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Zo5lcrRavceOcFBo0ajBByqItsCerdS05tnWYO8RgvoSl2bM73UatP8hwvRknvcA55iEupfeiLi6sIzahF3YfO1WVTpB9Be1bgLBfevfT0fh1nhXjMhjNA6uEj/oPy\u002BiSUUGDki8vvOAz0uUHAvN2mBF\u002BK7kgPAl8yEsk\u002BLYzC/SHzOm2EH\u002BJReF1r19zhcD4Djeo0aBvchV4RsnjyoQqAMbwv3XJwEfRtOWXqkyqCQJKbOq\u002BSjpUGFrUPcm15XsdC66YQwaK7k2v11z614eIjn2HmZ3Zq/bMnGcbNYK\u002BG49qul7eEYY7v35cznKdmUCTC29L7kudA5\u002B3y\u002Bafr/iLMfvNUB1o6rz3i9pfvN2ELwLmSCoTMm1DjXb/ZkXfXA9F0Zy2kAkjamDylCKxfYbCM5zj\u002BSfOd/9OiYLmaYR22G\u002BK2asBDV75gx3JYJ4Kkg/wPXKpO6Mnt1ndKAZGfMDce7vy5qPbgOY96jYKBNchA/dy9mxRjdyMoyJRY\u002BVYc0YdLOUiV6ur1HxMqxGs3bKCvCQO00aUSu3fZkNBilzA5bav7RfyPuwLxuIvxSKLH4WvzqfBCV//iKI3QzFoKknfS8Wa/TBakH13wwxkpIWLFEb90fu1P5wW8GS1\u002Bvv645yYELldMCKVFT5qiQYTWyPcrC6qqliOKkwpRAyL5NWBvN9vzFQMbeQkKLy9SnZVw1VAmQ6NEHlDyiYtM6vVyTBo6Qwm406P0H5KhkGcEJ/Vk4D3S0uG9GymK8Jt3zp4Dh9MFKFqLx/GsIjQQoo35/lGV2ArHr3k4fSfgLeMYjED0ngiD/w\u002Ba2Rg8JqCtrHibkQI50eaTS9hZzLsyq5oeg6XjHAR1Zf9SCw7ii4jYitCvRJzQ7rpqYVIwKjJUaD2OLZL6uoB0JisC59bnoLBfgTHqg1b9PaTriLqyRTvM/ZLBZG313dBAOy5hzfbjcrCR4KjweeTmgO/uHzHFseDvReo0FkxCWaNhmkg4i2\u002B\u002BCAYKEGSS3IO96tOOB86uiolNgogMr1xkX4cFjt\u002BcvfVwMAcru5GMXGlWdjt4xFHUwx/O6wjnoWippcDdnU2kISzuDdfHcs7nwSYupikg\u002B4s1IMvPzcLsmI6uchXQrs8rslUOirZ6DUBA5yniuPs/iLo1qGyB5GNqAWVZKQC5BxJW8vPUEmDEuxN7jtaY\u002Bd\u002BDfulrmvZimc3xpIlRIORPl9AXi8YHW3ZJYP1JBmWMwQeVxboXTXwr9Gkl4m3nc4o/O\u002BcGgX4ZjBNjEioJGZNoZNOBu2s6KEpj65dc0WkIYf1jGcp\u002Bhk\u002BJfDmWtDtCItrFvY2aVbgvBROckpXmvKqqWqA8lg/I\u002Be6T\u002BE8hk3QfEci8lxPrfhw1RBS20eOpor\u002BO/FmLBYzbDMOu9m15DWGvjYDdOiWWvuyUB1H7Ehf6\u002BkWPkqcqhAxL0YpQTIeuvEajB1Ri3HiZ\u002BD1s9w467/q7pAwX\u002BWrKhQl0gVibRnJk5VsLSAqziB3M9Zp5vZ0OAPGflKh7lsLb6IJa7ksv/rHLCAGzL5f/\u002BBvuSwPAQNdsdnBnC6HJ6V6IP294aKnSrPbovqWLWuFZr6yMjUu/C5e67nfKyPMf8S6jKvA4d59yG64M55Ih0SufDWv1TVwC2SPHzXoiB\u002BQD2L126C/hISgdCnGtsiP1iQ1cK8uHGrPCkFHcYLoVUAO6CR7Uqvj7vdwz6DLqZSb/wjRsxdwofL4JtEfeFLB997pt46kFEN4UYH3vUyJw2Ds63J6FqIo3kYxQ2vaxLZkbxeB4jIF9\u002BrFWWGVuORmbiNwckzgh6F8gNkIcpEXnUzLUw50x\u002BFu5vNHtL1AkyVhixUIapIpQ\u002Bd2RWFY/UUZrbvUiiXWMWZCAUtZmNLkPC2z5ue7zzL64c9m/oK/1imubcbBa8j/i5muxmkGj\u002BrUUklz5NadnZ6JGegWr3Ljgith6ysL4pAktBsNzQiJtFHkUmw5TDETENAoeFIg6RxmywR9pOT/yG/5TzC7T5CV/2WWchzG6nY6Ttpa46p9w8s\u002B5wHES89tJIo8f/zAV4E/krjsinb/X\u002BDOA1XKZOTFe0tlvGiOkXNWKQ2Symp5OfcZW1ExUTlUf0chNki5Yv\u002BlNsRxmtsYsMEFlqFpbJW2lQle8QmTlCpSEX0hbZsq3IZN7ZOlx58bwKpP6/qX6tKxqmE/GrG2EWLaH4leNwNmGrobG38B0I1qQzCfQ6hv\u002BiZqb4M568HU19wwy6gVvYlnKdEAfM\u002BTr5nT1NeBFo26qmWjM8eALC74BgNjEQTlVIVnOBnXL30Wlv/pZhbqU4EOdmFCsonB5v3iSHaMMF6U7oASGd6z43soTF0HloYXzbKCVNrjoqI7pRFb9ObGSqZhVLeW2HmimlLmGiYs\u002BlB3inrECduDsQveFnTNV\u002B6UYgH2pgIOgTU437pIPYi7zurA5GpsAgCK3aNruIHE1UJkEffkdlQOKQlFi2ohO7ODYgeJzHOEKCABK4ieoshzc8o4I\u002BuQl5iW8vshJnbWaeHv6Fa6OwkOoCmX4wqLr4YA0ldgKNfH8opvMxl4osHpKoGmrrqxuTjBKUPCOPRNy0N04FQftkDKKDWMCwgvlj0n7riI5MDLjxkeXv\u002BTxfnV4WfWA4KtibQA3EaE5a4w0VMGmgo7xOZCaRE7AReBdiJ79imgGVJ6emTESAi6Bumq7Y2sTSuvmhxBU5qxskicv2YkSO9EULfAzF/ld3zdiCJnUA=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "MW09D4prJuq7dkP7w7TjqQ==",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704E6E01A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a6327154-7654-6ead-9e37-e15261986890",
+        "x-ms-content-crc64": "OdHrid14I/c=",
+        "x-ms-request-id": "ec263e96-401e-005d-26af-a39b06000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-88a7891c-6d93-03bf-5bf4-cdf51a37fde3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-415d7b03782c3d2393dbbf473fb06aaf-4663256715981b7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "42e2eaef-a3ce-b596-0968-0850b615d3cd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704DDB9B0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "0TsT7hXen1Jpa22rAAC3xw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "42e2eaef-a3ce-b596-0968-0850b615d3cd",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec263f09-401e-005d-0eaf-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "yL3q28nBn1KRwnBCvzsgWZusWAWhIfO1DJwzmM9DDFcdPmxWaIpaRN1LDGF6F24AFWg0o0qoXabJNM4tjQeDTbYYJYHPyvAQUhQnVRSSOvQtMoNnD2kNdOHFjDO7LbbWx7\u002BrYfHtMEt3I1E1gAeRNvna/1qEHD5NC7GfCj28VSReUI5V59gDQAI47\u002BsY1/TaM1Y64S1bUquAXVZATSYNus0s1y95PE8g1r9YTCxTNDO8xdbngnT2Av7i1YmCw/LbKjQd6wDEYPcGGQpuAgZ\u002BLSkjg4dQJjhZNdQxlmbGnhLMfSH4NUkz\u002BGTe4GhphwD4ZKdgX0BrigT8xLUrk8qQQHv3ooTkhvjg74oickXP763UODG/ZT7SYfMd/HGTCGWaTaDtceV7FN6vgG\u002B1SBi\u002BLNQIVlqZ0do8JUGRxoqGTecliCSl4n7IWSRTD\u002BXPHRjaXs\u002BdirEKAHvFsEyk6U1UKDOIj8DzGUlVP/02RsH1bQcptmi66cI1G4eo3zExI2/W/ueyRo1X5kSGR0u007q6z0NEezLlmj9xUnQ4SzoXIxuNYEfaQyZ50dAjM6J2gUfN7hDu7ag88WSnQfQZH5sKbyMvJ3Nz34wdyqpiwWac\u002BtEta1wpKTZzUG7iMgIxYLE0GcR/R1nUWQ\u002BD0CL\u002B2jD\u002BC0Yj7LQ\u002B4EXsvNYEkKyJ62n4LqihHbJ3WBFNplgUdHY\u002B5Ce7DnT99Th\u002BkouDz8li\u002BeW4BquHXO6Uq5Oi8Trt2EdgxayFztz1\u002BjhvI4on9IlH66xyW27Ktog5J2PhWwT9kLlDIwkd3SsJwwtyFzljbbcJWgaOe33ZlQ4kS6d5E580cZLR49B/Kg2BaZhjWJ9O1rmr1wD9bxU8ao36\u002BZGEj69rPaWmkonmijD4DBHkdj1v1XXtzTyfNwJ8lHhDhTF8/dno9xr5qEQvxE3QBWIEV/RQiiQblsFyzAajKv0RowX\u002BfA84/H4jdiwxvQnvzzGfeDyE8voMYGYXdSsTVX1GHiBI0YhTy1t1LRT36dm4g/3UBLLAjLAK8RupIIZSDyGv657op/2pS6zhDsXmFXeNX/IuPlDLhZJwPd9tqqvVIh3zSP460Nz/K7gF333qJNyjG8GTJNHQ42UMeGoeO6EBDOuo8815Uo4WLxKXxqYUhRgDyY7qQf5LImSYLlhy4fAXBNKSQjEOKskyffW\u002BOB2\u002B9/JRGnETFsrtXNBo4CM2pE0igMHUgkPn9J/Et8QJjepH2jZlIMZ\u002BA\u002B0IpOVhpUql\u002B9mnnLdb6nWvaSbSTl8G48/lIQbs0YOHo33Uy91dhk5UH7zrYvAz6\u002B/Btrafq7SOAsEVe4RDuCpVH/g5hx6XUePYfS\u002BiGoHfsjUWKxrM6PfJRckcSArJEGaSlUL3\u002BWTRKmXTxy2E7Oc/NshOLY0PiTcAcEJVewjYDmzIEIU\u002B57jRRQC1\u002BSDKRFni3BFCe\u002BPZggwL94kie69c\u002BrnAu9thAU8PfeiMWo8WNivocp73lpOJ7415Mu8vr8lRWP9nCYl9gNrCMv37TCh89cBdOQgQZWMlN8xO6M5f4M0eOgGQri2ia/LENWSVjqJk/D0v0nbAQfObQdG9L5gLYlIv3BEn60aTu80WSy//kKkp6euRMA1XXfkN9G1b5TtZuNIRZbGQPRD3nBeoqvXDnLEok0atejJE2H4YGvbZN9WSvJNd7Sr4mKvamZT2r7MDSVi7M1H0rD2gzY0yeCIaHmVBFe1iZq6GMPua0uGeTSjLFdCeHQOEnRBWvCCcxSCIwHsutZnGoeKqNQNWWtlbAn9lZmNRewFhvXjdC6qO6WrbEhJmb5iPBXPu8\u002Bj/LUM2\u002BrmgN169NkR5zfgh6ZU4HEuZekjH9ZPn1mHvY4gZYY80phHw7bILHtvN7KGfbRvettecZrP7bgQluWH9zdO8YGto7EKDRy\u002BZjVxs\u002BQjxR2hFEK2wfPrcOTcMyzRQDlAHEYw1N4HZWm6oA9hWjnX7M3H5t70lC\u002BNxjLIKd3z6SH8LZeh8vBDnbLY\u002BCHghhavCEJfCV1eT4gWoxKrOzuPyrbtZSymNf3dhEkoG5gNqTwYHSGbkOPAoeILi0/dlGJ3TS1q9yDqBNZEfYUUMjPsBPXWkx4V8DXTKMdKmqquA\u002B/msM5qorYbMhRPUxderHOuH4JaBwVEYVj3l85dn24rmnmVLX1hgWJDu10Fyp0idHhTmH8kV/zqolN1dw7nvZKqI7iZxX7ySJogFkukQpa71R9SCgLvB0Z8qo8p7A5XX/3KW6bkhLL9YU/hBD2xQmO8uZ3vlbeTvxx2HRrzyFyPyLZN3ebv10xsVKizCf8Ey2gvbTZsa8ZGOpyKcmeUDZTzVTuHZ2R8zOZNf0EO3LEdbVGywF8qH2DwB6dGZWDk1EsTw7THfWQDspxMHuiFO1nvaQEV5Uk5yTnal1/BNmeBZKb5\u002Bxj8WfPprxG\u002B2fx0ashJWvhj0vL92fZ\u002B6OYIQng0zrpBj0A88xMNKDo3evM5YiyTd99vIZW3\u002BB0mgW0N4WiZhg9GMtuICGflUqq4yl8HQYq1dMqcya0kjZcjGnGmA0bNnfTn9y9RC293hc7q\u002By3CHz/iVGid\u002BLheIaVEZO32Q1Nj7yxqI05bYG1fJUfeOZJlYP8xw67eL6E4hdGKDKKBfUJ/iwwBV/vxivP/QtN0f\u002BQS3wfuxIOkhb\u002BLMZ14zVfK3agBYrKGYA0HQDi63uzNwAXtey2ekrjC2wFQeiZadLmcNGUrcx00="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-79fafa7c-e8bc-a6dd-b735-eb8043435467",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5248f93270afe349e6709bb184037c94-82e3798874d730cf-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "77637176-26b5-6dc2-f2a8-57a45f0bc916",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704D72AF9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "SCoA04cYMEQXSv11PJyj3w==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "77637176-26b5-6dc2-f2a8-57a45f0bc916",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec263fc5-401e-005d-37af-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "ErvQoutMenqqMt/HqaHolDot\u002B6yp6c0e\u002B1agby0wuljdgwaODCRiFqRDEK4y8sASxscrttrc4CnusaeUrAtMeXiG6iaaWocVyuUIZtkf7AiWjalmBAN\u002BAKLdoFt9zmmY95Y1qwiad2s/Fuv11HpQz8We/h9i5nV1COmDvbosmPx7cG5C6UD//BU9Ju4YiSwojdCW3s9KNREhwKMfFrqxE33ueWQLDeWEngIJJb\u002BGXH\u002B9Wi/plbksMTpcICmd4OVbixJxKQ/HHIDrEUDNQBBRm2MjYbuLyH7DwUcpruy8574crpmtFTNv9T6v/oR5X/EqC4XFeX4pz8OUrWfInm2TLiqBsZJ2pIUwtGx93Mr5SmJW/6Nm9m0/8t7WGWfLplfQG89a965es2YAlcQSrPP5mmMEcZ7JLDi8Qr6zn4sdZQ0UrMD6n1K090s9ZmCoLUbr3X4ExjS4Bu\u002BWnbXvqxTb4jC3/f8z/voQUHpTjMXXExV3yMEMGZ7YXKXQYwKdxEw3YYQw8S9Gt9\u002BD83a6ZXopv4mfd\u002BNSzsmR3qFaYpr4c4suGypBpiLlMRDiiSUnHvYrp6R4/U1p5ZO7nxON7FREin/rjElP6BhnuUbSb0Wjab\u002BqLrv1gHY\u002BxTaXhgcOV0W7nv6lPJGt3L\u002BMEUMGlnVOFzVT472ZTgoJrccTt2EQWGEAFtFG/S0t/VL8aG4yNy7BSW7SunSHIk/zm47KmiRdfLjhBYCkBxoHJuVrneab13aZUW7zPZ3tefOCUmGeY2Mtnuy1UDGtHUFUy5SPHIVpV8QYMUi1aj8a9IyMIbS4acKBPf755YZE6zQsn3IJXl1uGPudhTEbeDSsm1ykIPuNm2LRDd6Hb3I900UTiMvNEZYvHgi5G\u002BORZsXJTEoqn8o5nwMQN1B\u002B56mJX7LrB\u002B9p34nFdQLy1H9\u002BQKYYvSInEzN72unHvdpFsDZfMLwxpV7WYG3BZCrHR8qEkfaqZSqHYUt\u002BcC0FoiKvgMXMkqPDTZtIQl21Za4Js5IeQivjm0oM2M5wszQw0L1KEuRl\u002B7QmwUNbYiPN0fuddLyb5l/2y\u002BR6v7rVUppmF3GfalPJpLje\u002BIHoiDknPwbS0z53lepeU0YA6jv5UW6p9UuxLWao088EvO7eDkOrUoC0An9b7oGHQRcMybp85KYSP5PudhGfKv9vctn8gEQDVZe7RE7vTQbJKuxPmwoViNdHy8\u002BvvNxvFdiA7HuoisDSCHQiwJ9XI/KMJEskT470WeoBtLV1VJi6TC92bmCLIZ8rfJKW88c38KfdI5eRSsVJi5ORptYLXbTbZ3Rw4LWRAQKs\u002BNL7XmUiycMNmDAAKQFpLePN\u002BnvIIB/euotTxw/xSyGU5FHyTSwtbt0S/cWD2j1yBrPSxAeH49izHaPazwG0HEwOa0Swdt\u002B2n4udtiJaWuBO4MBbH4caDQF5Py\u002BJU5/bXuF4dG74wpDTGyR76i22WMPDi\u002B9BWPzF9F5DNjavLEzswldA4eVxVR0whwRiniLTw\u002BZsxsevmQXls4AQtYtZI\u002B/YjyfVdXfeUTbREdD4YlY7b3NPQ2aEPChSWy1kYaCR1mQUiQ77/U1vjXSR3og17VEq1EUXCeCIU1L/gxpJee\u002BVPzps49hHQHEm4LXx816gHG3cOo1becyDjDa8\u002B3oyJhSE\u002B55NyAp44pPT8Skql2D0XmasbD5iOsVu6Faii0X387mhbPe/UlRjZFf5iIijWfXWx5wThrnVIsHY39\u002Bz1ldO2/5viCpoNAwSSAjmaLE9yo9hzMOo5G3/y0o253N0sI0Aq62KM9HLbZKQAT2x7rkPmxRQUQqTpvaRcLzfMk2YnZd65rwEs5a\u002Bll4wF\u002BMvTt2QJktfJF\u002BDbAW2\u002BcMU6ztF\u002BGOlNgj8C\u002Bd9krqrYo4TYSHfTgsBOXg493q3TrrTqasj6x5/iRfVlBtk4ZGk1wl2opeiNJwvQ7/qbT\u002BNRbwtqugPiHdvk9gJCrrwnVfnlB9wQKsiMXQO86hflBvYR05eNjeplE\u002BSBg\u002B\u002BmCrhP6ZnA9kgHQQRCnlzAJTPEP\u002B8McNrkWYgPf/P3jmcZJhKLbQB95BCuClKTSy9NZO6wvYPAWdnda0/R8XZUD7KdabgKdPgzRhueniZIUQ6YghrFRtDjGIx47cHwrDLaWjqf9eF3QvA2vXdoYfuzVRoBeS9bTsjhuhDrkYb2AtnoxAQrqFttIT9qzolZeraQxVin7zMDvssx/nuQi/FpAHqdv533R6z\u002B1BfwMIA/SH\u002BaWswuTlOm5UV5OeofnJVNwY4O\u002B/rY2X2r6NrbE05LMnX8NjDlevIm9ppYvk3C33eCYi8x8ExEgUFOQqV4i5H27gd0I2ZkaEacKAVgQFsvqMmjWPFfGQIpt3TvlvhMrisIoZBGjvvRXfmoVYhHJADmXpmblXLgV9TFSmvxdNFOT7naF97KqRoN0jr3tsN5opMzyThesNj4aAn7QURP3\u002BkoGcYOrMxiG7W/TcN36ODRi6eY/auZL56g4e\u002BVDyeVvfIRz1z9avXG0e2C32MVgH8o6fWctyJ9TypnbcrcjMxN6Y/RJhmEFCDx0ev\u002BFlB7iyFwbGVx\u002BQbP1IAylf0q6gThNPWTRJplpJWU6qU2vzjZ6\u002BKpbCCnG/CIwRFZUb5jhyem3SFa6EaHCsePnQ5hmVVHWKoagX4kOhjEykNIzBMXcSO9j6IXfwOb4mFZF37iZ2e8EjjUSQXpguLIlh4DPj60eGvq5AnzL9mmvo="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-6d69ab2a-20d0-3000-3d87-d58a4193306d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9f876552ca91a1d522564fe04f3ceacc-89e74ed3fbbe4568-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "44daac16-5bb2-f017-ecd4-754f33e98d09",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:20 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704E225DA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "ydfogoXG6kKwTCNoDNtZCQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "44daac16-5bb2-f017-ecd4-754f33e98d09",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec2640d8-401e-005d-39af-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "/DujlmOQipJ8TN4NdyOIfbcqmzPfAbrO7J3FEmjVDzRA9M\u002BEwgSX6\u002BiZDhurfvgPYOxUddscU/uA1anFy3gqpjyqzYJTA7qzkrBLRvKeIm6ltrJ8gJlYI6HUBO1a0SBvb2jfAbF1u1wxoeIr0Q0I4bM7IBTGrSWiUangf/7NWMGP29aKvyC9L/pVSt62LFKUzCI5H7ALqcFCPK8HlTxdZEkhm/U2fSKSfvEacGJH7CVWTLLckzkQhDEVSIJxtZm99\u002BaVlZBcXU4Ap6G/8Dle\u002B1CKsUiJgdEQEBfEITSfIclXXHh8sVaU\u002Be5k2\u002BuXUZT4tk0y5wNRM3YUhIR5mDwZYIbYZ5PA4kn59bdaJaXleL6Cy2rnbDrFBigCZyzRG2CxSntlv\u002BoAN9MEOPFL9g7QLwzF9szRMvRMEmBqvnocJ9pWqNoqgLjUgpSW4jNIeRAaMTggDCST4BiGGa2KlXhZ5xEX9U40pq9T8XM4Ok/AA5lQUI1C/Bu1wsjBo2YLSu0bPfoiMITB5YqJzBqwW6XIxhUUOUTrFuv1YjKGcgJISKeGHf1UndIUjmoCuS8BBGci\u002BN1Q9xCoLycPLc5SOnOIQINzKT2odChC/6rZ6F279F3KY3kl91GW3u3VRXAEwlT3enisjdopeoS0DfdlzkfJUzhwh9f5Ykkx3EtQ0i\u002B4PjxW4m7kD2aCoOn1celZMA\u002BmDPE4kzp8/hgverCP2ahV/M\u002B7DuzY5ETR7ufuA/Bf2Ks7qsY9gKsB2eNWtZS288dAn3UaniEjzSetZqVTjvonz6IEUy7iGHskuTQIgi\u002BvG/ofrWR7RTmJGN2ejxkFrUvpL\u002BXysZ\u002BYXof59eXsG0r4/kqqM\u002BGWq4poejtRQ4liHgvpH1NJvGpbh07cgU9UnP2SpZDPW3lqUoNbiTZkRxr\u002Bl9fZA/v3r0LgTqySuSk7FN4\u002Bvp34ksKRf8zP7TI09j8z3up3epkBm/ZO7wzN15laH3VYJYh8BgQUSIMvJ8EPq1htXts/w5pEPSOnqaO2xKgydc693NC3ttflYzIV0XM0P0O0X3i9GlzaE\u002Bhk1VxhXoPb/LLzUc\u002BHtqgDWWBoLmuwcmpgAWQvdVpx48joUuF7hASuOtTAQe1zLanQucD7cuV8tGLxAFwfrIdXgW4Gn2PGiNVbufSX7zF87NS6X7uZdnDja55\u002BiYOnj41Nab9/bY1GCTHrn7nw5cQxdRSIZEzLvQv\u002BIzTFR/5RtCpmSYZx/X9GdFWJrta38oXaTRRvHypAgau0gUlZgMEzmeuOiZw9v3eVQe/3QQ81RzCu6/rp4pT/JcjavHw17POTVhTqKGnpnI2c2d07ST\u002BcfzoZq5XHSbdXj2TUYwP7X1X7Y\u002Br6Sx7HxU9sTQi3xNyIPj1CG0Feyw1dkpkFFTiKoXmIP\u002BVUoTQbUuVGW/uuoMuHSyTFuUQTnZfdnbiFwrAW4quPLoT2M50JJslbF3ARr/LNfckUxOc1dKFNdwN7lY81MHlPHnFGkRiGvJJ6t4Yny\u002B7FuEXmAR3EWbriqLuajZE5Jef3wZCBhuuwjQhVu7wbJqwVtt1KTi5bi8W2ZOld7C4AQJKfLwldQzFZNnMUb539xoIPhNa079e4mzbKyiICU6HZVHsqfPait3Os8Ri7RhwnuZ1nTmdYTFG75pPTkngOV\u002BLSOxoi0kqLbM1jCP2\u002B/VQZoxGFmwQ5gQcqb5VizyT6nZo16AsBBOZT2\u002BKa9ERT/Ok/ue9nibvdmLkT\u002BGO0KJypaGpjiBRJF54qMb8in4zD1nKrIxU0kxTeV1BS7gyDn7NF8IzZ73TV9aJRPFf8u/gsTyHwCASHdNRWhTDD9imRppIM3a4A6eb\u002B1i1z41e84pxXJp7rk5auvXy3g2pDEv94v5XF791KK2Y68TLWFJB9maKUbNCKphP7XSAySGV8u8Mu\u002BiTB9vK/Dfo3sKJk16nrOunHrqYv7hiCypG9F\u002BIBvjVuqBlsvKOw1V7VUvZwl4Z2Rg57tA0d/wwLPixgAvUXNvJs9S\u002BPf31GF9lHWZsiETILRtDUhQkoUKkNYH12T9JovhwEBKFX58eQNZwz1qVx6Sz5VLskQ7HoRKWFgR4Az8cG3pp/Hg2RtF8JQ1Bs9XkDnHdQffoXQ3tqG7/70WWpkGXVLPcL8csfaJ9cG/9ge08rguWmr1LM75ofFAJNleP5YLLql8iC\u002BKqsMRRauih7CqBw0E6AAuETCDxc693I0dK8Y7pNdeOGqYk6\u002Bn49cTRyowli3cWUeF7R14\u002BLJQzN419BnldtLpS86SfERgdj1ZYI6kfTZvQNJ\u002Bpce55T\u002B4N9bRce\u002B9PdBXV1pfOdzzJWbQL5gzvE\u002BXxqNHZtELL2ae6jR9jwRNnDKuXSXsEBb1i3BQ2bWndHuHOatMdccPTCfjsE\u002BohaZikoNlhW8pq7aMQetQulWg52W49kVY8SZrrwEN\u002BF/HXPXZ7kcyQe8cbZ30sCPbroHSMtjZ749RGZFc\u002BeZeG6NWxPTlhswOfqV2rJi3ZEDygAB/O8WG7X12eNSl1UgIvkHqrfs\u002B9hfFw8QzUzL2maVQWmnV3u/tz9d3fw3naJldfe5W3MZVw5nouWfxU4o6f\u002B8vRYreIt9R/N4Tt3cJ7ls61eVUr8zvCpbf7SV3/HxNTP8uuCMOf0sO9N/4MgwS7tsctn2k5dASQDrkDjW52gBR1nqH6yY4LFaqRars9tiavQ5aazX\u002BqGcvDHfoKnEFVRrflmuRmwOk5JoXA="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-6a1fa4e2-fc0d-336f-ac00-d05e823ebf18",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1d0cc6fe9ea41e3afc174420de6934fb-10d3cbe49d345eb1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "b28d2bea-8530-0b63-9ac9-812ce3273173",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:20 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704E02A55\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "4R/gKaOgGVv9noM6IXXySQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b28d2bea-8530-0b63-9ac9-812ce3273173",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec264170-401e-005d-4aaf-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "6uQAHllOCQHVBs\u002BRIKpXar163G\u002BdcudcEv3fWcBUM9jjIlBpSIMWW/lRfo9VA/LLoILnuATG8Hf8owxcb69BgdP3rf5a7SE6Y4F1TPRYBg4KE7k9bHrUHTLYbKR2uexJEPy8XlX0cbJgrVWCUKSDpJ39Ulv2AxVZIpDLgYF8w6qVLDv3nKe4FaEH3b8lUcyOVMcHeWeQUwznYjzFKPAx4\u002Bmr7SRojAj1RT267yZWM9DDPSy5dUpDBNkvDzlr8\u002Byx1vnVemOoJci\u002BEjMp1mTmkS9rAevDd26fZ\u002BlLOHzPiVJQCBktgLlsGxdj\u002BmIWGS50SX4J//EB7V6KNhJ6Xe1M74jh2c1LuBB1/\u002BbTX30LiE661u/9xYpgTxq6okqm8b4qFwvaNT9gKZBukwAKLo3hf67DwIb9Tin\u002BgIqykBbFzw0nqEhyMVMOWaxfjzGKVSCN2SKc4zE3Lcnh27S1rpl5qMTy44ZFbk5atGbanr73dCtpJbbzKevc8Ht\u002BkFWfWKsT5eZtl3KaR2rUQS7KXY4K6maJTIjihX/YFfILx974u1u7x7jYity4zt5MH\u002Bi9EpPsc6buFQwiMF9nlIKAj4CM3IXSD5XVMl\u002BK0H6qlmaWGwJfHlM4CaVPmJZYcPZaNz5dwEJi6wP9FkBGZEWNeJr50Hl/IHEsU9Pfgnb/fMJpL5k/TNUjNC//YggS8qRgwR/8X5992hfNMGxvg2iM/pl\u002B3DSrTivE1ZxJf75oGmEufsBXAh0i7FWBchxotLDGcmNulBVvtHP0N4kDM1pYZBYLQASoNft8XPDfKtsPWyHrggxa\u002BoZLv8lNYsuTHrj6KQ0FXXOrHj1o8jclj4qX5NtoF7FN/WqQwIE7W9Iv6D035QDOCf6tP2PP8gdOJS8\u002BtX7wKwcGrCujdZ3ycMNqOAr67qqJydvcutdNfgtjQZpS/KVUP7w2MDnVK5Nhu8\u002BfZLr9VDeFteuiE3AvuS0gPzQCoHQdFvlNxL1wtJ5He/8IrRlRZe1jzEe6sStMBncLtetfXhpbgk7AsI96FABMW5dxJgsUz9pGn9MsYmTNAb1FZf\u002Bz5x3krSvKkLVd6LhGblaT2t9s9uURGL5HLh/q86/SNK8BmHN6jHnfST8k6bcb5vQNOSbd2W4Zos9enX4M4JwGi7QIRNXiGU1mja2m7C8HK0cq3LqI9FtA6PakG\u002B/60mmiHV4CEqEeKiDYd0vBcrWfV3E34QPifZZYx1zfPv1ea7pEBM/RBBilC7GZsH0Pf3VABMR\u002Bw/Blv5/HqkpFP\u002BwiegyRfG7mzlJYkdZSSM0YSEjnnjo44KfJ3kQvCVrNYMzFdjVxfgIGWjVxJTIaEnfRr2ECXqCx6ppkyJ0qtsX4ijAJjNGXpspF4EQExrp1rszMXVr4ygIrE4ybDbZk3KNweZoBEYWlOgiXvX1crSPf7hnRXVlq/78u3XlF/JkU4ASgk00gc51GJyNRYQ2Fz2Vpux6ck35KBnra0zMMYD1ugt14uxrWv3t8izU1GZ2yqA4T20B7eE2GVo3TRaBqOcfl4t8wDBNLk/yjIAdIFOzcKCok\u002BIT98wqP8mWMAnnaElFuTza\u002Bgpz6yEhD2FhFPUGg9h12RUFC6O/UoBmuvpCCyA612cS1HaWNKTA8uRuySrUj7AtcZMwQLGdH6eGCTAm3wQ9JkGN86tl36BsRBS/TIlZkitKEJmNBpa1dbjTDC90mhfgMaLpRpgEy5Hyw/yY4dMaLHsE3MpurCOq2H3yltNw\u002B6oA2x7qbE\u002BPQUkHnkKWHJfltN\u002B0b71JcYGDPm4eEjTCfchSlAawM8ArdZuBZxHdFL/mCN3zvIvsu2WdazHhcS8QRRx2Q4SRNYEfiPYhxA5zoimuOAlWzsE8ZdydFsiOSgRobR3xZtE7VNdc0DeVzvNbKcUIMzUlvXZfOd2n8B64jT7ttVbwfjtUduM1\u002Bf6JqprtQekDhhrPRrOnliz3k2C0pEb0pBWYaq\u002BNs7hV88d70Y9Cuq4xtQskHnKnSOgKYOOCfVG7lQKBUNs9ddZeeVLsL8CdsNiyhu87zIWm9SHDg1LU03ZxwDiMvWXW9EM0yaEftxkrbKwKz/Zmf8h43lu5efKDhaXcemuEEPd235KsBwbghz4EmBKmzgd8C0RwE98KGXpMsUP/Pzixo1\u002B4k\u002BxnunTBlFsZtN3j3LuiXG8nE/0UaMYUX1XG5UgFUvi26joXGFDPrn\u002BH7GCYbNSEWN7Jio9epCsqT1si/q8PFGHlKPJ9i0QeV2GBjHxhf/KBPoxpO8hpWEYS6Mz5rLPMdNQCs0PiCs2arzcp3ReqyM9kobwipdyZf9CoaqJ7IKaxsRekYsyunze\u002B0oiRP3suZCP9kQ7zqdL7ZTdzNZwvI4qMeCgABmoCugKIZ9dQBDxVfgJ\u002BeZOXvgtArPmVO2Wbj7MCBMdTLmG1\u002BtcMa0H7p1z3HbuZrKX69L4cv1lsaX6Y8NgkUgN5Bk\u002BgxH64i1LFRQmYnh2p/d8JBwwJMm8ISY1Yc3pp11Fdfhdr\u002BOQnPm1rW3ZT089c7vL5G0r3b9PgmH7tYBvUW3G0PxwKQgT25ciendb4uHXB/4CLbLgGZhJDi2BpNd5VkvwEm5SvVqzuBjWCVNH869wFL2CXTOq1sdUNxrakja/uSQ7W8BzhFqTTnWqGgBE8RqOAYAp5vkIRTum/nY/6RXiFlAvHJffDJBi7x7OAMy3HzXwTJCmlcI7IwaU3JXUY1Vfx/OwFeSCs="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-6fca66a0-90ce-5c13-faca-3c3413526523",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-784f00e1e1dd40a3deb215176c366169-2b9cabcf1304e354-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "0765ff90-db5b-64d9-ffa8-a95b612e3ad3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:20 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704E225DA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "kW56WCq76B4fP4eh/evADg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0765ff90-db5b-64d9-ffa8-a95b612e3ad3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec264206-401e-005d-4daf-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "CN8\u002BmBOi/6nou5fjjY9wlBbY2btt7KQOjCNezGlBO42oxjIhILAYTE9ShsIMwbhfjF/tIe6YShw6MAzvRDNAp38KOsZcT3RmwIxrGmXiActq/z8JUxmeEHwW5vCkKAgcEt9CAobyAj3qh2FhLS\u002B2WC5BhUXzNlNlaypKRmiEwpeETgiGn/9EePwCHsy4PONMYI3BY6PCKdyM3JdcqLvUZsTJ3d4nMLgu/A1I8BeGrS5H/ebawl/0wSUs\u002BcJo6M9ALrgI718EJS/Vk2aVeTjEBS9oFKrV\u002BaNl1Bu5\u002Bzb1xhM9CMJffr7PQ9e2BS/4XkfsZ/STANMkajQUohpDSir538xTWHF1ZIZxmdHTH/N0bXbTzJNCYsY/GJ2OS9yji/itvSZipAbWdwNtImYCUUtBoDWjcH2Xt3wGEz/U5xmqzQ3ZJWLMEchv/VWQ1EBfPcZRTKqm/xt6FgWqXJHHAY/pwlRYKCzpdI5sNHIoBuI8p9Z4g5puA83yXg9cIrU3qPzFphHrBhSaaNgcOsupUQ8jbbW6Tn71er6HZsocjFHZNYx1Y2DQUaDB3RrCUskBSQwAObQAfFl\u002B0CtTY6BKftuGQwQ/M\u002B6vUhwU\u002BHBjMij1hR29HFOc2bky95I0fe0Ad18/Ow/FwhYdUOeY64PoGp0DXd2DjGGH6mpLDDtcetQvFIERI/cZL8MGn8tsBO01St31MR8Pfev\u002Bt1GkerbawdYSadcC1/am6S4afOyVG\u002BV8FcJeZkm0H5aVE2umdLUMLN31WZsWM3LmT0fx9AH\u002BaJxrKGT0fFuMXklAbMSK/3V4Dk8PoMFKZuJPdxcCwiqVl6rPOkxRGK\u002BCaftR1cauXE/Seeax78jaIcGCpARDiZsfqtUZu8UoJvWgjDbG\u002BZAboBvIMElD5Kfi9BiKznOqPt9gMSrxlaCJqVLxEWKRFCgwZwTpe1lR28YtNsasnViB9U1XZcdmKQp6Pob2UtNFUODwWWdvwcOFDlZjw17a3Az6bxsVOa5gyj35bjzTWonz6Oblu0PwETOJ0lZxAmasn2F6/OK3LxYxkI8qdVKHsrTNcNt49SHICl3oi2dX78jWTc7aWF6mPLjPsyu0xZzhAh\u002Bio5GKM6pAsfKEz6Su2qDHUyiDrFlWJjQjqUH1E0XBBohItUs2TBkkmadrIm0TINmK7XFzXVbGTH1dZ4ppS52twsgcZiRUkAcOXxKy6gTGD4hoaibTTqgxgWnO2OWPu04Jvl\u002Bk97m0NVxpZP5DFGF4l1gCAeB32XQf6uW7hrgif6TDqCulIhfOszXJaemq7m0HVkGMjLpukeXrhA3U\u002Ba\u002BkR\u002BVaf2s203RAM02rrW\u002BKdfx3sy93lfLpVRdFuZ0K\u002BrqFJSIEUG4B0YLMS1lsw\u002BR2YA8RXEV/LbLycCpU8BnXNjmTJYdNhiSOdeKtqkmZfZEyz1mN\u002BZ10BfhwEd9DreFp9RUg2J1cKNnrgudj0oJoWfKZISDAST2cHyCP3XVESscBQ7Q0eaTz1aZ/ona1ETJ1B7jtqovAqKvXg7l9zUtkpjgfYY7NM\u002BBNpUx5QafH5g3tGdW9V6A8QJsIXPXrdgdbGvw\u002Blq\u002Bkp9PXnwU/R2cEEJ2rkLR2p06X4yHzxdfqYi5EHiaqiE9eSXEB5bib/PgzBExXP\u002BZT5HOuprONsOL87D3W\u002BylBWYdNTUdCdMGV/OYov8CKkyJI8Tmy/OKc0JiPBPh7xADP8qrECvKfEW\u002BxGKnMZPAhcVkajQrvj12lsH2us3DJGjfmWc0Wxogwqd/JAOQ40GunbZKeYDb24GJMH1l08F3/6P1y5gsjC6vR6uQqJo54bOASB0XdK7oA73lqyaYvvLmCyRjnxupfhGLnzXVSzLnU1LJ4YekXIr1CcfaSuEEEoS4rqFx2kab2soLj9l1EriK/lvX0tlrPaqdbpFXzzcsg4itHJyRdXkMMgq9mNCtf/cLT0iFMEOvUWz20GuxQA\u002BW2whMx/Yb\u002BYTix5zOraTZ7\u002B6eSH/qp1NFAcszmqENXvH/Jr3EXLQA81XHpmim3KfIHOR5EvuTrDO5C8Yq6GLn0Wiq04bnEY86nVkmJwDmoiEnZ3m8kEv6a3aKC1Tt1gb239ED\u002BA0c4QtVQnWeaYky0mWlB4DlK0EcsGgMWQo2SMdWM0cv5qYUBoJyZ03SWAHtWzTvSM6CEbST40ehDIgBHvmuSDpCAu/DkPz\u002BdsPzSlhmIv3RRv/00CGOmANecvn6bURUJBPLr1RJL7vRh5r0oJTvPu2KM9f5tXgUs2boYR4HBAV7myZEnnepiBtEJ0yGmftubzQIbD1sWm6bsvvtXM6Zzn\u002BVeQVuqpx54Ke8tZIrkhlvffHp\u002BpfIC0C7rO97uC9MrljM8Rzx/8SXjo\u002BVs6TYbCDegd7Yr9PrzW3Etvmw/iR4cAs5XqD4eYIpVmwIMluf30DKnTpQc/6E5SOzLUTO5pBnHT\u002Bdow2D4gRYr1ln358SKNe45mDuJAAIsHl9SUw5Xm/bpREcAjwzSrsx98ClIQWEnQRxFgAzdPU/kO6UApi4H1DpiDaJ9iqXhZuluDA/Y5Nz9KhHyEhvqCwb3G1Nn0QeedRzu5TS/qrd2YxkibzFADFfIA3wcFcEfdwGchm9SeZXi0Jby6v6oPoBae64CyJzUtw/7n86LgWBaz20yIiNIJOmEQJ6bTSFZH8T8wZoSHa9kx85fVtrGVk42mBqQdhtcElfFfoj\u002BOWnton8Jj8DFR7K\u002BzVpV6M4="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c/test-blob-9e9d7d05-ea24-2e5a-3b35-c1cf4fa2adfe",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-740d7bb1af8541d353e1e0c539806ef4-9fc907fe03119688-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e49b3cd2-29c1-8d17-49cc-c520d0acd223",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:20 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "ETag": "\u00220x8DB71C704E6E01A\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-content-md5": "MW09D4prJuq7dkP7w7TjqQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e49b3cd2-29c1-8d17-49cc-c520d0acd223",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-last-access-time": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "ec2642cf-401e-005d-0aaf-a39b06000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Zo5lcrRavceOcFBo0ajBByqItsCerdS05tnWYO8RgvoSl2bM73UatP8hwvRknvcA55iEupfeiLi6sIzahF3YfO1WVTpB9Be1bgLBfevfT0fh1nhXjMhjNA6uEj/oPy\u002BiSUUGDki8vvOAz0uUHAvN2mBF\u002BK7kgPAl8yEsk\u002BLYzC/SHzOm2EH\u002BJReF1r19zhcD4Djeo0aBvchV4RsnjyoQqAMbwv3XJwEfRtOWXqkyqCQJKbOq\u002BSjpUGFrUPcm15XsdC66YQwaK7k2v11z614eIjn2HmZ3Zq/bMnGcbNYK\u002BG49qul7eEYY7v35cznKdmUCTC29L7kudA5\u002B3y\u002Bafr/iLMfvNUB1o6rz3i9pfvN2ELwLmSCoTMm1DjXb/ZkXfXA9F0Zy2kAkjamDylCKxfYbCM5zj\u002BSfOd/9OiYLmaYR22G\u002BK2asBDV75gx3JYJ4Kkg/wPXKpO6Mnt1ndKAZGfMDce7vy5qPbgOY96jYKBNchA/dy9mxRjdyMoyJRY\u002BVYc0YdLOUiV6ur1HxMqxGs3bKCvCQO00aUSu3fZkNBilzA5bav7RfyPuwLxuIvxSKLH4WvzqfBCV//iKI3QzFoKknfS8Wa/TBakH13wwxkpIWLFEb90fu1P5wW8GS1\u002Bvv645yYELldMCKVFT5qiQYTWyPcrC6qqliOKkwpRAyL5NWBvN9vzFQMbeQkKLy9SnZVw1VAmQ6NEHlDyiYtM6vVyTBo6Qwm406P0H5KhkGcEJ/Vk4D3S0uG9GymK8Jt3zp4Dh9MFKFqLx/GsIjQQoo35/lGV2ArHr3k4fSfgLeMYjED0ngiD/w\u002Ba2Rg8JqCtrHibkQI50eaTS9hZzLsyq5oeg6XjHAR1Zf9SCw7ii4jYitCvRJzQ7rpqYVIwKjJUaD2OLZL6uoB0JisC59bnoLBfgTHqg1b9PaTriLqyRTvM/ZLBZG313dBAOy5hzfbjcrCR4KjweeTmgO/uHzHFseDvReo0FkxCWaNhmkg4i2\u002B\u002BCAYKEGSS3IO96tOOB86uiolNgogMr1xkX4cFjt\u002BcvfVwMAcru5GMXGlWdjt4xFHUwx/O6wjnoWippcDdnU2kISzuDdfHcs7nwSYupikg\u002B4s1IMvPzcLsmI6uchXQrs8rslUOirZ6DUBA5yniuPs/iLo1qGyB5GNqAWVZKQC5BxJW8vPUEmDEuxN7jtaY\u002Bd\u002BDfulrmvZimc3xpIlRIORPl9AXi8YHW3ZJYP1JBmWMwQeVxboXTXwr9Gkl4m3nc4o/O\u002BcGgX4ZjBNjEioJGZNoZNOBu2s6KEpj65dc0WkIYf1jGcp\u002Bhk\u002BJfDmWtDtCItrFvY2aVbgvBROckpXmvKqqWqA8lg/I\u002Be6T\u002BE8hk3QfEci8lxPrfhw1RBS20eOpor\u002BO/FmLBYzbDMOu9m15DWGvjYDdOiWWvuyUB1H7Ehf6\u002BkWPkqcqhAxL0YpQTIeuvEajB1Ri3HiZ\u002BD1s9w467/q7pAwX\u002BWrKhQl0gVibRnJk5VsLSAqziB3M9Zp5vZ0OAPGflKh7lsLb6IJa7ksv/rHLCAGzL5f/\u002BBvuSwPAQNdsdnBnC6HJ6V6IP294aKnSrPbovqWLWuFZr6yMjUu/C5e67nfKyPMf8S6jKvA4d59yG64M55Ih0SufDWv1TVwC2SPHzXoiB\u002BQD2L126C/hISgdCnGtsiP1iQ1cK8uHGrPCkFHcYLoVUAO6CR7Uqvj7vdwz6DLqZSb/wjRsxdwofL4JtEfeFLB997pt46kFEN4UYH3vUyJw2Ds63J6FqIo3kYxQ2vaxLZkbxeB4jIF9\u002BrFWWGVuORmbiNwckzgh6F8gNkIcpEXnUzLUw50x\u002BFu5vNHtL1AkyVhixUIapIpQ\u002Bd2RWFY/UUZrbvUiiXWMWZCAUtZmNLkPC2z5ue7zzL64c9m/oK/1imubcbBa8j/i5muxmkGj\u002BrUUklz5NadnZ6JGegWr3Ljgith6ysL4pAktBsNzQiJtFHkUmw5TDETENAoeFIg6RxmywR9pOT/yG/5TzC7T5CV/2WWchzG6nY6Ttpa46p9w8s\u002B5wHES89tJIo8f/zAV4E/krjsinb/X\u002BDOA1XKZOTFe0tlvGiOkXNWKQ2Symp5OfcZW1ExUTlUf0chNki5Yv\u002BlNsRxmtsYsMEFlqFpbJW2lQle8QmTlCpSEX0hbZsq3IZN7ZOlx58bwKpP6/qX6tKxqmE/GrG2EWLaH4leNwNmGrobG38B0I1qQzCfQ6hv\u002BiZqb4M568HU19wwy6gVvYlnKdEAfM\u002BTr5nT1NeBFo26qmWjM8eALC74BgNjEQTlVIVnOBnXL30Wlv/pZhbqU4EOdmFCsonB5v3iSHaMMF6U7oASGd6z43soTF0HloYXzbKCVNrjoqI7pRFb9ObGSqZhVLeW2HmimlLmGiYs\u002BlB3inrECduDsQveFnTNV\u002B6UYgH2pgIOgTU437pIPYi7zurA5GpsAgCK3aNruIHE1UJkEffkdlQOKQlFi2ohO7ODYgeJzHOEKCABK4ieoshzc8o4I\u002BuQl5iW8vshJnbWaeHv6Fa6OwkOoCmX4wqLr4YA0ldgKNfH8opvMxl4osHpKoGmrrqxuTjBKUPCOPRNy0N04FQftkDKKDWMCwgvlj0n7riI5MDLjxkeXv\u002BTxfnV4WfWA4KtibQA3EaE5a4w0VMGmgo7xOZCaRE7AReBdiJ79imgGVJ6emTESAi6Bumq7Y2sTSuvmhxBU5qxskicv2YkSO9EULfAzF/ld3zdiCJnUA="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-3dae3acf-f295-f3bc-5b25-8f987647195c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a75e906c80f3bfbf04a6a73742a50580-a95b83a058598028-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "258966dd-5592-a212-8fca-8ca9b98d9f77",
+        "x-ms-date": "Tue, 20 Jun 2023 19:46:20 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:46:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "258966dd-5592-a212-8fca-8ca9b98d9f77",
+        "x-ms-request-id": "ec2642fb-401e-005d-35af-a39b06000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "901411152",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,1024,10).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,1024,10).json
@@ -1,0 +1,293 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-475b244d205bc6dfe98943c035312e84-747cf6efe960f450-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f94cd0f5-806e-57dc-e7bb-0d4738867172",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "ETag": "\u00220x8DB71C7F0AEF5C7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f94cd0f5-806e-57dc-e7bb-0d4738867172",
+        "x-ms-request-id": "64d6b888-401e-00a9-16b0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16/test-blob-c838a3a9-5b7d-a985-a40b-4fc7b7da6767",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-2b5cb7cf81a80bcd5ccd6ed08b22c141-c693c616020c7df3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "a6ee4e8a-0d3f-73ae-0547-1590533bcfa9",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "ETag": "\u00220x8DB71C7F0C531DB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a6ee4e8a-0d3f-73ae-0547-1590533bcfa9",
+        "x-ms-request-id": "64d6b926-401e-00a9-2cb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16/test-blob-4bdba4fe-0265-c4a7-672d-b8ea017118ae",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-419b2b2fd04f5413299b5c0bd496c580-e3516095f0251322-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "dd1c0ee4-ce5d-2903-71bd-9e06c77994c4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F0C8179F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dd1c0ee4-ce5d-2903-71bd-9e06c77994c4",
+        "x-ms-request-id": "16e8da65-e01e-007b-7eb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16/test-blob-c838a3a9-5b7d-a985-a40b-4fc7b7da6767?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-fb162b20856b58a6406f21545c5ca030-5ded631963d5c707-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "45acf313-f11e-3b4c-f042-77489bc019ae",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vedKLb4ZoplKo1RiMBWfDVSlSJSrJgym\u002B3NgUKObqDPyoQnQkDqp5QFBAMKuRJRSjaqWWyiEA5faozFKuVL1rvogcI4Lz3wa/GOSaSVK\u002BLffDsL4BU0KbZ1x9e0IXyuvS1LHjdQFRr4ufF/F8plyj6p6a6uP/amsFgLwmdmPEZ034h3Tgmri2ccDyojuRXsE/2VCjvOAIE6oG3fSFKzlnmrCjRB8nw1Al5HjjDIgvtCH7JpzTYKpt8HOKmfzEMUbHSseK7hqiGBYAvdinZQch1ynSycRclHoGNZPrXSlTIbMyG4HApMXHGQ6GkuLRxktsqMLS8WdCavZNhLhG9vrsrVwltQlFYXJjy7C11cGXNG8IfrRmgHBLr7DLcyANQGJTmiWG7FFB50eQryX2jFT09lBJfngGRizrmgVYui4SVksOYjvcEAgdxlcs1hEKlONb1nyPhAIqDVP4mxIL6S1ZfljaqGpY2KYIK7fhGa/b4QUiPOOxQpIJJBTn47U10h1p01f4b\u002Bx4wz2WR5hKCTOkHLnNKaxJ6DuGkYQVcPUxElmatwYYI7FY6Tml2vs5/xshA8b7KOhw3\u002BtcMd5oY5IIpXV\u002B71Hti/kItEBy5A0AjNKpNGzudelxKddavDHS8EWnXXVF\u002Bs\u002BJM7gNsrSoPfveW2TL/28lWm9LzYV6ks/HdYP6i0bXutHC38C04IN0iSvbfGCMxzEWQgLGOe0KDqDoRnzw7XK1BuCTCN9usLmsFwSZn1avOq6SpAkD0YDk\u002BJFfzFpGg9v5JjV/\u002Bf4Rp9GJWeKosK9KOQuOHgkpcXUf7lBODuQfZVMooHkhL0DwgPx3uneePAgiFZNOuGXSz7TAYAutw5ktqjRPgBA2KMnK3Z0Msfb9gbIILDkQkKztVdCEYM81Qv1jSdBDDrw36\u002BzJg9rIhh39wt5ZZZegHNlHoio/ccg6lZrf6WfmunM2EABMRwzSJM/yxp4w290lw203O6yR\u002BHnkjy4AKJy11whrY1VXE9XMdX1aTKtqCfn9uiY6736GZBeGZ7ge0jwzPS9VhXiHjq\u002BXaoYvd6vOukV0Qm62uueJpP990Owd7aNBJw\u002B71IRBdiu2o0T4lyxr960yqk\u002BNvIIHi\u002BB5Cf2Deb0i7hCcUuXA8wxDP9di0Q2S0dl\u002B6wMTs6pNdAjkCCwt8ynHlakbj2SHcfdDSryqpPqSpnfkRE56DzqmTt7dHOsgFQytm3ukt0J0t7lLkCjtos9OEWH0Ca7bTYaudUCF6hTMY3VwPQl/Le71r4yVLn7RuKwPTsuJK8td0g31NkHB7s2kf2zzfaWFzyNy/poiBl8HnPyUdlsJQzdqEir7ijetM4D/MO7R3jrGSb/oFm1xe4vug==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:54 GMT",
+        "ETag": "\u00220x8DB71C7F0CBE7A1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "45acf313-f11e-3b4c-f042-77489bc019ae",
+        "x-ms-content-crc64": "ElG/VpUj3Zo=",
+        "x-ms-request-id": "64d6b94c-401e-00a9-51b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16/test-blob-4bdba4fe-0265-c4a7-672d-b8ea017118ae?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-fec77b73b6b92f8040fa36b2017cfc5b-90270de2927c4b9b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d3f2810b-4fcc-44a6-d234-a78526c7b5c7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "tWYUteHJa/DWJa3qKBSuFyxljFXB1voGOLNthbMo41p8NHJ4nxghMlfKcVM\u002BLv7r8UKJX2HZ\u002BN5rDn0tXOY9rkJTbvOhNngTQ1r\u002B9mWnyAm1gpNwnoP4ozuTDJGb9NVwjMIQ6sAKSbvJdRwG2gJ5xEVzeNpSzA\u002B/W8q3DSnnd06Fjmmilt5JqjjYpylm8ck5GkhLKHz6HcCzUY71UzuR4v7NgUyZ1y1mKc2ieiXmWGkBfvPgm0/SinCp70VPU1f8RsQrmXB9n0Mb5f6vWKOazPkl9NRIsUau\u002Bvbb8OfoF9Z1pTNhu775hN6wxbZRIzLNDiJMKl\u002BDtJV9fJ55oa9bM80oObNvORE6LG/1mOuQXdbEDeHFm\u002Bx28vGe4z4ff\u002BIvVJLoKep/XtUQEf7vjRyq7R/HtZPOlpfgsUfB0VXSGqyMxkNYpzTsRa8LtInuhmTU8/YfWMpOYb77B3eivYx/PvdRYsbYUUXq2nDkwuEN8Sri7d1fs8LiPWWEXaC8SocjjHaSnSOd\u002B6KwNH1aap7d7RVNv9CuH4o1byVhVPOkLpDowTZre1QGRPE7rn5Eh9PGp2\u002BKb4q3dGzrXS3\u002BPKeuCwbscalocXLBRnrec3EM8OdRmqyDGr4FME3JgB4mBwhJjKJ4WBYpXjX9ySgP2AD732xGrKL6KvFH5kBcnvFUmj9ylefOk5jRKDt2hlGW9lhMzqCx4FplTmGxMXHVzcBEqC7pnUMYLEvUdYRmg6SgsPDoD89Qo7rkDEaFHGIn\u002B1t7Mt0irFgUNKFV3GrV/sq8EYCA7L3w8wV0BJD9khDprXkp61HGfQSX09su\u002B8ZPDg17yAvipg6diz/YrajIF6GRbC/xrBN59pN86Bniwvc/JfaCgcoEBgZri2AS7tBbz7w6nI\u002BWXmL6AdJ4Zr71u8hHmIiyRZXXjWUohSCyZwfCIBhcpyVoqMaTh4D3i6BIddCXylVHqYomYw8qbthBR5nLtUWlmBOj3vDCHr0V3wLE3w9QG5yxe3aONkQWPjruUkDmK9Vao9289OxlhYvMEIMNZY7I8Cz9GjrOFmLPjKC208t9L7QsaTwylCewS/brwibACdirJWIU6BGbi4x77GdLrrG/T\u002BDP4PtRllsETM5D41Q8DoPICq5paUeikd6vt6jAZJ1FK3JF8SjcWo8GD5tCV6g3P93jg6QCVuWZLE8dod6zROgx/rfh9h1a67AeY1qrXzk1d3jK3OH5QtWNrMTYvrixUsqzEVnwVki/iJjz4/OL7cwW6Clm6WcHOLziVElZgiz4bRCP\u002BE7fRSEvClNJBV7iAb73wtaOS2lirNmdDgH\u002BZgZr\u002Bnbi/PV\u002BNqIINt4TvjJdAFKLYb9VaiKnLEt0Qg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F0CFDEA9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "d3f2810b-4fcc-44a6-d234-a78526c7b5c7",
+        "x-ms-content-crc64": "XZJbm6Ekcxs=",
+        "x-ms-request-id": "16e8da9a-e01e-007b-2eb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16/test-blob-c838a3a9-5b7d-a985-a40b-4fc7b7da6767",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9de8bb2bc7e45fc7c28f55aa97ea86ab-3edcae0f5dfe187d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "193c6725-45cd-91e1-96d1-d044f3d41f37",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F0CBE7A1\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "193c6725-45cd-91e1-96d1-d044f3d41f37",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8db03-e01e-007b-0ab0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "vedKLb4ZoplKo1RiMBWfDVSlSJSrJgym\u002B3NgUKObqDPyoQnQkDqp5QFBAMKuRJRSjaqWWyiEA5faozFKuVL1rvogcI4Lz3wa/GOSaSVK\u002BLffDsL4BU0KbZ1x9e0IXyuvS1LHjdQFRr4ufF/F8plyj6p6a6uP/amsFgLwmdmPEZ034h3Tgmri2ccDyojuRXsE/2VCjvOAIE6oG3fSFKzlnmrCjRB8nw1Al5HjjDIgvtCH7JpzTYKpt8HOKmfzEMUbHSseK7hqiGBYAvdinZQch1ynSycRclHoGNZPrXSlTIbMyG4HApMXHGQ6GkuLRxktsqMLS8WdCavZNhLhG9vrsrVwltQlFYXJjy7C11cGXNG8IfrRmgHBLr7DLcyANQGJTmiWG7FFB50eQryX2jFT09lBJfngGRizrmgVYui4SVksOYjvcEAgdxlcs1hEKlONb1nyPhAIqDVP4mxIL6S1ZfljaqGpY2KYIK7fhGa/b4QUiPOOxQpIJJBTn47U10h1p01f4b\u002Bx4wz2WR5hKCTOkHLnNKaxJ6DuGkYQVcPUxElmatwYYI7FY6Tml2vs5/xshA8b7KOhw3\u002BtcMd5oY5IIpXV\u002B71Hti/kItEBy5A0AjNKpNGzudelxKddavDHS8EWnXXVF\u002Bs\u002BJM7gNsrSoPfveW2TL/28lWm9LzYV6ks/HdYP6i0bXutHC38C04IN0iSvbfGCMxzEWQgLGOe0KDqDoRnzw7XK1BuCTCN9usLmsFwSZn1avOq6SpAkD0YDk\u002BJFfzFpGg9v5JjV/\u002Bf4Rp9GJWeKosK9KOQuOHgkpcXUf7lBODuQfZVMooHkhL0DwgPx3uneePAgiFZNOuGXSz7TAYAutw5ktqjRPgBA2KMnK3Z0Msfb9gbIILDkQkKztVdCEYM81Qv1jSdBDDrw36\u002BzJg9rIhh39wt5ZZZegHNlHoio/ccg6lZrf6WfmunM2EABMRwzSJM/yxp4w290lw203O6yR\u002BHnkjy4AKJy11whrY1VXE9XMdX1aTKtqCfn9uiY6736GZBeGZ7ge0jwzPS9VhXiHjq\u002BXaoYvd6vOukV0Qm62uueJpP990Owd7aNBJw\u002B71IRBdiu2o0T4lyxr960yqk\u002BNvIIHi\u002BB5Cf2Deb0i7hCcUuXA8wxDP9di0Q2S0dl\u002B6wMTs6pNdAjkCCwt8ynHlakbj2SHcfdDSryqpPqSpnfkRE56DzqmTt7dHOsgFQytm3ukt0J0t7lLkCjtos9OEWH0Ca7bTYaudUCF6hTMY3VwPQl/Le71r4yVLn7RuKwPTsuJK8td0g31NkHB7s2kf2zzfaWFzyNy/poiBl8HnPyUdlsJQzdqEir7ijetM4D/MO7R3jrGSb/oFm1xe4vug=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16/test-blob-4bdba4fe-0265-c4a7-672d-b8ea017118ae",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d920b2915d3a81dee7499e2efba08e17-6badd3ef3364b0bd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "be60f149-9b8a-aefa-ee57-39793e6084c5",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F0CFDEA9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "be60f149-9b8a-aefa-ee57-39793e6084c5",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16e8db90-e01e-007b-0cb0-a3d31e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "tWYUteHJa/DWJa3qKBSuFyxljFXB1voGOLNthbMo41p8NHJ4nxghMlfKcVM\u002BLv7r8UKJX2HZ\u002BN5rDn0tXOY9rkJTbvOhNngTQ1r\u002B9mWnyAm1gpNwnoP4ozuTDJGb9NVwjMIQ6sAKSbvJdRwG2gJ5xEVzeNpSzA\u002B/W8q3DSnnd06Fjmmilt5JqjjYpylm8ck5GkhLKHz6HcCzUY71UzuR4v7NgUyZ1y1mKc2ieiXmWGkBfvPgm0/SinCp70VPU1f8RsQrmXB9n0Mb5f6vWKOazPkl9NRIsUau\u002Bvbb8OfoF9Z1pTNhu775hN6wxbZRIzLNDiJMKl\u002BDtJV9fJ55oa9bM80oObNvORE6LG/1mOuQXdbEDeHFm\u002Bx28vGe4z4ff\u002BIvVJLoKep/XtUQEf7vjRyq7R/HtZPOlpfgsUfB0VXSGqyMxkNYpzTsRa8LtInuhmTU8/YfWMpOYb77B3eivYx/PvdRYsbYUUXq2nDkwuEN8Sri7d1fs8LiPWWEXaC8SocjjHaSnSOd\u002B6KwNH1aap7d7RVNv9CuH4o1byVhVPOkLpDowTZre1QGRPE7rn5Eh9PGp2\u002BKb4q3dGzrXS3\u002BPKeuCwbscalocXLBRnrec3EM8OdRmqyDGr4FME3JgB4mBwhJjKJ4WBYpXjX9ySgP2AD732xGrKL6KvFH5kBcnvFUmj9ylefOk5jRKDt2hlGW9lhMzqCx4FplTmGxMXHVzcBEqC7pnUMYLEvUdYRmg6SgsPDoD89Qo7rkDEaFHGIn\u002B1t7Mt0irFgUNKFV3GrV/sq8EYCA7L3w8wV0BJD9khDprXkp61HGfQSX09su\u002B8ZPDg17yAvipg6diz/YrajIF6GRbC/xrBN59pN86Bniwvc/JfaCgcoEBgZri2AS7tBbz7w6nI\u002BWXmL6AdJ4Zr71u8hHmIiyRZXXjWUohSCyZwfCIBhcpyVoqMaTh4D3i6BIddCXylVHqYomYw8qbthBR5nLtUWlmBOj3vDCHr0V3wLE3w9QG5yxe3aONkQWPjruUkDmK9Vao9289OxlhYvMEIMNZY7I8Cz9GjrOFmLPjKC208t9L7QsaTwylCewS/brwibACdirJWIU6BGbi4x77GdLrrG/T\u002BDP4PtRllsETM5D41Q8DoPICq5paUeikd6vt6jAZJ1FK3JF8SjcWo8GD5tCV6g3P93jg6QCVuWZLE8dod6zROgx/rfh9h1a67AeY1qrXzk1d3jK3OH5QtWNrMTYvrixUsqzEVnwVki/iJjz4/OL7cwW6Clm6WcHOLziVElZgiz4bRCP\u002BE7fRSEvClNJBV7iAb73wtaOS2lirNmdDgH\u002BZgZr\u002Bnbi/PV\u002BNqIINt4TvjJdAFKLYb9VaiKnLEt0Qg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-845d5eb8-11f6-38ce-5ee0-c4d01bb2fb16?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-05996834d88cb241279d071a424167ef-ace8fec00ddcc995-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "01fbfa28-6173-7aad-93ac-90fa144abe7c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "01fbfa28-6173-7aad-93ac-90fa144abe7c",
+        "x-ms-request-id": "16e8dbb2-e01e-007b-29b0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "80524022",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,1024,10)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,1024,10)Async.json
@@ -1,0 +1,293 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-6701dc151b843cc0dafccb99ee4a88bd-08826e9cf6b0f9f2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d58d0e4b-84d7-ec42-d40e-30f309a81801",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F8F11912\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d58d0e4b-84d7-ec42-d40e-30f309a81801",
+        "x-ms-request-id": "6828f8bd-501e-009a-19b0-a30f5b000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3/test-blob-6d6290b8-1be7-7f11-b350-15280552e321",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-36aca34e1978d25ee8dbf0bc569682b2-faf3f3323e4a4912-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "5efa1786-83e6-dff6-72aa-e34db279a202",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F8FACE4D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5efa1786-83e6-dff6-72aa-e34db279a202",
+        "x-ms-request-id": "6828f921-501e-009a-78b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3/test-blob-5780f0ad-e735-911b-075f-ae2753660b87",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-bd6932f56f633f279bf67c378d57d3e2-e2d95809df84781a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "bea2a120-7f0c-f9a8-5947-1c84744b7ad2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F8FE2925\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bea2a120-7f0c-f9a8-5947-1c84744b7ad2",
+        "x-ms-request-id": "64d6e93d-401e-00a9-6eb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3/test-blob-6d6290b8-1be7-7f11-b350-15280552e321?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-ab8d299f9c3a877616f65eb829483c8d-5f17028827b08fd6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "112dd3cc-e4d7-37f5-8a9c-08a580ea482c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "8z0Q3ICZHzD9DiGGbxrmgioPRRgnwcvQddFlh23qK0xFjTTHQQegFNFQWifFlSHteCv8QyDyXzJxQGavM5fDEuLUQOHlH0EjbzFG1makC\u002BCveA5B7egsUi4CVQGg8eA6jUdF8FRAB1nq2dTurIjLzTSG/7uJgSX6qO6y48k/gn5RC0keXxqLbnC0VxMTPaalNojMGfElsQwiS0hmjSSQqldWnaE/rW4a\u002B5BK1CoR5mpHDa1AcmiMK1o9/BTSJeBLI6y8vaAFZYkash5g2tzhEWTdHoB2UDfuyXFGArFaR9Ww/rB9VSjKQqgkJsBKLFF9W\u002Bqv9Qdg1dN0zfQuvmLYv2pJsNssY7s8EtvXUil3pJwgyafGq1LNTyncCYcznIRFTGdWAHx1Ufcvc\u002BMsiIKq/ClXDfW7ERQYe2GxT1ozCHVXkgXCIaMgq3evljdvocamMgxe3I6OiTpSPoQbwwGd\u002B2tt1PZ86NuFN2J9DHrcqNqaCh1N1CvnyAjLb\u002BMeBed2EpvMAczPKkkx2aQsEX2/dZWqgLjjUCY/hgztsXj4ZjF6B/nfD6cNyuDTHPuHureLC/pOdIUvksJ0jXvA4njROHNzsgmD4GXtnbXXDzMruMtUYaV\u002BqvKsSnQ3aoIrTOhoAuOIEwitByuUYNfPV4KOSdWvbIDSU46Bx2eVTHXjwlDNbw1Qo6TDplp66koa3PLxqCGsfOBnla9VB0ygGLu2sJ6GAeh1PqYx7MUmWGlEZup0o6NUNkZvZdld\u002BpxYIo6ewzmrk9oKfGp7e48bQTxGEaBhLHUYYnlYFpsOF0MK2Mk2iJQvmNIPaic42Lu2VCSdF\u002Bn79vYZhWG/U30/\u002B2QncKLG5LinFnjOUsFO4Im\u002BocJ3cQBaDuLSHQIycERV0G7CEWcY73Br9QFwLKM1yqXYALG6yIpkzGK/9Ma2dKY0eYJSi84hprJSC3v/6eE/nVJcWm\u002BSmgjkXkQFWPuptYBaPLMh4j/Xt1r/aLwOZeOAgFZzWRo2od55bS2JG022qFX7pK0uHboThaIUkjJL1vhhhdekNVxmJJrVqHQSTZwNSL9nE8E1UWOcYNN3Ig6sLpc0KJV1EnL5lX8TWHVFATgGB0py48M3LDN0CNWI7gGLKXnd3SUGlzZNbn1BIvnuVl\u002BbcBvEOUrU/PthAQmdcKZ9hy/7aCMTAG8TJXVF9gk6hbF17X3mxu8vCeEppZUsr/3Ww5rJ8u48iHCrsRTUjgbxJntXJ4MplsE/y19C6VvZ5nV3bjJvcJPDOWQMOxXbWnraN34Z1Ih6rSzZiiaP\u002Bp4V0sqeXR/UgrXolO0eHFurZHHkZ7LcvxHt/cEFluZsND/G9mlKPP1aBrTIMUCaW5DQLQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F901D21D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "112dd3cc-e4d7-37f5-8a9c-08a580ea482c",
+        "x-ms-content-crc64": "Ik2WG0WDy3k=",
+        "x-ms-request-id": "6828f959-501e-009a-2cb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3/test-blob-5780f0ad-e735-911b-075f-ae2753660b87?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-575dccbc1b878e875d4d936c250ce4b1-ff90de4473f7cced-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a0b76f39-681e-a1fb-3032-1533038d69bf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "JbWqkus4ErmxX17O7M98X65YJvJhJ3OJYf0UjtFSojA0aMC2iqzavlaRip38N8j4tOHsAmrezP5BITHuJIPoX7wtmYMOxdUBfmicz5zVjSk0G9rvZaDGVpzCdWh77JnTqSvhzp5F6u4L64QCQvxha5QHuQip\u002BPkcZ0LnTFBshZHOyCZx9L6L7zHr5HobxBSfYAnUdDKRKbExxGdbXZ6en2byNHnV8HfVe8nWvhR/AaIuR\u002BtHmBFePJ91PzBXMJKTTEQUKZCbyXCS//hpumucssLELRayVwZUk/fZYLBGfks3Q3HPa9gSkn16tZkZ9YI02I1tkgN74PU\u002Bv5WYwWnAS4CsMnb6zUfqsZqYOKJtO550pYgj2OtIu2J7katCedAUumkYbMMLOQpFg\u002BBo46hT0IP3IxzhnHKVZHYUfjybpzjJhH04Vc/aaWt93VUK39i6J8EnS1W0Mx32gwhM97vOqtuon14qG3q0HLqwY74cioWeWld7c1ziFVFgQdLHjnKwrzN6YUB5jwxGcy6bA89f2fiCrZxjUjd/xokNytmo7Y5HALSLoihEJcpKNQAtRhGBAWfZRODVTFz8\u002B5u2a8QynYWgVAMb0zfQPYjSGR02UoB3jMlxz6mtcbNYj6eNjrkFF5d7jPIOZi0wCAZXAzM\u002BxakbPt/7wc7b8uJPw0OQQ6/PzAGGu8WNaSWbQcajVm6AGcr\u002BcU/aClbIn5kQv6PpoMVWiDYytwnjjdW5X38IOJxzzql5kdFf9MKqvhwrfamCsaEATM03TmHAGuR6IavWwGb9nPD5cA7z9pN0iPntuA8sNq3eB\u002BvOO4BHuHbt5dMX0/21LeC4iEGSDFU6w8Vo0mLUTur997h7L2FwsreXBhHAXbT7OIouc61rTPqWlHi63\u002BYUGJfpGdtFOf5/SNaJ\u002BgZEemYRbJnYpdo8kau\u002B5ZvptdPRg\u002B561kTYtv6LryvX4VH0URoRqXJMPHK8rIcwhlRjlpIDuHYXyaMhOLWbTPavZa9ZyZOB1wxghEd7vSq8qC\u002BqKBiY0yna3Ih273C8se98DUbX1r3B4r\u002BGojMvnAt4ZY\u002BF8CPeFpGGfuwKCuebpNNX/7Dj5dJy6EZYEjH1q0B8/YrhNsDLnva0UFfQttfY6/5f15xblX\u002B9EgjdhQRgkNKrjgxcuW0TjGC5L5R6ojFugCYzltSkIGgLIyO37hnyVMCEJCjLfDGQTEs8omXrQnDWbwTdLPr\u002BB22kUZZJW51HxtvU9X4JowT1okmJZ34DIOGz4X4UFCfFhhy6JiqbR/Ct9NuKFkzxzMwA6IqwdaDvoTG0lXofM7K0D29iT3zZWVtZ23OjeAmUwhSyEyucFBF8y4X55rF1jsAp1Qfdjw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F9041BBF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "a0b76f39-681e-a1fb-3032-1533038d69bf",
+        "x-ms-content-crc64": "nm\u002BrJqli4mk=",
+        "x-ms-request-id": "64d6e968-401e-00a9-14b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3/test-blob-6d6290b8-1be7-7f11-b350-15280552e321",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fc61330c730baaa6519232a8ce72bf40-6b355998023e51cc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "106b47a7-a732-6c0e-b136-7b29270c12df",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F901D21D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "106b47a7-a732-6c0e-b136-7b29270c12df",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6e9d6-401e-00a9-7eb0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "8z0Q3ICZHzD9DiGGbxrmgioPRRgnwcvQddFlh23qK0xFjTTHQQegFNFQWifFlSHteCv8QyDyXzJxQGavM5fDEuLUQOHlH0EjbzFG1makC\u002BCveA5B7egsUi4CVQGg8eA6jUdF8FRAB1nq2dTurIjLzTSG/7uJgSX6qO6y48k/gn5RC0keXxqLbnC0VxMTPaalNojMGfElsQwiS0hmjSSQqldWnaE/rW4a\u002B5BK1CoR5mpHDa1AcmiMK1o9/BTSJeBLI6y8vaAFZYkash5g2tzhEWTdHoB2UDfuyXFGArFaR9Ww/rB9VSjKQqgkJsBKLFF9W\u002Bqv9Qdg1dN0zfQuvmLYv2pJsNssY7s8EtvXUil3pJwgyafGq1LNTyncCYcznIRFTGdWAHx1Ufcvc\u002BMsiIKq/ClXDfW7ERQYe2GxT1ozCHVXkgXCIaMgq3evljdvocamMgxe3I6OiTpSPoQbwwGd\u002B2tt1PZ86NuFN2J9DHrcqNqaCh1N1CvnyAjLb\u002BMeBed2EpvMAczPKkkx2aQsEX2/dZWqgLjjUCY/hgztsXj4ZjF6B/nfD6cNyuDTHPuHureLC/pOdIUvksJ0jXvA4njROHNzsgmD4GXtnbXXDzMruMtUYaV\u002BqvKsSnQ3aoIrTOhoAuOIEwitByuUYNfPV4KOSdWvbIDSU46Bx2eVTHXjwlDNbw1Qo6TDplp66koa3PLxqCGsfOBnla9VB0ygGLu2sJ6GAeh1PqYx7MUmWGlEZup0o6NUNkZvZdld\u002BpxYIo6ewzmrk9oKfGp7e48bQTxGEaBhLHUYYnlYFpsOF0MK2Mk2iJQvmNIPaic42Lu2VCSdF\u002Bn79vYZhWG/U30/\u002B2QncKLG5LinFnjOUsFO4Im\u002BocJ3cQBaDuLSHQIycERV0G7CEWcY73Br9QFwLKM1yqXYALG6yIpkzGK/9Ma2dKY0eYJSi84hprJSC3v/6eE/nVJcWm\u002BSmgjkXkQFWPuptYBaPLMh4j/Xt1r/aLwOZeOAgFZzWRo2od55bS2JG022qFX7pK0uHboThaIUkjJL1vhhhdekNVxmJJrVqHQSTZwNSL9nE8E1UWOcYNN3Ig6sLpc0KJV1EnL5lX8TWHVFATgGB0py48M3LDN0CNWI7gGLKXnd3SUGlzZNbn1BIvnuVl\u002BbcBvEOUrU/PthAQmdcKZ9hy/7aCMTAG8TJXVF9gk6hbF17X3mxu8vCeEppZUsr/3Ww5rJ8u48iHCrsRTUjgbxJntXJ4MplsE/y19C6VvZ5nV3bjJvcJPDOWQMOxXbWnraN34Z1Ih6rSzZiiaP\u002Bp4V0sqeXR/UgrXolO0eHFurZHHkZ7LcvxHt/cEFluZsND/G9mlKPP1aBrTIMUCaW5DQLQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3/test-blob-5780f0ad-e735-911b-075f-ae2753660b87",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5027ed4d8c316f29f1fbcdd96ba78975-1da3ac4c25c015b3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bb8b9d94-5822-4d8c-ab54-a58ae5276788",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F9041BBF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "bb8b9d94-5822-4d8c-ab54-a58ae5276788",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6ea41-401e-00a9-60b0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "JbWqkus4ErmxX17O7M98X65YJvJhJ3OJYf0UjtFSojA0aMC2iqzavlaRip38N8j4tOHsAmrezP5BITHuJIPoX7wtmYMOxdUBfmicz5zVjSk0G9rvZaDGVpzCdWh77JnTqSvhzp5F6u4L64QCQvxha5QHuQip\u002BPkcZ0LnTFBshZHOyCZx9L6L7zHr5HobxBSfYAnUdDKRKbExxGdbXZ6en2byNHnV8HfVe8nWvhR/AaIuR\u002BtHmBFePJ91PzBXMJKTTEQUKZCbyXCS//hpumucssLELRayVwZUk/fZYLBGfks3Q3HPa9gSkn16tZkZ9YI02I1tkgN74PU\u002Bv5WYwWnAS4CsMnb6zUfqsZqYOKJtO550pYgj2OtIu2J7katCedAUumkYbMMLOQpFg\u002BBo46hT0IP3IxzhnHKVZHYUfjybpzjJhH04Vc/aaWt93VUK39i6J8EnS1W0Mx32gwhM97vOqtuon14qG3q0HLqwY74cioWeWld7c1ziFVFgQdLHjnKwrzN6YUB5jwxGcy6bA89f2fiCrZxjUjd/xokNytmo7Y5HALSLoihEJcpKNQAtRhGBAWfZRODVTFz8\u002B5u2a8QynYWgVAMb0zfQPYjSGR02UoB3jMlxz6mtcbNYj6eNjrkFF5d7jPIOZi0wCAZXAzM\u002BxakbPt/7wc7b8uJPw0OQQ6/PzAGGu8WNaSWbQcajVm6AGcr\u002BcU/aClbIn5kQv6PpoMVWiDYytwnjjdW5X38IOJxzzql5kdFf9MKqvhwrfamCsaEATM03TmHAGuR6IavWwGb9nPD5cA7z9pN0iPntuA8sNq3eB\u002BvOO4BHuHbt5dMX0/21LeC4iEGSDFU6w8Vo0mLUTur997h7L2FwsreXBhHAXbT7OIouc61rTPqWlHi63\u002BYUGJfpGdtFOf5/SNaJ\u002BgZEemYRbJnYpdo8kau\u002B5ZvptdPRg\u002B561kTYtv6LryvX4VH0URoRqXJMPHK8rIcwhlRjlpIDuHYXyaMhOLWbTPavZa9ZyZOB1wxghEd7vSq8qC\u002BqKBiY0yna3Ih273C8se98DUbX1r3B4r\u002BGojMvnAt4ZY\u002BF8CPeFpGGfuwKCuebpNNX/7Dj5dJy6EZYEjH1q0B8/YrhNsDLnva0UFfQttfY6/5f15xblX\u002B9EgjdhQRgkNKrjgxcuW0TjGC5L5R6ojFugCYzltSkIGgLIyO37hnyVMCEJCjLfDGQTEs8omXrQnDWbwTdLPr\u002BB22kUZZJW51HxtvU9X4JowT1okmJZ34DIOGz4X4UFCfFhhy6JiqbR/Ct9NuKFkzxzMwA6IqwdaDvoTG0lXofM7K0D29iT3zZWVtZ23OjeAmUwhSyEyucFBF8y4X55rF1jsAp1Qfdjw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-44650d03-4434-501b-04b4-f7cb66c3bcf3?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c4a1158597e7d644998a03a936d2df69-122f9c67cde44fba-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "8a947164-5780-f6bd-c98c-34fbf775f2f6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8a947164-5780-f6bd-c98c-34fbf775f2f6",
+        "x-ms-request-id": "64d6ea6e-401e-00a9-08b0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1963151572",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,2048,10).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,2048,10).json
@@ -1,0 +1,293 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-1158794aa70b0370c1264f6517fec510-514e003d5484a5cd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e8686b8-2354-d608-8416-b3cf1791ab2c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F1B82643\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9e8686b8-2354-d608-8416-b3cf1791ab2c",
+        "x-ms-request-id": "69fce97b-201e-0029-5bb0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68/test-blob-defbc779-8125-56e4-39ee-4575412312c5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-31bdf89895ef19e5230083cdb5a6514f-de8d2c15152a3708-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "78d891f4-d7ab-cd25-0944-0e7dea5f33cc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F1C00EEF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "78d891f4-d7ab-cd25-0944-0e7dea5f33cc",
+        "x-ms-request-id": "69fce9ac-201e-0029-04b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68/test-blob-5092792d-f1fd-de13-12ea-f7d395d4b24d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-199bcfb30220e38242f52d36d9c2c24b-7378ae5c97411f2a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "c4ef302b-ff6e-1ba4-0b08-352d1dca14f4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F1C31BB8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c4ef302b-ff6e-1ba4-0b08-352d1dca14f4",
+        "x-ms-request-id": "16e8e044-e01e-007b-39b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68/test-blob-defbc779-8125-56e4-39ee-4575412312c5?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-b13b6d00c83671a3fd7c61c859661d5e-a8febaac3636661f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ba513303-6e70-885d-022e-ca52aa8cfdfc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "mrmKf4DvtTaiL2Rm3ZOVYAPuoZ3/Wi6HsxzLOooRwWU8\u002BNqImZNEPsNbrs6MrQF\u002BVZbPpjIUTUCKAstjI3uskW7/KuW5DcZwqWPZpKxg\u002BwUbTOX0QRozJ6qa/ZfI4RtIrxxfjIMbxUjPX/zPOqmTKQbFR9eWuE9UzAI6Hw8vqMhHkfSQAW6CAIecJOIeZOwBBtSQAppEsffMC8CA4aY4oLczh6i0AyiYQ0dP\u002BZNsNWgVORg7nqUuA\u002BD9w/auAR7gY4Qr6txDTAOr\u002BL5T9LdjYNVXaqiO/QERBYPIt0Ay6kIobpUOQUuL0uwUj6Xn2g8omWMgVpZ2UmWCGuRZe5TDeQ58KoUiVB6KzJi7eW5bKit0oB3dEZOrshwvjCdmMldYURWXarCJBkRElon9utj3Ju\u002B55dp35mh60Hhp8sj3I5pBYyhZxL966prYmHsJrfdDOGU3rUx84WutHJk3IBN8TXLvvFewnmIwPvs/nk3scCOAJrljv3ZNxIK9rKcmQsmGXEsJGfGfk5oCB29RPEIdwKx2t/paGI38ovfV8vK7CvsxuUEC41Yx4ZIfYLgG\u002B4c/oOv7r4vPLEO9DHf6yqCoR/1zIIMAG91VRdVnO7fU9aZvllIGv1pvYY3\u002BRNbfNhbydhm7k9oEPoQOpWq1Z/CL6RfQizNOoYeiBL72AtcGdg6\u002BdcSeGWLLalfO\u002BBrwufqcclq/DqvjpNSSGY4cDTysCC9b9vIr7dC0BCDcgKltskrEWpB8Rmdj29DwDADTr10bIe/qlMIHcIWKCgqLByQqJGZEV7OsMMHI\u002BBshO\u002BHP4VTDwF65gx2IvekK8Ttd19SsxeeZj1epb/AtIZyn5TWkuim1yEbFcKFJu5rKoT6GayBGdXX5NlL8GVBui2GB4Ne0ZjcRqA\u002BN51RFUNO93s6yp7Z7YG\u002B/qoTXuK72V\u002BVAx9rCFjoHdMMRuI4hs\u002BZ\u002BPzuCu\u002BSqBn9n9LuyOu9hl5BvBYj4\u002BsiUqzLzaqjhnvedWHhyc5sAlcFbWiJ\u002BVDrTryD\u002Bsa1ehkRy7g\u002Bxt5zXhlbEFeF37iP0bnDHnZ\u002BmFVf4ILqH4\u002BxJP9Iz/4WLTt4kg9TLuT5YW8D8CUI9l\u002BilzNi4uZbhT6Jpe9UPQ\u002B6eaCCSohnL2lsYoMT5itmqDKjqjjOt05RHQzMyYj5pSRjRXqEiqvXO2fJ8nxnS58TIv28tJbS78ZSLS17lmHcdr1esJyw4h2GzG7RAMDR7dVtvaaPPPCRjFm0Mll\u002BW6EF6X\u002B/CJb\u002BYkDcNeQn/esBgD9UDdi/UTnMzSBG/K/EBHTJzxdFEuU\u002Bb1tlswcIaY5usrIaJknISphF8j9yu2WRGDFzXjLTvHFaGZ59VaIywGOV1En9qd4rAYR/Axypy7f10JrRmQtfnvZAwAyrSvD6Ey3b3OMbl25XRFyqVLlQsFHqh4ELYStYNjlTvOnNf7aTgPPyzerQ2j0oflCusUY48A\u002B\u002BwMNv8q4Cg6qpy9qEhcimFtPJXeJnGa1H3ubaqYDzGszaEr73I5JB7E5AKxJmo/SIBJp2b5ItV6cWKBPLK9YltrENrnMJsvNBi22QJvKa3TruUqTqfKs6qL8X3Pt\u002BdsR4HnBhWPWFflGnMOQgnTC0e0rU3NktPzYF0wG39dH7xxCpFAR\u002BOYRFaNRTQ0vDFg\u002BKY2GspZnvSuM\u002BW4XzzYSDr23Te4UoNkHCk3AA3fvqRrj2LZJsTx12ucklQ93\u002BUZ9P05Pd856KXikj6hIp6mznUBTM/aP2E2BMWL24AvZnwD3UtQ5kDFMeb89lTGEPTNNcQfPJMVf7VbwzkZbczls2vCXUUTFif0fBspHUjML/QQ/qW8EGmpLp2WNOMHq8PZ1wMpA7Ovud/cKsB4LGJsT5NFCK8nKaMCGW6nfSEErJBXT0ZF4ywAoQSF4CVpcMJ7aaVPwqNUsq2f5ypEyHz\u002B134wIN0cJmynBKdqYUm9mOhsa9O79KnswtyYpjwB\u002B5jHxwinORAlX0M46P476hEj4g4CGFxpQyLUQx4AQ0BwZQjOopoA1l\u002BYBwyQQsursRiLtMPt/\u002BM8noQlkvXyJNwCiEP1bUd24wuuadFPmMAXKNIFdM68QmVlkgPWGwOp5eIwTfqH9kPRVJG4P1XR7MXEDqoj7PANhgXej5tDYMfIBIPvHwsFjzJOc\u002BA8xEMPU6U\u002BEgyZhjjx4se0qWaoTfOJ8DqR4s26/r93lXjP0MHCzzw2BU67Ln6K/TxDUOXL5eYsstQIfXDXg1ONIjCAIdIFsdoqskilDsG8BuWRd22Za6\u002BS413tupHLHkH67gxOCttqPd8L4XNdh2QSjDZLRgwl87aBLT50F/dIX1PGqiD1bjvKZzmOjYp8NRw52y5bf9h11PpVzN3c9eXnw4Hflt1DXR46QR7SV2YsRTfienzI7N\u002B7kNUmX6EeLXFTpsoIXJ5\u002B9r3QIP65Y32UaYfl\u002BntpHtaiI8YIHP283BOtvvCb4\u002BhZo4P\u002B\u002BIvgwm1XkjYZeHM16ofzpjiYNpmAUwSrC\u002BSNOEWfTBa3qiYKgWGY8IqHo6Pgd5QoqD3vwW0qPqVHNfaIypmweewcfkCh6OTXP0YO\u002BK\u002BgypQQZFAH74rpjWuAg0urD\u002BYxFym3hDlThv9Y2IHm2wX15msieGYJaIphcrDU4SWZbC9f3eGF6Qaa/N2Q7tbIwrJlip0giJe/565fVlFIvqWZ/6yShz1kcD0kR7tIuLnzWK/\u002Br1ZIeKNX4DZzJlL1Ej439w=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F1C90E48\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "ba513303-6e70-885d-022e-ca52aa8cfdfc",
+        "x-ms-content-crc64": "JoTKwY2FrVQ=",
+        "x-ms-request-id": "16e8e067-e01e-007b-56b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68/test-blob-5092792d-f1fd-de13-12ea-f7d395d4b24d?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-7233b4b1db0a0b59069ee46db38ab1fe-df51b9c6e7024cff-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ea2a3a13-5978-0284-605c-654191526949",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "vKnZ7tMFaoDwBHHdvNKw94UnPTxFGyTqnBvEJqi81fRCBSojiNAmt\u002B\u002Bh8onuoh366VRPIbuil6CE7lK4QUPXNC58mranjG60AYZNpCma/Pn\u002Byj1UbbQ5oG6Jnpp\u002Bbnaryr5bcQhmUlzmmh81VPN36vFZuXcGg8Z5QvpIHu3TNpMPotprP4rxmHfgbdOVBEt7ErSpJLT/pEb34S8NHTRvEmOMJbIZC6pmaCD/JRXz5D2vzQs4KhLeEP2TdF1b43pDcFpvCN\u002BYYgcKQryU/38xA/3xXlAoN\u002BhRrhS1hZdMC4Smu7S6g9teFmsDLehVSRB\u002BYnBgaYUqGjlyHlrK49xvvTc47kTKdoAhkkflJQkA\u002B2QDNiMn7KH\u002Be6B6SGSBlDKOk3CxHVvMtOvvP9Y9RPUwciP2xqy4SNGVOXKkTy4bn/4UVpGYT90IN4I3N63LwTeqSdVBi82G1UueG\u002BTpKGW905/YKO1kmCNF7Y8qgRAkync7\u002BQVY2hQxjoFG\u002BTP5Hw8demQN8phJRrGy\u002B54\u002BXFQ6elFsri5fZfiLp5lsHp7vS85/DAesFtfe8bJTpd928jIsC3/hjXHgvRRrgkv/3CgTwq/Qvk9NjmR6jbx7DL8ZFLRmQBMeDr5cnk7yQJOL3xWKP\u002BMvpjPj3nwbZ/\u002B1ZbFVUm2XmJwV9LTwcyAAW03Q7q2m8czc6W6Ag2GWA6a/pzmdnO4l9Ed5dUsuPjIT4oMvSnhRDnPkeWj\u002BFhQ6f/AOMcvmYr5fqvpmLXyBras8baHeZ7gtbZnFuSOGJ90zPvZaIAxnLH/E0KB\u002B6uD3Y8u9wqhzWxc44MQxIamb2IMcM\u002B6FJ42e1EEhGpcXroK4zVZXyWQ0v\u002BPeIT9INQrWKPcdYbfycTw\u002BHu5nUUGAIDFBeVRTQw8e53MLpwVNVZ42S/Gf\u002Bk3LxlsaGap2zW6hXQENB7y2guXo/npE58o38MlPMQZQ4SXkdrP4OSpkqBoFaUoDQE7if8gLt/vSh96R4ijhJ5tnUHzbKJEIvkm6g1ZfPn1/M7B7bLI9RCkqEe7UZ1YBg4F/nRnOJxe82cB/UTSkc0hhEa94ZrrpKQtSsRaiNFfzuQDV4KFksQuYvpLxvvP1hZ6mclWniBzGlXMNe3YAGqVpjJc0z5Kn/WCj4Kcn92oYXSt4/MECSzDjDkotVjaVl6TtiDJcwLUL/3X1A6h0n54I9B1KiB7jZ0BnUMBIeaYpDkgDOW84vJx1bPxLDEiIbm\u002BsJGEYSg\u002BGCiDy9G/0w4XPy/VgcWUu0DiA1Bwhl1r43\u002BJRnFVEEcM5fS9PRccsgal3fEFSJ/0JfVQpmHbyZXLG\u002BhWNoycwirkyJvQ234txU1NyqRoYpbflSB4BG3lNRhi8iEqxn92CR/KHHwEI057It0QigLtXrVRep1sJLm9A5eDbeVZAwLR18GIokIa23HR/OGM0KsZcZdv2UveCeRiCRzogLVlHiPeQrI9ZLhzOqMvmifYLC7sZfxR6SW2883dJpklLla8bOK9spH03Aza/J6ksnO8idjt/B61FzD6J1LkXEIjSghMbylFGn2c94nvduyLDj1eHJi8OzI4B1mtx4tDEH/Ou7KSWENGe29fUQSQyZxEcxURikOlYxLaFGfTm1byWecOIL899LX\u002BF6EpYOYppz25aVR2MYY4JVijuEfbduAYaPchgqThCnpjE3aee/4osG0qFi4CfChc0ftmmjxyIqDBEPvzBCSU2F7aFx4Tna1adwvWsVyyGejOxLCtemw57PDR3WsGOahIkTnTJGkKSTRODCc0m3FADvsTIENz613yoCYpQcBGUDlfjhwi4vF/wHt8X25FAVWDjc5v9xlk1Knf3IRG4QtwC7vp1QlRISgFk2PH94vvqZ7QqbP11l0j\u002BrlyRwZpOONsCFe2XyhILmyiZme1nN0h7DLpdjdbfjFaxd5T3t4lmFp8V\u002B8wOU5yiHtDU2/5alnYUFbTg8aoFI4mW5lN9FOSeM4JOUTx7bbkdu28FCrFYVuEe46HUhiT0ENdDd21JJArsNqh7DEQ5maj7wzY7/xnYPY9xXjBCya1eWUFlOPZM1JZkGdQI3Uqd5En52cLuuRC\u002Bajnd2MXZqWz7HbIC1GCyru6f1uVEz2BF03rnSfDqb6Awps28b/zQi3BoDMCXmhDpRyvTT\u002BMreZrZlwRL8l97Ea0S0i6T9T/yzkp13MKgrjhp/QLFFiC9BSwy49f3hZkQ7PsShMjhVlHr4ICYtZ3XOOnL4fRdtvqNVcwBYBJo\u002B0mxZO/HjilviKew2TWfJU\u002BOWqrtK6OkszUAhC784PU/g\u002BU25lGtEKq/XFlMrN3F7TB8cgVnes\u002BmDbC6xgn6c6eycVZQaT7\u002B4UoALc9JVwdYO5b\u002Bf23v1wgVkNig80mgxOixmjqGdYTxfZG7Z00AXLWpYotz/PM6wplOOtllXu0AX2jmmL3M0cURDALbNHC6FTMj9pC\u002BLcj1d9ihODqrix\u002BjuwjkGcT43JDFYfDxXo4pkyWlQmdcQTGg8SDkK5mKZoDjOHho1vtvKhkA\u002BMvXBBlKd6QVBUm3RnnWQyikE7H3O/pvDiYVwb0pNhdOXElmyO0HmrT0dWE3K/H/kZPTyxdoCL3QaPXzNLXn7M4xaekvb3o7nHj9A8aZN\u002BI0Fi8qVmsA5VSMlWD3E2X\u002BDYiTBsIHzyEYmC6eawT3NzATvh6GvZViMIOUo9oaQ4kT//Y9BTEfLUYNEb49YnpQlV0v41VGd08=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F1C9F88E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "ea2a3a13-5978-0284-605c-654191526949",
+        "x-ms-content-crc64": "4a7JR578y70=",
+        "x-ms-request-id": "69fce9df-201e-0029-34b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68/test-blob-defbc779-8125-56e4-39ee-4575412312c5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-be6737820f7bff631ef3cbe17251f981-fd0cca835d3626bd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "703f4b7f-1362-a584-ef23-b9cc74293d39",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F1C90E48\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "703f4b7f-1362-a584-ef23-b9cc74293d39",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcea54-201e-0029-19b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "mrmKf4DvtTaiL2Rm3ZOVYAPuoZ3/Wi6HsxzLOooRwWU8\u002BNqImZNEPsNbrs6MrQF\u002BVZbPpjIUTUCKAstjI3uskW7/KuW5DcZwqWPZpKxg\u002BwUbTOX0QRozJ6qa/ZfI4RtIrxxfjIMbxUjPX/zPOqmTKQbFR9eWuE9UzAI6Hw8vqMhHkfSQAW6CAIecJOIeZOwBBtSQAppEsffMC8CA4aY4oLczh6i0AyiYQ0dP\u002BZNsNWgVORg7nqUuA\u002BD9w/auAR7gY4Qr6txDTAOr\u002BL5T9LdjYNVXaqiO/QERBYPIt0Ay6kIobpUOQUuL0uwUj6Xn2g8omWMgVpZ2UmWCGuRZe5TDeQ58KoUiVB6KzJi7eW5bKit0oB3dEZOrshwvjCdmMldYURWXarCJBkRElon9utj3Ju\u002B55dp35mh60Hhp8sj3I5pBYyhZxL966prYmHsJrfdDOGU3rUx84WutHJk3IBN8TXLvvFewnmIwPvs/nk3scCOAJrljv3ZNxIK9rKcmQsmGXEsJGfGfk5oCB29RPEIdwKx2t/paGI38ovfV8vK7CvsxuUEC41Yx4ZIfYLgG\u002B4c/oOv7r4vPLEO9DHf6yqCoR/1zIIMAG91VRdVnO7fU9aZvllIGv1pvYY3\u002BRNbfNhbydhm7k9oEPoQOpWq1Z/CL6RfQizNOoYeiBL72AtcGdg6\u002BdcSeGWLLalfO\u002BBrwufqcclq/DqvjpNSSGY4cDTysCC9b9vIr7dC0BCDcgKltskrEWpB8Rmdj29DwDADTr10bIe/qlMIHcIWKCgqLByQqJGZEV7OsMMHI\u002BBshO\u002BHP4VTDwF65gx2IvekK8Ttd19SsxeeZj1epb/AtIZyn5TWkuim1yEbFcKFJu5rKoT6GayBGdXX5NlL8GVBui2GB4Ne0ZjcRqA\u002BN51RFUNO93s6yp7Z7YG\u002B/qoTXuK72V\u002BVAx9rCFjoHdMMRuI4hs\u002BZ\u002BPzuCu\u002BSqBn9n9LuyOu9hl5BvBYj4\u002BsiUqzLzaqjhnvedWHhyc5sAlcFbWiJ\u002BVDrTryD\u002Bsa1ehkRy7g\u002Bxt5zXhlbEFeF37iP0bnDHnZ\u002BmFVf4ILqH4\u002BxJP9Iz/4WLTt4kg9TLuT5YW8D8CUI9l\u002BilzNi4uZbhT6Jpe9UPQ\u002B6eaCCSohnL2lsYoMT5itmqDKjqjjOt05RHQzMyYj5pSRjRXqEiqvXO2fJ8nxnS58TIv28tJbS78ZSLS17lmHcdr1esJyw4h2GzG7RAMDR7dVtvaaPPPCRjFm0Mll\u002BW6EF6X\u002B/CJb\u002BYkDcNeQn/esBgD9UDdi/UTnMzSBG/K/EBHTJzxdFEuU\u002Bb1tlswcIaY5usrIaJknISphF8j9yu2WRGDFzXjLTvHFaGZ59VaIywGOV1En9qd4rAYR/Axypy7f10JrRmQtfnvZAwAyrSvD6Ey3b3OMbl25XRFyqVLlQsFHqh4ELYStYNjlTvOnNf7aTgPPyzerQ2j0oflCusUY48A\u002B\u002BwMNv8q4Cg6qpy9qEhcimFtPJXeJnGa1H3ubaqYDzGszaEr73I5JB7E5AKxJmo/SIBJp2b5ItV6cWKBPLK9YltrENrnMJsvNBi22QJvKa3TruUqTqfKs6qL8X3Pt\u002BdsR4HnBhWPWFflGnMOQgnTC0e0rU3NktPzYF0wG39dH7xxCpFAR\u002BOYRFaNRTQ0vDFg\u002BKY2GspZnvSuM\u002BW4XzzYSDr23Te4UoNkHCk3AA3fvqRrj2LZJsTx12ucklQ93\u002BUZ9P05Pd856KXikj6hIp6mznUBTM/aP2E2BMWL24AvZnwD3UtQ5kDFMeb89lTGEPTNNcQfPJMVf7VbwzkZbczls2vCXUUTFif0fBspHUjML/QQ/qW8EGmpLp2WNOMHq8PZ1wMpA7Ovud/cKsB4LGJsT5NFCK8nKaMCGW6nfSEErJBXT0ZF4ywAoQSF4CVpcMJ7aaVPwqNUsq2f5ypEyHz\u002B134wIN0cJmynBKdqYUm9mOhsa9O79KnswtyYpjwB\u002B5jHxwinORAlX0M46P476hEj4g4CGFxpQyLUQx4AQ0BwZQjOopoA1l\u002BYBwyQQsursRiLtMPt/\u002BM8noQlkvXyJNwCiEP1bUd24wuuadFPmMAXKNIFdM68QmVlkgPWGwOp5eIwTfqH9kPRVJG4P1XR7MXEDqoj7PANhgXej5tDYMfIBIPvHwsFjzJOc\u002BA8xEMPU6U\u002BEgyZhjjx4se0qWaoTfOJ8DqR4s26/r93lXjP0MHCzzw2BU67Ln6K/TxDUOXL5eYsstQIfXDXg1ONIjCAIdIFsdoqskilDsG8BuWRd22Za6\u002BS413tupHLHkH67gxOCttqPd8L4XNdh2QSjDZLRgwl87aBLT50F/dIX1PGqiD1bjvKZzmOjYp8NRw52y5bf9h11PpVzN3c9eXnw4Hflt1DXR46QR7SV2YsRTfienzI7N\u002B7kNUmX6EeLXFTpsoIXJ5\u002B9r3QIP65Y32UaYfl\u002BntpHtaiI8YIHP283BOtvvCb4\u002BhZo4P\u002B\u002BIvgwm1XkjYZeHM16ofzpjiYNpmAUwSrC\u002BSNOEWfTBa3qiYKgWGY8IqHo6Pgd5QoqD3vwW0qPqVHNfaIypmweewcfkCh6OTXP0YO\u002BK\u002BgypQQZFAH74rpjWuAg0urD\u002BYxFym3hDlThv9Y2IHm2wX15msieGYJaIphcrDU4SWZbC9f3eGF6Qaa/N2Q7tbIwrJlip0giJe/565fVlFIvqWZ/6yShz1kcD0kR7tIuLnzWK/\u002Br1ZIeKNX4DZzJlL1Ej439w="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68/test-blob-5092792d-f1fd-de13-12ea-f7d395d4b24d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b45fa9a23b70814507928bf1db7cb881-d1292b17a9025db6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "46c26e21-f912-abe7-31f4-08422206b49e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F1C9F88E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "46c26e21-f912-abe7-31f4-08422206b49e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fceab8-201e-0029-73b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "vKnZ7tMFaoDwBHHdvNKw94UnPTxFGyTqnBvEJqi81fRCBSojiNAmt\u002B\u002Bh8onuoh366VRPIbuil6CE7lK4QUPXNC58mranjG60AYZNpCma/Pn\u002Byj1UbbQ5oG6Jnpp\u002Bbnaryr5bcQhmUlzmmh81VPN36vFZuXcGg8Z5QvpIHu3TNpMPotprP4rxmHfgbdOVBEt7ErSpJLT/pEb34S8NHTRvEmOMJbIZC6pmaCD/JRXz5D2vzQs4KhLeEP2TdF1b43pDcFpvCN\u002BYYgcKQryU/38xA/3xXlAoN\u002BhRrhS1hZdMC4Smu7S6g9teFmsDLehVSRB\u002BYnBgaYUqGjlyHlrK49xvvTc47kTKdoAhkkflJQkA\u002B2QDNiMn7KH\u002Be6B6SGSBlDKOk3CxHVvMtOvvP9Y9RPUwciP2xqy4SNGVOXKkTy4bn/4UVpGYT90IN4I3N63LwTeqSdVBi82G1UueG\u002BTpKGW905/YKO1kmCNF7Y8qgRAkync7\u002BQVY2hQxjoFG\u002BTP5Hw8demQN8phJRrGy\u002B54\u002BXFQ6elFsri5fZfiLp5lsHp7vS85/DAesFtfe8bJTpd928jIsC3/hjXHgvRRrgkv/3CgTwq/Qvk9NjmR6jbx7DL8ZFLRmQBMeDr5cnk7yQJOL3xWKP\u002BMvpjPj3nwbZ/\u002B1ZbFVUm2XmJwV9LTwcyAAW03Q7q2m8czc6W6Ag2GWA6a/pzmdnO4l9Ed5dUsuPjIT4oMvSnhRDnPkeWj\u002BFhQ6f/AOMcvmYr5fqvpmLXyBras8baHeZ7gtbZnFuSOGJ90zPvZaIAxnLH/E0KB\u002B6uD3Y8u9wqhzWxc44MQxIamb2IMcM\u002B6FJ42e1EEhGpcXroK4zVZXyWQ0v\u002BPeIT9INQrWKPcdYbfycTw\u002BHu5nUUGAIDFBeVRTQw8e53MLpwVNVZ42S/Gf\u002Bk3LxlsaGap2zW6hXQENB7y2guXo/npE58o38MlPMQZQ4SXkdrP4OSpkqBoFaUoDQE7if8gLt/vSh96R4ijhJ5tnUHzbKJEIvkm6g1ZfPn1/M7B7bLI9RCkqEe7UZ1YBg4F/nRnOJxe82cB/UTSkc0hhEa94ZrrpKQtSsRaiNFfzuQDV4KFksQuYvpLxvvP1hZ6mclWniBzGlXMNe3YAGqVpjJc0z5Kn/WCj4Kcn92oYXSt4/MECSzDjDkotVjaVl6TtiDJcwLUL/3X1A6h0n54I9B1KiB7jZ0BnUMBIeaYpDkgDOW84vJx1bPxLDEiIbm\u002BsJGEYSg\u002BGCiDy9G/0w4XPy/VgcWUu0DiA1Bwhl1r43\u002BJRnFVEEcM5fS9PRccsgal3fEFSJ/0JfVQpmHbyZXLG\u002BhWNoycwirkyJvQ234txU1NyqRoYpbflSB4BG3lNRhi8iEqxn92CR/KHHwEI057It0QigLtXrVRep1sJLm9A5eDbeVZAwLR18GIokIa23HR/OGM0KsZcZdv2UveCeRiCRzogLVlHiPeQrI9ZLhzOqMvmifYLC7sZfxR6SW2883dJpklLla8bOK9spH03Aza/J6ksnO8idjt/B61FzD6J1LkXEIjSghMbylFGn2c94nvduyLDj1eHJi8OzI4B1mtx4tDEH/Ou7KSWENGe29fUQSQyZxEcxURikOlYxLaFGfTm1byWecOIL899LX\u002BF6EpYOYppz25aVR2MYY4JVijuEfbduAYaPchgqThCnpjE3aee/4osG0qFi4CfChc0ftmmjxyIqDBEPvzBCSU2F7aFx4Tna1adwvWsVyyGejOxLCtemw57PDR3WsGOahIkTnTJGkKSTRODCc0m3FADvsTIENz613yoCYpQcBGUDlfjhwi4vF/wHt8X25FAVWDjc5v9xlk1Knf3IRG4QtwC7vp1QlRISgFk2PH94vvqZ7QqbP11l0j\u002BrlyRwZpOONsCFe2XyhILmyiZme1nN0h7DLpdjdbfjFaxd5T3t4lmFp8V\u002B8wOU5yiHtDU2/5alnYUFbTg8aoFI4mW5lN9FOSeM4JOUTx7bbkdu28FCrFYVuEe46HUhiT0ENdDd21JJArsNqh7DEQ5maj7wzY7/xnYPY9xXjBCya1eWUFlOPZM1JZkGdQI3Uqd5En52cLuuRC\u002Bajnd2MXZqWz7HbIC1GCyru6f1uVEz2BF03rnSfDqb6Awps28b/zQi3BoDMCXmhDpRyvTT\u002BMreZrZlwRL8l97Ea0S0i6T9T/yzkp13MKgrjhp/QLFFiC9BSwy49f3hZkQ7PsShMjhVlHr4ICYtZ3XOOnL4fRdtvqNVcwBYBJo\u002B0mxZO/HjilviKew2TWfJU\u002BOWqrtK6OkszUAhC784PU/g\u002BU25lGtEKq/XFlMrN3F7TB8cgVnes\u002BmDbC6xgn6c6eycVZQaT7\u002B4UoALc9JVwdYO5b\u002Bf23v1wgVkNig80mgxOixmjqGdYTxfZG7Z00AXLWpYotz/PM6wplOOtllXu0AX2jmmL3M0cURDALbNHC6FTMj9pC\u002BLcj1d9ihODqrix\u002BjuwjkGcT43JDFYfDxXo4pkyWlQmdcQTGg8SDkK5mKZoDjOHho1vtvKhkA\u002BMvXBBlKd6QVBUm3RnnWQyikE7H3O/pvDiYVwb0pNhdOXElmyO0HmrT0dWE3K/H/kZPTyxdoCL3QaPXzNLXn7M4xaekvb3o7nHj9A8aZN\u002BI0Fi8qVmsA5VSMlWD3E2X\u002BDYiTBsIHzyEYmC6eawT3NzATvh6GvZViMIOUo9oaQ4kT//Y9BTEfLUYNEb49YnpQlV0v41VGd08="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-24b7dd9f-27ba-5927-41fb-544ad7838f68?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8640c4816c7dd038b13b2f814d2f7706-c4760e35a9e118e7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "06aa05a1-f766-7826-bc47-657cacd61461",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "06aa05a1-f766-7826-bc47-657cacd61461",
+        "x-ms-request-id": "69fceade-201e-0029-14b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1065696819",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,2048,10)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(2,2048,10)Async.json
@@ -1,0 +1,293 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-3056902c465f6b3778f8663d68c2d11f-007b9cd22b868bfa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "bc3605ed-90de-e9b5-3456-14694f22d4d4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F9E76DD6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bc3605ed-90de-e9b5-3456-14694f22d4d4",
+        "x-ms-request-id": "993de586-d01e-0002-5fb0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b/test-blob-d23e2aed-3f1c-e8dd-7653-91019149ef7b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-b688e91aa8d54192e621b913bf4b7ccc-aa5ed378ccefc6c8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "046d9a29-e77e-f023-b9e3-665a50ac2f94",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F9F2506F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "046d9a29-e77e-f023-b9e3-665a50ac2f94",
+        "x-ms-request-id": "993de5ba-d01e-0002-0db0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b/test-blob-b3bbaffd-9e82-f23c-9203-b4cda759f4ce",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-798b77bfc09b28755da103087a0ddfbd-49f9ea7052cad853-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "76ea2acc-eaa6-254f-c250-12b35a5d0861",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F9F3AFCE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76ea2acc-eaa6-254f-c250-12b35a5d0861",
+        "x-ms-request-id": "64d6ee97-401e-00a9-54b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b/test-blob-b3bbaffd-9e82-f23c-9203-b4cda759f4ce?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-91862b927f5e97c079a51144314bb6c0-7a491820ff75dc1d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9e72c7ec-e2cf-cb9f-4f4b-0da9dc8a610b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "ximn2feBsGlj8PReDAiEa76HvoKGJiGduMFS\u002BSpEINgzILanVUOlGo7wWFHZ1o3tN06SmTP\u002BCZ8HCSE1L7Y\u002BHtAbK\u002BtR3BZ64aP0lc7PxOE0ZMLcsYekNBcXn0wicOvXsTmBvaqhm1o4GLeQCnPRN0U/Acv0YmxJdvbUOjzKWHG4HOSUTgc3k8lno5nPFCqjRWgG4m8f407MOEa0zGAdbsBG2O2PPeg\u002BCG0CjL7TeWLMMfXUw3UCmDmVxxXAg8ZoSjXZiDw9Ewd/yNoBHVaQ\u002Bb7k6JtqSapLRD\u002Bz\u002BnbTfYWnmUKI\u002BfEljh3tVPqaAHriBc5X3Jsq/QGKjkT8iRmRrEtVWYQUB//Nvll9ffSwsEPF0fWnfKDqfJtA/musKAUEXKiuRKf2zv3OiR1BrYAM2t0AN7gk6TCqa9zo0wmTIJVTeCBMAWuczwP32fKCqM8bNCONq/FN4HJ3BNnKDfr0OmiI7jRfv9hxZGi0LBA9KMMNzZ/lBnSkBpiu1f2S0cEIAp6J\u002Brqbu3RLG0eJmLNhOdsVvT9aDjTz4\u002Bibserb35OmrCpysy0JchIqmuotG23lTJshfROCrvRqlRbS/wqJbzyz4uyJ74auDEstMHRJxsh6tmRPuWF/I/02CB0WN3IIoCqteTiAW10Uc3DIVX1/IM9OV0ilOrbaNL7uU\u002Bdol9XYJI9JnEyP\u002BVoHOkbxt86AtudOyN8pYmZ00kV5kgh1rNub7zDuNoSDvl3unv9v6Xzwbp3/Gs/1rsEo1MkGFmdRkY5rVsidkX9jywmCO8RnBenJiSNrdpILpUBuxWG6fKj2nAxxBJO0Utwdm07Gc3P9wc/fPY1D5hv7X7CHL8sdqE9hi5\u002B39QBWFTZGTdpDRTLNcQOR2z4as7XxdaTiLCMR//P/ZOfTRczOiShW/JhBtxp9ub3IjM0QRtjpxoBcc\u002BgTNU7nROBK\u002BSw3w1EWxLYdsL2KZHJmSHMl7x0P6n5MchU/Q8ZKWXM5M8CQkMh7\u002BoIiyxbC0g51rezawVTCOw\u002Bu61A81oDv01ZKUDGy1biqqfWb7B5oiaAHypbZb5cedvew4qR4PyMCMvi/d4Hcw9c0MBhfJ07xRWGwNAzqFmS\u002BK9o5AfMTMmrRmbolqBEeKga/pT5/v06pv5xDyAoXFxuUAEyno8HjIP6ujY6Ty5xPkQoFKnElPmyLkEFW0GlfuoGekafFd4dF24RA0THAFfT/8zf/Eu2qb8LgGxJ/jFCUTtMN9Dr1ihmDv0/s5G07y3tNV90yX6iU9CHl5Vt0xU40rIJdsiC6CmgdfFKdvopUpVCWMjVyYe8reQAYD6W9DvoBtzjq3Rhbkkx0FeNW9jWXkT8K3pMYwUqTMjkfovvDX25XnAZSacc4O5/p/kwM1YLKgH5lsjBn6PbtVqveO/BRsLV0/lovRCd40aLzL8L9h1y3VCF9Xqw98LQPZBMcWv\u002BvmE6Xl9YomzxW7OGNc7kz8M9OJ\u002BbP01IINw2lH\u002BAUXHeiRJd0ZvCGjrnlJnHLsH373HRDzTMZ4MT8jl/IgntbQpBp6i4hv4reyJgs6a3gPIaQqkNs0I5EiWTSd9eQvQs\u002BiePgYsVO2RzpZQWa7PYXG1HZONc373IBJWHKT0eyTguM7mDJ/9rAQtEmgmqJqZxuu1yFt4Q0Bppx3zxkhInVNxf5Df2WThx3GPYGEW0HeHvEXJTrLJaGWOjGVyCeXL5HUUtTj5ye2Gw/Dp6OLfUtaWbAoCf16QqAc7QV0Pb72bw4vr8htOjfJYQnqx74\u002BCrzmO653byWUWdA0hzniQd2RDXiVW81C7V\u002B4Xqjzj7riHuJITcIQvsAoWxX4eHM\u002BJt8sGfoFaK7vY05O/tB8oIpVEqhXWfQbgI54rMC3SnTsujfJx7XA3PYzmSpzwYAvq/qLoyXK5ozq0JlrzPuuN9jZYkTYstkUVHXyI8DJ5/7OSMEGK\u002BdPIdNq3vcclQ/6hWERWl97Vzjhd06wGILMISjanUP6aAwxikCxbdPiN/9l955f\u002BE1fUzGIZLRYnskQnv3OAjeLwB1U39Aeyilk/3\u002BPSmEkbCibewpScgNX2Ot3YI7WE/WHmfdBCxi9QEkII2V0yVSoLDKVcsbteY4Z/Mbkp6laTuuJx7BpoyEP3jrBSg6eIs\u002BWz3ScQODu2mApZ04RmNjf7ZS5qsGkPkjRhVSMLC9/e9o3Tdg0vg3Kmy0QQDvS/kVh4Vx6JHfN8pDrivtMYq5wqit0GkrAqy\u002BGrw/UU/4M/scPagqTBVeiKVsHSTNSvnh\u002Bn5YQnqP6YTZs83VoOV6Snow0fPhj3aST0jEvuWH8dDCXVfRoPGAjFMkUJhHiOi/8tKpnXgFAGoHxfIyyyqfUcH8EkKOqKqJr0WfvT/eS8ZgBMwS3lRXvV3sytr/TcAphP7WSnalMEkoIO0zZUMrKXor0sZejHNtpFTlot7PiWKEdjhBBwBQutSC6b5mJFcawaBf03v5y/iKaaYhv45rWZaLru4K6SJ62xfy26K1BoD9y\u002BA9b7bniqs/tp1ZLvpFF5An23VoD9d\u002B5PdjBu9V1WIlJPStLenfpCRDyjKEIK0crcQRjSsKlLwJv4q/g4O76uE7NAoGmOmnRzdRJUSk\u002BsRKRlkqQ0c2GpA4pG5eICCgh\u002BBRSOyjFhXaaUXzuW53ZMXGdDwqkKaZBBl5zfN7SScWsZ1jU7HXpzBET9kCQ2EhwECol6vjdvY6uEPTKUghXyAe3AfRFBET780=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F9F9A265\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "9e72c7ec-e2cf-cb9f-4f4b-0da9dc8a610b",
+        "x-ms-content-crc64": "6me8kEnTVBM=",
+        "x-ms-request-id": "64d6eeb6-401e-00a9-6fb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b/test-blob-d23e2aed-3f1c-e8dd-7653-91019149ef7b?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-f4a472128037c5b2002d56b676133a93-a1f655edd4ba3942-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "258ebc41-b8c1-beee-8fb1-ce655a6e27be",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AIa87PbKqK4nTUWL/7RY6maZa6BnIVFO7UtAGYsPQR1ewgEKjAOEMwYMizVZsfPeqslnDe1UZ980bv\u002BqiY4jFwsoLD2zTV1jFDiZWpUb9TxYYW7BqDQwClsi1h4D2ql36XQqMYW2K11rA/i0ugxKGHnDUSggYW7X9yHhkHc/XzqPIXAg8cS2ojYRVqU7e1BO172lQIiBV4gFUzlj1JrlK6O\u002BJZibKSe1DK/xDwrJnHvRkri6mR\u002BxDsroGp6KU82cKyoBfFa3s66W8DTZj0d9PLa9kkHhK5KEDRbNsw6IKrnhVePgxx8lGd8KJKnq2H\u002BCat7nzcCMugCYfW9A6v\u002BfDcV79zpknXSXmHlh1gbomTSXSkgwoF34VZrjR0qw5C7fahbkb\u002BBFHs1pUDVGKuP5sOM6qJ\u002B3b2xogqGfgFUq57NKgmvwAypUUit7xlAnsiu26ZdmdTuPKPuqe\u002B0\u002BpZ54P2mB/Kh4Cay55lZzPKgcQNB26Ja9w3F3u1lwRYg8FayNAofnprWDPuDrrI/lG\u002BxTjjodyL0Hunv4CkFOCMMkfNGp5jkhNJoa86m10hbhkZ9tHLdNH0zvhUgL75t0NDYdxy\u002B\u002BPDWzMlmgA9UTUehlFnih4esL1l2EuWDxFkX\u002Bpb5zmAvmI1VpueperRx33DNfptgj0lNLEfDSOYLUwhsToV0WoLjdfvMiNycArSlBDN0skXBt29JrJ4caFOnTlffOSgy\u002BYTx6giflAJorSmPHkC2lpzCrpsaKq3gxw2oJT6IvMmIdgquhsQ9Ih9o3P90kUoO8Lu3HIqRFM7bDSb\u002B927H4/BgAqg6BBPYgYx7rUmubDXDmTSG1aA\u002B\u002B10/13WhQiqwpP0PEI6h1Oir3pr\u002BFWeBKKDxO1o6PQpQJQdO\u002BjCaO0NhywhMo1unHcRL3vsFQOX1uqrQrAbMdmfyvu\u002BHVtq4DadbmE5fNIVJSh2V8mITSuQhVUOJyYs4kVCgWeRoI8rpk9FTraSXmoIhi2HpOoQF33ALYf2XLkAYHwb5utqg3SpSrF6Mv5k/ib69ZEIpU1rInnpwYL3JUmGNO5Kdmd\u002BngKo7lo4ldR/Wz9hC1coB8susMRhgLHxohVn9A4QKne/fFeeX7bzMpyVamZDlinibj0jK8WjDR1Apzw0wJHWbzC3oY8PiagEO34n3BZLrhv7dZXQ/Q6iDG9KTbiKvmH6vws1m\u002BSq4tSFHuBXezEHBQkQSVsMBXIyBaUfxTv/eX0MPR0LFhI3QILBS94eWoE\u002BM0ivanUG/rmY84ZPiy2YlZVzS04j\u002B\u002B7m6PjYOsmUI7sT4YHzQB8H9U5jchKb57VVOLY4qw9DGjdZyIF8PrP/9M/LO6mrlUWGa0YPsHncWvEzgwIDa4irwNdKmYeNi8aKY41CwLwbuZNwoj\u002B5Q1m9jX2QOLuh7JlHH2rSUQvOCN\u002BPdVz8iYo1J8l\u002BkrlY8o19jRwJ/UMa6Ib0C6FROViXoqlQOd4MwQPjWxDiM0nf/izdVMPvtAuMZJzGCH3Y0\u002B5g1uAP\u002BLi/cMwYJqIyKKU9FB2Eg\u002BSUp/6d08VBNsiGCncicWxpwAV0LdQH141pWjvniORgVFAJ3C7xciTjfknzghwrD7c400QYAGYAnNBhNHmJWa3UFaYXGJU9aF3ggK\u002BaBEVxPkqErrWgWFP6CU9egD2rWhScL3xmE/cSC2rmJ4\u002B2ZoiK//Y/BKr4M81SHR9V3uggNSabDeTZCypTYqNKuiDEQ6K2w5A3fFV5k\u002Bu/A/bXzCyCxfJZG1ijseTb26IHrYmcndlsnxtH6MjBEWn5Kgcze5Z2x\u002BQ\u002BayhKExG7a5CzcfZiEnYtez0ROt0piAn\u002BupftmGALgOWVbiKhEnv5nH04Ha9zhweBFgBpVY0HBNMuW1h5zdMwp\u002BEA3LRTfFixF55v8XpaeyOAXIJvoitYjllPgscjj86qB2W\u002BcrpTPZmnqD3upwNow9A06XFA0QXFqF5bA/mBnZfPtfoErAh5PS7ot/nteddV5r727pZdWTZv\u002BMpsCCmgJhqmHvEZVBfHu7xCaBkb2D53BR06mq8BclzDpLNOHTT1SIHvR1rmPIKXLyLqCvEdRBCb5PMcZYtrpKyURb9kia6HXS\u002BXLJDjkMiao3t8J2dbtlCSoigx6NMGc6KuQfbTMpWEYr3RhhePqEQ6ccIf7401OJ9ewdeGRXRMgLjuNU7Bx2DV98S5ijA5EvnT92cQ9oQlaQlXdHC\u002BDh05lPVukXL1aLpROffIi75fJb7dok4NK5okyNxFalLwJ/mnf/VK2nGG3o68z7ycXO1bCE7B0FvPPGlbOciWv/5nURH\u002BEQu5FFs9VsO/QGvtmGvu6mIEPked2EOb75Co4C6AVX6qnkvRkePzhImYD\u002BwNfaFsp9WcUxLKYDjILSS6hGalLvr9MvogDUiOALm\u002BBdhXnnHvTEhI8/Jb0D4DGXS/SPAi8tDxADqnPJqNDlJpDFpgYJ6yy0guXDsIkVLMHPPTzse5mxL3Zo43SA\u002Bty/Wf8sPTkrjV/H24BJal6H7n2y\u002BmuT\u002Bav3FHePoQi4M4cIBFaK6O6Ho6/cJZ8ZZ8QX4fX2zv9xK2BUNSnCm\u002BxXDqf4QGYI/AWPKla7ttQL3qyyeL8TwmWIl9j2NrPFxQjChRb3ICZeD\u002BTvZ6OotXSLSFd8DyMsRExCb6mNEsZSymVO\u002BTG\u002BE72GVGjbI1rB4OJkau1bSLXllUDJtLB90P0dnJw\u002BWbxCzTWZ9ru6USDxgY8=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F9F89119\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "258ebc41-b8c1-beee-8fb1-ce655a6e27be",
+        "x-ms-content-crc64": "vVCuQqYfaJg=",
+        "x-ms-request-id": "993de5ce-d01e-0002-20b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b/test-blob-d23e2aed-3f1c-e8dd-7653-91019149ef7b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0eac6aad7cc7f532beb7b4a136a8f2d6-979083dc8b36ffcd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9279c137-89fb-e5ef-3a1e-ff19f9a444af",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F9F89119\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "9279c137-89fb-e5ef-3a1e-ff19f9a444af",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6ef31-401e-00a9-5ab0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "AIa87PbKqK4nTUWL/7RY6maZa6BnIVFO7UtAGYsPQR1ewgEKjAOEMwYMizVZsfPeqslnDe1UZ980bv\u002BqiY4jFwsoLD2zTV1jFDiZWpUb9TxYYW7BqDQwClsi1h4D2ql36XQqMYW2K11rA/i0ugxKGHnDUSggYW7X9yHhkHc/XzqPIXAg8cS2ojYRVqU7e1BO172lQIiBV4gFUzlj1JrlK6O\u002BJZibKSe1DK/xDwrJnHvRkri6mR\u002BxDsroGp6KU82cKyoBfFa3s66W8DTZj0d9PLa9kkHhK5KEDRbNsw6IKrnhVePgxx8lGd8KJKnq2H\u002BCat7nzcCMugCYfW9A6v\u002BfDcV79zpknXSXmHlh1gbomTSXSkgwoF34VZrjR0qw5C7fahbkb\u002BBFHs1pUDVGKuP5sOM6qJ\u002B3b2xogqGfgFUq57NKgmvwAypUUit7xlAnsiu26ZdmdTuPKPuqe\u002B0\u002BpZ54P2mB/Kh4Cay55lZzPKgcQNB26Ja9w3F3u1lwRYg8FayNAofnprWDPuDrrI/lG\u002BxTjjodyL0Hunv4CkFOCMMkfNGp5jkhNJoa86m10hbhkZ9tHLdNH0zvhUgL75t0NDYdxy\u002B\u002BPDWzMlmgA9UTUehlFnih4esL1l2EuWDxFkX\u002Bpb5zmAvmI1VpueperRx33DNfptgj0lNLEfDSOYLUwhsToV0WoLjdfvMiNycArSlBDN0skXBt29JrJ4caFOnTlffOSgy\u002BYTx6giflAJorSmPHkC2lpzCrpsaKq3gxw2oJT6IvMmIdgquhsQ9Ih9o3P90kUoO8Lu3HIqRFM7bDSb\u002B927H4/BgAqg6BBPYgYx7rUmubDXDmTSG1aA\u002B\u002B10/13WhQiqwpP0PEI6h1Oir3pr\u002BFWeBKKDxO1o6PQpQJQdO\u002BjCaO0NhywhMo1unHcRL3vsFQOX1uqrQrAbMdmfyvu\u002BHVtq4DadbmE5fNIVJSh2V8mITSuQhVUOJyYs4kVCgWeRoI8rpk9FTraSXmoIhi2HpOoQF33ALYf2XLkAYHwb5utqg3SpSrF6Mv5k/ib69ZEIpU1rInnpwYL3JUmGNO5Kdmd\u002BngKo7lo4ldR/Wz9hC1coB8susMRhgLHxohVn9A4QKne/fFeeX7bzMpyVamZDlinibj0jK8WjDR1Apzw0wJHWbzC3oY8PiagEO34n3BZLrhv7dZXQ/Q6iDG9KTbiKvmH6vws1m\u002BSq4tSFHuBXezEHBQkQSVsMBXIyBaUfxTv/eX0MPR0LFhI3QILBS94eWoE\u002BM0ivanUG/rmY84ZPiy2YlZVzS04j\u002B\u002B7m6PjYOsmUI7sT4YHzQB8H9U5jchKb57VVOLY4qw9DGjdZyIF8PrP/9M/LO6mrlUWGa0YPsHncWvEzgwIDa4irwNdKmYeNi8aKY41CwLwbuZNwoj\u002B5Q1m9jX2QOLuh7JlHH2rSUQvOCN\u002BPdVz8iYo1J8l\u002BkrlY8o19jRwJ/UMa6Ib0C6FROViXoqlQOd4MwQPjWxDiM0nf/izdVMPvtAuMZJzGCH3Y0\u002B5g1uAP\u002BLi/cMwYJqIyKKU9FB2Eg\u002BSUp/6d08VBNsiGCncicWxpwAV0LdQH141pWjvniORgVFAJ3C7xciTjfknzghwrD7c400QYAGYAnNBhNHmJWa3UFaYXGJU9aF3ggK\u002BaBEVxPkqErrWgWFP6CU9egD2rWhScL3xmE/cSC2rmJ4\u002B2ZoiK//Y/BKr4M81SHR9V3uggNSabDeTZCypTYqNKuiDEQ6K2w5A3fFV5k\u002Bu/A/bXzCyCxfJZG1ijseTb26IHrYmcndlsnxtH6MjBEWn5Kgcze5Z2x\u002BQ\u002BayhKExG7a5CzcfZiEnYtez0ROt0piAn\u002BupftmGALgOWVbiKhEnv5nH04Ha9zhweBFgBpVY0HBNMuW1h5zdMwp\u002BEA3LRTfFixF55v8XpaeyOAXIJvoitYjllPgscjj86qB2W\u002BcrpTPZmnqD3upwNow9A06XFA0QXFqF5bA/mBnZfPtfoErAh5PS7ot/nteddV5r727pZdWTZv\u002BMpsCCmgJhqmHvEZVBfHu7xCaBkb2D53BR06mq8BclzDpLNOHTT1SIHvR1rmPIKXLyLqCvEdRBCb5PMcZYtrpKyURb9kia6HXS\u002BXLJDjkMiao3t8J2dbtlCSoigx6NMGc6KuQfbTMpWEYr3RhhePqEQ6ccIf7401OJ9ewdeGRXRMgLjuNU7Bx2DV98S5ijA5EvnT92cQ9oQlaQlXdHC\u002BDh05lPVukXL1aLpROffIi75fJb7dok4NK5okyNxFalLwJ/mnf/VK2nGG3o68z7ycXO1bCE7B0FvPPGlbOciWv/5nURH\u002BEQu5FFs9VsO/QGvtmGvu6mIEPked2EOb75Co4C6AVX6qnkvRkePzhImYD\u002BwNfaFsp9WcUxLKYDjILSS6hGalLvr9MvogDUiOALm\u002BBdhXnnHvTEhI8/Jb0D4DGXS/SPAi8tDxADqnPJqNDlJpDFpgYJ6yy0guXDsIkVLMHPPTzse5mxL3Zo43SA\u002Bty/Wf8sPTkrjV/H24BJal6H7n2y\u002BmuT\u002Bav3FHePoQi4M4cIBFaK6O6Ho6/cJZ8ZZ8QX4fX2zv9xK2BUNSnCm\u002BxXDqf4QGYI/AWPKla7ttQL3qyyeL8TwmWIl9j2NrPFxQjChRb3ICZeD\u002BTvZ6OotXSLSFd8DyMsRExCb6mNEsZSymVO\u002BTG\u002BE72GVGjbI1rB4OJkau1bSLXllUDJtLB90P0dnJw\u002BWbxCzTWZ9ru6USDxgY8="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b/test-blob-b3bbaffd-9e82-f23c-9203-b4cda759f4ce",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-adfc962f95d2642f5c8771ff16cfbfb2-efc161f4bec2fd27-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b721f8e-ce11-3a0f-3bff-97ad15cc41ca",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F9F9A265\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "1b721f8e-ce11-3a0f-3bff-97ad15cc41ca",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "64d6efe9-401e-00a9-7fb0-a350f0000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "ximn2feBsGlj8PReDAiEa76HvoKGJiGduMFS\u002BSpEINgzILanVUOlGo7wWFHZ1o3tN06SmTP\u002BCZ8HCSE1L7Y\u002BHtAbK\u002BtR3BZ64aP0lc7PxOE0ZMLcsYekNBcXn0wicOvXsTmBvaqhm1o4GLeQCnPRN0U/Acv0YmxJdvbUOjzKWHG4HOSUTgc3k8lno5nPFCqjRWgG4m8f407MOEa0zGAdbsBG2O2PPeg\u002BCG0CjL7TeWLMMfXUw3UCmDmVxxXAg8ZoSjXZiDw9Ewd/yNoBHVaQ\u002Bb7k6JtqSapLRD\u002Bz\u002BnbTfYWnmUKI\u002BfEljh3tVPqaAHriBc5X3Jsq/QGKjkT8iRmRrEtVWYQUB//Nvll9ffSwsEPF0fWnfKDqfJtA/musKAUEXKiuRKf2zv3OiR1BrYAM2t0AN7gk6TCqa9zo0wmTIJVTeCBMAWuczwP32fKCqM8bNCONq/FN4HJ3BNnKDfr0OmiI7jRfv9hxZGi0LBA9KMMNzZ/lBnSkBpiu1f2S0cEIAp6J\u002Brqbu3RLG0eJmLNhOdsVvT9aDjTz4\u002Bibserb35OmrCpysy0JchIqmuotG23lTJshfROCrvRqlRbS/wqJbzyz4uyJ74auDEstMHRJxsh6tmRPuWF/I/02CB0WN3IIoCqteTiAW10Uc3DIVX1/IM9OV0ilOrbaNL7uU\u002Bdol9XYJI9JnEyP\u002BVoHOkbxt86AtudOyN8pYmZ00kV5kgh1rNub7zDuNoSDvl3unv9v6Xzwbp3/Gs/1rsEo1MkGFmdRkY5rVsidkX9jywmCO8RnBenJiSNrdpILpUBuxWG6fKj2nAxxBJO0Utwdm07Gc3P9wc/fPY1D5hv7X7CHL8sdqE9hi5\u002B39QBWFTZGTdpDRTLNcQOR2z4as7XxdaTiLCMR//P/ZOfTRczOiShW/JhBtxp9ub3IjM0QRtjpxoBcc\u002BgTNU7nROBK\u002BSw3w1EWxLYdsL2KZHJmSHMl7x0P6n5MchU/Q8ZKWXM5M8CQkMh7\u002BoIiyxbC0g51rezawVTCOw\u002Bu61A81oDv01ZKUDGy1biqqfWb7B5oiaAHypbZb5cedvew4qR4PyMCMvi/d4Hcw9c0MBhfJ07xRWGwNAzqFmS\u002BK9o5AfMTMmrRmbolqBEeKga/pT5/v06pv5xDyAoXFxuUAEyno8HjIP6ujY6Ty5xPkQoFKnElPmyLkEFW0GlfuoGekafFd4dF24RA0THAFfT/8zf/Eu2qb8LgGxJ/jFCUTtMN9Dr1ihmDv0/s5G07y3tNV90yX6iU9CHl5Vt0xU40rIJdsiC6CmgdfFKdvopUpVCWMjVyYe8reQAYD6W9DvoBtzjq3Rhbkkx0FeNW9jWXkT8K3pMYwUqTMjkfovvDX25XnAZSacc4O5/p/kwM1YLKgH5lsjBn6PbtVqveO/BRsLV0/lovRCd40aLzL8L9h1y3VCF9Xqw98LQPZBMcWv\u002BvmE6Xl9YomzxW7OGNc7kz8M9OJ\u002BbP01IINw2lH\u002BAUXHeiRJd0ZvCGjrnlJnHLsH373HRDzTMZ4MT8jl/IgntbQpBp6i4hv4reyJgs6a3gPIaQqkNs0I5EiWTSd9eQvQs\u002BiePgYsVO2RzpZQWa7PYXG1HZONc373IBJWHKT0eyTguM7mDJ/9rAQtEmgmqJqZxuu1yFt4Q0Bppx3zxkhInVNxf5Df2WThx3GPYGEW0HeHvEXJTrLJaGWOjGVyCeXL5HUUtTj5ye2Gw/Dp6OLfUtaWbAoCf16QqAc7QV0Pb72bw4vr8htOjfJYQnqx74\u002BCrzmO653byWUWdA0hzniQd2RDXiVW81C7V\u002B4Xqjzj7riHuJITcIQvsAoWxX4eHM\u002BJt8sGfoFaK7vY05O/tB8oIpVEqhXWfQbgI54rMC3SnTsujfJx7XA3PYzmSpzwYAvq/qLoyXK5ozq0JlrzPuuN9jZYkTYstkUVHXyI8DJ5/7OSMEGK\u002BdPIdNq3vcclQ/6hWERWl97Vzjhd06wGILMISjanUP6aAwxikCxbdPiN/9l955f\u002BE1fUzGIZLRYnskQnv3OAjeLwB1U39Aeyilk/3\u002BPSmEkbCibewpScgNX2Ot3YI7WE/WHmfdBCxi9QEkII2V0yVSoLDKVcsbteY4Z/Mbkp6laTuuJx7BpoyEP3jrBSg6eIs\u002BWz3ScQODu2mApZ04RmNjf7ZS5qsGkPkjRhVSMLC9/e9o3Tdg0vg3Kmy0QQDvS/kVh4Vx6JHfN8pDrivtMYq5wqit0GkrAqy\u002BGrw/UU/4M/scPagqTBVeiKVsHSTNSvnh\u002Bn5YQnqP6YTZs83VoOV6Snow0fPhj3aST0jEvuWH8dDCXVfRoPGAjFMkUJhHiOi/8tKpnXgFAGoHxfIyyyqfUcH8EkKOqKqJr0WfvT/eS8ZgBMwS3lRXvV3sytr/TcAphP7WSnalMEkoIO0zZUMrKXor0sZejHNtpFTlot7PiWKEdjhBBwBQutSC6b5mJFcawaBf03v5y/iKaaYhv45rWZaLru4K6SJ62xfy26K1BoD9y\u002BA9b7bniqs/tp1ZLvpFF5An23VoD9d\u002B5PdjBu9V1WIlJPStLenfpCRDyjKEIK0crcQRjSsKlLwJv4q/g4O76uE7NAoGmOmnRzdRJUSk\u002BsRKRlkqQ0c2GpA4pG5eICCgh\u002BBRSOyjFhXaaUXzuW53ZMXGdDwqkKaZBBl5zfN7SScWsZ1jU7HXpzBET9kCQ2EhwECol6vjdvY6uEPTKUghXyAe3AfRFBET780="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-839738a5-ebd6-07f3-b09a-74a8b8b85b1b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a727aa2639e2b20a468306a6933a01d6-d112e42620c480c7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d98be40e-2932-ff9e-e1bb-9bbd1094c114",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d98be40e-2932-ff9e-e1bb-9bbd1094c114",
+        "x-ms-request-id": "64d6f00e-401e-00a9-20b0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "14862022",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,1024,10).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,1024,10).json
@@ -1,0 +1,745 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-03eba3052013fb9857ac8d9e950ac612-b4b5b6d21d87df79-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f00cae8b-2e34-6728-5a44-656cd50ac4dd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F109E7AC\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f00cae8b-2e34-6728-5a44-656cd50ac4dd",
+        "x-ms-request-id": "16e8dbd7-e01e-007b-4eb0-a3d31e000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-b81c2fd5-4dfe-b2d9-f778-65657c65b357",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9b4a55ada2b360e42be075f2207c2a67-95c2d68ec56806f5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "bec9fe12-4817-b23c-cfe0-9f6e7eb7f685",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F115DE19\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bec9fe12-4817-b23c-cfe0-9f6e7eb7f685",
+        "x-ms-request-id": "16e8dc1d-e01e-007b-0ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-da9045aa-986e-8263-42ef-c96c1bbc5e22",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-6e10854ca811028af4b68f61f504adc8-1b89c0766fe31ebc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "645a0715-d19a-67e6-c540-499f2aa548e3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F116A14E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "645a0715-d19a-67e6-c540-499f2aa548e3",
+        "x-ms-request-id": "64d6bae7-401e-00a9-5cb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-2fb0ed4e-0844-3eaf-d55a-f9bcc8c3eaf5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f10d2ff19f25cb522e0688546e076478-6bf2424609f708d2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "775997a7-915d-d3eb-212e-eca9043fe8b7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F1198712\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "775997a7-915d-d3eb-212e-eca9043fe8b7",
+        "x-ms-request-id": "6828bb94-501e-009a-7cb0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-8fc10e91-ea7a-3c6f-cc9a-750f836c963a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-5b4a606220e9173b54f86659578bd003-70fe3e7cc0ab0ea2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "93f75d44-d04c-9b86-d572-8d411b19bedf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11A4A49\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "93f75d44-d04c-9b86-d572-8d411b19bedf",
+        "x-ms-request-id": "146c1e07-a01e-0055-72b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-8e164319-84b4-a212-9552-04139fa7ba7f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-c336b8c89afc89413090871b3d01d599-94bb52484339a321-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "a765d200-5448-7c6a-a5c8-1f29fc55f129",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11BA9BF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a765d200-5448-7c6a-a5c8-1f29fc55f129",
+        "x-ms-request-id": "16e8dc44-e01e-007b-2db0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-b81c2fd5-4dfe-b2d9-f778-65657c65b357?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-50c581926de4aebca3aee84f6c43264a-49e8902c517d7b7b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4941d00e-16b4-7996-40b7-667de72621aa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "w76ihaxbQAz8H/kn5VucJd/2Cq\u002BRij5Km7IQQSFnD/WXm1DgBDXTqZPOENzVgH8i1j3LnJYL1zl/V\u002Bn6Sv/rlA8EkEkLvCCqImAbwnlidRoy7WrjnHJei8QWYK1L2F6U43zM0PA1FhodIHk28BS/HeHOx12UB/edpgSF9FtyXkoBht/9lqUq/dZQxXv4KJuvVkPLfBEBANuELyrrsCK/qsEvNGk1woc8pMqGQ0F7pH1p1Z0Xp\u002BI4/4YDeGZ6Pky0kRq6yfMxepS8jthHe7yZCYqsgtuEpwPf9zXjMkogwWV90bInwduKN1oJWxkJ8YPJaW/czrxwMOkX2tG\u002BTkhJm8xzyaoJckevIkuAekzq1QaxGcjbRPOoDKDJD\u002BcJzOkSv79MlifYv/YoLKxx8LWcLQTLDDR/blfZyrwKQGNfplZhbbqNnj/e2FrSsxhHNxzqLeLjPb\u002B1k1Fncsxqzn\u002BTyIZWD4L6Do/E7DPZrLs/kpKgHxKAfGiWrNppJitzdAnaP\u002BqR8Sia7x5THlGM2\u002BeVKOA5ya9sEksdv2OokehkUXgp/m3QraFqBi/zLV4XCdDy1P5KOapabi2fdDHE8V4278zYYtx6xHo/z8N/eOTsBrWTtbzqGRjOz5A/MTlvphTQvT6SPqfzeA\u002BDCmrn2vZIs217MTyiTNW0CpNMOpNA0Cmur7umWscOnzysZg6t5vSa937L9HTYLnFo3TQTpz58QzpBOCs7olilbJEA9eXGBiOeskIVdNu01oBJPXyT\u002B/j9MCPTbK7JXlUlJofj1zmLodYQdPT8Zs5ejGKr8WTbEnGYAsTC8pp11VPt705U0P5Gvpumg4YDAcpVdd9MHW3wShMVStR1yK88m56gDnZ/CrxjZDLJNY/rlQH6bX27Kbfm/KU7P4Yp0fXsaujnY/JT1Woj6Lg7JxSEKrXSelsxgHHnuhLQRMo1OZM83MqnAzIPppcSl0D\u002BqtWQthXQVlaau\u002Bl2AKjggpGg7a8l/kpK3SaDw9TEHukx6BA8P421ZOI9oSHhMAOJLyMFcqqR2ayLRtnvTZOB1pwARRiXo0MD6ojN51woaKwi\u002BZOwvqs\u002BoA5jsPizxhdOu8uF4evr8YvgAYghxPFPYt4tzFP/0RjwwaQJM/NKTyRxfiyRo4fANwcHz7wjHNwcFE4ahvnDTuqzlB9G4b6YlrFjsEXFvr9XbJVM9wFczKTI7R\u002BkL8kqrS9C3g9neVZJbzkKv2uWV1aPwxpkdlboVsd6ffOe82boOQMWguCv7/I/AojIUgw4MpXJFWyuxjbYWYdH7PxiqnvSIYZof9R239MnJXPOIAS6QUte1d36OXPMPShZaAL23FgN9TCG0LLAUjaYh6DCCjmCjA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11CBAE7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "4941d00e-16b4-7996-40b7-667de72621aa",
+        "x-ms-content-crc64": "GAKYY1Gx1aI=",
+        "x-ms-request-id": "993db600-d01e-0002-20b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-da9045aa-986e-8263-42ef-c96c1bbc5e22?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-071731345686726e2cbba2b5217e8d5d-432a11b2344cdbb9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2c1a5078-a813-c175-cf9d-8479ba5856e6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "qrAE1Z3Y5xOcQqwdd9ExSBvAK9M0cZidgqdistIJM\u002B/W21dF2IJvHElzM3AUNb/HVVinSQ6uVzkXZlL2djRAkw68Rpt562\u002BZUQ6KwT4oiUznm1x6YunhJ4MeLnIveaYVMqBhV\u002B8jTWroDvj/JJb6790GDtvXxjEk2x4YWr39addodY\u002BexjFdxE3ykVTx4gPtIz6UKWvKPWtvPHvQC/Kt6qUglq8GXCisqUqN5TXcM/kbKzd\u002BaT9snTcjLom1jLlaRKav0EtT5sYW6IAhPFg2kgmCteC7L4FltPh44i2e9hyQM6COLWOtyERwZ4C\u002BS2Hf7ZyAM9fZnxUkSRxT2wOYd/FjkAm3p2Sm1O2bSscAp2iXmPWRHsNFt5SLauRHWuxA1/CPWrtXJ0U42l7pPVRNI6Gzu0IOB1ktHdh1LD1/X3kAWnPXcUytP3GwWENlW3o/PUZCk5\u002BqMtCWYTzi4voIuXvk6eLhdbFVBXvRXa8VyMJeNe73PMvaViiiQBAPy112p57IgHKXXseU7Y4j2NQggZh6hKwMEXywCpO6PjWhRjodWrUQTEhPxtYmYk88t31Tgr93lEaxapYiGHbf3SCS8qZUBX0eEDRQK73V5a4tc1MVZrx1KbHzbPAf7jTRcOm1lG\u002Bo6LH/NHGKJ2mJ24To9aQjyXZkHMn0YJmM/yIAfrrUIFE/hIuhFTFK6wJIaZBsNviPrqdyUHemtIcYczVPiqivtbszqXAZgbREGjHGrPYIIMgpcNATYc/amNADiaL8\u002B2BambTVOI2IdSzzLTZF3weRD1JsJRnXm1PsWRCgFvgRSB/QbBNBM\u002Bg6ofukIDSYlLjIcnlQkNVHgv1h6d99518z4eUXdHP0T9xqMYQeM3seU8RX2KR\u002BwbdJieoV4EkIvbqccD5PgSBF1COc5l5RKU\u002BBQpUaJQ\u002B6tCAtzuuI3m6SYXPKgcI8z9KkEgSB4ttZ\u002BGCbk5207piq4bseIrI0vPW0CoTqhqeMRHPCdhMLOdJF09WL7UrQ3nPbH6AHHq0fb1UOzNhWbnG4Dk8q8XiFn6jo2U7cqc\u002Bq4ysRDmcGhSbGowa\u002B/Gz67mRk0t77puz7Vn/3HkRfQsaFZOmsRF8JsYkoZE5xxqM87erpeNbwrjw\u002BFrjnD2fhZmA/OJeCTqkFWiBV00KeiY/cuzBZdcrvlbWsbS6nIqIiRv3uMo4LuZ9B5B21m9v5oI0oC1M2iPGVT6Pi1eB7XTh\u002BMoxFsFYA0AGQGJGtOvnass2hfhZP674MWOLrKeS\u002BxobkN2hOtPA2JzpRpW9f5xWpCCIS2d8iL0bOOVdzFacd0VILyQKRi/7da1bb/UVPrHDNQiDBq\u002BynwgghgHqYwhKTM9QcVB4SGA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11CBAE7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "2c1a5078-a813-c175-cf9d-8479ba5856e6",
+        "x-ms-content-crc64": "qxd3sp8UaJk=",
+        "x-ms-request-id": "64d6bb12-401e-00a9-03b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-0cdbd405-cffb-64a8-7e73-62aa92a0ba68",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-0bfa53d0dbeec5c27d19cf0bf22c5fe9-a59747a77f977a08-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "960480d7-f40c-b297-942c-16531a1223a4",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11DF33B\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "960480d7-f40c-b297-942c-16531a1223a4",
+        "x-ms-request-id": "69fce5d9-201e-0029-0ab0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-2fb0ed4e-0844-3eaf-d55a-f9bcc8c3eaf5?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-e3f6f08c8260c6330ab1d564dc975ea2-ddd6a5a40ad50db7-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3aa2afe4-c053-c3da-51f2-fea5538b5532",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "fCQ1bohGMQF/jOam0oZcJWZjBvpvC4NEqUNIynEyWFK6KqSddn4fe9cgAO6yGz8M1q628BgYqXGg8MVE/maPTDSU66jiv6/oRIsiTgqVko0EO/PDe2c5ooEz/IW42n1wkbO5HjCXKRf\u002BzqyN9VpmC144QMJzy9HMWkgnr8IpL2kNsr1X23NcbBHcxK27rKwmzPEmgJq6/MXi7cPnb3pU1J9Cf0KdDi/r29OxlwcjEK2bAOLRAq7PU7X4dO2vdf2Xh\u002B8NeS1qib3BO6XGCWW\u002Bvt0WS26XgtLxciyMpZpCO2bWGg8XFZaAMXckEMcICEpQObUQmSmO/wQdHAYB3eQjfwA/8O9VpqhGlhn3cnIL6GniPGvkMqE8RxoK\u002BfiPf1STAZHGyRhb\u002B5MMyQMQl42SEjSdH6F5Pk1fAqjUSq2wthbEY3HhRB5Rh0DY2GidLLCNeObE8mCzGsJEZ8ZwhrDlXBPsSzMbsc4VS5dgoWbkwdb3R9LG68O2EUmund1Y4QCQ8ntVseF9cccYrqfIU3lcX6XveD7eHnBPNTnpbRPwvWqX0K7qjw/1etYKrjwc7r3QUj44aGjCsdMKBXunlAOzKPE8MYPKcc\u002BV\u002Bv1o03AzMkZ8GBvVuFQB1B7a4ImUTebSV4ZL4L06BeBuom1qWt1j1tM0K3vo3m\u002BcOlxk75FGAawXlXzq6FKJQRM7ZxXnlnpAdwm2XyJq6nkWrqVh1hZOKKDAU8Rhee6Aq\u002BlorXZataThI3iIj6GKraoD1DmtJ2v87D50JkO23/4bNrM4Aj0CvPkAgLKexpn/NqYZXaW00oR\u002Ba8A45Y9gK0N5bVjtUaptARdArKe4XiWlde\u002BdnIJZZmMvupd8ytdqoFVvJFlAEeX7rFyNdCXcxgybkm\u002Bfw47BHwb1vpcT8TdA1gxRSTnMZWQKoe8mzPE\u002BUvSK4TdnytzGrQRSSlNO6LslTJ4YinzSziwKlCGem1MVtmuiiA//2Qsvi5s1ehoRvLg0AIBTJch3txILXDW7JxKxPZPoq2CrJnKS6f/hnVMR\u002BdhoaprTwZGiK9D883zVdGOIgz2GKBFYiNoNwTzIlhq\u002B\u002BWNdUr143nsCRX\u002BPrjL2vHSbWBkWitDHEOG/xQBV2pW2PfkZeCKmEKXBhOORydqoFgTHLD0AqG\u002BSlkLbuBh7rGrq2HA43URS9Ed0VQbsNUYHF677ja1XtpWKhuLfy1iNRdd5pvBpbznAdTj1i1NopWD71KBpgB69kiLbrVZhcinv5w8uc49Wnad1Ohh1YStCIuGB4/e3I8W5uxPOjsLjXgIPBqREOjHRpTb49EUGRzH2mIt1348xOMNJdbd7iA/lkdsWZluH/uevsD7Avi9/snTi1/U2bQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11FA0A9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "3aa2afe4-c053-c3da-51f2-fea5538b5532",
+        "x-ms-content-crc64": "mWJlcb8IZaM=",
+        "x-ms-request-id": "6828bbc9-501e-009a-30b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-8fc10e91-ea7a-3c6f-cc9a-750f836c963a?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-c4822f412fe2f86ce1f1590035875b71-bf2316bf5724615a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6a6e6ee6-e970-1050-daf2-86d34f6fbbe6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "f3PdzeD6xXlWHCcTYmrw4dVvmqTGL1BxeZTKwkOYsRmvI1yiiI2mAyE1WiKYq8wVwpINZ1uSp1AibFRLMAI2vWsOYz4NTVlHyZaCkdQu2M7HtACxikm9HXwMfxw5WtMe/py2ikeOB3Q5xp7EDxZ79JOFhHsChDMhUEbCAc08DW7CY5I3d06GOa2Md8Sr\u002BA1lkIqJs9ZYHHpplDkBywWm/LkvAqyERH1F/0rOdgxvdlg5XHFDs1mXakcYzuIUhW2n5XsLe/Zh4UwNQ7SMiqZt\u002Bh7hx2\u002BUY0lfmJdla3WaMHndJpCRY/th2HolNW\u002BkC9\u002Bgq9PEM739E4Ixq\u002BNf/HXWchI6r2MV25YigO/0by3Zuoy3xMCi1v283xMOYLgXAtsETsJcaVx8is89obPNCKNUV/BXpze0NJwVfs9QB3reC30T7yBrfVAvOznwZDRK7tZvuQjHwFqkUBolR\u002BuMK4JVXpY1uhiC6dqfJ2v9w89oy5D54E5xF0ojb58GRTVlog\u002B2mwaeFTS97NAuJ5jvpoxKvXxak0s040dLEkp5fKOlOoVbRijJyrZcPPN\u002BQ\u002B\u002BxNMgTvIe5Cw/Egri\u002BUgLpQ3Asie0Tk19jgPPG/VZXtp9Ymd2BZb8b6y51l8RwC3ezc/iCUboCnqForzuU8g25bMwYZrgkZ96wEJ2\u002Bnvub83V7E4pd1GXlVfs8GbWEh/ghvCr4WKS/jgwa0kAcRAClzbzFGN\u002BDW5dnMhC8504oLIikneHQo5vRvIR\u002BQwIkyRH7l0v5vm8ZnWCTkCWTAqa98aW3eKYe1Ckg9FtaBRiUQmn/wVACL24Zi/\u002BBPRJ1PbrewFFdbFBq3MIi2MkTvphI/k68lEBVu8I2nuymnZcXq7ehfETGN9YYleSO4FakBc1nOD7Eual5iAWPJs1kwz8qCi0RckFTgcd3pP5cx9pskpgfP2RYUvIOKPM/NxAItNGlY9Uok5OLE7Z3TBSqHMEqIpQ1RYTa0rg7A0pOFEq2b/Att2QFQ/4Fkyut4QbdYwsyFRR7029NypEd7Y9JPf9swN0kfGVcJd\u002BVL7FYLfCxXp8\u002BHP82O5uA4O3T51ZvvFYsQSEouOel1e805qO99Z2ga47vCiEANoVBo5x4iT2JJXNbLOvPiaa4mUYPAVT4w\u002BtQMnzHgLI0Kwub5xRKLUyyq8AwYsix0eLoNnHa8TUwSeCxKFbBwaXBJgDgM6KRbmv6XFWUx2EinmGZ3klBWTrWa50zmAX18eoabzvI0Z1AVsgF4JTfm4F/j4n1J\u002BJcgMzGCcgEXtVmBWtqelgmWc3DWYiAO3ml9s8ctAl7AMoIve5uAsfVPPjzntsodSEoWDW8Mc1a20RSIBP456nL6wWhYrxptw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F1208AEB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "6a6e6ee6-e970-1050-daf2-86d34f6fbbe6",
+        "x-ms-content-crc64": "WfAHguJbyOg=",
+        "x-ms-request-id": "146c1e29-a01e-0055-0db0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-8e164319-84b4-a212-9552-04139fa7ba7f?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-0cf307c934d26b868dc76ab07f3eded6-17683f461fb4dff2-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e4be529c-eb1d-55c2-56ab-ed7f593b3bfc",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "VwXtHZCNnZ59ga3zW9O\u002Bzvyt4qob4bPdVE4nstWHEmW\u002Bod23RK/KTqa0o5JK9E33LTaktNq/nHVRD8lBZevI9W5HNLr1BolM45MEZz4hkmABL4Sf4l2L/wVoZTTmiOm7660kAr\u002BTAiatV9BGujQ3MH1oQDVmKRIQvDW1jaFVZVupSXyQ/Y\u002BhbS1e8ouMREXQMDS3fki0VMGbE0aK3XSFWPF1nXG4pjPtx9IHCDeHg3fv5F1snecS9PS69elIF5C52ZqZF6fTGIkBybZ2rEyJE4/PmvgXGLoKY6h8/bFJpLBBTi6d7mzPHMzTa9Qwm0ioMOFaeXyXosHfjrP/VxvYtyQGNF4d7CUi/34sQ6zl2cdg1MzQ7yszqqxtvV\u002B50MSx\u002B7SwKmfpi0S7N3r\u002Bal4U\u002BrXrnoNOB8j40oqyry7GaS65e0f4Na5gdkiIFLexNT9NWcOpzTJBYvPrt1fdN9sV9c5LRe8WHMUGiyc6xvMQR51KZFZrHJz8dxhUDH1Wgz9tch7pZu9QNzz9okIKB5wA2m\u002B6ktKEqdkyTs3Wwg9HsAfozFPVJ\u002BGt\u002BS0ZbnlZ8nB8UzIOnPBt6chFtxcienQttvI6ITpIK7OODJmkajtf2FxdWm7dORMXeuOLj3DKi3\u002B57LeHH9A1Myh\u002Bf5BXyH6M5t\u002B6xCAGUHzfI6dXvZtDxIAa636D17iLKCZFXrmDv7Jl/qmQD8desps7qPwp3XWNO7sPPd3/CA4mLpz5wPHDXGP08r/ysrS5uzjiSC\u002B8YkqxuCL\u002Bc4LVZfWaauArZfKpd0yYNOu2m4kGVoGkHMDeacxRRwjPxengH43JV0jUjVVGOdDjJC1e\u002BxyZ9xwBMEg1uwAU2R3p2rJjtxRe7ERAMsgrXePv\u002B0We80zrNc3M3\u002B5ElJtHwLQ4XF4egGwZAA/YWMVT1dNkRsC6debQ/aXlltgmGVep\u002BXEU8wGF0HvZhfI9E9wHeQob303ajErOZ1\u002B4OOmU8ua3L19TP\u002BHS33VF4fDzk\u002BnJ3RzNCjkJzmwnRYyizJiRRZILhuR8szooSQDYlatZ2tN171rNxuesrWDzLPlVMBLdtJxe5w0FTCnipME5MTnAzWu4Ldw9xH6qX9iEiIdB0xnu\u002BuEO\u002B/LGb6Mx6iEmc3snMl6NnAM1n\u002B8ds4g0gMOiodGoSjZXsdF48b05DNldhOtdXVUoszYWuFvx8Uhqku7fjklQfShFz4CMFatF/JMWvy6c1yNtee2akpLbZsCJDV/OWX2QDQbCGI3Vm52L0LvH2zEZzbvLcRRbteuWaWjAAwdMd6IWhbIn2b6VmN5PDsHWFIuObz\u002BjA\u002BhoNVcaLK4kFJiWP1kZsVV\u002B8vT8Ndg2C6YqwFXdMZTIqHS6rQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F122D482\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "e4be529c-eb1d-55c2-56ab-ed7f593b3bfc",
+        "x-ms-content-crc64": "XMzQU9lIWR4=",
+        "x-ms-request-id": "16e8dc79-e01e-007b-5cb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-0cdbd405-cffb-64a8-7e73-62aa92a0ba68?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-48a8521fc095b93d9141438df9278c6b-f3509650a3f70f2b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fc361b3b-d7b1-68c9-f31c-5d8290b6aa66",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "UFsMrRBxg0a5z2i9YzUQfUunzg8yKbDwa1lH4wTOluReAwUj5Ubsw1XwUdfBA/GoIRZ8AaWreyarG0K2KqBC6zmDXl8v7JcFugq6QdjZL2hnnsLtUZQ/s4jfd8kENZm0rmWdPaSSeTR/dkeb8DlN0uzZToveVJqkRKvXT3XOAYVwBZJzO/HD1SSNbdpNo8JOkaXcKucO1lnL\u002Bfn5uym/sHXCK\u002Bun2pf7FnlmUOe/V6DoiL7P8dedYi85p0L3yRr7zr1li3jXp7cO4RNtp4VyC6FYEDJr77\u002BdJMm7bTJVA0xea4IqWcsoEeEGwRDDMLuqxpugn7nokN79x2evGzmEud7HDzsDSLLWL/9RZC6v2vMOEaeWtGOTdtujLJJkefWnggcx/CB/pn3pym\u002B5liuvTu1zoQmS7QR6M5hgXxwfcbYJqeEnfd3Tjmoprerz2d\u002Bv892k8NjsFZQCt8mHHkdhyVi5sOxJiNEQoBKfaEAahlq5sGs\u002Be4HdHZRNJMUUS28jx\u002BOSOijzZWoMlFDGTaxU6DBuzm3bIk7X3JNY/GQL/FSie6Fdh0wxxksAMucwF9Do\u002BTuVpX0BR6SUu12VmmkGAZf8I9EL9mHkPQgi2/BnpsXDbwMpdlfXoDT8yMzumyvi\u002BjFPNPP\u002B3QLasGd032y0LRSY0itl3IpAJIOcDi2U9aHdQOC/F3LRxJIAT8XvYsHIR5u4VcgAfB6mDg9vYs7URbvGl56L9RWhxw6YZY3FUcHC1MeS25/Y3cTCGAljYWLEKwkKKcsiPFKFF466ZxeQ4L1NrY0GQmob7braydwMPWWs1DmDuyj2n5d1DMQQHnWtMThLFrTUveif7zwRSHN1edkpDpLdDCWVVw32kTalCs5ELZekwCew1xdQ5Mzs5Fcj/5Pq5w/jzyQStr6m3iuy\u002BeRtzRvc0LiyeDZ7jChZqXK20pGiuyO\u002BYF1ykgpoCvnrnevnfhc7Ri/aOG7ZZ0L8uQxM7wuZDz3Brmy\u002Baj6tSW49j\u002B89cSpbe4tiyIO15fkadtj9HBrtUo2tJdCqfdzwLe7/m9hTv0fi8XSANke6DMhzo/Nlry1TUD1hj0xasP2ucpqUtUohxreRGyumbRtG8xkHN9roin3Bq0qb8i/7iEB20cStJVd\u002BUtw81JQCreMhGpwyUnkjxecd0wn/hdSHlZPqL5tXmc3CiOT9rLXpvv5nedeTyDXGUwvcj1JNfswItT4BF35HyoHOcMqUJhkyNBQLmAz89M1eJNyQegl7dQoY9fd256d/H69VxFhqMS3xqls9QeW/C8BxovOit094U/u/fDAiu0xtjHldpzB08/Kuns\u002BuPjMkWOo2BEWz3Wdf3XFdq7X8z\u002B8Oz7VsYmSQ/Q==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F12433DD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "fc361b3b-d7b1-68c9-f31c-5d8290b6aa66",
+        "x-ms-content-crc64": "WTYjml7icKQ=",
+        "x-ms-request-id": "69fce60f-201e-0029-33b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-b81c2fd5-4dfe-b2d9-f778-65657c65b357",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-eb00671b1c5f677d1c735b0c215784d4-11d76fccbe88e561-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3e438c37-3e04-624b-73a4-635843fbd881",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11CBAE7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "3e438c37-3e04-624b-73a4-635843fbd881",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fce669-201e-0029-08b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "w76ihaxbQAz8H/kn5VucJd/2Cq\u002BRij5Km7IQQSFnD/WXm1DgBDXTqZPOENzVgH8i1j3LnJYL1zl/V\u002Bn6Sv/rlA8EkEkLvCCqImAbwnlidRoy7WrjnHJei8QWYK1L2F6U43zM0PA1FhodIHk28BS/HeHOx12UB/edpgSF9FtyXkoBht/9lqUq/dZQxXv4KJuvVkPLfBEBANuELyrrsCK/qsEvNGk1woc8pMqGQ0F7pH1p1Z0Xp\u002BI4/4YDeGZ6Pky0kRq6yfMxepS8jthHe7yZCYqsgtuEpwPf9zXjMkogwWV90bInwduKN1oJWxkJ8YPJaW/czrxwMOkX2tG\u002BTkhJm8xzyaoJckevIkuAekzq1QaxGcjbRPOoDKDJD\u002BcJzOkSv79MlifYv/YoLKxx8LWcLQTLDDR/blfZyrwKQGNfplZhbbqNnj/e2FrSsxhHNxzqLeLjPb\u002B1k1Fncsxqzn\u002BTyIZWD4L6Do/E7DPZrLs/kpKgHxKAfGiWrNppJitzdAnaP\u002BqR8Sia7x5THlGM2\u002BeVKOA5ya9sEksdv2OokehkUXgp/m3QraFqBi/zLV4XCdDy1P5KOapabi2fdDHE8V4278zYYtx6xHo/z8N/eOTsBrWTtbzqGRjOz5A/MTlvphTQvT6SPqfzeA\u002BDCmrn2vZIs217MTyiTNW0CpNMOpNA0Cmur7umWscOnzysZg6t5vSa937L9HTYLnFo3TQTpz58QzpBOCs7olilbJEA9eXGBiOeskIVdNu01oBJPXyT\u002B/j9MCPTbK7JXlUlJofj1zmLodYQdPT8Zs5ejGKr8WTbEnGYAsTC8pp11VPt705U0P5Gvpumg4YDAcpVdd9MHW3wShMVStR1yK88m56gDnZ/CrxjZDLJNY/rlQH6bX27Kbfm/KU7P4Yp0fXsaujnY/JT1Woj6Lg7JxSEKrXSelsxgHHnuhLQRMo1OZM83MqnAzIPppcSl0D\u002BqtWQthXQVlaau\u002Bl2AKjggpGg7a8l/kpK3SaDw9TEHukx6BA8P421ZOI9oSHhMAOJLyMFcqqR2ayLRtnvTZOB1pwARRiXo0MD6ojN51woaKwi\u002BZOwvqs\u002BoA5jsPizxhdOu8uF4evr8YvgAYghxPFPYt4tzFP/0RjwwaQJM/NKTyRxfiyRo4fANwcHz7wjHNwcFE4ahvnDTuqzlB9G4b6YlrFjsEXFvr9XbJVM9wFczKTI7R\u002BkL8kqrS9C3g9neVZJbzkKv2uWV1aPwxpkdlboVsd6ffOe82boOQMWguCv7/I/AojIUgw4MpXJFWyuxjbYWYdH7PxiqnvSIYZof9R239MnJXPOIAS6QUte1d36OXPMPShZaAL23FgN9TCG0LLAUjaYh6DCCjmCjA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-da9045aa-986e-8263-42ef-c96c1bbc5e22",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6fa88ae1001ada06f02a968841a0419d-313bf1811c077c56-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "034af8e1-6c73-9e61-85c2-ecc7fc9eb7da",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11CBAE7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "034af8e1-6c73-9e61-85c2-ecc7fc9eb7da",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fce6f2-201e-0029-09b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "qrAE1Z3Y5xOcQqwdd9ExSBvAK9M0cZidgqdistIJM\u002B/W21dF2IJvHElzM3AUNb/HVVinSQ6uVzkXZlL2djRAkw68Rpt562\u002BZUQ6KwT4oiUznm1x6YunhJ4MeLnIveaYVMqBhV\u002B8jTWroDvj/JJb6790GDtvXxjEk2x4YWr39addodY\u002BexjFdxE3ykVTx4gPtIz6UKWvKPWtvPHvQC/Kt6qUglq8GXCisqUqN5TXcM/kbKzd\u002BaT9snTcjLom1jLlaRKav0EtT5sYW6IAhPFg2kgmCteC7L4FltPh44i2e9hyQM6COLWOtyERwZ4C\u002BS2Hf7ZyAM9fZnxUkSRxT2wOYd/FjkAm3p2Sm1O2bSscAp2iXmPWRHsNFt5SLauRHWuxA1/CPWrtXJ0U42l7pPVRNI6Gzu0IOB1ktHdh1LD1/X3kAWnPXcUytP3GwWENlW3o/PUZCk5\u002BqMtCWYTzi4voIuXvk6eLhdbFVBXvRXa8VyMJeNe73PMvaViiiQBAPy112p57IgHKXXseU7Y4j2NQggZh6hKwMEXywCpO6PjWhRjodWrUQTEhPxtYmYk88t31Tgr93lEaxapYiGHbf3SCS8qZUBX0eEDRQK73V5a4tc1MVZrx1KbHzbPAf7jTRcOm1lG\u002Bo6LH/NHGKJ2mJ24To9aQjyXZkHMn0YJmM/yIAfrrUIFE/hIuhFTFK6wJIaZBsNviPrqdyUHemtIcYczVPiqivtbszqXAZgbREGjHGrPYIIMgpcNATYc/amNADiaL8\u002B2BambTVOI2IdSzzLTZF3weRD1JsJRnXm1PsWRCgFvgRSB/QbBNBM\u002Bg6ofukIDSYlLjIcnlQkNVHgv1h6d99518z4eUXdHP0T9xqMYQeM3seU8RX2KR\u002BwbdJieoV4EkIvbqccD5PgSBF1COc5l5RKU\u002BBQpUaJQ\u002B6tCAtzuuI3m6SYXPKgcI8z9KkEgSB4ttZ\u002BGCbk5207piq4bseIrI0vPW0CoTqhqeMRHPCdhMLOdJF09WL7UrQ3nPbH6AHHq0fb1UOzNhWbnG4Dk8q8XiFn6jo2U7cqc\u002Bq4ysRDmcGhSbGowa\u002B/Gz67mRk0t77puz7Vn/3HkRfQsaFZOmsRF8JsYkoZE5xxqM87erpeNbwrjw\u002BFrjnD2fhZmA/OJeCTqkFWiBV00KeiY/cuzBZdcrvlbWsbS6nIqIiRv3uMo4LuZ9B5B21m9v5oI0oC1M2iPGVT6Pi1eB7XTh\u002BMoxFsFYA0AGQGJGtOvnass2hfhZP674MWOLrKeS\u002BxobkN2hOtPA2JzpRpW9f5xWpCCIS2d8iL0bOOVdzFacd0VILyQKRi/7da1bb/UVPrHDNQiDBq\u002BynwgghgHqYwhKTM9QcVB4SGA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-2fb0ed4e-0844-3eaf-d55a-f9bcc8c3eaf5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-325926abd099ba4d9135b8226beef385-85bbb066fe53ff17-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4a76d95f-d5b0-530e-01dd-c40a262edf86",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F11FA0A9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "4a76d95f-d5b0-530e-01dd-c40a262edf86",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fce77a-201e-0029-05b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "fCQ1bohGMQF/jOam0oZcJWZjBvpvC4NEqUNIynEyWFK6KqSddn4fe9cgAO6yGz8M1q628BgYqXGg8MVE/maPTDSU66jiv6/oRIsiTgqVko0EO/PDe2c5ooEz/IW42n1wkbO5HjCXKRf\u002BzqyN9VpmC144QMJzy9HMWkgnr8IpL2kNsr1X23NcbBHcxK27rKwmzPEmgJq6/MXi7cPnb3pU1J9Cf0KdDi/r29OxlwcjEK2bAOLRAq7PU7X4dO2vdf2Xh\u002B8NeS1qib3BO6XGCWW\u002Bvt0WS26XgtLxciyMpZpCO2bWGg8XFZaAMXckEMcICEpQObUQmSmO/wQdHAYB3eQjfwA/8O9VpqhGlhn3cnIL6GniPGvkMqE8RxoK\u002BfiPf1STAZHGyRhb\u002B5MMyQMQl42SEjSdH6F5Pk1fAqjUSq2wthbEY3HhRB5Rh0DY2GidLLCNeObE8mCzGsJEZ8ZwhrDlXBPsSzMbsc4VS5dgoWbkwdb3R9LG68O2EUmund1Y4QCQ8ntVseF9cccYrqfIU3lcX6XveD7eHnBPNTnpbRPwvWqX0K7qjw/1etYKrjwc7r3QUj44aGjCsdMKBXunlAOzKPE8MYPKcc\u002BV\u002Bv1o03AzMkZ8GBvVuFQB1B7a4ImUTebSV4ZL4L06BeBuom1qWt1j1tM0K3vo3m\u002BcOlxk75FGAawXlXzq6FKJQRM7ZxXnlnpAdwm2XyJq6nkWrqVh1hZOKKDAU8Rhee6Aq\u002BlorXZataThI3iIj6GKraoD1DmtJ2v87D50JkO23/4bNrM4Aj0CvPkAgLKexpn/NqYZXaW00oR\u002Ba8A45Y9gK0N5bVjtUaptARdArKe4XiWlde\u002BdnIJZZmMvupd8ytdqoFVvJFlAEeX7rFyNdCXcxgybkm\u002Bfw47BHwb1vpcT8TdA1gxRSTnMZWQKoe8mzPE\u002BUvSK4TdnytzGrQRSSlNO6LslTJ4YinzSziwKlCGem1MVtmuiiA//2Qsvi5s1ehoRvLg0AIBTJch3txILXDW7JxKxPZPoq2CrJnKS6f/hnVMR\u002BdhoaprTwZGiK9D883zVdGOIgz2GKBFYiNoNwTzIlhq\u002B\u002BWNdUr143nsCRX\u002BPrjL2vHSbWBkWitDHEOG/xQBV2pW2PfkZeCKmEKXBhOORydqoFgTHLD0AqG\u002BSlkLbuBh7rGrq2HA43URS9Ed0VQbsNUYHF677ja1XtpWKhuLfy1iNRdd5pvBpbznAdTj1i1NopWD71KBpgB69kiLbrVZhcinv5w8uc49Wnad1Ohh1YStCIuGB4/e3I8W5uxPOjsLjXgIPBqREOjHRpTb49EUGRzH2mIt1348xOMNJdbd7iA/lkdsWZluH/uevsD7Avi9/snTi1/U2bQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-8fc10e91-ea7a-3c6f-cc9a-750f836c963a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c2dde235a97611247d01a9543b3e5c35-4afd3ca91a3c5c96-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2267908b-6c27-a729-1b9e-bf102a8dfd68",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:55 GMT",
+        "ETag": "\u00220x8DB71C7F1208AEB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "2267908b-6c27-a729-1b9e-bf102a8dfd68",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fce82e-201e-0029-2eb0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "f3PdzeD6xXlWHCcTYmrw4dVvmqTGL1BxeZTKwkOYsRmvI1yiiI2mAyE1WiKYq8wVwpINZ1uSp1AibFRLMAI2vWsOYz4NTVlHyZaCkdQu2M7HtACxikm9HXwMfxw5WtMe/py2ikeOB3Q5xp7EDxZ79JOFhHsChDMhUEbCAc08DW7CY5I3d06GOa2Md8Sr\u002BA1lkIqJs9ZYHHpplDkBywWm/LkvAqyERH1F/0rOdgxvdlg5XHFDs1mXakcYzuIUhW2n5XsLe/Zh4UwNQ7SMiqZt\u002Bh7hx2\u002BUY0lfmJdla3WaMHndJpCRY/th2HolNW\u002BkC9\u002Bgq9PEM739E4Ixq\u002BNf/HXWchI6r2MV25YigO/0by3Zuoy3xMCi1v283xMOYLgXAtsETsJcaVx8is89obPNCKNUV/BXpze0NJwVfs9QB3reC30T7yBrfVAvOznwZDRK7tZvuQjHwFqkUBolR\u002BuMK4JVXpY1uhiC6dqfJ2v9w89oy5D54E5xF0ojb58GRTVlog\u002B2mwaeFTS97NAuJ5jvpoxKvXxak0s040dLEkp5fKOlOoVbRijJyrZcPPN\u002BQ\u002B\u002BxNMgTvIe5Cw/Egri\u002BUgLpQ3Asie0Tk19jgPPG/VZXtp9Ymd2BZb8b6y51l8RwC3ezc/iCUboCnqForzuU8g25bMwYZrgkZ96wEJ2\u002Bnvub83V7E4pd1GXlVfs8GbWEh/ghvCr4WKS/jgwa0kAcRAClzbzFGN\u002BDW5dnMhC8504oLIikneHQo5vRvIR\u002BQwIkyRH7l0v5vm8ZnWCTkCWTAqa98aW3eKYe1Ckg9FtaBRiUQmn/wVACL24Zi/\u002BBPRJ1PbrewFFdbFBq3MIi2MkTvphI/k68lEBVu8I2nuymnZcXq7ehfETGN9YYleSO4FakBc1nOD7Eual5iAWPJs1kwz8qCi0RckFTgcd3pP5cx9pskpgfP2RYUvIOKPM/NxAItNGlY9Uok5OLE7Z3TBSqHMEqIpQ1RYTa0rg7A0pOFEq2b/Att2QFQ/4Fkyut4QbdYwsyFRR7029NypEd7Y9JPf9swN0kfGVcJd\u002BVL7FYLfCxXp8\u002BHP82O5uA4O3T51ZvvFYsQSEouOel1e805qO99Z2ga47vCiEANoVBo5x4iT2JJXNbLOvPiaa4mUYPAVT4w\u002BtQMnzHgLI0Kwub5xRKLUyyq8AwYsix0eLoNnHa8TUwSeCxKFbBwaXBJgDgM6KRbmv6XFWUx2EinmGZ3klBWTrWa50zmAX18eoabzvI0Z1AVsgF4JTfm4F/j4n1J\u002BJcgMzGCcgEXtVmBWtqelgmWc3DWYiAO3ml9s8ctAl7AMoIve5uAsfVPPjzntsodSEoWDW8Mc1a20RSIBP456nL6wWhYrxptw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-8e164319-84b4-a212-9552-04139fa7ba7f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5ee4bfcbbcd64f27fc3abc7ac6b2eeeb-1ce92256603c1139-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "967e2d57-bdc6-165f-2239-e685c58bc7d3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F122D482\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "967e2d57-bdc6-165f-2239-e685c58bc7d3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fce8bf-201e-0029-36b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "VwXtHZCNnZ59ga3zW9O\u002Bzvyt4qob4bPdVE4nstWHEmW\u002Bod23RK/KTqa0o5JK9E33LTaktNq/nHVRD8lBZevI9W5HNLr1BolM45MEZz4hkmABL4Sf4l2L/wVoZTTmiOm7660kAr\u002BTAiatV9BGujQ3MH1oQDVmKRIQvDW1jaFVZVupSXyQ/Y\u002BhbS1e8ouMREXQMDS3fki0VMGbE0aK3XSFWPF1nXG4pjPtx9IHCDeHg3fv5F1snecS9PS69elIF5C52ZqZF6fTGIkBybZ2rEyJE4/PmvgXGLoKY6h8/bFJpLBBTi6d7mzPHMzTa9Qwm0ioMOFaeXyXosHfjrP/VxvYtyQGNF4d7CUi/34sQ6zl2cdg1MzQ7yszqqxtvV\u002B50MSx\u002B7SwKmfpi0S7N3r\u002Bal4U\u002BrXrnoNOB8j40oqyry7GaS65e0f4Na5gdkiIFLexNT9NWcOpzTJBYvPrt1fdN9sV9c5LRe8WHMUGiyc6xvMQR51KZFZrHJz8dxhUDH1Wgz9tch7pZu9QNzz9okIKB5wA2m\u002B6ktKEqdkyTs3Wwg9HsAfozFPVJ\u002BGt\u002BS0ZbnlZ8nB8UzIOnPBt6chFtxcienQttvI6ITpIK7OODJmkajtf2FxdWm7dORMXeuOLj3DKi3\u002B57LeHH9A1Myh\u002Bf5BXyH6M5t\u002B6xCAGUHzfI6dXvZtDxIAa636D17iLKCZFXrmDv7Jl/qmQD8desps7qPwp3XWNO7sPPd3/CA4mLpz5wPHDXGP08r/ysrS5uzjiSC\u002B8YkqxuCL\u002Bc4LVZfWaauArZfKpd0yYNOu2m4kGVoGkHMDeacxRRwjPxengH43JV0jUjVVGOdDjJC1e\u002BxyZ9xwBMEg1uwAU2R3p2rJjtxRe7ERAMsgrXePv\u002B0We80zrNc3M3\u002B5ElJtHwLQ4XF4egGwZAA/YWMVT1dNkRsC6debQ/aXlltgmGVep\u002BXEU8wGF0HvZhfI9E9wHeQob303ajErOZ1\u002B4OOmU8ua3L19TP\u002BHS33VF4fDzk\u002BnJ3RzNCjkJzmwnRYyizJiRRZILhuR8szooSQDYlatZ2tN171rNxuesrWDzLPlVMBLdtJxe5w0FTCnipME5MTnAzWu4Ldw9xH6qX9iEiIdB0xnu\u002BuEO\u002B/LGb6Mx6iEmc3snMl6NnAM1n\u002B8ds4g0gMOiodGoSjZXsdF48b05DNldhOtdXVUoszYWuFvx8Uhqku7fjklQfShFz4CMFatF/JMWvy6c1yNtee2akpLbZsCJDV/OWX2QDQbCGI3Vm52L0LvH2zEZzbvLcRRbteuWaWjAAwdMd6IWhbIn2b6VmN5PDsHWFIuObz\u002BjA\u002BhoNVcaLK4kFJiWP1kZsVV\u002B8vT8Ndg2C6YqwFXdMZTIqHS6rQ=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998/test-blob-0cdbd405-cffb-64a8-7e73-62aa92a0ba68",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2eafb3f298b6d6b00f20582b024f0fed-e65e9011d449170b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fdb9559d-670e-cba1-3230-a8d54fb215b2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F12433DD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "fdb9559d-670e-cba1-3230-a8d54fb215b2",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fce934-201e-0029-1ab0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "UFsMrRBxg0a5z2i9YzUQfUunzg8yKbDwa1lH4wTOluReAwUj5Ubsw1XwUdfBA/GoIRZ8AaWreyarG0K2KqBC6zmDXl8v7JcFugq6QdjZL2hnnsLtUZQ/s4jfd8kENZm0rmWdPaSSeTR/dkeb8DlN0uzZToveVJqkRKvXT3XOAYVwBZJzO/HD1SSNbdpNo8JOkaXcKucO1lnL\u002Bfn5uym/sHXCK\u002Bun2pf7FnlmUOe/V6DoiL7P8dedYi85p0L3yRr7zr1li3jXp7cO4RNtp4VyC6FYEDJr77\u002BdJMm7bTJVA0xea4IqWcsoEeEGwRDDMLuqxpugn7nokN79x2evGzmEud7HDzsDSLLWL/9RZC6v2vMOEaeWtGOTdtujLJJkefWnggcx/CB/pn3pym\u002B5liuvTu1zoQmS7QR6M5hgXxwfcbYJqeEnfd3Tjmoprerz2d\u002Bv892k8NjsFZQCt8mHHkdhyVi5sOxJiNEQoBKfaEAahlq5sGs\u002Be4HdHZRNJMUUS28jx\u002BOSOijzZWoMlFDGTaxU6DBuzm3bIk7X3JNY/GQL/FSie6Fdh0wxxksAMucwF9Do\u002BTuVpX0BR6SUu12VmmkGAZf8I9EL9mHkPQgi2/BnpsXDbwMpdlfXoDT8yMzumyvi\u002BjFPNPP\u002B3QLasGd032y0LRSY0itl3IpAJIOcDi2U9aHdQOC/F3LRxJIAT8XvYsHIR5u4VcgAfB6mDg9vYs7URbvGl56L9RWhxw6YZY3FUcHC1MeS25/Y3cTCGAljYWLEKwkKKcsiPFKFF466ZxeQ4L1NrY0GQmob7braydwMPWWs1DmDuyj2n5d1DMQQHnWtMThLFrTUveif7zwRSHN1edkpDpLdDCWVVw32kTalCs5ELZekwCew1xdQ5Mzs5Fcj/5Pq5w/jzyQStr6m3iuy\u002BeRtzRvc0LiyeDZ7jChZqXK20pGiuyO\u002BYF1ykgpoCvnrnevnfhc7Ri/aOG7ZZ0L8uQxM7wuZDz3Brmy\u002Baj6tSW49j\u002B89cSpbe4tiyIO15fkadtj9HBrtUo2tJdCqfdzwLe7/m9hTv0fi8XSANke6DMhzo/Nlry1TUD1hj0xasP2ucpqUtUohxreRGyumbRtG8xkHN9roin3Bq0qb8i/7iEB20cStJVd\u002BUtw81JQCreMhGpwyUnkjxecd0wn/hdSHlZPqL5tXmc3CiOT9rLXpvv5nedeTyDXGUwvcj1JNfswItT4BF35HyoHOcMqUJhkyNBQLmAz89M1eJNyQegl7dQoY9fd256d/H69VxFhqMS3xqls9QeW/C8BxovOit094U/u/fDAiu0xtjHldpzB08/Kuns\u002BuPjMkWOo2BEWz3Wdf3XFdq7X8z\u002B8Oz7VsYmSQ/Q=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-93ac2033-4878-12ea-b86b-f41c887a8998?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9728e88fff21a91e51e169a0ea552482-90e51d96e5374a0f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "70e7cefa-cad2-c1c5-63b6-8d1f13b206a5",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "70e7cefa-cad2-c1c5-63b6-8d1f13b206a5",
+        "x-ms-request-id": "69fce950-201e-0029-33b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2013229847",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,1024,10)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,1024,10)Async.json
@@ -1,0 +1,745 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-df6dd104fdb983821c519b2a8548bc46-afa1d7847b4975a9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "cdbf1e21-a75b-4104-ffe4-a00423c81256",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F93F68B0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cdbf1e21-a75b-4104-ffe4-a00423c81256",
+        "x-ms-request-id": "64d6eaa5-401e-00a9-37b0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-f619bcfd-e8fa-d948-62e7-d4b80b2ddfc8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-460f5451f1548d9fede31604fe2665e5-6b5414131703d6fc-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "509a1282-ef8f-04b5-2ee6-841964f18be1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F946E769\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "509a1282-ef8f-04b5-2ee6-841964f18be1",
+        "x-ms-request-id": "64d6eae3-401e-00a9-6fb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-e1c64298-2d1f-8bf1-ee0f-a5693235377b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-018b23ae0551f33152a40066fc041bf2-894f9fbeb278b4e6-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "1d0f5ff8-ee42-5811-4e68-02388efbadb0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F94B2C76\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1d0f5ff8-ee42-5811-4e68-02388efbadb0",
+        "x-ms-request-id": "6828fb56-501e-009a-0ab0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-16045d28-6894-38a1-d5e6-6a74d34b35d1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-729975a0e71c49b6f2b02c9fef827504-a74778e692198b6d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "04218022-6de1-4f9f-5da6-0f8309af2aa2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F94ADE63\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "04218022-6de1-4f9f-5da6-0f8309af2aa2",
+        "x-ms-request-id": "69fd1845-201e-0029-39b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-e06cd704-3001-cf37-ca8e-08ea42dea62d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-00ff7ac745ae63d2349892bb475acf0c-f3de8a2e707a5b71-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "0d166d53-a8da-61cf-d9dd-78f3be506d7b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F94C8BCD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0d166d53-a8da-61cf-d9dd-78f3be506d7b",
+        "x-ms-request-id": "146c3cd1-a01e-0055-36b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-ae9058af-c829-3034-a18d-0b39c27db8a2",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-f31041b2f57206c7306d7bd47d8a38ed-fc892b679fa2397e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "9c2f5e8f-1c99-0dc7-2ee7-9c8e75766c3b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F94D00EF\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9c2f5e8f-1c99-0dc7-2ee7-9c8e75766c3b",
+        "x-ms-request-id": "64d6eb07-401e-00a9-0eb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-f619bcfd-e8fa-d948-62e7-d4b80b2ddfc8?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-0d94f334cfea31f13ee1cbf70a6bb5e6-d6ad356c5206da1a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5f6300ca-d020-9ae1-4966-146c029abfa0",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "Pz3Fe7uHqDyiOz90JP4MTdZmEG55TGNX3piH9Hwu0OuXFfqFtzznUisouI0YBdIoJ/4w\u002BaWGffPZbZ0iALO/dGpT3A8Dh5aZfr5DUZPVP9jFX81\u002B/tdFEZcHrEmexFJ3aEQixCnDJKBnlnrnQyxfAy3EXKHlQXWTDst3/NpM\u002Brpsy\u002BhPsnuvAjotFmhdXs1rp6gc2mixkSfOj7VeSyjFG5u/e3dDD1GyFVpmuCsNNbD9DFQyMCBRujnBgSLFUbcSZ/vMneJVKJhXacQOStn8wFoFYD/Tk\u002Bp7bsA\u002Bgo4u7MSiVFEvQZfNqOO828ZcQ3BgxcDIwPB3PtQQUS8iF6UJKHz/a/WHzH/DN7hbF7gjHipP3bzOZizUKxV9H/Bnq5E9srJKXNh62PlABYk4HCcb7DIF0jnpO8JQK0DgCqyPW4wnHWQG2cFR1ATDjWCjmw7tYTO\u002BYthXVHbv\u002BjGYms5Msar8Ef7DFRJws/40Ja5irI8x8ql50fizz8jtF9\u002BQuTo2d9u2pooQKksgTa7aIi/IjU2hZqck0uCxSUE11f4z4PnD/a7SqwYFIMhdWYNK2ayZJYmR7lKSEaT6BV1I2lRN7G21FiWB9eFHnEXex3hdZ3CVnK90ovGmMOsJ2KWpvUZ0EG0WlMKHGDCoSVENtEosnZ7ssz6k2Ep7DuU5dx07nt//arcLRtKtDYN/zFigmXyh3DoHvAkHzzcjmobcTqATbKtyDUmSIVbMP6W6JQzx23Rpl5riNOLV95uA6KtL0b/jbF\u002BtLYwzD7vjO3xkTKoqMb8Sc7YFMDjInRWuEjiqgG3l17isRK3oNYjf//hlcKrwVbbsOV4I3Twn5JB2hfyCOLoPfnXxfu0SKT0uJjA/Yyxqvb2CvkcP3Pp8hF8ccrCLXMc\u002BVvE1/9bI2Q8g2rYL6IFkC8c/AHlz/6J7dfmN9beMosppAQw6Nb7mueU37gJDcZveuGbpTFtNylZPuorcO\u002BRYlDfsoed0KdYIWEaUPBGgNwNdrzxRo1ZuHDe26no0CX4A3lnKVs\u002B0aY6P4PMVuY1Er4KGfoynB/HhfoWwvj9b1E7Ik1631eE0qUWuwcJiWWOpcTv3rYrxWNdo6NhKBKtPNAukTCUvjdmhUtVH\u002BUYufyUhBkwDYybE1jqGT\u002B0J6aWZXo22vQw\u002BeuRhVlu1ql\u002BROWmzKP1eS9Dl4HbqqD3smGgwrZu4d8EY44xoog3KDizb9RWDVcGnOxK90dyWU9KmdL7zhP3D2MGnmkRx9qnCGtFJDrIoaEKniHGI\u002B6bkgo\u002B6wi1O14kuFx1T3Lt8NkVo\u002BrcKTEUffQx7S/uLOtwbwhi0tzN8dEJIGvaV1YyHKlIsIAHu2jZKmkQg04yNow==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F94DEB25\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "5f6300ca-d020-9ae1-4966-146c029abfa0",
+        "x-ms-content-crc64": "f4yJzb0hxys=",
+        "x-ms-request-id": "16e912a2-e01e-007b-38b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-5a65d3da-57c9-f779-2634-4c065fb6f5f6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-ef009789cbc6e89bea33387051165c2f-d4c63f4399aaf968-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "74c40201-0c12-5a1a-950e-e10abff0b0aa",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F94EFC6E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "74c40201-0c12-5a1a-950e-e10abff0b0aa",
+        "x-ms-request-id": "993de290-d01e-0002-2bb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-16045d28-6894-38a1-d5e6-6a74d34b35d1?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-5bc1411d09ae1f84cc97e14ff502083f-12d61a4caf736415-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "7773041b-f533-3ad6-f701-80c250d26a41",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "C3b0yb0lLFx70hCaZmnTpyvPePypeFn16c9RhbM6cVzeZfhQBl/UYVm4l/J9cZH/Ji2Bp0GJ0ZMc/9/t1KapQGGzuwFwg6DL\u002Bhej8OBmd3g\u002BUl6GuckbVZNlMweA5oyyD1eRyrWQjqOMtqwp5eGztodnr4FHIoaXmGZtC1CYSxSK8eGJ1a3CrsO7\u002BgId8W\u002BysXx/GDYLau3Q\u002BTFOIoJT82uYn/T/KeHZpQG9jCiEeqb3u1nTGTLdf4bzuNt7c4tAZwaXhFF6soibpXM1Td3ETH\u002BLV2cpgNo4uiBtC3EFXjF1fCUi7fVUfAjRN3O/pzGpL2xc8BwkF\u002BcrXsoxDaYWlUdBwNC4ol\u002BJNtpeV0hneRLuxNwEqW0VUGU99o4rI29iuqIrfudh8IwN0rpBxr\u002BexOW3Q0jJEuvaLHBreqzQXhNq/J2mO/orjdRQ9tey04qlnzGpc98nmKi2UVJ29XbfPXSn18oi\u002BInqjLV0eRsUJ1jmxtt7J\u002BozQ2P08OqotJddcLljC/y/gqaovucpsx\u002BMoSn5kC\u002BbZBaJc5NmLgieQdcdFghisRxcJkQ00mgDCZBDaE7BryNowgyj2ZhoWFSeCX0QDJwXKfANnGrqZ5GthWkCI8W53ZKztFP7v9eD883vlcnr8/3zLD5dtBK5flt69VMuZTWO5CzqXFdIG2oYiaic\u002BtHIwpJsD/aGXCmA\u002BTb4gcmDVY6XYbCcAJamqxDTRStpHIOJsjPBwVY\u002BB4gDamMgUJqhlDMaBJkhK8L8xmPlsxf9Ftyzbs6WwpM3WFknmZUyhVp2MrD3ThfpaIdwxPvyWVRxBVSGbOLLC9Gf4qw/\u002BZEsyUAJb4BmBsfEyQVHJf6XRf8FtpRBrBl3qybeWGxrqW/1RPu76OrTCv\u002BMwaLdg\u002BXTB52sOkL96x0nkcNah65bWSCVUuED3FwVMauUtep2midBC1DOv28s91ndlFcmeYNRMGiCRzEE0CtBlgiXaTUysPecGXxdjZmwaVuIJUcF77goQ4SC81P2PDskjChmlI4jq\u002BNfiWAG86PO0d7VfKrkPKdQbyWxr72kptxBOQBwStTNZHljpWVYIk/hsyF1IL\u002BQQFCBFiVocvsmu\u002BODxLqiXocJCBcxgJdB\u002BE3Wz/ybL4Ycsfiw7zSuZfJ9PeqC1F2VPlWaaxeoX7\u002B5Px3YkaL/ioxdZhPC8W5SWqMks0OsvyPvQZCmAcNudFI4968W1tNQfrJeJG1K0kzmRxB0g6t8DH/66FARWIjI7vLBifq\u002BPITP1DSQTpq1pW5DwLqz\u002BfCmvOsvG\u002B2CPiUqlTZ7iElSJwqLpK53673lREPizpjOFfUBGswPjyCXTZYPZrlkOhwk8ZivJ1RCL9EuSteqnw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F9516D18\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "7773041b-f533-3ad6-f701-80c250d26a41",
+        "x-ms-content-crc64": "5cWLODNyDCY=",
+        "x-ms-request-id": "6828fb78-501e-009a-2ab0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-e1c64298-2d1f-8bf1-ee0f-a5693235377b?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-3b06721574dd5e98c90062b87dd6e31b-6a5ea6c0a10e7920-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "ce95aecb-e98c-1e3f-fce2-7a6aae76e26b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "3EA3GqLHfxHshXXCMU6KqID0IKlfGtss6OJqHO9boba6dxlUnXHkYtMaM3t5FwT7EJug3mvkRMJlCzHAXWIhkOS/CLo1NQsOD73WROdfs9HdbgxUusJK1TJX75I/IwVw\u002BaOWug5JxduPks\u002BtDgDaBldg4\u002B5WzNYidDOH3kZ5zuu4ZUpEyPjCk6gwxSjznccyfOk630AWGSzMc0XbwueUFcPj9ai1lj1fnU9FJQetL9drVWFdP\u002B\u002BroUsed1Sy59HAnK9kD6cefOWr20Hx0PMkH0Rub2yGN9bUN1Ndlx/prLZ9hIlYSR8vTdh8sWOuudBX\u002BVgQRHhkOmTYj9dUweTFwi\u002BKc0tqzNUkPiGTCoZzJn6CBZ7H2Gc\u002BGEolgLpH24z0tu80I0WF7S2C6wVW0DDeZWhZ0rtG/unHTFoBREwb3GOVn1SWPgM4/RdwROxi50caRxpR7gjQrbgFbdfqg6jhZw\u002BhwTHcRydlIdSk1bn8ZWQS5/0xyu5axPGckNArTXluj93dwCYWPv/z68w0LNf\u002BCQhy2JyrsJ0hR/0/QLdWOdRbNUbcH6Q9/Kn\u002BPd4hJpcanYfIuHXcw98/vHgp1/1InbH42PeRIuljNdvzrHK\u002B/yBlJaIvjYBffnFmnGMrFCSrtZ8tKU2giHqdZIOZ6RZsgbxYw7JbGBAwmVqFK4aGNyC2SPbSkdbSxJ0nkSj9xZRb\u002BRqm01ByUJ2P/JDzG1z0Fy1i4qEfmu/mhf4VM4bnM9PFKjFr32TQRPhZQ5RF36lAM3r7muLzO18rwE5RXRwWqMm8LvAqiDjJkp6pxlZaoKVV1P8M7Jjw0e7SQB4VfubbQ5vLiLG4FapCMgdESnUI0CCo/IgdCrswzFwCWEgZsxS4zYO7jxf0nL9VyrmRrId5yXD\u002BbYFdvjjfm7xVtrxhKH/zjHzxTUAIs2DJxz8BniDUiI/YGkWSWg9K3PNan\u002BUC86E6nh8KiHwv9rkhk/b53fycgC4tiQ05YDFsp3FNrRR6xtSexwAAygATqCSMccYZUf73vh631WqTAT3uneAK4kikp8wiWxb7m7YuGuDore9qU1ZyVe71w/FqCsXDEiwfCMbc58r59vXo\u002ByJoiLuJq1NNg0qJmIxZruPbuFBQOImJDhEZDMYlcF1gilrLjTo24F9xdY7hlnA6gjjmHj6ll8OZ3nqpb56NKBLtKQ0xjSGppNfx3sL7qHih34mNPlIeu/KXMq7AjXDA5Ex79GxiCPUWPXlms7gAnjYBB5AU/\u002BnAzm0amltz6BdnMfp1f7MLP9aUdwHYuAg6lpR3v4XgrORjuiX/R22ao1Rh/4K\u002Bih6C9ce6gIjo6BVl4ATG\u002BymShoUVEsWNDPho\u002BtStdrmGew==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F9516D18\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "ce95aecb-e98c-1e3f-fce2-7a6aae76e26b",
+        "x-ms-content-crc64": "x2R2rDpa6VI=",
+        "x-ms-request-id": "69fd189a-201e-0029-7db0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-e06cd704-3001-cf37-ca8e-08ea42dea62d?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-2871f2e00ca94f5f082206cbfceda5a2-34660bf22a9212bb-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "74894cab-fdb6-9330-9530-08d4caca2d50",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "cI1bgEB5bn1DmOr0VxdnhAOACia\u002B3P8e7aC/6/vhREntrSaBCjgjwK6nrv/FM/0qx0wqycyE4ZONPZOguoKCYVSgB6nx5nnLXEl3Fy4AWbqilSSvt3p8aMuS9M2lgwYsJEyrJCxUOOHSX2yDDMpkjeTY/iVd0qrZJJ7dXvGsJdlCS/LiVDSNTlxD3FgN\u002BVwBLWbpzIXhzlGh0QCNdtnvJjmTQMHYgjivSq/IGvZSzCtB3DGLwlhUYXygQIMzANeCVLYeeribKastOoHVGLRbTgXVTJqoZGTgPt5EOEK1e0rXRsY/NFJyprOGXYjWf0nIRPF\u002BXrM92vBSPTvaVvFoeL42/dLuHBqyY6XmIgbbCr6VfPNQNx2WmmzV7fYWl0/CHeXJn4J22SjWy/sOV7fpdjN8RNr9GECgoGNmGC8knMtWJAUhEmo8HqLLeWwhiEO07HbCmVN0xASkKP8eEMH5si4wtzKyyGTJQCY4MZ7TfxcgsSu4YQN34l8AfOlqHQ7g0sc98dEQAiQR\u002BVktO5Nl0ano/l6VQFEruNXSsUt7XyIXWF/XlY5GD68HpmepSqbMmqs/gR6vSpF1Ejj7PVHYlpo2FeMzjjsbou\u002BvjpnpgW0vBhafO90DaA3NYYNVStFdLhDNcjXCmAxwJN8v/7z4jJDKzDc6OVq8M6zWZiy3xVgdUWCJGw44bG0JLxf902hR1dXyin2aI/W1ED\u002BI6zLguF6HEa5cbnCCkl/KMQlCv19EhZBWxTvagy5q0wvPsIE6KXa5dsG59WZkcPgdz/LrclHgQ2ahifMirY6A8Zpls\u002BLejweSiUidipAq8VVCvLM8fmC572wamJ\u002BDlsgzOQPL/70WP0DqWekIQrnWd5ee4PDaQ3I6rMR2w/ZnD/J/alCMX/KXLH1zUSV2sKyyRCEI5bbYWPaQkVP4oHtJgkr3iNhoSRilBrRzZ/FNw/sXw3/VXyk7pxFa/M2fnosBKc/bfyfUSfoJYt8CZPAEQ85X4dz7dCIgu\u002BHGDk1KBmcocT4icUPTQnmEy/1KOUMhVrn/R72uBbSsu8NGDjutvlx32fKx4dGKg55jd6gl1YGepLeUS76peWuJdrZ/jTQ91g2h0l9Qb3XndMMeS44LhuVBqGmEGXOdzWCGJ2oaCvZqJaCbhAIhTTVCrNb7ii3dfvDRPuTKubyZAwX/yUcKzWrNtCbtcAHiIFo0QW2doUIyqal6ScwRn2vjAYD9IoTtON9rLdYH7w7u7h6KlXhP/GLCzR\u002Bdj4OeuxW6Cm6A5f3WRwmOMXRsKrqbi1uuhwnzlAUeO1VkT6hbzXHBTeWgbgggtE5uwMvtVaJlAgMo7zQLxnVoYamocfdhM2MCq93U\u002Bx1Sjg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F952F381\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "74894cab-fdb6-9330-9530-08d4caca2d50",
+        "x-ms-content-crc64": "yNp1a8aExuQ=",
+        "x-ms-request-id": "146c3cf1-a01e-0055-53b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-ae9058af-c829-3034-a18d-0b39c27db8a2?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-49bb1ed2d35ea0001bad67c2dcf4f747-191d970c3f36709e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "03168326-f548-9c8b-4bed-be55a7000cfe",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "0ruF1Dox5bL\u002BTaQz3T21hm83DF53QlYNjWfrqsWRB\u002BbVYWFQQaEuMMP2cqq8/4bF9VZkwxDzFo9kd0bTRTvsbUW\u002BXXvbZUXOCdyagdCsUY3hJrRvLEPV4UvS7MlaW\u002BuICQVk/qIK6ZAQlbo0WJW/uCa58R6HfUAC6HwwCXl7dK3xEnfKR1Lr1jwjXpaIoYi2EjOjoGnMAIzEYhUm2eAXlSENQ0Ud9XHTzhvhYx6qekfzevZF19NEJBLrBuU9xP1bDMh1e11CmB3Cz9JO65xtGujNMl/p0b1OyB8zMe6LlQkdhVdWNf7qsOHZgggA9jh2fuz9cJKdcjoLJrI\u002BD2cuNjnJMGVEF\u002BXp44J9EE61TdLmvbMCjiV3fxMcSg5Lq6F6q0vON8XSMWcHE40PIGHrVtngV1KzK6gUUbBSKMzWnTfhA2QD5xUNE4xL\u002B3uYZ1\u002BxMPQ1a1ROxn\u002BjuuYVgAiaMHZVLhz86G/D00PGZzAse\u002BpQoPfXoTLjkjzlXy0v95ODsMsFQjhDtEiFcZgQiF5Odz77xN8Rwo5DcpzgF4lBlNuwQrdlJzmxDeuvUjCZ0gndlujuMzOzce08wc\u002BcYp2\u002BQ9y9X0Wn6U8FSbb0YXBeqqCSAoChU2Cn/dDJKWZpFapN8A5T3HLDNq2Y6el8vxB93RcvCWAdHfB8FWJ13sDpnDQMpnBhC80tz8zSCGl2Kj3AS0tPOQtKMNMe18cQTlftr021cBmfG9JJAjqUShSGBeoltJJ1mmIpwXWdQjQGHYB05VgcwbkkIS94BTfRteW/mNHc65rEdxXqi66jAtmeQ\u002BW6IGW7akMwAJJj/JQrVwyQ3qpiKTLmr21DMTUKgB9W2sFRF5WAAy6Oq\u002BoHYXuAvzOiEyQuPBqz03D3eDgNJoBzDCHT2UB3D9p8035H3k7ywnIBaG37KJ2nnkMkiIr1gYVqlFRZreXzKwNJsWica/UiBbXFC70Sd\u002BSDLDr9UoZPhlL43Un5mBWNDjxpsnY1CjNNAoPVMHXHVx1w1YCq9dl8\u002BSoWo46sKGygN/yBqMVtTiEHsFADelbcMIUsicKU4xlj7bhMHmelodkXNPh5Rq5XAoZfokSIeX/UOnMIf5\u002BpDFTiHbsNITC6Yg9360ZdYurW1YY8NUDV2nM5d\u002BP0nCE5bSijlijzSeFWpEA1EY04dteIMqoZbdcUDUJH1KlMxsbuPX4euszB44uk5ZD/oMnmAAAMa2l2IABQjonlq3U3Cd55RtMPGrwLx04fdIdGFW15YdOoQFtcdx1\u002BzStC2zcVbdyxhVn11\u002BZEAKQbV6x4CXkcbEqijsiDHc\u002B2kE2QyOsXCgarlY8ThIntZD\u002B2QR9xBcOyJm/tct4TLmiJPkaYsw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:08 GMT",
+        "ETag": "\u00220x8DB71C7F953DDB8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "03168326-f548-9c8b-4bed-be55a7000cfe",
+        "x-ms-content-crc64": "FVBUDtcX/xA=",
+        "x-ms-request-id": "64d6eb22-401e-00a9-28b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-5a65d3da-57c9-f779-2634-4c065fb6f5f6?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-aa55a76965dcad83c31c772667a17d16-a11bcabda06b5a76-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "47ae8f6b-29b4-6207-a050-3d8eea35c32e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "N7gETaXNdOoI6MC1KojM3LBFioneonwplyeXZieKRUNUsAj\u002BPdLLOE7HHYcsvbSKYozZ\u002BbsP1ZU82rZ9NQ7DfqN9YHmAzp7eeVI7FoT1/dlzDASasUuHRdtywWIbTgJABJ/jrl06CpPt\u002Bn9p074QR9zcCSkJKMxX9RueDQw7witP\u002BhHkEU58OAJwrbbMHnEcYnqGP0TZNtzTjLlCnPyHsThUGdmsLDaOYNEmmXoWi9epgquStYPmdcQ1EYSVOpwG6fx\u002BdwSYbzZD995zs5xivADimBpQ9Pu0baQUdxqx\u002BSY0ILB9mBPSERJ1Tr2kc8In01SDs6KCtvQByQlgg/gbkv64PpLs5CTtD4YI2qU9EPrh7aTFLUWEsmq7fM4KcY4ZWby/7DQvOu4wlqMbettPw7gPfpZUVmW4NIwoMWdV4p747oDpfiPFsrK1lZaiaDeObLgV\u002BvP4xQNXBrinBgmG2rMFI4taZkWVSczjnsHOFstVmsWuQOir/yl9kXhrHqupLrrinUWrMwVzgLEmFSZCiPDsUmxD2JnLWiNi3dTNKSshOXAG63iGqWa/O782hOoDOwmHfss/ZlYgF0MhSVUxpVeGBdu2O513ZqgFhJzalNU4X6LLRapf4tMZ5dQ1ZGAQjZVosH8PTP9rEBgjOeK6RoJt6eqzZmCsJiIInFbIQgFI9PYHceNVKRKjXzWRPKjxX55Rx3t2XSc1u4pcB6\u002Bpo80X2kTrstSeGL/XDwcqGup6Fj23dnuF0pbP0bVZ\u002BSJi\u002BrtnemFjBazKsq67nk4fCqGf4vBy8ixSkQitHOEeRR\u002BddRVLw6CJFhGR7MPMyjNIr8cUuhYx8AePFOlYtunLq22PHik400YBFczf4QVohsfVZWwZCYoIbIQNvK63MGAnxUFWPKwJD9yAE6RKUg4CJ44hg1B8saHih7GkKheYSeRrtxvEEkkby1WQmfbmvhl1C5Ufla0PqhSfc7X6ZOTE6Mm/3pvzPhVFBrj77Bir/MiYLh\u002BCeLQ3XAwHJJ6UIWZwzLAsJt9\u002Bgsx/2o71E77783fsYTbFQW8ViIGP6xl2sOVRiyBnftXoGqxSAp0mQkhNCzEmp78wq4pBF55e75ezCSqoo4ielHShA0eKcj7R7kU5QeDoTwgmIeCVJmc2iisVn/lzfZ7Ar3e8hKR4pjhMbyhYJa22y7khgoGoCG0NangbddNEXnGmeJFoLMpkrXunSbc\u002B3WV9XtNAUvodGKYKrhorXDFlBxG3sqwcTp/uvNQGAL\u002B1zo0SnRb/BAt2iWDqXn2wOFFKQkKmhyu5YQ80UpUlFhfnVOCNGb4aZQIFQChMMfAhPYSDu759D0ZhWTwHy7J1UHNIAwmdIx\u002BSMNw/oA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F956275E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "47ae8f6b-29b4-6207-a050-3d8eea35c32e",
+        "x-ms-content-crc64": "TGpdwEItg8A=",
+        "x-ms-request-id": "993de2bf-d01e-0002-56b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-f619bcfd-e8fa-d948-62e7-d4b80b2ddfc8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-99b02131c8a5de8ed00572b2c8b1007b-c874d42a4b75002d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "17ea597d-c452-834a-7aeb-a94113f3198b",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F94DEB25\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "17ea597d-c452-834a-7aeb-a94113f3198b",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de31e-d01e-0002-2cb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "Pz3Fe7uHqDyiOz90JP4MTdZmEG55TGNX3piH9Hwu0OuXFfqFtzznUisouI0YBdIoJ/4w\u002BaWGffPZbZ0iALO/dGpT3A8Dh5aZfr5DUZPVP9jFX81\u002B/tdFEZcHrEmexFJ3aEQixCnDJKBnlnrnQyxfAy3EXKHlQXWTDst3/NpM\u002Brpsy\u002BhPsnuvAjotFmhdXs1rp6gc2mixkSfOj7VeSyjFG5u/e3dDD1GyFVpmuCsNNbD9DFQyMCBRujnBgSLFUbcSZ/vMneJVKJhXacQOStn8wFoFYD/Tk\u002Bp7bsA\u002Bgo4u7MSiVFEvQZfNqOO828ZcQ3BgxcDIwPB3PtQQUS8iF6UJKHz/a/WHzH/DN7hbF7gjHipP3bzOZizUKxV9H/Bnq5E9srJKXNh62PlABYk4HCcb7DIF0jnpO8JQK0DgCqyPW4wnHWQG2cFR1ATDjWCjmw7tYTO\u002BYthXVHbv\u002BjGYms5Msar8Ef7DFRJws/40Ja5irI8x8ql50fizz8jtF9\u002BQuTo2d9u2pooQKksgTa7aIi/IjU2hZqck0uCxSUE11f4z4PnD/a7SqwYFIMhdWYNK2ayZJYmR7lKSEaT6BV1I2lRN7G21FiWB9eFHnEXex3hdZ3CVnK90ovGmMOsJ2KWpvUZ0EG0WlMKHGDCoSVENtEosnZ7ssz6k2Ep7DuU5dx07nt//arcLRtKtDYN/zFigmXyh3DoHvAkHzzcjmobcTqATbKtyDUmSIVbMP6W6JQzx23Rpl5riNOLV95uA6KtL0b/jbF\u002BtLYwzD7vjO3xkTKoqMb8Sc7YFMDjInRWuEjiqgG3l17isRK3oNYjf//hlcKrwVbbsOV4I3Twn5JB2hfyCOLoPfnXxfu0SKT0uJjA/Yyxqvb2CvkcP3Pp8hF8ccrCLXMc\u002BVvE1/9bI2Q8g2rYL6IFkC8c/AHlz/6J7dfmN9beMosppAQw6Nb7mueU37gJDcZveuGbpTFtNylZPuorcO\u002BRYlDfsoed0KdYIWEaUPBGgNwNdrzxRo1ZuHDe26no0CX4A3lnKVs\u002B0aY6P4PMVuY1Er4KGfoynB/HhfoWwvj9b1E7Ik1631eE0qUWuwcJiWWOpcTv3rYrxWNdo6NhKBKtPNAukTCUvjdmhUtVH\u002BUYufyUhBkwDYybE1jqGT\u002B0J6aWZXo22vQw\u002BeuRhVlu1ql\u002BROWmzKP1eS9Dl4HbqqD3smGgwrZu4d8EY44xoog3KDizb9RWDVcGnOxK90dyWU9KmdL7zhP3D2MGnmkRx9qnCGtFJDrIoaEKniHGI\u002B6bkgo\u002B6wi1O14kuFx1T3Lt8NkVo\u002BrcKTEUffQx7S/uLOtwbwhi0tzN8dEJIGvaV1YyHKlIsIAHu2jZKmkQg04yNow=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-e1c64298-2d1f-8bf1-ee0f-a5693235377b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7abeb93daef33111b9200ebf0401e4d1-41557449015848fd-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9010c902-ac4b-cadc-662a-27f5d1a5c10d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F9516D18\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "9010c902-ac4b-cadc-662a-27f5d1a5c10d",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de36f-d01e-0002-76b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "3EA3GqLHfxHshXXCMU6KqID0IKlfGtss6OJqHO9boba6dxlUnXHkYtMaM3t5FwT7EJug3mvkRMJlCzHAXWIhkOS/CLo1NQsOD73WROdfs9HdbgxUusJK1TJX75I/IwVw\u002BaOWug5JxduPks\u002BtDgDaBldg4\u002B5WzNYidDOH3kZ5zuu4ZUpEyPjCk6gwxSjznccyfOk630AWGSzMc0XbwueUFcPj9ai1lj1fnU9FJQetL9drVWFdP\u002B\u002BroUsed1Sy59HAnK9kD6cefOWr20Hx0PMkH0Rub2yGN9bUN1Ndlx/prLZ9hIlYSR8vTdh8sWOuudBX\u002BVgQRHhkOmTYj9dUweTFwi\u002BKc0tqzNUkPiGTCoZzJn6CBZ7H2Gc\u002BGEolgLpH24z0tu80I0WF7S2C6wVW0DDeZWhZ0rtG/unHTFoBREwb3GOVn1SWPgM4/RdwROxi50caRxpR7gjQrbgFbdfqg6jhZw\u002BhwTHcRydlIdSk1bn8ZWQS5/0xyu5axPGckNArTXluj93dwCYWPv/z68w0LNf\u002BCQhy2JyrsJ0hR/0/QLdWOdRbNUbcH6Q9/Kn\u002BPd4hJpcanYfIuHXcw98/vHgp1/1InbH42PeRIuljNdvzrHK\u002B/yBlJaIvjYBffnFmnGMrFCSrtZ8tKU2giHqdZIOZ6RZsgbxYw7JbGBAwmVqFK4aGNyC2SPbSkdbSxJ0nkSj9xZRb\u002BRqm01ByUJ2P/JDzG1z0Fy1i4qEfmu/mhf4VM4bnM9PFKjFr32TQRPhZQ5RF36lAM3r7muLzO18rwE5RXRwWqMm8LvAqiDjJkp6pxlZaoKVV1P8M7Jjw0e7SQB4VfubbQ5vLiLG4FapCMgdESnUI0CCo/IgdCrswzFwCWEgZsxS4zYO7jxf0nL9VyrmRrId5yXD\u002BbYFdvjjfm7xVtrxhKH/zjHzxTUAIs2DJxz8BniDUiI/YGkWSWg9K3PNan\u002BUC86E6nh8KiHwv9rkhk/b53fycgC4tiQ05YDFsp3FNrRR6xtSexwAAygATqCSMccYZUf73vh631WqTAT3uneAK4kikp8wiWxb7m7YuGuDore9qU1ZyVe71w/FqCsXDEiwfCMbc58r59vXo\u002ByJoiLuJq1NNg0qJmIxZruPbuFBQOImJDhEZDMYlcF1gilrLjTo24F9xdY7hlnA6gjjmHj6ll8OZ3nqpb56NKBLtKQ0xjSGppNfx3sL7qHih34mNPlIeu/KXMq7AjXDA5Ex79GxiCPUWPXlms7gAnjYBB5AU/\u002BnAzm0amltz6BdnMfp1f7MLP9aUdwHYuAg6lpR3v4XgrORjuiX/R22ao1Rh/4K\u002Bih6C9ce6gIjo6BVl4ATG\u002BymShoUVEsWNDPho\u002BtStdrmGew=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-16045d28-6894-38a1-d5e6-6a74d34b35d1",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6758829fbf18cdbdb4199c0dd0c19c79-08d0df914d5fd5f8-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "493f793a-88e3-ae40-39c0-37ffa58d1d03",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F9516D18\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "493f793a-88e3-ae40-39c0-37ffa58d1d03",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de3d8-d01e-0002-57b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "C3b0yb0lLFx70hCaZmnTpyvPePypeFn16c9RhbM6cVzeZfhQBl/UYVm4l/J9cZH/Ji2Bp0GJ0ZMc/9/t1KapQGGzuwFwg6DL\u002Bhej8OBmd3g\u002BUl6GuckbVZNlMweA5oyyD1eRyrWQjqOMtqwp5eGztodnr4FHIoaXmGZtC1CYSxSK8eGJ1a3CrsO7\u002BgId8W\u002BysXx/GDYLau3Q\u002BTFOIoJT82uYn/T/KeHZpQG9jCiEeqb3u1nTGTLdf4bzuNt7c4tAZwaXhFF6soibpXM1Td3ETH\u002BLV2cpgNo4uiBtC3EFXjF1fCUi7fVUfAjRN3O/pzGpL2xc8BwkF\u002BcrXsoxDaYWlUdBwNC4ol\u002BJNtpeV0hneRLuxNwEqW0VUGU99o4rI29iuqIrfudh8IwN0rpBxr\u002BexOW3Q0jJEuvaLHBreqzQXhNq/J2mO/orjdRQ9tey04qlnzGpc98nmKi2UVJ29XbfPXSn18oi\u002BInqjLV0eRsUJ1jmxtt7J\u002BozQ2P08OqotJddcLljC/y/gqaovucpsx\u002BMoSn5kC\u002BbZBaJc5NmLgieQdcdFghisRxcJkQ00mgDCZBDaE7BryNowgyj2ZhoWFSeCX0QDJwXKfANnGrqZ5GthWkCI8W53ZKztFP7v9eD883vlcnr8/3zLD5dtBK5flt69VMuZTWO5CzqXFdIG2oYiaic\u002BtHIwpJsD/aGXCmA\u002BTb4gcmDVY6XYbCcAJamqxDTRStpHIOJsjPBwVY\u002BB4gDamMgUJqhlDMaBJkhK8L8xmPlsxf9Ftyzbs6WwpM3WFknmZUyhVp2MrD3ThfpaIdwxPvyWVRxBVSGbOLLC9Gf4qw/\u002BZEsyUAJb4BmBsfEyQVHJf6XRf8FtpRBrBl3qybeWGxrqW/1RPu76OrTCv\u002BMwaLdg\u002BXTB52sOkL96x0nkcNah65bWSCVUuED3FwVMauUtep2midBC1DOv28s91ndlFcmeYNRMGiCRzEE0CtBlgiXaTUysPecGXxdjZmwaVuIJUcF77goQ4SC81P2PDskjChmlI4jq\u002BNfiWAG86PO0d7VfKrkPKdQbyWxr72kptxBOQBwStTNZHljpWVYIk/hsyF1IL\u002BQQFCBFiVocvsmu\u002BODxLqiXocJCBcxgJdB\u002BE3Wz/ybL4Ycsfiw7zSuZfJ9PeqC1F2VPlWaaxeoX7\u002B5Px3YkaL/ioxdZhPC8W5SWqMks0OsvyPvQZCmAcNudFI4968W1tNQfrJeJG1K0kzmRxB0g6t8DH/66FARWIjI7vLBifq\u002BPITP1DSQTpq1pW5DwLqz\u002BfCmvOsvG\u002B2CPiUqlTZ7iElSJwqLpK53673lREPizpjOFfUBGswPjyCXTZYPZrlkOhwk8ZivJ1RCL9EuSteqnw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-e06cd704-3001-cf37-ca8e-08ea42dea62d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-c793018e88ab246f3469a0562d9e3541-b6915cec73033d33-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "58bb898e-7765-7129-7621-6225784a0a48",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "ETag": "\u00220x8DB71C7F952F381\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "58bb898e-7765-7129-7621-6225784a0a48",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de45a-d01e-0002-4eb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "cI1bgEB5bn1DmOr0VxdnhAOACia\u002B3P8e7aC/6/vhREntrSaBCjgjwK6nrv/FM/0qx0wqycyE4ZONPZOguoKCYVSgB6nx5nnLXEl3Fy4AWbqilSSvt3p8aMuS9M2lgwYsJEyrJCxUOOHSX2yDDMpkjeTY/iVd0qrZJJ7dXvGsJdlCS/LiVDSNTlxD3FgN\u002BVwBLWbpzIXhzlGh0QCNdtnvJjmTQMHYgjivSq/IGvZSzCtB3DGLwlhUYXygQIMzANeCVLYeeribKastOoHVGLRbTgXVTJqoZGTgPt5EOEK1e0rXRsY/NFJyprOGXYjWf0nIRPF\u002BXrM92vBSPTvaVvFoeL42/dLuHBqyY6XmIgbbCr6VfPNQNx2WmmzV7fYWl0/CHeXJn4J22SjWy/sOV7fpdjN8RNr9GECgoGNmGC8knMtWJAUhEmo8HqLLeWwhiEO07HbCmVN0xASkKP8eEMH5si4wtzKyyGTJQCY4MZ7TfxcgsSu4YQN34l8AfOlqHQ7g0sc98dEQAiQR\u002BVktO5Nl0ano/l6VQFEruNXSsUt7XyIXWF/XlY5GD68HpmepSqbMmqs/gR6vSpF1Ejj7PVHYlpo2FeMzjjsbou\u002BvjpnpgW0vBhafO90DaA3NYYNVStFdLhDNcjXCmAxwJN8v/7z4jJDKzDc6OVq8M6zWZiy3xVgdUWCJGw44bG0JLxf902hR1dXyin2aI/W1ED\u002BI6zLguF6HEa5cbnCCkl/KMQlCv19EhZBWxTvagy5q0wvPsIE6KXa5dsG59WZkcPgdz/LrclHgQ2ahifMirY6A8Zpls\u002BLejweSiUidipAq8VVCvLM8fmC572wamJ\u002BDlsgzOQPL/70WP0DqWekIQrnWd5ee4PDaQ3I6rMR2w/ZnD/J/alCMX/KXLH1zUSV2sKyyRCEI5bbYWPaQkVP4oHtJgkr3iNhoSRilBrRzZ/FNw/sXw3/VXyk7pxFa/M2fnosBKc/bfyfUSfoJYt8CZPAEQ85X4dz7dCIgu\u002BHGDk1KBmcocT4icUPTQnmEy/1KOUMhVrn/R72uBbSsu8NGDjutvlx32fKx4dGKg55jd6gl1YGepLeUS76peWuJdrZ/jTQ91g2h0l9Qb3XndMMeS44LhuVBqGmEGXOdzWCGJ2oaCvZqJaCbhAIhTTVCrNb7ii3dfvDRPuTKubyZAwX/yUcKzWrNtCbtcAHiIFo0QW2doUIyqal6ScwRn2vjAYD9IoTtON9rLdYH7w7u7h6KlXhP/GLCzR\u002Bdj4OeuxW6Cm6A5f3WRwmOMXRsKrqbi1uuhwnzlAUeO1VkT6hbzXHBTeWgbgggtE5uwMvtVaJlAgMo7zQLxnVoYamocfdhM2MCq93U\u002Bx1Sjg=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-ae9058af-c829-3034-a18d-0b39c27db8a2",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8092c5898774769116435c33419a8473-49efb0f218b31989-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1b717a74-c4d1-9f9d-0f34-baeab424d833",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F953DDB8\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "1b717a74-c4d1-9f9d-0f34-baeab424d833",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de4d4-d01e-0002-38b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "0ruF1Dox5bL\u002BTaQz3T21hm83DF53QlYNjWfrqsWRB\u002BbVYWFQQaEuMMP2cqq8/4bF9VZkwxDzFo9kd0bTRTvsbUW\u002BXXvbZUXOCdyagdCsUY3hJrRvLEPV4UvS7MlaW\u002BuICQVk/qIK6ZAQlbo0WJW/uCa58R6HfUAC6HwwCXl7dK3xEnfKR1Lr1jwjXpaIoYi2EjOjoGnMAIzEYhUm2eAXlSENQ0Ud9XHTzhvhYx6qekfzevZF19NEJBLrBuU9xP1bDMh1e11CmB3Cz9JO65xtGujNMl/p0b1OyB8zMe6LlQkdhVdWNf7qsOHZgggA9jh2fuz9cJKdcjoLJrI\u002BD2cuNjnJMGVEF\u002BXp44J9EE61TdLmvbMCjiV3fxMcSg5Lq6F6q0vON8XSMWcHE40PIGHrVtngV1KzK6gUUbBSKMzWnTfhA2QD5xUNE4xL\u002B3uYZ1\u002BxMPQ1a1ROxn\u002BjuuYVgAiaMHZVLhz86G/D00PGZzAse\u002BpQoPfXoTLjkjzlXy0v95ODsMsFQjhDtEiFcZgQiF5Odz77xN8Rwo5DcpzgF4lBlNuwQrdlJzmxDeuvUjCZ0gndlujuMzOzce08wc\u002BcYp2\u002BQ9y9X0Wn6U8FSbb0YXBeqqCSAoChU2Cn/dDJKWZpFapN8A5T3HLDNq2Y6el8vxB93RcvCWAdHfB8FWJ13sDpnDQMpnBhC80tz8zSCGl2Kj3AS0tPOQtKMNMe18cQTlftr021cBmfG9JJAjqUShSGBeoltJJ1mmIpwXWdQjQGHYB05VgcwbkkIS94BTfRteW/mNHc65rEdxXqi66jAtmeQ\u002BW6IGW7akMwAJJj/JQrVwyQ3qpiKTLmr21DMTUKgB9W2sFRF5WAAy6Oq\u002BoHYXuAvzOiEyQuPBqz03D3eDgNJoBzDCHT2UB3D9p8035H3k7ywnIBaG37KJ2nnkMkiIr1gYVqlFRZreXzKwNJsWica/UiBbXFC70Sd\u002BSDLDr9UoZPhlL43Un5mBWNDjxpsnY1CjNNAoPVMHXHVx1w1YCq9dl8\u002BSoWo46sKGygN/yBqMVtTiEHsFADelbcMIUsicKU4xlj7bhMHmelodkXNPh5Rq5XAoZfokSIeX/UOnMIf5\u002BpDFTiHbsNITC6Yg9360ZdYurW1YY8NUDV2nM5d\u002BP0nCE5bSijlijzSeFWpEA1EY04dteIMqoZbdcUDUJH1KlMxsbuPX4euszB44uk5ZD/oMnmAAAMa2l2IABQjonlq3U3Cd55RtMPGrwLx04fdIdGFW15YdOoQFtcdx1\u002BzStC2zcVbdyxhVn11\u002BZEAKQbV6x4CXkcbEqijsiDHc\u002B2kE2QyOsXCgarlY8ThIntZD\u002B2QR9xBcOyJm/tct4TLmiJPkaYsw=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d/test-blob-5a65d3da-57c9-f779-2634-4c065fb6f5f6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f16aa66e2e7184aa3a81ce55acc302b3-a72706cff6e121c0-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "feb18cb1-efd9-1777-cdc1-36cdafa7700a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023/1024",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7F956275E\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "feb18cb1-efd9-1777-cdc1-36cdafa7700a",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:09 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de535-d01e-0002-13b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "N7gETaXNdOoI6MC1KojM3LBFioneonwplyeXZieKRUNUsAj\u002BPdLLOE7HHYcsvbSKYozZ\u002BbsP1ZU82rZ9NQ7DfqN9YHmAzp7eeVI7FoT1/dlzDASasUuHRdtywWIbTgJABJ/jrl06CpPt\u002Bn9p074QR9zcCSkJKMxX9RueDQw7witP\u002BhHkEU58OAJwrbbMHnEcYnqGP0TZNtzTjLlCnPyHsThUGdmsLDaOYNEmmXoWi9epgquStYPmdcQ1EYSVOpwG6fx\u002BdwSYbzZD995zs5xivADimBpQ9Pu0baQUdxqx\u002BSY0ILB9mBPSERJ1Tr2kc8In01SDs6KCtvQByQlgg/gbkv64PpLs5CTtD4YI2qU9EPrh7aTFLUWEsmq7fM4KcY4ZWby/7DQvOu4wlqMbettPw7gPfpZUVmW4NIwoMWdV4p747oDpfiPFsrK1lZaiaDeObLgV\u002BvP4xQNXBrinBgmG2rMFI4taZkWVSczjnsHOFstVmsWuQOir/yl9kXhrHqupLrrinUWrMwVzgLEmFSZCiPDsUmxD2JnLWiNi3dTNKSshOXAG63iGqWa/O782hOoDOwmHfss/ZlYgF0MhSVUxpVeGBdu2O513ZqgFhJzalNU4X6LLRapf4tMZ5dQ1ZGAQjZVosH8PTP9rEBgjOeK6RoJt6eqzZmCsJiIInFbIQgFI9PYHceNVKRKjXzWRPKjxX55Rx3t2XSc1u4pcB6\u002Bpo80X2kTrstSeGL/XDwcqGup6Fj23dnuF0pbP0bVZ\u002BSJi\u002BrtnemFjBazKsq67nk4fCqGf4vBy8ixSkQitHOEeRR\u002BddRVLw6CJFhGR7MPMyjNIr8cUuhYx8AePFOlYtunLq22PHik400YBFczf4QVohsfVZWwZCYoIbIQNvK63MGAnxUFWPKwJD9yAE6RKUg4CJ44hg1B8saHih7GkKheYSeRrtxvEEkkby1WQmfbmvhl1C5Ufla0PqhSfc7X6ZOTE6Mm/3pvzPhVFBrj77Bir/MiYLh\u002BCeLQ3XAwHJJ6UIWZwzLAsJt9\u002Bgsx/2o71E77783fsYTbFQW8ViIGP6xl2sOVRiyBnftXoGqxSAp0mQkhNCzEmp78wq4pBF55e75ezCSqoo4ielHShA0eKcj7R7kU5QeDoTwgmIeCVJmc2iisVn/lzfZ7Ar3e8hKR4pjhMbyhYJa22y7khgoGoCG0NangbddNEXnGmeJFoLMpkrXunSbc\u002B3WV9XtNAUvodGKYKrhorXDFlBxG3sqwcTp/uvNQGAL\u002B1zo0SnRb/BAt2iWDqXn2wOFFKQkKmhyu5YQ80UpUlFhfnVOCNGb4aZQIFQChMMfAhPYSDu759D0ZhWTwHy7J1UHNIAwmdIx\u002BSMNw/oA=="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-18429cab-c0f3-b32e-77f7-dee7ffdefa4d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e55fb945f264cdc77a8001c37c42f713-a8c92355a4ca608c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "27383390-d973-655a-fa5c-053fcfed7450",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "27383390-d973-655a-fa5c-053fcfed7450",
+        "x-ms-request-id": "993de556-d01e-0002-31b0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "540093834",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,2048,10).json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,2048,10).json
@@ -1,0 +1,745 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-eea2f369f99620123e2207ffa17e1926-ea6e3a662ce5acff-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "79b4a581-5830-4fe9-4cb9-756d4f55a5c2",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F2063AE9\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "79b4a581-5830-4fe9-4cb9-756d4f55a5c2",
+        "x-ms-request-id": "69fceb01-201e-0029-36b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-864ecc4a-f9a5-e030-4dfc-c8fdbf4b56e1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-4e61ed5381fe5fa039fb390357c4ce65-ec375c5556091779-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "a5f7a16e-5dcd-e0f3-9e57-f03451432fdf",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F211CC70\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a5f7a16e-5dcd-e0f3-9e57-f03451432fdf",
+        "x-ms-request-id": "69fceb34-201e-0029-63b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-e7ecbae9-5df1-184b-cb86-07a2f420546b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-ea56a226674982aefe0d21444e3c5539-71ba4b85acfc346d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "f8fbdb70-2c8d-4669-85fe-c911576ce542",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F214D940\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f8fbdb70-2c8d-4669-85fe-c911576ce542",
+        "x-ms-request-id": "16e8e1de-e01e-007b-1ab0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-7f56f8ca-1b24-87a6-75d4-2b348fec9001",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-38517493ec3bd3579ace6d9bfc6df111-a3dcdc7f7ada63b4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "75c3498b-3748-ad52-517f-a2e26d368902",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F216D4C3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "75c3498b-3748-ad52-517f-a2e26d368902",
+        "x-ms-request-id": "146c2243-a01e-0055-27b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-94839363-be68-edd0-8035-bb1ef18eeb2c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-9ac61bddf6957c4c1a8bbd977da436c6-86056e3fd42c9715-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "0d859aec-70a8-b2fa-b841-bbfa2a9dca22",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F218A93D\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0d859aec-70a8-b2fa-b841-bbfa2a9dca22",
+        "x-ms-request-id": "69fceb5c-201e-0029-04b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-864ecc4a-f9a5-e030-4dfc-c8fdbf4b56e1?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-3888d4420122625e3a907dd6cccf493b-db4c224f9ed084d4-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "d3f6e5b0-7cb1-a45a-a98d-093d023179be",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "6P6MMrjJDYvXtIAES7O6aazbJ\u002BpPi4/oWiaeitjNbozNjDQzi1YmLfmziOk//sB1rpRChF\u002Brll1vo9eSKoKzCkXzNr9\u002Bh95VtfrxnAKmqFtlKdtDiuotIvXXw\u002Bd\u002BlAJ2/36jTMgB9ie27M5lufpayft7LACmb4BbxhPKpsP21yD3e5yEAlyTZDK0jJ0bx2j7ffrsAmgCz5D\u002BSIa0NlBjvxWubj5d1sae6MfN8uLiP/6rzijJCtS49asMhbrW3i3iUcyIbVkqnqczTRqgNN2tHAiHCWgnmbVB9XmSUFAMxwmZ66AVWtKlgDCBlry5F8DOX2mxT9XFu7gXRnjfmE5XJoUQB0k8l8I24Yg3pQL4h924w/DmW3g00zDo/hNaxujiKm82qBB3ksenem1MjRW1H76aJtRdcMsN3DMYU5mu3BufVXuSwd/NQTEpPuAK50UaM95Uv58UhbmkKczcXj4u\u002BZ5SrTiaIl3fzOWjNDLrA/Xt/iC7Whx8is/B7pgS8eLy\u002BkVBuDoNgBGAdPO5cVGGuCbX7mAec5\u002BB1SJo2DPFzNsDsDntqUq74H0POuUpwxl\u002BOjVxOwKB04emwOIXpKjduqcYtcAXmQ/bHA7jDzi5WBII6Z3\u002BU5HYgdyxR\u002BloozvVMX89EQ1YZqEmlh/0nsRO7GjPDroK3mYWPzTkZlElc3jSDd25e0YEsIL8171x4\u002BIYYlqBmJSAylMYJ9HZdABPACOmIpDmlXEhyl43DgeppVxRywP3pNrkUUOKoFN1KzuCrNeaysFRMs3pX801SLxMb4J1iKj9WFtIwtBNW/Qdq58itWEvDtqa/5k1DUUNrgiGPjHRAKOThFR7UgfwBNbZzLMtEpNaHGCn2okOx0oWOhPHxx3CS6v8jzANtLzSqfvDXEGR35t1LCLRKSUZhL0JZRfzKTy4FoAIMYNiTGik1TCOS2sJhVt4UZr78SKG4gtzBE6k3oC\u002BCkXBia4YE9\u002B5LVT0izlRAOC8e9ehvSVdgU5370gZ//awz0AlR/usXz67QcPOkVbSIQNu52OpHE0fYwdfoSSXoC1dRLz4K7jkDxyY5ntij/D3pc1EqheTBrPyBuT0Tb0aI6GVcEya2fVKithGEDXSvdMWaPxWUvUVyj4IBiXU78JefsLazB\u002BkXMvX\u002BR8/TPV9IEgQ3uXBw9GrgKYNkdPQdpsV6JJy\u002BPG0cQswf1nV1n1Ii\u002BXcxBHdnLrxLkx5lsr3B4OEKmRjCihXW2zZkUR31akoxQbt87GJN0vYgcmlO9tAOHfVUasY5IG9hWilAwt1eViiUNDECRPR\u002BvIZiolesR\u002BQmVjNooT\u002BD\u002BCEMG1I5DQ/YgdxA\u002BsKfC5jA1a5/1n3XtNIFGqzqNfUo0DwP9mmiBW\u002B2SiC7a40hhwpaZ4tRRCGjdKa/9DJjLovnF\u002BqGjxVvXtA\u002BiUxdXAkFI5NiT85pl4vabIHC4hF9UxtUlBPiWvg06sj7UrrVBdhdetCewN79vYAerGKTrHy\u002BwXYxCMg1YoibbaTFbkURBSbppadA3lJ8lxZTw66VYX5MfFFEpD0QJ9gHw1M5\u002BA97Dac76gbVPiLjtLGxoZ7ZxcwmuTHzzKEpmX2PONr/Ap7HGLYHmbc3tz5uYO\u002BLXoZ5bj2HE37dh0DGEhDJBgUH5LHS6kjokmwVLwIzRWvxXnq3VcrdeC9f6ZF1QUembnD5Zrx9uLQ9kJvRciR86gHVFLOWEfB6amxCssD3s1DkroCROh7vc\u002BXGecUvDAYK4z9PYCzT0ByAvvwQOwXzRh0K7MNjq6/jJaDNz5grC15mN4\u002BBqBNkEJ5kELsi33igEzPoJB8C53ePbHqLxgBEVbOdqcN2MZ3J5txk/5s0wEYoLfykQuc/I1BYMjvY2Apd37sHhTW1KeFV3n1C3eecWqw0Y5hD4BKMXkazHj\u002BiMQ6RxyAgLXsQssPbDmSp/EVo\u002B5dPpHRyGf9oeybuwgvh861usNbHfG1w47CUaNGt4qHBCmJoEkyaH\u002B0gt7IUYfD4OVr3e0uuoX9qHsDD3fEtuphE7ffpuaEg1FDp5sT7HIH/3C\u002B29mcWUmji/jOLlkI78vzZj7P5Dr/5lqc6hPq6rsI/BAGBtsQxbltOxrttlT3O7fPH4U0Nxo2vvV/AG82uaE9xTJJAenw4qGEYqkfES8GpK5cGso11MT1z0flkcRJNoF5sPEhrjnO3zzkr9RxFq3FeVzA2p/WB/BuVDGhClHdOisnpmE\u002B5PV1jTuOUSXvg7maIBhniVzhoqkAs1oHLNTqBnSoSm9Mh5RmS0xkR7XLftB4B\u002Bo5dbHPRgS4PjCbbWFmo0qwRzlJTpmDAT0PfVrzNDWJjyXqsZHD2QNrlEhjy93r/aRqGzeXLrlQtXRzv8ipxAn7Ed48e/G57W013blQHzZgJH\u002B2iRn\u002B8mBrmvsdTxk7ws8/aLn/r4KysC7JYVH/AJY\u002BE5tI8zvv/B5\u002B0OH2nJ1U\u002BRvqEbd8YHX9A9jrNZEPbJll3zx\u002B8s\u002BUT2ubgN6hvBSQdGc1Fe/fwrIlS\u002B9jBMeNb2RHkL1h1QdMVcFL4OCWXEfDWsAp2VaqhR2JWKbfMUqjDhF6WStXL59g6L8tk\u002BHSj\u002B\u002Bnn6kHY5UNnQqg2HxgbCR2p9LOHAIcbCshyfGXfPI7tsm3N5GhnKp7bLwgtlci/3uatuwPA3LsizJ95ZqkdSAYZCGzqTSS1QonUq9G\u002B7XU/8l1/MYFLLJXyqxeI7YQ1/abB1I1blZGB\u002BDh6LE=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21B19E6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "d3f6e5b0-7cb1-a45a-a98d-093d023179be",
+        "x-ms-content-crc64": "LWJ\u002Bru7ANDo=",
+        "x-ms-request-id": "6828c379-501e-009a-50b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-e7ecbae9-5df1-184b-cb86-07a2f420546b?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-58a165fc88728cc220b30ef720709769-037a12833908fe71-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "00b32d73-35e7-0118-0ad7-e8c1ce3a5579",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "wqWPfanm0C94WRI4blzeiDOyUxZ7uav0Y56Qcy715SRDAZQkHOF60ECnfUH0GccSeL7TLo3SNQn6mxkKVl0Ag3Tu9GzHuWxSN4PV0ztp/0nXffpwIbeWccyLKoDIcHrjp/rNBiVaSr5RgfYJ/GHNkZzQMthikGG9V4OgPI/siccJ8ixBm/kkfTM8HqDAjXRrvZjk\u002BD2hgRaYEK6iug4vZfcvAAo0jPajrLWlJnHB/MoONH/2CJGJZ3AWqYpKgcIkDLmokYxqNjGiQEuI/Ful1hPklIWPOF1mpZiZHuJrWSrygBm3GWs9pP5NVMdFAGoVcNJ2Ze09ldRcQuvz0BhONuchlnxB7b2opvCHQeSWIKUuhK0P9PM8tepFW9eAStPl/h3gJGru1IMVzr79tlTvxiFFxUxqP0Lz5OGR/JHmJ1wcoULGtfs6P68q\u002BiY1P/\u002BWVZW1OoSHe7/b7ECJXdjxLqZi4RQRKRAmC4acP0QbvaTh\u002B6b7Me3XlCWC6si7seLXOct/0l7qhCuFji/\u002B6zt7vy\u002Bbp2Ex9f25i0zujz5Ha1mkxAZ4nOtG93Z7dqK92KnpByuZHwqApkPOxkcS\u002B/XsPiPVWiY1AiNDVK/qtn9a\u002B7KiBIcTrUtPIx7CqtWjNPuBjjd/532DtAUHVcpalfDDc8uUb/Zt2ZDYhjcIcldNoCC0aShH2xM1H1CCDFeA9I4t/jcKDsQEE7SnpmBGekGtubWqpizIfJe3X1Cm68w4WJKo2nQfQ5Fbr1VzoDWy7qQO1VKi1U1iZYKgU650Xijnbk7OnaDNjXYjTvfWVNtiBXGrlxZ6loJERnXxf/Di51EsizLm5FAEQUfcfodWixCmPk09yMYSbdfMiVcr2w6GQWemqcmpeyEgp1bOnhj77rtkSkGipR6KGh1aGlr52WU4VTwfsOFH/cIsHCFwQ8\u002B\u002B0ZqbxpHN5JtJG4\u002BrTmHGJ83wlUjb2z7ZHU1\u002BdYj8GdZOm0i/XRLUa3Gg1pRSm65hZvRUf66G4vZcwqlDTm4TTQG4XbMYBsq6HCrXOgSphoKfHQ\u002BTp5kox7hSY5ppkRwCjYmSmj37SF8qmWOEr6jxsjsnozFef6VnkJb6xaMvUYoN1K17F\u002BxEpNSwaQ42pBcQYbBfQu3rpA7jKgqnAIO8\u002BkfYdtv7dZtO4v9drhWWMet\u002B6WPy0A\u002BdIjCel\u002BzinaNR9G7GXS08FewVEF/ujfX4TfkeKRcfySo4O1SrXN2ua0VbC7qmz9S\u002BQdN33L\u002Bvr5Q6pUrzxHOMMipEjiHYkbkPZqQakoI6Un0kX\u002BhDp\u002BxqiIvAcLaSu6fRztmPYkGy5a8aaHUalRwS/1PMzmSLSIo92QWVGCECfKv9SMOoq\u002B87cXo4KT93UPNvrXBixuxCRoZPUog8HMyOF\u002BvKHU1YalRjkVzqUx5KxokSJmuwn7a\u002BugE9WVhn/1StqRJTrTKlFkMb/zSPWPNnBYv/KfZh3Xc1C2JMGxH7/JEIPKkM9hlWbA8nlaCBL2IN1VTNZ9VeTMyaHqHQWfsyHwKjhxxKWg5yqL3nOkjWtNwAPkW9LpS7qfDdcth3hRMT9HWe3adFw3tFWr8YdhGDw2nF0Bu2dfBt6N0sbOg2\u002ByKp00XSONY0unrJd9TVojPeWa5usbX3XH\u002BEMPXJGVaTD16cbqPMsIuSkBWh7P4cmEWqTRM5x0ltsnbGTgfha6EjNmh1OTOPEqgi3CGgVnCBaJiwH8tDWUgVL7wsBWKEsSVzfbaVpl4RGjtqFuoozFsGReVuMUzV390gYAp3YwxGniv7LNi568E5ngSQ2UJd7GJgJcB8FYDZnp7ZdUVUmrcuJHe/LKCDTFkkNZJHRQaawnSnFj1MyYmrIo464HV85QRNYrTKnsDC3dlmWODtkViXP7PRrIN54lvuFAkRSWzkqFCO\u002BuJRzySz5Tlk5XCpvZE1oqHCqjiA04BZ3Im2sJRsgbCQX5Z2Rm\u002BOHcZKFfzqRVZ426bKIv0XDSdi\u002BPOa/DWl92PAGV36v1wxM41xNr6Db5czPtTtol\u002BzeFJvE0189CCRpR2YKiv5fRxKmO9wptdo3olbZ75gt1UEDaALiqsOtT9s35Cg60RrOcC4owlwQtJ6BjTEIIxiMe3IlB2K7fNwO\u002BOwBMZGyPNE8C39qBRMlMrOkIN2SpSyCa2j2FYn4EzNR2clvz4LND5BgC9eZYnYewBTvFxv\u002BvFO/foYo\u002B\u002BdHBDhMGCsJtSLwlxENcpkU6QkylxW1CTvXU121sJD85BOpGMffTQoLFUrx/kAKsQm6qlW9NiTRkfs8dITNU8SR8/L9pFmRdZv\u002B54HKg0q7zKIT\u002BwY7f63u10bM4tiFfYFGYAqNDQzwKXT5/k6jBs6wQKfi\u002BVj\u002BVrQFDozShFKDOWnARGMALv\u002BVI9HRQUFfC9C4HKJwokQoh8mWR/6AHWTiNoTk4oJrcFHoTdWG7RUy5cK8WmfwUpcl17yZqebA1MZs70r8emkODKwQiFSuodr0Y2I7w8L9MaQt/wrF0cZrJ3jPGf3KdmtZbg27n8pCdzXh5QZEhREDr/2mjrteCDrlpWDb30gc6iz2olW1AZHZ60fVJCy/5mJni6nAY6ewOyYS1fppZpftxPsZjeK7jm5rjONziSQOZf8\u002BdBOeHIaFBqdvomuXcETv519xplh/7D17lJaEfHIBxLA7avJED\u002Bg0VEd7TCvClFyeQ6HE3L9mvogWYkgvwMo1LZ37nAVSa5e3PRIRBJ/ReMB55g=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:56 GMT",
+        "ETag": "\u00220x8DB71C7F21C0422\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "00b32d73-35e7-0118-0ad7-e8c1ce3a5579",
+        "x-ms-content-crc64": "W2QXQrLk7Ac=",
+        "x-ms-request-id": "64d6c0d2-401e-00a9-1fb0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-c6335da8-d7f4-cebc-1464-721d321789df",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-c5aa0e6c68c3dcef756dc8ee1e427de3-d0cfa3e3593d6762-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "444a0189-f7a6-1071-d918-2bfa4671cbeb",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21C0422\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "444a0189-f7a6-1071-d918-2bfa4671cbeb",
+        "x-ms-request-id": "16e8e20a-e01e-007b-43b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-7f56f8ca-1b24-87a6-75d4-2b348fec9001?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-09a3ba2db65a19363b309e753f50ff03-d00d517a809b00fe-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "1986f8cb-cabd-7004-4289-131b0d1fe875",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "40H0n8JSsam3tX8RTvQYejgc4F0wYCk2frVW6KATpR/Ya0WTwdcrHWSf96hc4vpP\u002BgUNxyCKZ4IYvSEN/MgIow9gOeOvhLhg8cL5kGiA2Zu6Bu6bBt7\u002BTQPCewS2HSGbl1OY/KgXoHVNrdVekdYal\u002BOGU/XabZ0xYezf7AmzqdOgXfkV593yo2V4TlgIoLssqOMgMMoswCq1Z5u8N7RsmQMCvTPdBK8Gk6\u002BPYR5EKMAwskMlk3kJdJ3PYIBBNWyxDLRVBuOIT6QzGpwanF8LcD/bi4RwRgaJ\u002BEiWDaQvxF5D3VRq7yHcqGOf8Xjd7tc\u002BxO9AZqrnQcauzA6a8UH/BFU\u002B174KoIEd/uMh0FSNqwlwWEm07l2zXJyOuyITQbYhoO0inxcZMyNuI2jHxXFxICAEKZn4SxX4inoifOReCbwsADBnagzxVyQmRsv17JYrHJsBDxcdKFTXKhSc9rc\u002BDxmrmsVACbYUEtJ00gVJAp3k919JXfqkDtfbjz/3VWBt5zaySVHR6hLl7fxFqVZPjSd3uP9Y9LIeBoztZXp2Hb1xB\u002BrOl7lLEg1MZG/9X2WAiwEXgJxhFfKEk0LF44SYbtA/1KJsgPZuK6XyC5BCIacmbNl4XpwgEPH3SgN2hS\u002BIs/WfvYvDFAoLqVT3bwliQXKbn3arIBAzH8SwdDby\u002BKV2aViao2McYljObLVIKKDolAiR2\u002Ba43ZPlbJ7GE6DUGbCugQWxyJ4Pfjwe3LNb6vYjx98uYR2/vYzFtTfFVU\u002B3\u002BlMEmqebN8xqglypmgDfiYGno0vApreT7sN47BNnSSjtZuJgVlBOh5ATw97AFSOL5Su1HbED9lSbcavkIku4Ajg0vDMefzMwWBy7reLZ09if7QbosSt26W\u002BOxOWkamREWsGmi1nwbGb4hMWVR0lxwp3SRDVF0FAMvdLDkLpNi\u002B63dlMhMkd/r4Cf7yxm4aEmHAJI0iUv/4lwmc6GLdusqvnX3tD1UI9WU5W0peAkptwwnHS4BbnIiHfJsJl5\u002BYKl80QzjwPQMcty8n\u002BQe1qoTPLxVZBn86U/DlVZLJ/13FkSD7Kc8BfZYGuoRRM6NwwcIGSmiKTxPf\u002Bf9ICtdgQsfBUlfWynDFvbF/Ulvq6SBNdJPQs6T1S1IdGz/fuXLOlmfMn9FbmgdRQJy3CuzH9RDO\u002BoZDn58S3Bb1ya9A9fROsMvkHkle8dqMf2MYPkBlVSYvAM7sivbIubPKVdBoEEqYaEog09bHf/i7tyAr\u002Bp3WgHSJIeU1YjXVG2SFhKv6JG8of9X2RHFPV5DGIMPGrL8l88Vr3u5VYwYUW7hiMetMsZKxA4rH0EvzOcpUbzFiDn6lb5DmnkVwwxzP4ejI3SW1iW8hFZk0XhOJaJUkAQPEol05vMJKZiNNQEBt9\u002B5TKlykruXSMPjVcQF9XSWgTLIJC0\u002BbjyBTaxNL49VYxmY1Jk44j2It8mFkVEvA3Rj9rPOOZPyux6s8UTPChl0TjKqrSDbnZ81f6xjeNyrUgp4KXjbR2mF5hm6TDD4uW3wEQNeRJYTSBjUmLonj0JBwZ86lyCgWQaJJIbHIRGufMY\u002BcyeZDM20JKEgBu7vnlbXeEpRviJND/g81V/PDGbHJluz6RwaqLSRRnK/QBIX2UZwL\u002BjHHL7j8WNvnHet5Nh6GSCTO7V6vM/VwHevjY\u002Bl5TvZnxx\u002BP8mc0De46sx9I6FaBWcxhJ3RNXMZMVxHNCOTybd7lAX7/BlW9iu9gdHDWJyWVUhodGBeCGmpZQ5tFdvUJOFUwU9bXkkN2o6yE7OhFZi/8N7ba1VXHYvcEpbK6aBP6VzwbldNOvc/GpnR7DT2CA\u002B1rWT9OPmL/ePDv0vyQvDuImoWsKcBcrYnnBC7hXGW5cpHVXx7UvCjJLCzSXtrDNfo44nK35dodHqu1VypEHiybJlBay20so\u002B5c0w2jel6vE940qGnjAZy3uDBjL1UOhQ4ARziKaHqdHE6UWwLMeZRdFjNcH3WyqCSzowMsuXSJXk4PkzMmFKtjl5wbXraZ\u002Bz6sBhkRonWYTa8DxsVnYFLKCvy0zOZhNvGH\u002BHfZl0luKafUcKNrd7vIZ1WEEk3l/Dc5UVO51S5YSt8XiboNvqZVla0dku\u002B/XpNA7FWA3SSjofwwoEXltFSJfDXUU\u002B3xyrivPnygyGlHifLAaOjYx22qc9fN3Q5gb\u002BFYlBa52wqlTyGs4a64AumC\u002BSZDJUtroKTIKdAGM/2qTs6LSCRSna74GxnHO\u002BXO8mD\u002BOtPoHTqV/ONh4aEqrxsz8pLQLLq1MFt3WxoxpHTO\u002BTd/GAkZsiGD9Vsw4Lv9zWwOgzlS7sWmOQqIYLIgZEh\u002Bouh5u5cSKkBhXDdvhF\u002BveZ2uIxFLfAphyN8OkUFvY5ESwj3DhAHU/Gjo4ZKeRrS62PckcjEnIzbeF\u002BK4E4j\u002B8fiWXLIR2/WL2Ta4Uop3w3IqU7haSuFf66729XwfLOjf\u002Be\u002BqB/nymQzxqKj6fsC8ZkRwjc/QlLcHNmETGuZ5bKxd2Giq3cuIJ7qraJJIZWzeSp8nrp8o/1UoksGY734meDv8rJZoAYiI\u002BFYFNTwUztD0NNBHUb4NNNkDcjr570g8hOBmS8jWdkkGrrZJE8opE9PglKqt3yaN72e9VJ9djwkdyKBbvnMYLc6HQLMHxBEe6m5nGVqdnqW52GxRGRG5uR\u002B9K0sZzVVgyGbsFo5zhitGrnog5nWucDn6kdYWxxSs3ZeTSpjV8=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21E74C7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "1986f8cb-cabd-7004-4289-131b0d1fe875",
+        "x-ms-content-crc64": "zVLpO9wyYyg=",
+        "x-ms-request-id": "146c2261-a01e-0055-43b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-94839363-be68-edd0-8035-bb1ef18eeb2c?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-f8cb815dde0498904c089bf4cf8c33bd-cbde4143595b378d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2ec78196-1229-c7c1-b4ec-897a97e88e76",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "UdCQZA86F4J0ZSMQpqp4jCqg67ER8rf1oBQk849tA7gnCpXRfgJLrOwdNbc9W8qfVUxPk77bTV4YmsT6FiPyB2Jr6ZwVpg0nVT7F870AuEVKhJ5CHW/5S7w2uOM\u002BUJbIKy1V0XIuiq4/KD6AFlqgGOJ/sJKEsOnzcp3f3u0p6AWo/MiQq\u002BbSG/rvA/QxeDRilaABv6ADQ3pDYV/UT6vBFT842BqREG38rJSYlaz0wvlofElNKCllpLhOTEmH/sxOLu21\u002BKAa0YQyBRMLa67NTp9la9Jic\u002B0W0zRhQ8QkdK3ISWa/P8lZTqvEGiMVWTgJgP2qIZP57LoAnyRsuI7ADpBlQiJHDg/VDB0nnVjJAHn7V8PHelMazlysvqCk7ZUdBAyTsBcVwnHt1BR10k9hNp6rcGDL\u002BJM8S3PFm1BuMB\u002BICZhMNlBi5pVR2aU\u002BpPwNSocB\u002BXw0UQt4VmSjUCYgf6T17ci2FQBOSIrLeR/u/aZ3uFDJbDaiU7eM0\u002BDrvpVuMFoBSbczVjWHs7DyaNjsili\u002BK5fWVxJtUpkQKkIfY4n0XEjF7LTvRGEbQbmGr\u002BrfoEiILZP\u002BmNhHlPcdIizzZ1Am/gyPJ52kz\u002Bc1uhVZ56KuMYr5lzX29cRvfVi90SE1KNpoX7HeT3iq5F6ryN7D7q1UbvGi\u002Bc8aLwhIIKlF5/3GAJE78Ifxz\u002BERTrPXSy3lrI6qaGIvky4KTi\u002Boli/PZf1g5MhMh/4lY54PkKscQuTbYnMam36alm1iMKFYSDmyQum2dmdlmSWQhQTDHwKD7gtLzTS8tMl\u002BxU1b6VZczRtlXU7CZsx8dshOihZ613dq30KWDHsE9Y0fOLEZCq/OM7fpXcKzwIg/zlZrbSmzA\u002B7W8AoUxsCfYWfBoy0aY2wZf1ZekHm1tx\u002B6Vz4kmYdjazTCQxmlum33Svxa8h1aJGvqUu7SVXN1ITnrWW\u002BBesjfXTf5WCBSc8XpZkZ8WsQBYDLTOkaZkRbATSHgumD9dc80epXlYMxKmN4o6e4s\u002BMZ06fg8rkCBRcwhOAr\u002Bcrlk6/B3SOAvG/9miKJocagnlFVabNFnwceOszTJxCfBTCYkw/39ta/mRM341iaeGNQk\u002BaS1owbo/Sop6JWrZlfYpDx8Q66qKt\u002BldCcDb\u002Buh8JpgpcqDDKggPMbS08waOt51IDHqItUlec/FDy/e5I0\u002BiPj6S8GMVJiTXAfo2FYSijpIjU66ts3FOiz7vv15QVc4k0vTH\u002B8d6MyYVsbNPaF4soT1llY/hNEqNRCVkZabGhuwr0QLP2tKKqWCIWAH9/2Kggt4hKoA\u002BA95qOneiFc1/TyrHY1cbXMZqmuxvWNxIz4TCg6KIpZwr7c1kZaBbKJNTCMjXNlvLhWYXtk\u002BTjurB4Wry35Iq9qmOm7WJ9vcmD7JY3FATcdlo9z48cS8MmF7iYkR1qAkBKBIfSFrmQY5u8abdOrKa7m9RSeiT7kW6QgNWp1Ry8KdpV7Q99Cm\u002BgrVvzX\u002BIb12sR7PU5B5gbXmMpQYXj5o5/AD/c\u002BL\u002BXPpF0sdzJCEGMhLlql/gngxJCOp6cU7jZzLbNdF\u002BiPt6req5jxFW7UkYhrMzceV6WV40dmr4Q\u002BurYmvUV\u002B5Ph2kXavx1Zs77MhuhYeqb8DUNoNxzShJQgmo\u002BziylQlVayT8J3AbpBTJPOURPFyIBD7J2hvcR3D0WxuiSNljiVe\u002BGRpirkhQuZFvqJFDOAWtH/f66LvueSSzB8xUeFs6ZrKOUiNBJlX2eSCKbJ/fsSIV9SnhaaGb0KD2r6Z7\u002B0E1NEHetebia/mhA26aYwyE01apP4IxWPwR8oGCS3aven7fVDddAPw8M4owQGUyAW2TcdtQ0bu\u002BA9tFzcJkXx\u002BC8onwug/UJ9NabQz4ARiX3vEU79qaX6jCIVBbGDI519Nqrk3cQkZevkkI9WSvxgLDre/RT3BF55PgLZm\u002BeQ\u002BgIZU4jVPKu5yqtjCQkmlEE1tOmGpDZ4djJca6\u002BxStn0U6aNTOdzmv\u002BPJTJpk/tFUpnBo\u002Bb\u002BClXLkN1GeMD7\u002BH/RbqVimUdZshnp938EDuI3BwkF76by9klAsawKLRIugyyymCVV4slSZ\u002BHNFBLWx5H7D2G39hjI7mhsEdebT4UHu3RCQXa84SRPs4fFJeI2eeoaHy2wdp0T\u002BbnM\u002BcDhtyhcxViulIYbPh5NaDKRA7h2Jaf9cTBnV0TXPkfM//djbfxfaGCZl\u002BVj/tEPYw5aguXxRsQo9EXn9X4Dx1Y\u002BXk4m6gpGMatX7J3CiXJfZ\u002BQ2fKthy7kzOnm2d3LylcCPJaCS6IkEFEFKqWomVmrDmJ2ZzUqq3IKU46\u002BAj8o4VUbdQ2PRzI9bMlhaFyJfDOQe8t7VaMh11FkeDfTpc5SHEkQTWRL24dwePoriQLVgRebLcZzrUvyOV28as76KYb7D0wTeO6PBGAECxyo9g4OTrcgOLgH3q89HhQGz7C4dg9zcLn2wggoy\u002BlmL6IvSQMPbdxX2jEO8zDdFhraiHSvS5UNNYWUV4yu92yOoe7MzdUQ92HUYFweZH1JGewtDgO0tuPM4lO9uxYPqOKEQBFB0AhFydDS2us5LtEICz3gQeko2erKwCuBUzwLhPd5WeRrx0mjp0Ry4dv4k/NCdXAYbyc5m2YmttAcxHaUxxYz/9Ts3EP0PNpktjgO0ix4Px2L81WQP76\u002BBVB5huMN3dqFxNPelZksZDJM1OUuF6Sj5IVYyNPAo4AWbtbzeo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21F8619\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "2ec78196-1229-c7c1-b4ec-897a97e88e76",
+        "x-ms-content-crc64": "YI\u002BNCDKpgqM=",
+        "x-ms-request-id": "993dbaf9-d01e-0002-14b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-603f06f6-bf9d-0c02-2869-feef5f8796e6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-ab5eed051f8507b5fb692a5fb17f63ed-112dce738d1c3e77-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "d6f5df53-3cb4-20bb-ff72-ba60e9cd8500",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F220E572\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d6f5df53-3cb4-20bb-ff72-ba60e9cd8500",
+        "x-ms-request-id": "69fceb8f-201e-0029-33b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-c6335da8-d7f4-cebc-1464-721d321789df?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-7c4fced9df5306b732cf24c374afe88e-805fcc4d7f84e4c1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "67c943a2-5705-98d6-5d80-ea7d71a1e2c6",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "19xbYXUkNWFmphJ\u002BPIwNq2VAtq9XiHfTVBsUhU8hmwjkpvFW\u002BDNCOl0tLG5RpRN1gFXzeqQdkk5lhwxaD68SRAsJmpWatrIx/XxRKVwIgq8HngT5LSBjxhOj8HAn6CutG\u002BdjRwp928miwn0oy2nyXQVdUnCqGBfrpdOB98VCChRQpA51pDqkicM6V2uiO/qqsZNryZa7AgLQeKI3\u002B\u002BQEYLdp2CdbfbjKuciscMGsSGrY10Yy1kB\u002BlaELpSuYbI3fNvazOGLSTzTaoBDNDpJBIy84XiSe0Yl360KGT9eNMkw6zTnK\u002BBAHBogSVzUwsIYOyoH7Xw5pQWVtPEwgTP9cTW7EkkBZdiofMFibi3pTRzu7d4RWkdI90YzUXLzD57mJtgnHax1GtVRW2y\u002B2zrXqGfURZNV6BbychsG0hRluXEmeEtVwjNsddcIwALWjhwPW6ULHsYLkDrBNKuVbkS866H/lF7vfeY0a8\u002B4SSgUG\u002Bf6\u002B3ZvWpqrHugQkI2H1wuSS9hc1vXBH92\u002B1rb2U0cSrRjHmnLOTY0LUHly3ulYrJDEKf1Pt0DuOd\u002BYrIfjsMuhAedwwDyUw/pLVYJ8TkDwZiYmMiVJwvnb1WCXMaEJJ6Ot0dkF5\u002BhUM2YDAF2\u002Bbe\u002BeqEpdvYKmWz7plO7f/ZJZQjHi0nhn6n450f7DRr6YGWd0\u002BIlWq2odC3qeGE79eDHXqcIv259zNr3II\u002BuH4xB8UX\u002BHZwUFApbLxcsByc4vPFnM75z8aEHIAcHLjot\u002BmSRqHcrTehEozqcrZBXUcWzzmOeRuvd3g\u002BU9v2FHPXQPSSyim6gHW8JIoBz11QAv85BQ2/Gj6N4w8pnhlb6v5ZEzGBrlMdXA6D0lSRrWfarlEcvQ8mGCb2BOcaUOJcYDmLqPxrzpRsG6k\u002B\u002Bwfp/HWnTy/If22vcvrKy6msAwssZ7IaxcSrbt\u002B8sKFl510ezAhxcwHyU\u002BDL3DXBoMMq/9id0lNVzvaxO\u002BAQC87MSUudq/9hOpAJOdPRDunOqc3ckfCIyBTJiT1RwDch4kgSP5KqY/UDicVIVJh/hL/MopISM3neQ4F2lCKCDzqY51eL/w9XJEXYmQgrQHO8igS9RV2lD67OM/vRc4/SgbqKr60A84WwtX4MOVpx8sNN\u002BgneBInc89fovcsTRfC1xhdNYJCGe9Z/DM/fWNYUnAD4g3mF9Lzw7bvVWDX6XS9NlnNDJJJyh74zXzf5/ZrB1CGKGsJ3MBGaXLLU8OPghK\u002BgUcKi0beuhfv7UpWE9vAg04PUcAIs1qYhqIffXZaaUtpIGWvYXsKp25TGu518FaXC9B1fzFRts3tcQSkvzyhlYP\u002B7PJ1ESHSBalStZlrI5ZLiHKm5OoaGGqYwfB3ZugysoRrdgNjIfquonqH/wAzgU5uWDbK\u002BrCZ5NSI3U8xW57AHwIVAKyS6GZ390FwkhhpZECiCQ6yZ7fT0ZIv20SrfUfbx9/9HoGh22/QUgNuKFG7HngOj1GQDrhLQS4ZYw0izHr5lMs5a0W/AC2e4RW0ZalBc7zLnO72Srgnst1SiHhhrYWJdJOFgrIzT48j8iyiltyF2O9QVjCLA0oSEblnbHe1PDOPK/AVu/EKmExf0leMhBsBza\u002BIEVdV/XBJc3D5y\u002BIXbrX4E2vrcB3\u002BRr7jLDHyho2dZp/ILCvcOS5/zEiAEMxqR2Oik3CwFVySisqYctA/VuzjW2RDT0GKHNo9bKTVfTXxeOXNUPMc7VFCNaJhQ8ZeQHVcnLVnJ/giF3eWcqi4vQyUp/nqcQb4x24TABmeKdgT3ywueeCAilHsqzh8hXqoiXiVzJzMc85vY9VGUybfg\u002B6eg5N8ikQsExyn/sXNe0L0a3ahCVw8RmxdvxULOjYrDSdK3gLmLP8zabl/JHQIoueTUeiwPXqSYjwnHssuIdnmfPGeg51ADj93baCjvCH3VB0ud\u002BhOes\u002Btt3vFvg00BUjfmaeDah5JU0OoOdDZ76UaMMmuAKnwmAEh8csiek8xQmhYwyN5c\u002Br\u002B5CSkpUH/08jVqo5EhgSe7gGmYnlTJ9j0dvZngSuCoLzfrxyETPLAIR0CTNDA7bxjudQi0xFxqrxLry5Ll1KdUwnRZdboGqIO5UBbUNsIM4k6BMdXYM2rbgVfOZzDdIrLZfnG7ojle58yE\u002B3QFVrhQnylEZOKRvI8JvbRiOEGSnC2kOviQkQAVIkoJUzf2lmrfvYgHmP2QB8GiciRFPK\u002BK8l9GoRu/wA3pLwKYiGmXUydJgrq5SsNv1DL27h8bz\u002BWafmDYsDUPH716Xqn7N7\u002BYCx78\u002B7n00adb1ozoyNIujR8c/gnIvuLyeqL9fywZdJyzHuMAHtRrpay5fJmoJhbrS5FKnnl1j0w8CoDW91J7AmHwdaou7m5KsVhdD0JJShRMEjNaztZjPY9WxBQTlK4afjo3t/BsvF1jP\u002BzhGH/J8oCsiuVfIHOLTTgal\u002BpaNxyqQtFIUdIj31WV947pgiUPjRGTpwnIux2GbCq4UiSzCQjQdpWugWDuSKtPySikocsTCwqYhlAS4YfzgeWnq41w4u6GGQtPoMuw5R5euLI04YpfpUcZ2kK4/VUNuv\u002B7Btzd3uY6Hoi/g6o/J\u002BExtGjV/qAbR8ZGFwisDVv2QeXMNZ5BgJnL\u002BsMBn\u002BHdGvJhRwksN/xfX/8Wl8fdjhFsyUGEMvJC8DOPCgPdGafkqTxWCoYSignprNWfauiSLizx1NagGOfAHpcVXS34Qg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F2226BD7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "67c943a2-5705-98d6-5d80-ea7d71a1e2c6",
+        "x-ms-content-crc64": "nE\u002Bq8soukpM=",
+        "x-ms-request-id": "16e8e222-e01e-007b-59b0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-603f06f6-bf9d-0c02-2869-feef5f8796e6?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-d2372f6ee5e59b111f6cdb75ac36b3ea-84268502da57a1da-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "53d73ab6-261e-4370-0a11-250269aae621",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "GFzIui0eDSxo/d5qF3KOFCv0b1utE0URQFFYsLv1s3DEqj4g4ugamqWa6l2h\u002BYeN60cpgEeGWwUXtnrbxV1wc0lupW00bTJD2dW2EynncEfJysR0yzIoPk85CSxtPtRHKXYTMlQaWX4V5ady0EfbL0YyEvqZ/KcWRmYd\u002B2QF1ZoAbumy0z3yrnFFXuWLtW4HXdnlOizZrizO/ezt/V4ZDw8McWFeKVwIQGOJU53Ci5D4FZ6LIJtuJ8C849ZQBbATLE/Wf0QMqTN83PrIUFqODHFc9OjAju90nUqhoUWFuDqydSdO7AtL7GtqDkOgptdmLddk9BHIU55fYeH6awfu9iTAFdoyQCBmEAh8VX\u002Bs1PdyO3NuIcMp6iKJ7oopUYBkexce35D8M\u002B22/uMITP0es4zqhy\u002BUf9Vglyu3qVGVPL\u002BHGNpnjfRmdQiFtyLfIJ0kajv9P8lRz/xCvkhlRYmcIcIkgDQjtiaYhBEnDseygHaNkj4Wl/31NkjdJc\u002BrATB\u002B6ZZgup9pAbQUZbq3KcE0jz3S17JKhonEL0rrRZBX7IPhqSUxUsXWJJGKATFCPQyHqZaS2Sl\u002BNGINm4tVfbsjvXk31oCbAz13/LMgv4VXgvE9ZJz6xRJZYnTCI7Y6gKbWZ0O4CmaM66ZYGt12XXTdtRmZGBkfKPhm3nQL2d\u002BGPHsMSlhBnneKsHj1oao14gQA5G6doGiMtj5LUizygRLG0t5haRMbnBahD2ehKYdOMPxvCvRx6ZwTgJMZ9UxLly9mL8/L1Hjx5EhX\u002B5EB64y3/SEwg3YdVehBTul/AqbJVnc3Ovq3glyDfiarGu4LEZUHYvgrGxS5SNnnioaPceKijaQZyrCSAHrFrAVPcjr6NjxTeKCtnjtjffEg0PfV9AxECYxJ8UfkdGF9Zm4Patae7VRJO/lC9O9ptky\u002BcTCC77j4C2musET1bgM\u002BLzjMVBMbgeKji7gTARSd3zv6JgIx\u002Bna2Fl5t8DwPVMz1A8W3nGI5o/BN32P/5QlUENEJ\u002B0gBDDTBFj21rZCmkzfrHf5O5kPYwIMS5BsStjFUGOBrBlmE9PaQ9YYkhPVfpkssE8cLBimOMDrF7igYrl8MYJSwO43dZykIvvC9szuNsj3Q5qNqSRK23dYfvwXNd0cmGCRgr2u9TqydA0c50Hz\u002BNzzrSMe8oheC\u002BV63vqgkOkaplpsXLALSEpj2zEbKfQxZIIfI4i9/aXYM3rUMBo8EeckBjzrg5gs5GDUvxdXRt3xSXZ4gW1cXKSwlC05NxgsI8lN8ye3ReDp8j8r5UKSgOyY5uqnx4x1x6WYNu9u97FIpJ9KCVO6OgORjo8yNHdmIhc8nEwtiFg41C9\u002BHxL1ev6J30CjRHec4qznFjUBR5MuMhDYLldlGxxHDTUgOBrwmBeMpFU2wt2fo72jSnIjO5CcT\u002B0CHUyrJMQgXDdCeKaR9nohcJ85\u002B283OI6ZwcyqI9Wkh\u002Bgt7n7G5YOREmamXSsXDVf3/crxYlR9yuC\u002BDWL3djhhmfC6ZAf/WosfqOUIjNtjgrR4tiYKsyWXsCOeCNgcnZguRMc2WKlP\u002BKM/1blzdT4FWoqqesASVubPJrfgYVGy/w9I2kgULSoPKLmCzt1sIDrllK5NdiLYG\u002B3cazX1b5tNjNquJprx7S1gn04Kk4gJYwJ4\u002BsinYYjocMJeO8HwGb0iNT4Cvfmj86d87NbQzYhh0wgzfHDOqitRwbXYl7VvbIGQ5FpKBqEE1QshKnSyF6M1\u002BGi5wJ1IU48SsPhHx1vyEXxRP\u002BUuF8hnKqdprX\u002B2o64Sop9Isa/kSJTPN1WkwQ2vMxT0XNe6C\u002BCcUpX53qYPXBFOMSS8pV/QbPdQXuB2wmmVvnpmwkLWWJq6rGMV7mnyw9tAVo/o7om5J/PgaakAKZAsYCArpJ3Oe9iOAfj8un6JXZ8FMmvZqM/srZpS9fLtuoLO6YpJyxs9cd63XuyQuGlxVwgN\u002BvsoUrdUOvcDf4XpoEt2LczwQ5aDx7yJJk3fX/Uw4Z7m37\u002BLpprS8YwkPfZYzb6hGoqYfRdxjjM6nyxpdN8Bzp3nAsCL7os2IU4KX4nKLFSTOkFqlGCLcVGIUQduaXitIm9Ydcr6GSwDZl/Fay6pbHLX1jqdmzo5X41u/5mDx7fVWTkacbqJlSERazIEwgoi4uCUmpdCE4s1HxY9jxmWf56r8BH1jv60Sj0ZjCwENJ2HSBy07y0ck0Wx4VakTAoHfu\u002BTWNH4LVPl4ExaJIdbLOp4tkL83ZBti1zIQ62oE/ozEg1AdNvLjx7I0wrcxmrCVrBoK5XHCp1bJdFxL\u002BmmPcxWJxZ2GrgOrSskNA6FjMTyCez5P\u002BRgbAtv5U8KVl8xIpE\u002Bip9USD/0XX5uotKS1ZUIgyX8rQHr8bsPBjFpBFbP9xV5SwYlnb2tAN5l9c003RO5/dc1NHGTUpjkRUYOj1Unnq\u002B9GY6S5uFoT6wjgfvt1ikdswp/lr6j6fRpQVR3onWFPlche8OFJxb1zOTFb8yc9nMY8NhOqAvtGTOWJaGM8K06mkOgzFpllIvzicnV3nonyErlWrGZOpZPMGKT8wF1aNg7itGM/CoUs1hQWx4\u002BFzq1bl1aq5X/nWOtUZv71aWKfiDxmlOkmswczKdVSN90DRkn2oCkGsFCP\u002Blx46qSHN2yxdz9THjrENONOdruplSANUR\u002B1/8k5mNjr15mNrsljrPJpoMCerygPMmtFuDmU5mU8apmE0jc=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F2272611\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "53d73ab6-261e-4370-0a11-250269aae621",
+        "x-ms-content-crc64": "dQWgy6HS0ZQ=",
+        "x-ms-request-id": "69fcebb7-201e-0029-56b0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-864ecc4a-f9a5-e030-4dfc-c8fdbf4b56e1",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b918c805dabc9009b3f5bd46605d9377-9411e2cb39c557de-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "37c7551f-8fca-5aa7-eebf-fff427f0d8af",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21B19E6\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "37c7551f-8fca-5aa7-eebf-fff427f0d8af",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcec01-201e-0029-1fb0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "6P6MMrjJDYvXtIAES7O6aazbJ\u002BpPi4/oWiaeitjNbozNjDQzi1YmLfmziOk//sB1rpRChF\u002Brll1vo9eSKoKzCkXzNr9\u002Bh95VtfrxnAKmqFtlKdtDiuotIvXXw\u002Bd\u002BlAJ2/36jTMgB9ie27M5lufpayft7LACmb4BbxhPKpsP21yD3e5yEAlyTZDK0jJ0bx2j7ffrsAmgCz5D\u002BSIa0NlBjvxWubj5d1sae6MfN8uLiP/6rzijJCtS49asMhbrW3i3iUcyIbVkqnqczTRqgNN2tHAiHCWgnmbVB9XmSUFAMxwmZ66AVWtKlgDCBlry5F8DOX2mxT9XFu7gXRnjfmE5XJoUQB0k8l8I24Yg3pQL4h924w/DmW3g00zDo/hNaxujiKm82qBB3ksenem1MjRW1H76aJtRdcMsN3DMYU5mu3BufVXuSwd/NQTEpPuAK50UaM95Uv58UhbmkKczcXj4u\u002BZ5SrTiaIl3fzOWjNDLrA/Xt/iC7Whx8is/B7pgS8eLy\u002BkVBuDoNgBGAdPO5cVGGuCbX7mAec5\u002BB1SJo2DPFzNsDsDntqUq74H0POuUpwxl\u002BOjVxOwKB04emwOIXpKjduqcYtcAXmQ/bHA7jDzi5WBII6Z3\u002BU5HYgdyxR\u002BloozvVMX89EQ1YZqEmlh/0nsRO7GjPDroK3mYWPzTkZlElc3jSDd25e0YEsIL8171x4\u002BIYYlqBmJSAylMYJ9HZdABPACOmIpDmlXEhyl43DgeppVxRywP3pNrkUUOKoFN1KzuCrNeaysFRMs3pX801SLxMb4J1iKj9WFtIwtBNW/Qdq58itWEvDtqa/5k1DUUNrgiGPjHRAKOThFR7UgfwBNbZzLMtEpNaHGCn2okOx0oWOhPHxx3CS6v8jzANtLzSqfvDXEGR35t1LCLRKSUZhL0JZRfzKTy4FoAIMYNiTGik1TCOS2sJhVt4UZr78SKG4gtzBE6k3oC\u002BCkXBia4YE9\u002B5LVT0izlRAOC8e9ehvSVdgU5370gZ//awz0AlR/usXz67QcPOkVbSIQNu52OpHE0fYwdfoSSXoC1dRLz4K7jkDxyY5ntij/D3pc1EqheTBrPyBuT0Tb0aI6GVcEya2fVKithGEDXSvdMWaPxWUvUVyj4IBiXU78JefsLazB\u002BkXMvX\u002BR8/TPV9IEgQ3uXBw9GrgKYNkdPQdpsV6JJy\u002BPG0cQswf1nV1n1Ii\u002BXcxBHdnLrxLkx5lsr3B4OEKmRjCihXW2zZkUR31akoxQbt87GJN0vYgcmlO9tAOHfVUasY5IG9hWilAwt1eViiUNDECRPR\u002BvIZiolesR\u002BQmVjNooT\u002BD\u002BCEMG1I5DQ/YgdxA\u002BsKfC5jA1a5/1n3XtNIFGqzqNfUo0DwP9mmiBW\u002B2SiC7a40hhwpaZ4tRRCGjdKa/9DJjLovnF\u002BqGjxVvXtA\u002BiUxdXAkFI5NiT85pl4vabIHC4hF9UxtUlBPiWvg06sj7UrrVBdhdetCewN79vYAerGKTrHy\u002BwXYxCMg1YoibbaTFbkURBSbppadA3lJ8lxZTw66VYX5MfFFEpD0QJ9gHw1M5\u002BA97Dac76gbVPiLjtLGxoZ7ZxcwmuTHzzKEpmX2PONr/Ap7HGLYHmbc3tz5uYO\u002BLXoZ5bj2HE37dh0DGEhDJBgUH5LHS6kjokmwVLwIzRWvxXnq3VcrdeC9f6ZF1QUembnD5Zrx9uLQ9kJvRciR86gHVFLOWEfB6amxCssD3s1DkroCROh7vc\u002BXGecUvDAYK4z9PYCzT0ByAvvwQOwXzRh0K7MNjq6/jJaDNz5grC15mN4\u002BBqBNkEJ5kELsi33igEzPoJB8C53ePbHqLxgBEVbOdqcN2MZ3J5txk/5s0wEYoLfykQuc/I1BYMjvY2Apd37sHhTW1KeFV3n1C3eecWqw0Y5hD4BKMXkazHj\u002BiMQ6RxyAgLXsQssPbDmSp/EVo\u002B5dPpHRyGf9oeybuwgvh861usNbHfG1w47CUaNGt4qHBCmJoEkyaH\u002B0gt7IUYfD4OVr3e0uuoX9qHsDD3fEtuphE7ffpuaEg1FDp5sT7HIH/3C\u002B29mcWUmji/jOLlkI78vzZj7P5Dr/5lqc6hPq6rsI/BAGBtsQxbltOxrttlT3O7fPH4U0Nxo2vvV/AG82uaE9xTJJAenw4qGEYqkfES8GpK5cGso11MT1z0flkcRJNoF5sPEhrjnO3zzkr9RxFq3FeVzA2p/WB/BuVDGhClHdOisnpmE\u002B5PV1jTuOUSXvg7maIBhniVzhoqkAs1oHLNTqBnSoSm9Mh5RmS0xkR7XLftB4B\u002Bo5dbHPRgS4PjCbbWFmo0qwRzlJTpmDAT0PfVrzNDWJjyXqsZHD2QNrlEhjy93r/aRqGzeXLrlQtXRzv8ipxAn7Ed48e/G57W013blQHzZgJH\u002B2iRn\u002B8mBrmvsdTxk7ws8/aLn/r4KysC7JYVH/AJY\u002BE5tI8zvv/B5\u002B0OH2nJ1U\u002BRvqEbd8YHX9A9jrNZEPbJll3zx\u002B8s\u002BUT2ubgN6hvBSQdGc1Fe/fwrIlS\u002B9jBMeNb2RHkL1h1QdMVcFL4OCWXEfDWsAp2VaqhR2JWKbfMUqjDhF6WStXL59g6L8tk\u002BHSj\u002B\u002Bnn6kHY5UNnQqg2HxgbCR2p9LOHAIcbCshyfGXfPI7tsm3N5GhnKp7bLwgtlci/3uatuwPA3LsizJ95ZqkdSAYZCGzqTSS1QonUq9G\u002B7XU/8l1/MYFLLJXyqxeI7YQ1/abB1I1blZGB\u002BDh6LE="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-e7ecbae9-5df1-184b-cb86-07a2f420546b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5ed06f5f86679b837e3cc3cfeb089325-1af314224d19f3c9-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "14e3e463-aee2-0957-b9c9-1a5c2e542d5f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21C0422\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "14e3e463-aee2-0957-b9c9-1a5c2e542d5f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcec9c-201e-0029-28b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "wqWPfanm0C94WRI4blzeiDOyUxZ7uav0Y56Qcy715SRDAZQkHOF60ECnfUH0GccSeL7TLo3SNQn6mxkKVl0Ag3Tu9GzHuWxSN4PV0ztp/0nXffpwIbeWccyLKoDIcHrjp/rNBiVaSr5RgfYJ/GHNkZzQMthikGG9V4OgPI/siccJ8ixBm/kkfTM8HqDAjXRrvZjk\u002BD2hgRaYEK6iug4vZfcvAAo0jPajrLWlJnHB/MoONH/2CJGJZ3AWqYpKgcIkDLmokYxqNjGiQEuI/Ful1hPklIWPOF1mpZiZHuJrWSrygBm3GWs9pP5NVMdFAGoVcNJ2Ze09ldRcQuvz0BhONuchlnxB7b2opvCHQeSWIKUuhK0P9PM8tepFW9eAStPl/h3gJGru1IMVzr79tlTvxiFFxUxqP0Lz5OGR/JHmJ1wcoULGtfs6P68q\u002BiY1P/\u002BWVZW1OoSHe7/b7ECJXdjxLqZi4RQRKRAmC4acP0QbvaTh\u002B6b7Me3XlCWC6si7seLXOct/0l7qhCuFji/\u002B6zt7vy\u002Bbp2Ex9f25i0zujz5Ha1mkxAZ4nOtG93Z7dqK92KnpByuZHwqApkPOxkcS\u002B/XsPiPVWiY1AiNDVK/qtn9a\u002B7KiBIcTrUtPIx7CqtWjNPuBjjd/532DtAUHVcpalfDDc8uUb/Zt2ZDYhjcIcldNoCC0aShH2xM1H1CCDFeA9I4t/jcKDsQEE7SnpmBGekGtubWqpizIfJe3X1Cm68w4WJKo2nQfQ5Fbr1VzoDWy7qQO1VKi1U1iZYKgU650Xijnbk7OnaDNjXYjTvfWVNtiBXGrlxZ6loJERnXxf/Di51EsizLm5FAEQUfcfodWixCmPk09yMYSbdfMiVcr2w6GQWemqcmpeyEgp1bOnhj77rtkSkGipR6KGh1aGlr52WU4VTwfsOFH/cIsHCFwQ8\u002B\u002B0ZqbxpHN5JtJG4\u002BrTmHGJ83wlUjb2z7ZHU1\u002BdYj8GdZOm0i/XRLUa3Gg1pRSm65hZvRUf66G4vZcwqlDTm4TTQG4XbMYBsq6HCrXOgSphoKfHQ\u002BTp5kox7hSY5ppkRwCjYmSmj37SF8qmWOEr6jxsjsnozFef6VnkJb6xaMvUYoN1K17F\u002BxEpNSwaQ42pBcQYbBfQu3rpA7jKgqnAIO8\u002BkfYdtv7dZtO4v9drhWWMet\u002B6WPy0A\u002BdIjCel\u002BzinaNR9G7GXS08FewVEF/ujfX4TfkeKRcfySo4O1SrXN2ua0VbC7qmz9S\u002BQdN33L\u002Bvr5Q6pUrzxHOMMipEjiHYkbkPZqQakoI6Un0kX\u002BhDp\u002BxqiIvAcLaSu6fRztmPYkGy5a8aaHUalRwS/1PMzmSLSIo92QWVGCECfKv9SMOoq\u002B87cXo4KT93UPNvrXBixuxCRoZPUog8HMyOF\u002BvKHU1YalRjkVzqUx5KxokSJmuwn7a\u002BugE9WVhn/1StqRJTrTKlFkMb/zSPWPNnBYv/KfZh3Xc1C2JMGxH7/JEIPKkM9hlWbA8nlaCBL2IN1VTNZ9VeTMyaHqHQWfsyHwKjhxxKWg5yqL3nOkjWtNwAPkW9LpS7qfDdcth3hRMT9HWe3adFw3tFWr8YdhGDw2nF0Bu2dfBt6N0sbOg2\u002ByKp00XSONY0unrJd9TVojPeWa5usbX3XH\u002BEMPXJGVaTD16cbqPMsIuSkBWh7P4cmEWqTRM5x0ltsnbGTgfha6EjNmh1OTOPEqgi3CGgVnCBaJiwH8tDWUgVL7wsBWKEsSVzfbaVpl4RGjtqFuoozFsGReVuMUzV390gYAp3YwxGniv7LNi568E5ngSQ2UJd7GJgJcB8FYDZnp7ZdUVUmrcuJHe/LKCDTFkkNZJHRQaawnSnFj1MyYmrIo464HV85QRNYrTKnsDC3dlmWODtkViXP7PRrIN54lvuFAkRSWzkqFCO\u002BuJRzySz5Tlk5XCpvZE1oqHCqjiA04BZ3Im2sJRsgbCQX5Z2Rm\u002BOHcZKFfzqRVZ426bKIv0XDSdi\u002BPOa/DWl92PAGV36v1wxM41xNr6Db5czPtTtol\u002BzeFJvE0189CCRpR2YKiv5fRxKmO9wptdo3olbZ75gt1UEDaALiqsOtT9s35Cg60RrOcC4owlwQtJ6BjTEIIxiMe3IlB2K7fNwO\u002BOwBMZGyPNE8C39qBRMlMrOkIN2SpSyCa2j2FYn4EzNR2clvz4LND5BgC9eZYnYewBTvFxv\u002BvFO/foYo\u002B\u002BdHBDhMGCsJtSLwlxENcpkU6QkylxW1CTvXU121sJD85BOpGMffTQoLFUrx/kAKsQm6qlW9NiTRkfs8dITNU8SR8/L9pFmRdZv\u002B54HKg0q7zKIT\u002BwY7f63u10bM4tiFfYFGYAqNDQzwKXT5/k6jBs6wQKfi\u002BVj\u002BVrQFDozShFKDOWnARGMALv\u002BVI9HRQUFfC9C4HKJwokQoh8mWR/6AHWTiNoTk4oJrcFHoTdWG7RUy5cK8WmfwUpcl17yZqebA1MZs70r8emkODKwQiFSuodr0Y2I7w8L9MaQt/wrF0cZrJ3jPGf3KdmtZbg27n8pCdzXh5QZEhREDr/2mjrteCDrlpWDb30gc6iz2olW1AZHZ60fVJCy/5mJni6nAY6ewOyYS1fppZpftxPsZjeK7jm5rjONziSQOZf8\u002BdBOeHIaFBqdvomuXcETv519xplh/7D17lJaEfHIBxLA7avJED\u002Bg0VEd7TCvClFyeQ6HE3L9mvogWYkgvwMo1LZ37nAVSa5e3PRIRBJ/ReMB55g="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-7f56f8ca-1b24-87a6-75d4-2b348fec9001",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-37f20673ae909b5edcb60ad218a1be46-1fcbd8117457daaa-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "43901d67-c40d-dbcd-f10b-cf2f3d1d5a9c",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21E74C7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "43901d67-c40d-dbcd-f10b-cf2f3d1d5a9c",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fced22-201e-0029-21b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "40H0n8JSsam3tX8RTvQYejgc4F0wYCk2frVW6KATpR/Ya0WTwdcrHWSf96hc4vpP\u002BgUNxyCKZ4IYvSEN/MgIow9gOeOvhLhg8cL5kGiA2Zu6Bu6bBt7\u002BTQPCewS2HSGbl1OY/KgXoHVNrdVekdYal\u002BOGU/XabZ0xYezf7AmzqdOgXfkV593yo2V4TlgIoLssqOMgMMoswCq1Z5u8N7RsmQMCvTPdBK8Gk6\u002BPYR5EKMAwskMlk3kJdJ3PYIBBNWyxDLRVBuOIT6QzGpwanF8LcD/bi4RwRgaJ\u002BEiWDaQvxF5D3VRq7yHcqGOf8Xjd7tc\u002BxO9AZqrnQcauzA6a8UH/BFU\u002B174KoIEd/uMh0FSNqwlwWEm07l2zXJyOuyITQbYhoO0inxcZMyNuI2jHxXFxICAEKZn4SxX4inoifOReCbwsADBnagzxVyQmRsv17JYrHJsBDxcdKFTXKhSc9rc\u002BDxmrmsVACbYUEtJ00gVJAp3k919JXfqkDtfbjz/3VWBt5zaySVHR6hLl7fxFqVZPjSd3uP9Y9LIeBoztZXp2Hb1xB\u002BrOl7lLEg1MZG/9X2WAiwEXgJxhFfKEk0LF44SYbtA/1KJsgPZuK6XyC5BCIacmbNl4XpwgEPH3SgN2hS\u002BIs/WfvYvDFAoLqVT3bwliQXKbn3arIBAzH8SwdDby\u002BKV2aViao2McYljObLVIKKDolAiR2\u002Ba43ZPlbJ7GE6DUGbCugQWxyJ4Pfjwe3LNb6vYjx98uYR2/vYzFtTfFVU\u002B3\u002BlMEmqebN8xqglypmgDfiYGno0vApreT7sN47BNnSSjtZuJgVlBOh5ATw97AFSOL5Su1HbED9lSbcavkIku4Ajg0vDMefzMwWBy7reLZ09if7QbosSt26W\u002BOxOWkamREWsGmi1nwbGb4hMWVR0lxwp3SRDVF0FAMvdLDkLpNi\u002B63dlMhMkd/r4Cf7yxm4aEmHAJI0iUv/4lwmc6GLdusqvnX3tD1UI9WU5W0peAkptwwnHS4BbnIiHfJsJl5\u002BYKl80QzjwPQMcty8n\u002BQe1qoTPLxVZBn86U/DlVZLJ/13FkSD7Kc8BfZYGuoRRM6NwwcIGSmiKTxPf\u002Bf9ICtdgQsfBUlfWynDFvbF/Ulvq6SBNdJPQs6T1S1IdGz/fuXLOlmfMn9FbmgdRQJy3CuzH9RDO\u002BoZDn58S3Bb1ya9A9fROsMvkHkle8dqMf2MYPkBlVSYvAM7sivbIubPKVdBoEEqYaEog09bHf/i7tyAr\u002Bp3WgHSJIeU1YjXVG2SFhKv6JG8of9X2RHFPV5DGIMPGrL8l88Vr3u5VYwYUW7hiMetMsZKxA4rH0EvzOcpUbzFiDn6lb5DmnkVwwxzP4ejI3SW1iW8hFZk0XhOJaJUkAQPEol05vMJKZiNNQEBt9\u002B5TKlykruXSMPjVcQF9XSWgTLIJC0\u002BbjyBTaxNL49VYxmY1Jk44j2It8mFkVEvA3Rj9rPOOZPyux6s8UTPChl0TjKqrSDbnZ81f6xjeNyrUgp4KXjbR2mF5hm6TDD4uW3wEQNeRJYTSBjUmLonj0JBwZ86lyCgWQaJJIbHIRGufMY\u002BcyeZDM20JKEgBu7vnlbXeEpRviJND/g81V/PDGbHJluz6RwaqLSRRnK/QBIX2UZwL\u002BjHHL7j8WNvnHet5Nh6GSCTO7V6vM/VwHevjY\u002Bl5TvZnxx\u002BP8mc0De46sx9I6FaBWcxhJ3RNXMZMVxHNCOTybd7lAX7/BlW9iu9gdHDWJyWVUhodGBeCGmpZQ5tFdvUJOFUwU9bXkkN2o6yE7OhFZi/8N7ba1VXHYvcEpbK6aBP6VzwbldNOvc/GpnR7DT2CA\u002B1rWT9OPmL/ePDv0vyQvDuImoWsKcBcrYnnBC7hXGW5cpHVXx7UvCjJLCzSXtrDNfo44nK35dodHqu1VypEHiybJlBay20so\u002B5c0w2jel6vE940qGnjAZy3uDBjL1UOhQ4ARziKaHqdHE6UWwLMeZRdFjNcH3WyqCSzowMsuXSJXk4PkzMmFKtjl5wbXraZ\u002Bz6sBhkRonWYTa8DxsVnYFLKCvy0zOZhNvGH\u002BHfZl0luKafUcKNrd7vIZ1WEEk3l/Dc5UVO51S5YSt8XiboNvqZVla0dku\u002B/XpNA7FWA3SSjofwwoEXltFSJfDXUU\u002B3xyrivPnygyGlHifLAaOjYx22qc9fN3Q5gb\u002BFYlBa52wqlTyGs4a64AumC\u002BSZDJUtroKTIKdAGM/2qTs6LSCRSna74GxnHO\u002BXO8mD\u002BOtPoHTqV/ONh4aEqrxsz8pLQLLq1MFt3WxoxpHTO\u002BTd/GAkZsiGD9Vsw4Lv9zWwOgzlS7sWmOQqIYLIgZEh\u002Bouh5u5cSKkBhXDdvhF\u002BveZ2uIxFLfAphyN8OkUFvY5ESwj3DhAHU/Gjo4ZKeRrS62PckcjEnIzbeF\u002BK4E4j\u002B8fiWXLIR2/WL2Ta4Uop3w3IqU7haSuFf66729XwfLOjf\u002Be\u002BqB/nymQzxqKj6fsC8ZkRwjc/QlLcHNmETGuZ5bKxd2Giq3cuIJ7qraJJIZWzeSp8nrp8o/1UoksGY734meDv8rJZoAYiI\u002BFYFNTwUztD0NNBHUb4NNNkDcjr570g8hOBmS8jWdkkGrrZJE8opE9PglKqt3yaN72e9VJ9djwkdyKBbvnMYLc6HQLMHxBEe6m5nGVqdnqW52GxRGRG5uR\u002B9K0sZzVVgyGbsFo5zhitGrnog5nWucDn6kdYWxxSs3ZeTSpjV8="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-94839363-be68-edd0-8035-bb1ef18eeb2c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-affb770437f19507b485db9d34d6361a-ce0a9153aa73b380-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "10f40787-eac4-ea51-9030-b007541989bd",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F21F8619\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "10f40787-eac4-ea51-9030-b007541989bd",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fced96-201e-0029-0eb0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "UdCQZA86F4J0ZSMQpqp4jCqg67ER8rf1oBQk849tA7gnCpXRfgJLrOwdNbc9W8qfVUxPk77bTV4YmsT6FiPyB2Jr6ZwVpg0nVT7F870AuEVKhJ5CHW/5S7w2uOM\u002BUJbIKy1V0XIuiq4/KD6AFlqgGOJ/sJKEsOnzcp3f3u0p6AWo/MiQq\u002BbSG/rvA/QxeDRilaABv6ADQ3pDYV/UT6vBFT842BqREG38rJSYlaz0wvlofElNKCllpLhOTEmH/sxOLu21\u002BKAa0YQyBRMLa67NTp9la9Jic\u002B0W0zRhQ8QkdK3ISWa/P8lZTqvEGiMVWTgJgP2qIZP57LoAnyRsuI7ADpBlQiJHDg/VDB0nnVjJAHn7V8PHelMazlysvqCk7ZUdBAyTsBcVwnHt1BR10k9hNp6rcGDL\u002BJM8S3PFm1BuMB\u002BICZhMNlBi5pVR2aU\u002BpPwNSocB\u002BXw0UQt4VmSjUCYgf6T17ci2FQBOSIrLeR/u/aZ3uFDJbDaiU7eM0\u002BDrvpVuMFoBSbczVjWHs7DyaNjsili\u002BK5fWVxJtUpkQKkIfY4n0XEjF7LTvRGEbQbmGr\u002BrfoEiILZP\u002BmNhHlPcdIizzZ1Am/gyPJ52kz\u002Bc1uhVZ56KuMYr5lzX29cRvfVi90SE1KNpoX7HeT3iq5F6ryN7D7q1UbvGi\u002Bc8aLwhIIKlF5/3GAJE78Ifxz\u002BERTrPXSy3lrI6qaGIvky4KTi\u002Boli/PZf1g5MhMh/4lY54PkKscQuTbYnMam36alm1iMKFYSDmyQum2dmdlmSWQhQTDHwKD7gtLzTS8tMl\u002BxU1b6VZczRtlXU7CZsx8dshOihZ613dq30KWDHsE9Y0fOLEZCq/OM7fpXcKzwIg/zlZrbSmzA\u002B7W8AoUxsCfYWfBoy0aY2wZf1ZekHm1tx\u002B6Vz4kmYdjazTCQxmlum33Svxa8h1aJGvqUu7SVXN1ITnrWW\u002BBesjfXTf5WCBSc8XpZkZ8WsQBYDLTOkaZkRbATSHgumD9dc80epXlYMxKmN4o6e4s\u002BMZ06fg8rkCBRcwhOAr\u002Bcrlk6/B3SOAvG/9miKJocagnlFVabNFnwceOszTJxCfBTCYkw/39ta/mRM341iaeGNQk\u002BaS1owbo/Sop6JWrZlfYpDx8Q66qKt\u002BldCcDb\u002Buh8JpgpcqDDKggPMbS08waOt51IDHqItUlec/FDy/e5I0\u002BiPj6S8GMVJiTXAfo2FYSijpIjU66ts3FOiz7vv15QVc4k0vTH\u002B8d6MyYVsbNPaF4soT1llY/hNEqNRCVkZabGhuwr0QLP2tKKqWCIWAH9/2Kggt4hKoA\u002BA95qOneiFc1/TyrHY1cbXMZqmuxvWNxIz4TCg6KIpZwr7c1kZaBbKJNTCMjXNlvLhWYXtk\u002BTjurB4Wry35Iq9qmOm7WJ9vcmD7JY3FATcdlo9z48cS8MmF7iYkR1qAkBKBIfSFrmQY5u8abdOrKa7m9RSeiT7kW6QgNWp1Ry8KdpV7Q99Cm\u002BgrVvzX\u002BIb12sR7PU5B5gbXmMpQYXj5o5/AD/c\u002BL\u002BXPpF0sdzJCEGMhLlql/gngxJCOp6cU7jZzLbNdF\u002BiPt6req5jxFW7UkYhrMzceV6WV40dmr4Q\u002BurYmvUV\u002B5Ph2kXavx1Zs77MhuhYeqb8DUNoNxzShJQgmo\u002BziylQlVayT8J3AbpBTJPOURPFyIBD7J2hvcR3D0WxuiSNljiVe\u002BGRpirkhQuZFvqJFDOAWtH/f66LvueSSzB8xUeFs6ZrKOUiNBJlX2eSCKbJ/fsSIV9SnhaaGb0KD2r6Z7\u002B0E1NEHetebia/mhA26aYwyE01apP4IxWPwR8oGCS3aven7fVDddAPw8M4owQGUyAW2TcdtQ0bu\u002BA9tFzcJkXx\u002BC8onwug/UJ9NabQz4ARiX3vEU79qaX6jCIVBbGDI519Nqrk3cQkZevkkI9WSvxgLDre/RT3BF55PgLZm\u002BeQ\u002BgIZU4jVPKu5yqtjCQkmlEE1tOmGpDZ4djJca6\u002BxStn0U6aNTOdzmv\u002BPJTJpk/tFUpnBo\u002Bb\u002BClXLkN1GeMD7\u002BH/RbqVimUdZshnp938EDuI3BwkF76by9klAsawKLRIugyyymCVV4slSZ\u002BHNFBLWx5H7D2G39hjI7mhsEdebT4UHu3RCQXa84SRPs4fFJeI2eeoaHy2wdp0T\u002BbnM\u002BcDhtyhcxViulIYbPh5NaDKRA7h2Jaf9cTBnV0TXPkfM//djbfxfaGCZl\u002BVj/tEPYw5aguXxRsQo9EXn9X4Dx1Y\u002BXk4m6gpGMatX7J3CiXJfZ\u002BQ2fKthy7kzOnm2d3LylcCPJaCS6IkEFEFKqWomVmrDmJ2ZzUqq3IKU46\u002BAj8o4VUbdQ2PRzI9bMlhaFyJfDOQe8t7VaMh11FkeDfTpc5SHEkQTWRL24dwePoriQLVgRebLcZzrUvyOV28as76KYb7D0wTeO6PBGAECxyo9g4OTrcgOLgH3q89HhQGz7C4dg9zcLn2wggoy\u002BlmL6IvSQMPbdxX2jEO8zDdFhraiHSvS5UNNYWUV4yu92yOoe7MzdUQ92HUYFweZH1JGewtDgO0tuPM4lO9uxYPqOKEQBFB0AhFydDS2us5LtEICz3gQeko2erKwCuBUzwLhPd5WeRrx0mjp0Ry4dv4k/NCdXAYbyc5m2YmttAcxHaUxxYz/9Ts3EP0PNpktjgO0ix4Px2L81WQP76\u002BBVB5huMN3dqFxNPelZksZDJM1OUuF6Sj5IVYyNPAo4AWbtbzeo="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-c6335da8-d7f4-cebc-1464-721d321789df",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f2df15e2261affd03e82ff5800ca2cc3-2147ba81bebfe21a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "36a8278c-4928-69d8-53fc-299e04c7e982",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F2226BD7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "36a8278c-4928-69d8-53fc-299e04c7e982",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcee08-201e-0029-78b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "19xbYXUkNWFmphJ\u002BPIwNq2VAtq9XiHfTVBsUhU8hmwjkpvFW\u002BDNCOl0tLG5RpRN1gFXzeqQdkk5lhwxaD68SRAsJmpWatrIx/XxRKVwIgq8HngT5LSBjxhOj8HAn6CutG\u002BdjRwp928miwn0oy2nyXQVdUnCqGBfrpdOB98VCChRQpA51pDqkicM6V2uiO/qqsZNryZa7AgLQeKI3\u002B\u002BQEYLdp2CdbfbjKuciscMGsSGrY10Yy1kB\u002BlaELpSuYbI3fNvazOGLSTzTaoBDNDpJBIy84XiSe0Yl360KGT9eNMkw6zTnK\u002BBAHBogSVzUwsIYOyoH7Xw5pQWVtPEwgTP9cTW7EkkBZdiofMFibi3pTRzu7d4RWkdI90YzUXLzD57mJtgnHax1GtVRW2y\u002B2zrXqGfURZNV6BbychsG0hRluXEmeEtVwjNsddcIwALWjhwPW6ULHsYLkDrBNKuVbkS866H/lF7vfeY0a8\u002B4SSgUG\u002Bf6\u002B3ZvWpqrHugQkI2H1wuSS9hc1vXBH92\u002B1rb2U0cSrRjHmnLOTY0LUHly3ulYrJDEKf1Pt0DuOd\u002BYrIfjsMuhAedwwDyUw/pLVYJ8TkDwZiYmMiVJwvnb1WCXMaEJJ6Ot0dkF5\u002BhUM2YDAF2\u002Bbe\u002BeqEpdvYKmWz7plO7f/ZJZQjHi0nhn6n450f7DRr6YGWd0\u002BIlWq2odC3qeGE79eDHXqcIv259zNr3II\u002BuH4xB8UX\u002BHZwUFApbLxcsByc4vPFnM75z8aEHIAcHLjot\u002BmSRqHcrTehEozqcrZBXUcWzzmOeRuvd3g\u002BU9v2FHPXQPSSyim6gHW8JIoBz11QAv85BQ2/Gj6N4w8pnhlb6v5ZEzGBrlMdXA6D0lSRrWfarlEcvQ8mGCb2BOcaUOJcYDmLqPxrzpRsG6k\u002B\u002Bwfp/HWnTy/If22vcvrKy6msAwssZ7IaxcSrbt\u002B8sKFl510ezAhxcwHyU\u002BDL3DXBoMMq/9id0lNVzvaxO\u002BAQC87MSUudq/9hOpAJOdPRDunOqc3ckfCIyBTJiT1RwDch4kgSP5KqY/UDicVIVJh/hL/MopISM3neQ4F2lCKCDzqY51eL/w9XJEXYmQgrQHO8igS9RV2lD67OM/vRc4/SgbqKr60A84WwtX4MOVpx8sNN\u002BgneBInc89fovcsTRfC1xhdNYJCGe9Z/DM/fWNYUnAD4g3mF9Lzw7bvVWDX6XS9NlnNDJJJyh74zXzf5/ZrB1CGKGsJ3MBGaXLLU8OPghK\u002BgUcKi0beuhfv7UpWE9vAg04PUcAIs1qYhqIffXZaaUtpIGWvYXsKp25TGu518FaXC9B1fzFRts3tcQSkvzyhlYP\u002B7PJ1ESHSBalStZlrI5ZLiHKm5OoaGGqYwfB3ZugysoRrdgNjIfquonqH/wAzgU5uWDbK\u002BrCZ5NSI3U8xW57AHwIVAKyS6GZ390FwkhhpZECiCQ6yZ7fT0ZIv20SrfUfbx9/9HoGh22/QUgNuKFG7HngOj1GQDrhLQS4ZYw0izHr5lMs5a0W/AC2e4RW0ZalBc7zLnO72Srgnst1SiHhhrYWJdJOFgrIzT48j8iyiltyF2O9QVjCLA0oSEblnbHe1PDOPK/AVu/EKmExf0leMhBsBza\u002BIEVdV/XBJc3D5y\u002BIXbrX4E2vrcB3\u002BRr7jLDHyho2dZp/ILCvcOS5/zEiAEMxqR2Oik3CwFVySisqYctA/VuzjW2RDT0GKHNo9bKTVfTXxeOXNUPMc7VFCNaJhQ8ZeQHVcnLVnJ/giF3eWcqi4vQyUp/nqcQb4x24TABmeKdgT3ywueeCAilHsqzh8hXqoiXiVzJzMc85vY9VGUybfg\u002B6eg5N8ikQsExyn/sXNe0L0a3ahCVw8RmxdvxULOjYrDSdK3gLmLP8zabl/JHQIoueTUeiwPXqSYjwnHssuIdnmfPGeg51ADj93baCjvCH3VB0ud\u002BhOes\u002Btt3vFvg00BUjfmaeDah5JU0OoOdDZ76UaMMmuAKnwmAEh8csiek8xQmhYwyN5c\u002Br\u002B5CSkpUH/08jVqo5EhgSe7gGmYnlTJ9j0dvZngSuCoLzfrxyETPLAIR0CTNDA7bxjudQi0xFxqrxLry5Ll1KdUwnRZdboGqIO5UBbUNsIM4k6BMdXYM2rbgVfOZzDdIrLZfnG7ojle58yE\u002B3QFVrhQnylEZOKRvI8JvbRiOEGSnC2kOviQkQAVIkoJUzf2lmrfvYgHmP2QB8GiciRFPK\u002BK8l9GoRu/wA3pLwKYiGmXUydJgrq5SsNv1DL27h8bz\u002BWafmDYsDUPH716Xqn7N7\u002BYCx78\u002B7n00adb1ozoyNIujR8c/gnIvuLyeqL9fywZdJyzHuMAHtRrpay5fJmoJhbrS5FKnnl1j0w8CoDW91J7AmHwdaou7m5KsVhdD0JJShRMEjNaztZjPY9WxBQTlK4afjo3t/BsvF1jP\u002BzhGH/J8oCsiuVfIHOLTTgal\u002BpaNxyqQtFIUdIj31WV947pgiUPjRGTpwnIux2GbCq4UiSzCQjQdpWugWDuSKtPySikocsTCwqYhlAS4YfzgeWnq41w4u6GGQtPoMuw5R5euLI04YpfpUcZ2kK4/VUNuv\u002B7Btzd3uY6Hoi/g6o/J\u002BExtGjV/qAbR8ZGFwisDVv2QeXMNZ5BgJnL\u002BsMBn\u002BHdGvJhRwksN/xfX/8Wl8fdjhFsyUGEMvJC8DOPCgPdGafkqTxWCoYSignprNWfauiSLizx1NagGOfAHpcVXS34Qg="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c/test-blob-603f06f6-bf9d-0c02-2869-feef5f8796e6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a1a6a6c2203a033334b0795cb01035aa-dba3b9771ffed09b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2d7acebd-5271-9a94-d18a-922c5da5ae86",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "ETag": "\u00220x8DB71C7F2272611\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "2d7acebd-5271-9a94-d18a-922c5da5ae86",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "69fcee73-201e-0029-52b0-a3aff6000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "GFzIui0eDSxo/d5qF3KOFCv0b1utE0URQFFYsLv1s3DEqj4g4ugamqWa6l2h\u002BYeN60cpgEeGWwUXtnrbxV1wc0lupW00bTJD2dW2EynncEfJysR0yzIoPk85CSxtPtRHKXYTMlQaWX4V5ady0EfbL0YyEvqZ/KcWRmYd\u002B2QF1ZoAbumy0z3yrnFFXuWLtW4HXdnlOizZrizO/ezt/V4ZDw8McWFeKVwIQGOJU53Ci5D4FZ6LIJtuJ8C849ZQBbATLE/Wf0QMqTN83PrIUFqODHFc9OjAju90nUqhoUWFuDqydSdO7AtL7GtqDkOgptdmLddk9BHIU55fYeH6awfu9iTAFdoyQCBmEAh8VX\u002Bs1PdyO3NuIcMp6iKJ7oopUYBkexce35D8M\u002B22/uMITP0es4zqhy\u002BUf9Vglyu3qVGVPL\u002BHGNpnjfRmdQiFtyLfIJ0kajv9P8lRz/xCvkhlRYmcIcIkgDQjtiaYhBEnDseygHaNkj4Wl/31NkjdJc\u002BrATB\u002B6ZZgup9pAbQUZbq3KcE0jz3S17JKhonEL0rrRZBX7IPhqSUxUsXWJJGKATFCPQyHqZaS2Sl\u002BNGINm4tVfbsjvXk31oCbAz13/LMgv4VXgvE9ZJz6xRJZYnTCI7Y6gKbWZ0O4CmaM66ZYGt12XXTdtRmZGBkfKPhm3nQL2d\u002BGPHsMSlhBnneKsHj1oao14gQA5G6doGiMtj5LUizygRLG0t5haRMbnBahD2ehKYdOMPxvCvRx6ZwTgJMZ9UxLly9mL8/L1Hjx5EhX\u002B5EB64y3/SEwg3YdVehBTul/AqbJVnc3Ovq3glyDfiarGu4LEZUHYvgrGxS5SNnnioaPceKijaQZyrCSAHrFrAVPcjr6NjxTeKCtnjtjffEg0PfV9AxECYxJ8UfkdGF9Zm4Patae7VRJO/lC9O9ptky\u002BcTCC77j4C2musET1bgM\u002BLzjMVBMbgeKji7gTARSd3zv6JgIx\u002Bna2Fl5t8DwPVMz1A8W3nGI5o/BN32P/5QlUENEJ\u002B0gBDDTBFj21rZCmkzfrHf5O5kPYwIMS5BsStjFUGOBrBlmE9PaQ9YYkhPVfpkssE8cLBimOMDrF7igYrl8MYJSwO43dZykIvvC9szuNsj3Q5qNqSRK23dYfvwXNd0cmGCRgr2u9TqydA0c50Hz\u002BNzzrSMe8oheC\u002BV63vqgkOkaplpsXLALSEpj2zEbKfQxZIIfI4i9/aXYM3rUMBo8EeckBjzrg5gs5GDUvxdXRt3xSXZ4gW1cXKSwlC05NxgsI8lN8ye3ReDp8j8r5UKSgOyY5uqnx4x1x6WYNu9u97FIpJ9KCVO6OgORjo8yNHdmIhc8nEwtiFg41C9\u002BHxL1ev6J30CjRHec4qznFjUBR5MuMhDYLldlGxxHDTUgOBrwmBeMpFU2wt2fo72jSnIjO5CcT\u002B0CHUyrJMQgXDdCeKaR9nohcJ85\u002B283OI6ZwcyqI9Wkh\u002Bgt7n7G5YOREmamXSsXDVf3/crxYlR9yuC\u002BDWL3djhhmfC6ZAf/WosfqOUIjNtjgrR4tiYKsyWXsCOeCNgcnZguRMc2WKlP\u002BKM/1blzdT4FWoqqesASVubPJrfgYVGy/w9I2kgULSoPKLmCzt1sIDrllK5NdiLYG\u002B3cazX1b5tNjNquJprx7S1gn04Kk4gJYwJ4\u002BsinYYjocMJeO8HwGb0iNT4Cvfmj86d87NbQzYhh0wgzfHDOqitRwbXYl7VvbIGQ5FpKBqEE1QshKnSyF6M1\u002BGi5wJ1IU48SsPhHx1vyEXxRP\u002BUuF8hnKqdprX\u002B2o64Sop9Isa/kSJTPN1WkwQ2vMxT0XNe6C\u002BCcUpX53qYPXBFOMSS8pV/QbPdQXuB2wmmVvnpmwkLWWJq6rGMV7mnyw9tAVo/o7om5J/PgaakAKZAsYCArpJ3Oe9iOAfj8un6JXZ8FMmvZqM/srZpS9fLtuoLO6YpJyxs9cd63XuyQuGlxVwgN\u002BvsoUrdUOvcDf4XpoEt2LczwQ5aDx7yJJk3fX/Uw4Z7m37\u002BLpprS8YwkPfZYzb6hGoqYfRdxjjM6nyxpdN8Bzp3nAsCL7os2IU4KX4nKLFSTOkFqlGCLcVGIUQduaXitIm9Ydcr6GSwDZl/Fay6pbHLX1jqdmzo5X41u/5mDx7fVWTkacbqJlSERazIEwgoi4uCUmpdCE4s1HxY9jxmWf56r8BH1jv60Sj0ZjCwENJ2HSBy07y0ck0Wx4VakTAoHfu\u002BTWNH4LVPl4ExaJIdbLOp4tkL83ZBti1zIQ62oE/ozEg1AdNvLjx7I0wrcxmrCVrBoK5XHCp1bJdFxL\u002BmmPcxWJxZ2GrgOrSskNA6FjMTyCez5P\u002BRgbAtv5U8KVl8xIpE\u002Bip9USD/0XX5uotKS1ZUIgyX8rQHr8bsPBjFpBFbP9xV5SwYlnb2tAN5l9c003RO5/dc1NHGTUpjkRUYOj1Unnq\u002B9GY6S5uFoT6wjgfvt1ikdswp/lr6j6fRpQVR3onWFPlche8OFJxb1zOTFb8yc9nMY8NhOqAvtGTOWJaGM8K06mkOgzFpllIvzicnV3nonyErlWrGZOpZPMGKT8wF1aNg7itGM/CoUs1hQWx4\u002BFzq1bl1aq5X/nWOtUZv71aWKfiDxmlOkmswczKdVSN90DRkn2oCkGsFCP\u002Blx46qSHN2yxdz9THjrENONOdruplSANUR\u002B1/8k5mNjr15mNrsljrPJpoMCerygPMmtFuDmU5mU8apmE0jc="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-89a0db49-7b6e-a2ec-548b-066d8da6d77c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fd5d29a47188bf42233fc3664393b886-2c436360264539b1-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "36e1c29c-bc4c-3f11-e825-ec900652a21d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:52:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:52:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "36e1c29c-bc4c-3f11-e825-ec900652a21d",
+        "x-ms-request-id": "69fcee94-201e-0029-71b0-a3aff6000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "526320017",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,2048,10)Async.json
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/SessionRecords/StartTransferUploadTests/LocalToPageBlob_SmallMultiple(6,2048,10)Async.json
@@ -1,0 +1,745 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-16a9a9c64eb607496edbc1c41add5f39-30531896855220c5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "2ad38dd4-27f3-295a-69cd-871fc0b222f7",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA386FBE\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2ad38dd4-27f3-295a-69cd-871fc0b222f7",
+        "x-ms-request-id": "64d6f041-401e-00a9-4cb0-a350f0000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-1606e1c3-bf36-9bbc-8413-4577e35f96b5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-05e1bfd5d14dda595de502ce2e9f73cd-e4a5e74dab66a053-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "ed934ced-0ff4-65ca-032b-ed12d4087460",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA40B31C\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ed934ced-0ff4-65ca-032b-ed12d4087460",
+        "x-ms-request-id": "64d6f085-401e-00a9-0ab0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-a8e1c191-8a9b-caa6-ada0-4e82488e283e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-22a6c55125dbaa4eada3ca2a892fba8c-b06d5053bebf01e5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "130f4e05-8374-ced3-b14f-8fbb1d81c703",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA434AC7\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "130f4e05-8374-ced3-b14f-8fbb1d81c703",
+        "x-ms-request-id": "993de73f-d01e-0002-67b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-deb9482e-a769-1444-d038-a6dfe1e24509",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-c733617b221834455a878e259422dd67-0b405334f7dd059d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "850d9643-60f9-2aec-7008-962b92192e31",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA456D58\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "850d9643-60f9-2aec-7008-962b92192e31",
+        "x-ms-request-id": "146c403b-a01e-0055-2fb0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-ff8ed137-7ad1-395c-3a3c-6996713952f5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-692d7c8372d0e3319aafb3b8ef23817e-2b23ff25712bbd80-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "867746da-4174-0009-dfd5-70761b30385d",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA467E9F\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "867746da-4174-0009-dfd5-70761b30385d",
+        "x-ms-request-id": "69fd1fce-201e-0029-1cb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-1606e1c3-bf36-9bbc-8413-4577e35f96b5?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-fbd633f00666be3e7181010bb7c2321c-060a5e338a2ff0e5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "4c50a661-a7a1-e4bd-daa7-44e2976236c1",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "5bD02pmpY36GpIIEovhVc1KeOyzu2/XBmZSvJhQeqs4oQH0z0g4xseHM8FumaBHyKjHaoHN2qAq7M0EE\u002BjxqaPm022F7IqBEbIpLIeqZGjCDvPzjQwpasphyd57NLbelYohi8oywdweQljTpKocfIhkQgT0/hyTvWSnJCKsCdz7Spr9hNiij00X0Uq3VcYcQUlSFvKx5Zdpkc5hj5m5cjh/1FoTIvuvwbK73SjR3GeehuLZWfLqSWEDk/cOPQOzXmMSO4FsCR5RolVD\u002Bghul7Fmwwi24BRFkY71E48AnYCzBILJw6DmLnnAh7edqlNYlPxBq3n2\u002BHpKzKXyevmTUQTQjPGFoNQMgJSO8lhcp\u002Bs/mH6SvvYGuAwEgvL\u002B87OAMTayzRld0vAoMSblaAYd6iS\u002BtuJ7AJIOydDlgSHhEZDhDsElrdrN3cWKZonTIVAF5pTOQDjRBTCgpANIeFHSSyOSBFlE9DxJ7NUY7JoIP6h835qNEtFUDAmMhQXXhWV3uB9qPRj6vPJYgFNnuBSamGhay5i3RTROPfRTuHM2cmdzoTR6nf6Phh6oMI6B8Ffw8eydfL3IvHbrG/8kqwR/IhHr8BbgI/ppy0F\u002BDxClzEmcXsaGmPWppuC9k4IDat8aKRJ8lfxBENHyM7F8TrFmQU\u002B1hEg9\u002BIUYQk0yJpB4amBiY\u002BH\u002BKTpNX0n0lGVALVgzV042TeKS2DCJYFezDu5BeclNGerTaBgVZCT\u002BSWQj2BDxAs9CQhx9z4utcMTimlBftx6b8xNtY\u002B82IOW9kJLMaYhCvgge/zes00pjIfdTMs3UopZJh\u002BT9g6LgDCE2wDr04Qc4o9hEQLfm7yPJDj334u4b6PH8huWnQT5pOvMSdg8PbjzsGo7xjF3eYpjBNHVg7C0zHtdI9FohlV6d3wnA0HUUuaABB8hfJlyUHiRI5gzFBErF41c3xnXiyoEwU61UGY4jrHrVY\u002BRg0/R6sNo11K9R2Nq\u002B/vEh3PcuHjlHLtavPACWKTmR86BiYQ9euRGbqPHV3nrWmR6ZAc\u002BHp0WvHaUhz3TVo691w\u002BU2WJ3lwyPhknFHcVBf1Kbl/StqCkhet0NmPO2cxglGXBqRoDx8sz6vphTUZ6xUwfbN86aAD7mc16Feg4IyRMxkARE1yjRmaUnoumQ3hlOXEXr2ztZmwlBg9MifIjO4eV1IbGabHvfCZ4ZYl1FVaU1Rx24LP3X5/T7A0NVry0cWMD0G6xXs\u002B/KDMGtMCir/D497TVrFsT3rUnMn2koiWpxDQmcQTn47YM97hAsOrfcTwcVF7H3oUH8DG5imxSGkYNnLCMfH6r0RQ\u002BiPSi0y3KR4EBSE2G4eVvHoETbhkJut0yMxQ6EvT9cENKiRXQZN0Dr0LrUJI4RvqLXV39mKL7NM4XsJ/Z0DTMQ9gKPBiPXrmkD77WXmoLOexZbrVXP9egj1RH\u002BPQ9Kd8N3sy6Lkqh\u002B/7kGYkj5NZjzHbzgKG/tUQAaWyER6WFZuWfiH\u002BdkQth93K2cuYOvOq\u002BI\u002By9CWl9jimIeYTd3bRZHrKjRBxWxjtrUckuyQJeMayCBmO5CB28YjoV1RdGg9m\u002BXRRza3iOJ12xEbegDsUnKkfYG9dQoBZVJuIiAPEj5M3vsGvuKoZ0NB8Fx/Zl3FM1LuqPbqgCbb093kRWa\u002BZsjSzpsF5ZeT/BpCf4Stgf70qO7RIGVHZl7UKusEwCHYg4mTqJvCv0m/WqzcpACeLlHe85x76UZji2g4Mb6ojz/4Zfv/GdVnMemhFcW4ar5aNfyZJdCBYJZDMCEviomPFs9w4EIIoxB4d8G21teAqyCt3f\u002B\u002BD2VrdwVhv\u002Bm0O6dcFf76S4Z4UZLoILISzo3CwoT8gaiN0QdmBWk8qucqxDwaVrzUhl\u002BaMYxo0e63WKh3ovlgt7X\u002BzkT7lEYZP6qvwVxx9HfM6jgpZkwcIP8YrqzAxQvpygyGH4h73PIZfPXlvRCOQWA0qrS9N1Fp3q1F3uWZWHqewftP79jvVQlKE\u002BVaOmfuim1IiB5TKJK7HDzbMgIIgCR7RvsVPlWHSVGrdydsE6RJW1B4TMxYT5VolM\u002BcECMLQZO83vNo1UgXwULIp7VrSwyUkdqxkDNUIvdlrKmJ6zUyoDGXrzCw4IIEZIuNk6ff/UnDB4JEWbFcaL/8AyiijdoJmgOH05vb561YqSuryo9Pha9fxuO26kqAO0Z0tN1VYdqxg/mkWC2x6yPQ66yFtJ4srH19Rsb2Uq\u002B5A5hRZy7QB0dQ\u002BkaVqymBrdvD5gKd\u002BoKoRARj1B8Tuy1J61iRXIPxAORlNL5blwFX/5TrMmypGwUZqSMmcC8oQT8VS7/Q7E1bzuUaNMXETK0HC9iGJITAnMxTe7Ngzoy1PPN/RktFhw9Hk2eLkuY/UVhyI2RWohi2VK7vfXSd9wBUYPvWRQphvYTJPpEhNQ3qECZa8qsoYp7WyO2cVgWaqZhjNy3uaQxODGHfiWOLlR\u002BdBWlSRwRVKAJY/3wYxWeDMpT0vgHj/6sWCOJFTNU7TzPSA1CYSGaUCgsrkW2QNUr\u002BXFrOktcduQXCODoiE98pIaxISsIW5uYuYLP6tG45gdebSvB\u002BbLxYtEpO2gwocfor/nO9S\u002BqE53VwnDIjJwCbhLpmisTurrDv75Z7yAjaAe65zrX6eDnpEmN7CdCONZFFs1VVwecxPVPC0VhUDR9smppDaVRKnQh8fXhld6TcYbYBNhS3hDwLhI1mO6rdkQVA=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA4768DD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "4c50a661-a7a1-e4bd-daa7-44e2976236c1",
+        "x-ms-content-crc64": "KSWQIy52mVs=",
+        "x-ms-request-id": "64d6f0a0-401e-00a9-25b0-a350f0000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-9b4907ea-b8a6-e94b-7ccc-d763e3c7e9cb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-728a037e35123093db1cc9fda253251a-cd3637c829cf49d3-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "7515cbf5-ecdf-71bb-49fa-6a710bada55a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA482C19\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7515cbf5-ecdf-71bb-49fa-6a710bada55a",
+        "x-ms-request-id": "682902f7-501e-009a-19b0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-764b445b-2900-b46d-eb7f-a42d3eaea396",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "If-None-Match": "*",
+        "traceparent": "00-8dfa87d8c090a0c8e5ffdda6101d5014-57f908ecaba75791-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-blob-content-length": "2048",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "cbed256a-c14d-1ee1-83a0-f8f2f7647f07",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA4A9CBA\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cbed256a-c14d-1ee1-83a0-f8f2f7647f07",
+        "x-ms-request-id": "993de75f-d01e-0002-03b0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-a8e1c191-8a9b-caa6-ada0-4e82488e283e?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-4724a3a0ce71c219218aa02cbdc5b74f-f35c1517940e237c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e606e4c4-dac0-c10d-ef8c-000da4c5076a",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "A5zNk7MOPsWSNVEbs/JruJvolLXCrUSWjvgyuBhXaLocyFlMaoW6cg7Am6y\u002B5i4x7tZPz9CLjlVXNgW63IWsOs2W/\u002BuYHk4WLiKnAhKY2KfKAMpBCJnqkToD9TOAAJWIE2HfJ\u002BdCmdCIOaGt44tDv15d79y7ajE0rG6wlCgalS2MH\u002B6wubDAh2f5uc/4PK2uwDXUIhC5zKgvq3p5kgSnbaNzIMSckgatnWd0wbFiO2/AAtTyRnMd01JGgQ41RvViUksrhBzoES0vJ4WpRQr2zG8LuI8wtCcwVk1xVhH3d1ZxEW9mN7dT2PCnwx7tc45HT7WfKo5mMp0j\u002Bi7PdrscN68uNzOakJS3t9\u002BeiPEIQuK\u002BKQdbWE3IC97SQjyIhGE1i4tvvzxarb4g53Kux6qrG7hMEEy0wN9iZitUyE5YLzN9aP1mmYOlY3xIOnHaGUM0JieDPHMVgcqsDVgQBuRvyLg\u002BMF6sRYE1pqzPa4Zth0zoIKEn1PLAaOczuowqlF2Y2HK5nOnlh\u002BGlTpbGRRZEPoULKOZDSPTFfsd3eYr0ChFPN5IUs\u002BtjApi/goVc\u002BSLQ7nsHHmx3VZB\u002B8x0hbQ5XsEOEdw6DL4qZqCVNg8VuaYSkpooO7eul1\u002BIClsDNQpWKaNFC14EUTb7xbXZGKdHKD4qYfMaDSMJX36ArgJnKy2WQwxv0LJEDkFjLHYB1Xq0QN4Y1NcbOBh8O6vjh6cwlJqERtma21uP4lexutypC4oDyGkkTlJafwbz75UGZIqaLpvbeZKhGWmGiPJ/ZYE/0zAd37s6DEZEKcfSqu/GhX3NF4hEzY37YrMDncVj3xmFtBhg6ITTYCJVl0/KznJ9vANwslH4\u002BwGiJn0IOm6A5E6uTPLTYZz4\u002Bbdp7zo\u002BLJQ8geHB7yjLiL0WwsILyymz0K8BHH1/ql5me7SakwvLY/noy7SMwvkh5sA1vJ7a8TKNth6PPQwWvNuDW3N0LPm1T17IIv91IxG13zm9Se2/i4qCDNjpOCLp1g7ZDWeFrbnGgHFADs43FJcM1WHWVXbpw9Po9hwgyBM74kzsmBGqMDGD9sV8f3i4SvRB3GLBE3yX802XmLeZpbheBCyBRnyBYqUsVl6tbUBXLKsn3uuses7MWKjEFpd55lENHntMNwR7vH29kL0d6oIJPGwMccbMsYlhtO3XvUgRtmwNoFLJCvmmrCJp8uYNsnImvtonbXCOPGzt7oIWoAM1q95NDEYzQDFyacWkZsKnUAJ/rP5t6kT7g2fl2xx3jAgfNEcLvKIr936ktQeu6dWqSpp/lvcEy72VVYzeTWUU\u002Btm5hS57n5NgU7WDxTVBTJmOO5CB\u002B/URGmyJcmsRTaoZk7ot8WCnMq8LH0c9gQKIVAT3TBXQkwLgpG7B7ikkTwYPajF/F1s06wTletyx15VqAR5iGgGURQC3SUjx5UCB5sxBMhrNCTypvmUM7xgmLtDZW\u002B0KwjEAdyEwx8oSQwHAY5AMcKV6mPfduFuYh1XokR50GI1XdyCbPLr1nEVym39jTI\u002BEFb4vXr75LQnVZ/PPSDKvmip0bOhvdTfqgPyubxzcOTrKYH9gSLnOXkoawdTHKlAWxv1Q6uOjFJyGQNm\u002BSsHo9S65AOu3T1Fspg6eVLdjI1qol6Qjj05XJ0ve2gfcEBOIMcimDiVoY3er4EDRBMPpJyGDEbMZxWncYdmf2HVNjJX/EiLquRUxPDQwd6sJhiKH8bbiXP5ccmhexaxPzIsCXleu0fKdAmoIUdV65U3C0tu7F\u002Ba\u002BazObnp\u002B6i/Nk5XOtMhlXXrAz6u9I1g8o4Y0an/bQkLigQ/MkFzdS5nZ2o2xhzbM0b3Qriyz3cZEkbrkSn\u002Bv8lFC7DPIqM0t83QB41jKixxfZ5jB\u002BqQmLqM5d/6R\u002BQEqKeg8bqsDBCjworqosfp9ehauhNLW7fe9HL2AjzDOm/py17lwnhxhXGN/0Vf5jXyou/3n42QuU0vgj1H9cnT4IhawNdpBDOv6PTh/Zwyvs58w59My1qiWRIRtgB7Kc\u002Bnud69BSUeSZ78R/bYrruxPMMvCvJqhtVtuGeFV03zdP8lekO9dbnpHroAUIOjyapWYLl9C97dfPLJT0y9WTIQyNL3s3R4M4dJBex4KjZRye69bzbUtijgCD1Q9CYta4VIL4ewrBY2Hm0x9AYypRK8t4WeACo7PFKp16t2539hG9pm8DquoR2YR1DJooIi7WLq1HygjytbTPN0xtSq/zctkNgri/TYDdZnxbjZcVmQhuoITBMCwIyuy2NHOZoJLYgZnBHqN2GuEoZmOImyghtZpH/qonMkKtALfMBRkNQ8Xtgwv5VH5o\u002BIWnlMnMfDPEkILZVaHksVNbFBnrqhXIHyadnxgcKF0f3wYgg5l04ISEB3CaN\u002BogCM24nkBggVJz23mnLuEXqGQhuXqfwDG15jeVY6KhMec4eZZOY44cv1mzsKQj0bGjcF8IdHpzhEScBrQIyyGvzqmSarVOyUTaAPoc6BOJkhCF8e9HlLlsyPVNslzaE/A4A\u002BH\u002BkWr4VKcaMnd8UpwxEnCjhtUyaDnsJaHD/RrkA\u002B0J5OQtjvypiZ1ILWJF7HZZHJ/oNo0fCZuoDm/FOFeMMjKGdm20B4Nz\u002Bf075j7XqjUrauB6/81j6ttMhYCQ5FFFv/szv3YEoRkceDiT4yNY0GA2mdF3ETZlJouWa33\u002B4xWr8ipDp\u002B7DJsXLXoOQ0Au397EgWkp/0qrEzpjo=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA4AC3C0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "e606e4c4-dac0-c10d-ef8c-000da4c5076a",
+        "x-ms-content-crc64": "A2aL62p8s5M=",
+        "x-ms-request-id": "16e918c1-e01e-007b-2bb0-a3d31e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-deb9482e-a769-1444-d038-a6dfe1e24509?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-88db153334364ec0aebd1c92d6091f52-ecfe049ecf041b2c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "132db30c-995e-bb46-6173-ee1cb764b34f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "nI5mx2ZJufs\u002BRUscXN3C6\u002BystRSg953yN6Eyygjf3rVUdiwjCw86mnsGr7ehK7q03Qi\u002BBX2RmaXwc5DEF\u002B7zXmaVx\u002Baxn9/ccRqZmkflUQvnfu3/Idk4w9yGMph/doONE1BRC2PTAz4p4ZRi\u002BP9dCyGE3ZgA8z2NXQQJKmxHXfuXDIf3lEanE3qv1kBE1crdKSd2\u002B5jqjB8TxK1fytjR4YOZy\u002Bx3Znbb3MkeURz9SIg6KwBE0WJirX9n49CYSEmi3fS8qwreZsOwmh7OzDsDFnslJZ7XjBAhNh1sEIKmQpOAe3MnQJ1\u002BW8U9lDZDk\u002BFEY8xVcyOqylHkmnTscVVACliKTlDI29Xep8nZmvjZ3aI7KKy2Uc5w1rEiQqUokelv/YneuUWRfIj3dsxa0TBYC7zRsUmoirmJGnefppgwtRbfaZxv\u002BiRdqqwkv9oCFQSAyTfpV9\u002BgxnPQVZ/N8tbvx8G2emeU6BCYdAadhMrehgRzHtxhRl42P6IonqWEj7jWNfgYTJud7OAnUOLZA0Ko8c6bWtT6jYBjgDvFa0pqE\u002BVNx07SxTpp1TH7OfZ7XDtgf6zX6TTk3Kd4tctf2IGWvDz9izvz1SuTMYSi/lOJ5yP/ZeudkymwaeunWhBvCv2vZH25ftEAbKqBRLevQd1T7s2oX3KW\u002BSkTTCJQTHsbJCeH85rWz2lS//hBHE9xAScOU2xDxqqKGWtUpjKuryAvZh\u002BPKE5CfR5kVV96VN3ZoUv6QvgO1119/Nkvgik2o1DYErYv4djZy9ZN3nBLEMSNegXntG0nII7CEit0E/r1LbIPoUInqr9yIXciwfnsMewUoQckT\u002B/isfInbc\u002BtZLfbWLG\u002BO26CZtBFdJP1BF\u002BV1eA/X3Hz0d3DLPBQ/zzwxby/R2lILvV9kjs33tpc7a2TkpfubQVF6IbT\u002Bw9\u002BMmaTVa/WNrz1Tafrws02u/ICZz9CvW2lAle2eV/idDLm/l/Uo4krhbbwnUXvA6s4DiyU0JTQO3X57VJYILxcE9h1BMNtYhhp1\u002BGIUR8ntv\u002BrfmszTqSeFsPp2rU20mT6k4lsev7oyqwUKviyR\u002BlV0TdTraFRKcUz1u4Ag4hiMgR9jr6VujwAwrS\u002BHyOs7M7ZlAh\u002B4iXDqGrEOaMP6EYksfjzNbkrwBb7UurtkgqhhuogJu9/40/fuuVT0IGY8dptmm0rubcUrdPxg5A71RZgIrO578FWpc2oFHvU2O\u002BVYmEPf/icds0zC3kbjWC/o\u002BTO867O3wEZFvWfg6U7QNXkXCAuLFYdw6zlheRHOxdt6HCWBeVBx4Ng9mgD/fMn98qkNjFAkXeOsS8B6Fkd0dvdMpo1pTvwo5SdzjXtGsa4vY4ZowTlLFb4CFS1P98pQySMJcpY8lKPtJOdosNBoJZoSCrLAy3X\u002BAVDPJznOmS1c4sRYPX8YMs8iu9xSImTt2e9Tfa0Xj/3tS3FFLa1qHku5y44MEChbOhfjnk\u002BZq97sIU0KexuABVLGavHNksUhuF1QmBaW4YnG\u002BENVc/GuE5\u002BSWQxgH6NwOcZ7BaV2jWdSwiXyCROIFT\u002BDQ4LYKtFhGFcSe3m4gVj6IF5QW9vkkGrcArHL/AqLykQM3NwgWA702i1OJBItmgCM\u002BCi1N/ljnvMX\u002B\u002BhflRwMhrE1q\u002BS8mYhPm4GulmxY7qixfwPiFtKKqT3oyFwmlUTRAZ2g9\u002B4b0B6gJZw3tQhG/w1/7lYYaq\u002BeqsLm05EsaMY83VTOt/a6VW7lQfF2UzP1YglOpubuuNbtwkzrdTxNc/yWOtfzuAcWxVjncyi\u002BaFfO8XGH3cIfDiS94PVpjyByV840oBgcAenCN\u002BFOB0XuL1o03EPKxZX6tuzzNZdRrTZ4tRsaicg/8q9HhaYgkQaez/FbdPKcZ5J4OilraMxSsEqrFVJqk6WSNSmUQwAv2iWmFGXmNnhDnA2Ioo\u002BelEnjNRUbdXu0dDxLiT\u002BJCCRSSCADhRRmrLoSZ7lE4jEV86Df8Q4q1KSqMeBpWm14upQpNlpvms81fIibCM3Cb1HLddWe6RcWJ3O7WZNz/RIMmazlG6vWphiRqnRFj8uW54JOniSX2dF9Ew7m9AE7wX\u002B2Tm9g3RPmNI\u002B8zX6ikJdn5LIRJV7ttP\u002BbqAic7/IXlak0zwGcdcpuqGmVGsyS2kJ3vs\u002BPKtvgiNmvhXULCUTdpXeVrcFVy26non01WFnzCI2GJXDiSGrNVAZn7PCVY18k97WVPWyBIbOg50heq3B//HynRSQT\u002BxzMiFm67d5\u002BEn7eEKDkHgtgxMO9QWDibqiWKDC0Ld560PxYiHTTBnOVItUJQJrPm55xBoAgVrm76lnxJMXtyiSgoz\u002BkS5XWTf6P6B5L2O3NxkySQuceWrpC3J3bIiFt5xjwaN1baw/IWriBUK6bMBFr4x55G4c9QgiFYa73\u002B2vdYcDFm6/Qclt8iehunMnLp6yMr37C9ItR8ubU1cmhEF9M5C6tlZRhW3CDPJHezuU\u002BuboCa0vtGm11s\u002BiJO5yRm7lI4bjbXhHYKxPOP/g5suQBlhxPnuUTX4nBN\u002BHr2B/UMaDYVe0sI1toKgA4Hxp1e8DER6VAAfzUdUHvGiYwLFLz\u002Bc5XIRz21XKA53Sk20CvS/vg51C6U\u002B\u002BkBCBrPQl1OD2tRCUMHhrkDbIyv1qIL1oBf84qDwTCOWXe8t08S5hpS\u002B93N5cbYy2hPNneh9SVHBSGaf07Cuk46wq/bWt954HZyXOrETeC5c=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA4BADFB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "132db30c-995e-bb46-6173-ee1cb764b34f",
+        "x-ms-content-crc64": "Y9ldbisIgmQ=",
+        "x-ms-request-id": "146c404c-a01e-0055-40b0-a38109000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-ff8ed137-7ad1-395c-3a3c-6996713952f5?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-2a3a9e4a06c96cf4872628d1dfb0cd31-f837d0e700dcff0a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "f100d2c2-f497-ac0c-4914-0d5a69c0fb4f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "coEkSKyOxkQmWyHYhmy4Axn4MjFw1wmNVV8T\u002BYSnK3QNEIJrB1s2HWS4jlHWxYD6bMqTS6zZJ5t3lvJMe8zAfzCsy3bqTfy9whXNt0i4t4/eGI25E\u002BDIM\u002Bjm83Bo6qGX\u002BA8hKfoKEB7O1omWDG9Sv99jbmM/BmtP5JeNA1qLVNdzNr85l42V1Adu6z1WMSd5kzSQBXw\u002BWPKj0URjfAzEQoGxI9WwGSdRzZlb0Bsu\u002BbNvFHAm\u002B09bNd3NlsZJMlf7qqi7pQ5RyXoMPjfi4ojWddiQ82icnkcyVe344oNhCJtCYCZyclOlHkr1GbwXeVJV9iHtuD7vXgtgiU8gWeb2qjaboIJhZAKE69QdpoSLG9yaouxidE9dUgEaEukDhcVk/m\u002BFe9nQ85Ieac1q0biG1G5zhbb5lDbmPk2AR1EZgGYPuKcVBZ8Dyq9aQwqC8oFJkz17kP8Oamk5nj2LT6xABehnWhgQcc7Ob7oHn1ErZEvMN7MTnfBmAU4922dhd3sCGT0iGphoOSFurCBFBssYDTnxvxj4LWf4AVnK0pVnbPg/BIUTCEqzZP6SpPHPIPqCJc4tcLhiCuzWKhk/nWaLBj8oBQJGBATvPlsaZYh2KOBeSK3HOvxA3PqYPd4wc8aXBp2xphv4PCHJPTFcSKRkYAE44VS5w8xC6CgHrcYmvsuUgl/qxILFZQyM/v3L45RVNN3d95Jx3kLRb77y8I5aon5mx8ZFept\u002Bc3tILcTOdwSUsnnpSMY4IqQcGFTD0nV\u002BMVx/ZRvNELlBXoQXKbB\u002BA/e5XT4UcVq3LaQiKGFHu6AGyvtoTxHoxqK/p\u002BpCIfnznhVcCXQ2acABxzh3q\u002BdY\u002BqPjEV\u002B1FbPm0ZebVclvdQurL4pM6rErz2A7ZofZcRq6Z6xGXhCaPYhhdjjdmxT2klIsy3xdCxDxuEL\u002Beq4rDF984O0dKBb7EfEB6nN4TTRMRNQ1raaeXVucVabOm8PaNWrZYbom2Wk8MLqLWyGdeGoOsTXZ9l653oOSgNNwLXUtJ7QIn\u002Bx5JWpr\u002BXzrEwI6/9w7wOmNAD8MH4I2lFiVywNEXTRslNl9lIzKbv3hzcuBWIH3NGyLoCZ1/H9pQpES1i15p7XNzWoCvixdwpJCKlK3tTzWnZeXuLwN9pdZE1H7uJfPaCYVs4oX9HZALt2UM9Etso1UOziW4u75v9fSqaraYgn6csIrogGyv6kgVorfeMPFK2HDpn1eOYY4HPSyREvLZcvTmsAPAg\u002BLonuPdYtjGUYTDH1IF7yMmzk88oYN/3tdVfC\u002BC94DtilSOAQCz8P61AKtnzfNgk4PR/\u002BG0w\u002BIfaIAMSCapQ1oEFZU9t64isx1QR6EYGBDkNKirsTefeIZybphAZ2jXy70RY/heItvV7wzEJLxBB1CvaFN\u002BPdJiZJzOy0jVogu0eHvjxvQYRhGMlYHq2xQKMSdHkT8Vmc3q7v8bTxeTAA0BD6wAXQCcVuIB8WgQd0mIxJphjdDMnt6t\u002BRf1PTb6OZW06YtoCdPm63pc0\u002Bhl2nd1Uop9MXI8NLDNUmPopxnrB7eSm02\u002BYLrGeuKWr4s2CB6gf6psfMhjePUaWrdv/gQgsYwwk37p9zHPdvaPpUTl10oFSGevfsrvbyKYo8XDlnyetj3\u002BxXTf9oi4XMXRk9NwNINtKrXcsTLBQSQcURMsC\u002BC58O9G5tHVZVGe9yHE3dtPaG8ClmuGwgTLPYQQg6V1TFElV\u002BLj6U3xV4VkfboRPGNIjOjj6XW08y7qe\u002BkNhOHsKWqQn0Y4q38hUT6mYoRK\u002BcFgx/a8kWLbsKSz\u002Ba1k49LjeBQPQFzdT\u002BGpwph2zlBqn4InrPzrb5fHtS7hRPGRvK1rwypwe3lkQ3gVEs7KpKIUCRorPTbV\u002BAi8B8suO8sv2AXqystmOmQIgylE1hzJPNCMzTuXpr\u002B2Vcsh9DOudkds5XqJH5mW7g714rnNUSHrswr6oS7PWDGGdLTARAYwmkziF/DiP9129h8soYPFqQTpNkEos5UYnY0JAqsklmoIxUgtK3kxCbMtg\u002BsP4rZtgItwFw2FB\u002Ba3iXpjmT0yEh\u002B049x72L3Lt\u002BzN\u002By/pyPrW24If9L8cQ/1hdaI\u002BzbB1\u002B3GLmv7aMafNpF9g9wy2zYB/TP17El1gWGAe2mMbjOp8WD/\u002BHm48PKnaEhBf\u002B4yw6qfhv0CzOujUawJe\u002BxcE8dd05J8M\u002BO8SQ1ATYMBNAJzTbi/7Oc1pyR1W6fMrnQFSlWA46xbto/H4j3vwn5nohyqli40nSbfJyttB9c78JqZOgMugFFVF5Yo\u002BAmpReWmDbiLIhdG0a0voLuA7q\u002B4i/KjVod7OSLKVX\u002BXC6QcNeJGx/kesM6CUmlV/t\u002BW1CjmcG0XBu9dKtSWwMyYrsUIEmrZOie2mdskIAQeJTpCNIBWsJo3BS/y6Jwkh\u002B8B6qOjTOx1vZoBMNeS8ubqPwWaVIxMQv0r0Q075lGLkRHrIzZgethOzHblVIDDpRJICKiXijJjtKeleHveOddIdp7Fps6wicUsS4gVZu19Zyz68t2o9Abeh26OugJdb5OfnN7h/f5EmH7jaj6qTU66KBBP40f5n4KX5x9gIs/Cz9z0dskPnGottlpfxYnIMzkg1JLyDYxMpvxbSRbf43avIJtitteEqoymISzsmdr5z7PlP0480MFPqM/MtFJTTtLjsKTtZX1hmykGS\u002BxfXwwiYnli\u002BaMoclDaEg0Ht/Y5UtJZCek1C2k1g6Q=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA4D0D59\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "f100d2c2-f497-ac0c-4914-0d5a69c0fb4f",
+        "x-ms-content-crc64": "sQ4\u002BtHuKdlw=",
+        "x-ms-request-id": "69fd2004-201e-0029-4cb0-a3aff6000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-9b4907ea-b8a6-e94b-7ccc-d763e3c7e9cb?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-f115edf529dc7d785611b91e01440b96-b29038425e87e860-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "e45ac7ce-c263-19b7-2d26-7b70161d0246",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "JDaE1PBJw6pR2PFVL7s9UxNTcFnjM835GQVVIuxWECx1/wM8ywUiw0QNpGBhfSpNq\u002BH4FsUpwPFoi7vr86C9\u002BsjE3y\u002B4AIgNMa0V1Y5sl5zaCHYKXvlnSz8R00BKN8\u002BjUKqYnJ37lKpZ6uUYFOpj/PMfEOspspzOXZPwpi1Hw/ndcoXk1Pv\u002B33PMsHMUTjdUrtdMKybjeZ0OyT4JC\u002B19EifrOqFkfyj4IDF3XQEouQ5cm/hW\u002B5fT\u002Bfnn1gq89NSFTp5MKRSW8C\u002BuVAr1bBub5g8wrW/1JxaPGECofKkdOyxd8Q9i25D5xavJp6aN3Y3dS\u002B/6jEZkkCaIvBDU7XOGkBndmHoMOAp/NufELIBwAjqyyjG5I67m\u002BGHo2h9/Jdc4QhaNr0US0RPle1Zen2OmF7nWISNBzG1q958ZI13q/xAPjOlq4lL0oPkd06hXh1n9QsNlqQS09nWoIrem\u002BK21\u002B3tGThN6PDRm4YEpJPnFE3BGHOGahFUMW5VzwcCaTqdLaNgsEThFgwaO/8iCi9J84w9HYNzMGnYmOfN\u002BBnp0y5LZ3rshmAE4AZnbDIWNic/D992xU\u002B7Kf05hBthEx3yLGjM1qKwWWkoOD19D8Q7wmK8jug\u002BcwnikDl5tv5Io8zocT/FSV\u002BAirJyTo0OPh40/cG0oIAxt7le6kZlOqZu35RslJ6IcnkHOAQ5yCR80FIfRLU4lANMtrmCal8VG1AIB270oamDrI9IrWR/\u002B\u002BuU3hX0SfHxMkuVI93hBgQZ8hywLcS1hDKon5Ql8\u002BaazL7R6YhFINFeFtEnY33PnqqHLr9Lz8oi31XnS65dzz5g\u002BlMfDxh/0NFPUhrzkiS03PztnsErUwD0rwoyYdUnAEuWwmUqrJOOC13p\u002BHmzL00xMm6tcCx5NatSKmAOSXL8KE3PXM\u002B/iixtY5dnPVaHRX\u002B9ATNmdZAfGYi52IYvf8Hu7dAv4859caQ\u002BQAyZFfhUyuDgUUQ/lbK9sEdDAa2qPefReE\u002BCW2GxP4\u002BLJDGDggeQZRGhTyp5r1gdbjOLOnP6lAYox5mo1m\u002BDMxG4tHGBPi5DrpycCO65W8j3YO0yJgEfkJAvVr5p65KiIhwYwPrmnDABS4vTWosXc2/QsXGCTQkMmSfdVedv2ccN/erSoJbSEMC5LN51SDYFF\u002BdSmTodH9ETCCfTCUpIlW3ExVygQNLU/qCsxSAum1Dt1D4AHUCI7N4Vw5hy/wd6cJtssIbVZNMQeZqZcFaw4GzW4TEISHQtP9h\u002BioE6Zf\u002BZNlSEwerKGG9q76el83yLZN8rnBnSbiQnP3CuWt5R2hea/Dn\u002BKCKGCMjBnVzMh0hb9yGiDsXlxsQwYYJ2H72RGRGQCvNCiTy8oZdNENDLVrQoUme4r89NtTl1zcagE\u002BkPMIRLPHxZGWnk5W0ylLX3aQ7KTclZ1G1GQlW1zLt2GJGqQdxIfBY7zzj518ZiGyCHfmS71cYfsVgbBPoqo0iubsjfiFLVquj0kn6QXACm4CsxMk5WvkbLipCEMXcYESvsT2j5hpLRsdd7x0dHj1VbcCDS9XD\u002BW7CGE/3CTXV12H1SoBCXqV2YY4B22vsDg/87LL1SSRu68fO4d3KRD2BeAerF9OtAw8rDOpXsh3y5ho/\u002Bhxy4J5Nhm7Ic3zHvB1AcGNUMOY8X\u002Bmz2jxKFymp2/vDmkohDpd5XYFk1I\u002BCY1DNF0G6nqUj86oizxZSA39FLqeA9CHDH3Hb6tNU13taMWbbjP/n/01Wr5av/k\u002BBJ1oCL7XoAW8\u002B\u002BffP3rPBzywu2J2vhnaPXS9qKlSbIyEyWrOJQre1YiAHnJMIGBCJhNBqcSWx0aDTgsKWjdcKo8bWnYPwSIx0eWZtl\u002Bnjh0UO0JWEIKILgHkSpc/lLuRZDPjMIYqMmUxT5ge/REnG4AuNh70xdnMU2x0a3ZLMn1qCBJrhJ1XKckdZMEqqTDwvW7W0Z5c3F5Z1p1Ztcbuph1a9PU\u002B\u002B1cilswV16DY4eo7g63HtCCezWv0Ea4//XQCLv6jj/R78cIX9DqSBwT9QPSzXjIZJzI8\u002B\u002BdJCumo4tmYE6iiNVI1v9Gr74AlzIYm9pD5TJ9B6MfMptPM8qcYbtFhOjNcGwuivd4gbTdyFu9hIhQY75Y6Firg1Y5\u002BaI1qk0DuhJKSyttFFo7BIXuQmo/kq9BTP787JyPIuwW9JFUQ9dn2Q1Icjld4k9kHePSvEHr\u002Bmbz815PBs12uyk\u002BVx/J5sGuh2hc9h915GmvmM\u002B4vGarKvoqYVB5GNM/0rcQHosvmjYiJDTZjwNHfQ/0n23\u002Bvv7CkywknoRwNW\u002BUHSRoZcXef/2YlZcy0Zv24\u002BRAhHhlQRO4TYpeCvyyse/ERHHf3hhKFiBvZSlnkMKRLrugMLD3L9sQsBg6gHQB5uOobYwpFwTL9m5X9tvqUbzIzNxBEYE\u002BzBWWzi7/D5Wrbn5FviM1Zxa21DpCnzn/JV9ccbOYwNVhaqB3k0jWzObYrIdcpZKYk2TFijxH\u002ByzclqnPo53iEq2p41SDvdTO4AhTavOxo4DMw95P0jaYGm5zm/2fByhI9pnas8E\u002BFdWQ96o09JE5K/MpAuC/k0B3EcnlDyLXL9jgCnNa1u\u002B\u002Bja0IvtuLZCbcOm8KdQRIiGJYY6L4WQazuMjRU\u002Bkd3lQDanQyt9Rl66yiCNWzzLnUmIERAXNNxjSnVQYSuhA9v1sbBwuQFdGO83f1VVAwAOsO/btnDN3htaM/i2LOUjGcZUk=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA4E1EA3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "e45ac7ce-c263-19b7-2d26-7b70161d0246",
+        "x-ms-content-crc64": "e2uk1kRJ/64=",
+        "x-ms-request-id": "68290330-501e-009a-4db0-a30f5b000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-764b445b-2900-b46d-eb7f-a42d3eaea396?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "Content-Length": "2048",
+        "Content-Type": "application/octet-stream",
+        "If-None-Match": "*",
+        "traceparent": "00-61c4e4d7241139905f10127b26670192-9f7ee8cb03a7d56e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "a28b827b-1766-1eeb-af10-b4cd8939d01e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "eZfFrUSCsIIN/Fhx5HZVGgO8VNWyfjlSZ1CJb8ChRVnvB7doJmC5OLeKz\u002BRcMlsUDLNOdEeQlvtec0bz\u002BUDBbLb/gd2/7fSiAxseKK5U9TT1dWIMUtARX3C7CbIaxT92yGIuXLF9VR\u002B/q3ErcW5NCX0R/oPetRrm7SJtBONBiD3bqF9LJpiDdyBDTKZf5e0BbQA0CMe8lxNISG6PEFA8fiMzUMkOAeLljoZjmmhzhgg0a5biDX92HxBMAt4p9GfPB86CK5Uk82weT3pAWPyq1MFmWqW6WXGjvTC4wv4Du5oflJOa8FtyEHgqxL0FNccToi4dw5nBFa1d321lazFtGpTfIcRpEONm9Eksj5WznYhppR/Q5vgAXX7lPBHtDaVHvakpJRQCqpJKt89QlYUYqUHl\u002B8URnDOb38NFg9PSeOak5dLriXd0ZvuNhi8pr8j5zJLQCBHfNiB2jUZQvSe\u002BeD7oq6\u002ByLSDJcZTKgxYDci/6TLZAAXDUxK\u002BydPwxI6nUzw3xQAQYRp9yBpd9FLIJchoWVXFwfnbOFOYAALgjl03r9rQIEjIr4gUXzfvYV6/8qAHhG804Y1CXIiwdGEbmTm9JkR7\u002BAWDo6nNrWbB79bw2BFe3Qnt/spNjce8GDcq\u002BMH6MjsWR/aeh\u002BTBZzAmgGyxv5hPvLwzzyt6Lm49w4typrSky72f3pQewFUlKJeaJw1XDlie2zwFymcTmBmEXMBdUsB/gbSzFeEEMPhnDqKT4Adg6rUu1894nv1aiEJ6lmOUy9nXHqFUo/R7lqpDnrvAg7gSJ3YLLnr1AuK3WI2iiZqUzkbEuMVmCEbAtz0hOQBFlgSKZHLtjZle4hu\u002BnUdq2Q0Pqsxw/8byrBsvSnc908niccaFFCErq0CpZdqpp27/Vd4wFY4z0JpBl7hXwkcmIQ5N2CuA5cDr4AOPy5XsSQisL/CZCb47sqEsQ4Bo1\u002BT9h0DMW8tDfnAdRDGOpAkAVU6vq5ZSiRdQFimKVKI8gwwajkBRH\u002B09aK2Ae8WIrQ6UK\u002B41uShOqvopfEWdtSnN4MUhcBXErzVdbkLk0hFRx2Ue8iiwBsXjz\u002BdGJ6Onn7OHspsAazj0z3i41ErpadTo27Tcgsb9GdoDQaQygoeRudKPYSN6UVwsJiKv\u002By569mYOXU/qxxzshpS9ASWUxkzxKx54XgS1copYsFigUSKrhEtCJCU7pvaxot6KuVA2l2PVutAT/phdVO7BkhLATDV2EXjeUp4ruYAnxrsqKrU6Jhj4ypZOm4mu4M86dhTj8ValFKvXWETBrgFP6DfdNyo1i2v5y4GjJ3nvL3HS7UNvR9VkgRIJYs3UNxyRAq9R0a2hAOqo6iXRBfEx5CjS8ry94KRieLIULCieIZBhDiDKnV3ALexUwl2vk38g23qhAURj0yIK81j7iNDCDsSRc/vMZ0rLDsTMaR5GsuU291St\u002BRxMATsCw6oExKEfkreZGiOHVHAv1fJ/k2oDwEBzxJV8EBGkRW68yaOcxkYjsNZmrZTBs6LkgiMpzHHRAwNpkQALn4Kl8NS0xorMkxOsX96XnRarshT2m5HyfnT478qgNzFGFBFXwLy8COkUF/MPfXCTOWXsveLrFQfss3Zju9rALFveZkfJQ9hZ66Ur3oOi4v0AZbJgt3VSWwMNZw1GXE0SV\u002BuXMRssxfmJktI5wzaASdB1Y1IkX3TijAtAv9jLE49UGYqYD63l05\u002B42yCjFJvIiRk4zPz66fhysKUP6AocvoNG5aWv6D4ik4\u002B2b4RUQ3dveDa/kkKSWS\u002BSKVsI1euVmBihXDL2HKDfGjlxRH5wHnEtoHPTXSw8tIh2Hb7jFb2gHNNrsuNAeVuV4HgJHRCxHgrp3zV3wjroYKumf/7h/AB7zSuvCGuN6ScUPXy0N5d3xQOz9TqILFqUg043mflcs\u002BB3jVPpAhWjW/IOY4C\u002BNC0UMrb/LgbF86DNFokZWlMpu42cPKpDjsLqEJ1IfczV2kshI2tGXYHdsZmzG\u002BuIhgGi4Kf3IfeG0KPwER1pfXXX9zw9\u002BDbn514Lvo8MkHbbXY6bpZkk3rhXnk7LUkhkcDAn3yCvTo3Ouv1J72NkdkApGLOS0dfYrxSH5lnkGJURo05e5LFSLBL8zO6f3vNY7yQKnjWU1aJYTywIJ2Qz5p5kNEgRCZGS2uygkgDpPNAlLvsx3X5jfM2oApmBRgSqzOpMN6anR\u002BGWe8dI9EOdcxJf5vhs/gUgBLt\u002BZQr0DZDn9cEanQUpfesVn2G3GoiKDpOLJWMMPdLhKDLvKN7Wnm4yYP5\u002BhtINNmURV2KnaO4y8Fp7bOgt27fyOXTSOlUIQvz3gLWKD4e9ee75/upwOb9EvDiAXy2CBIVGjEldOvwQBRBhr\u002BQ0pOTSvfL9M9zNgf\u002B1jXoYi\u002BPPcXwwR4M\u002BYELu6fXWDonXEBtTraE6hNCoeQpNp62B930wkj5oBGFllFmwDknm93dx4nlixNpCkOivh8p08LyVaPJ4pXhPbw\u002B57hlHinqKxYGW28UwIy6m7gFRuHyW7KedHqFXalH7JnNtpNrA\u002BwpyJMJI4hT7YUnH1bd6\u002BbKPIwFxqm/ZM1szm7VRwnpX5fL245e\u002BTgqOpblbk5SafCi84oHVT1CelPFnFUpjpaLPb\u002B/AgBoe0NT24wCygaPGmRuIkOP0fpaiWEqmVzTALvwajCOk1fgOog2s4mhP6BdRoHwu1xC\u002B1vFZIivTeHmgMrQAl/V8HcMc=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:10 GMT",
+        "ETag": "\u00220x8DB71C7FA508F47\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "a28b827b-1766-1eeb-af10-b4cd8939d01e",
+        "x-ms-content-crc64": "jIyj\u002BMTw7B8=",
+        "x-ms-request-id": "993de77c-d01e-0002-1eb0-a32f3a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-1606e1c3-bf36-9bbc-8413-4577e35f96b5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-501103fce5e6b56f9b5e5190edfe1b0e-b42abd272331d51f-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "94f44ce1-6091-41df-f62c-0d9b0d6533ef",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA4768DD\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "94f44ce1-6091-41df-f62c-0d9b0d6533ef",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de7c0-d01e-0002-59b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "5bD02pmpY36GpIIEovhVc1KeOyzu2/XBmZSvJhQeqs4oQH0z0g4xseHM8FumaBHyKjHaoHN2qAq7M0EE\u002BjxqaPm022F7IqBEbIpLIeqZGjCDvPzjQwpasphyd57NLbelYohi8oywdweQljTpKocfIhkQgT0/hyTvWSnJCKsCdz7Spr9hNiij00X0Uq3VcYcQUlSFvKx5Zdpkc5hj5m5cjh/1FoTIvuvwbK73SjR3GeehuLZWfLqSWEDk/cOPQOzXmMSO4FsCR5RolVD\u002Bghul7Fmwwi24BRFkY71E48AnYCzBILJw6DmLnnAh7edqlNYlPxBq3n2\u002BHpKzKXyevmTUQTQjPGFoNQMgJSO8lhcp\u002Bs/mH6SvvYGuAwEgvL\u002B87OAMTayzRld0vAoMSblaAYd6iS\u002BtuJ7AJIOydDlgSHhEZDhDsElrdrN3cWKZonTIVAF5pTOQDjRBTCgpANIeFHSSyOSBFlE9DxJ7NUY7JoIP6h835qNEtFUDAmMhQXXhWV3uB9qPRj6vPJYgFNnuBSamGhay5i3RTROPfRTuHM2cmdzoTR6nf6Phh6oMI6B8Ffw8eydfL3IvHbrG/8kqwR/IhHr8BbgI/ppy0F\u002BDxClzEmcXsaGmPWppuC9k4IDat8aKRJ8lfxBENHyM7F8TrFmQU\u002B1hEg9\u002BIUYQk0yJpB4amBiY\u002BH\u002BKTpNX0n0lGVALVgzV042TeKS2DCJYFezDu5BeclNGerTaBgVZCT\u002BSWQj2BDxAs9CQhx9z4utcMTimlBftx6b8xNtY\u002B82IOW9kJLMaYhCvgge/zes00pjIfdTMs3UopZJh\u002BT9g6LgDCE2wDr04Qc4o9hEQLfm7yPJDj334u4b6PH8huWnQT5pOvMSdg8PbjzsGo7xjF3eYpjBNHVg7C0zHtdI9FohlV6d3wnA0HUUuaABB8hfJlyUHiRI5gzFBErF41c3xnXiyoEwU61UGY4jrHrVY\u002BRg0/R6sNo11K9R2Nq\u002B/vEh3PcuHjlHLtavPACWKTmR86BiYQ9euRGbqPHV3nrWmR6ZAc\u002BHp0WvHaUhz3TVo691w\u002BU2WJ3lwyPhknFHcVBf1Kbl/StqCkhet0NmPO2cxglGXBqRoDx8sz6vphTUZ6xUwfbN86aAD7mc16Feg4IyRMxkARE1yjRmaUnoumQ3hlOXEXr2ztZmwlBg9MifIjO4eV1IbGabHvfCZ4ZYl1FVaU1Rx24LP3X5/T7A0NVry0cWMD0G6xXs\u002B/KDMGtMCir/D497TVrFsT3rUnMn2koiWpxDQmcQTn47YM97hAsOrfcTwcVF7H3oUH8DG5imxSGkYNnLCMfH6r0RQ\u002BiPSi0y3KR4EBSE2G4eVvHoETbhkJut0yMxQ6EvT9cENKiRXQZN0Dr0LrUJI4RvqLXV39mKL7NM4XsJ/Z0DTMQ9gKPBiPXrmkD77WXmoLOexZbrVXP9egj1RH\u002BPQ9Kd8N3sy6Lkqh\u002B/7kGYkj5NZjzHbzgKG/tUQAaWyER6WFZuWfiH\u002BdkQth93K2cuYOvOq\u002BI\u002By9CWl9jimIeYTd3bRZHrKjRBxWxjtrUckuyQJeMayCBmO5CB28YjoV1RdGg9m\u002BXRRza3iOJ12xEbegDsUnKkfYG9dQoBZVJuIiAPEj5M3vsGvuKoZ0NB8Fx/Zl3FM1LuqPbqgCbb093kRWa\u002BZsjSzpsF5ZeT/BpCf4Stgf70qO7RIGVHZl7UKusEwCHYg4mTqJvCv0m/WqzcpACeLlHe85x76UZji2g4Mb6ojz/4Zfv/GdVnMemhFcW4ar5aNfyZJdCBYJZDMCEviomPFs9w4EIIoxB4d8G21teAqyCt3f\u002B\u002BD2VrdwVhv\u002Bm0O6dcFf76S4Z4UZLoILISzo3CwoT8gaiN0QdmBWk8qucqxDwaVrzUhl\u002BaMYxo0e63WKh3ovlgt7X\u002BzkT7lEYZP6qvwVxx9HfM6jgpZkwcIP8YrqzAxQvpygyGH4h73PIZfPXlvRCOQWA0qrS9N1Fp3q1F3uWZWHqewftP79jvVQlKE\u002BVaOmfuim1IiB5TKJK7HDzbMgIIgCR7RvsVPlWHSVGrdydsE6RJW1B4TMxYT5VolM\u002BcECMLQZO83vNo1UgXwULIp7VrSwyUkdqxkDNUIvdlrKmJ6zUyoDGXrzCw4IIEZIuNk6ff/UnDB4JEWbFcaL/8AyiijdoJmgOH05vb561YqSuryo9Pha9fxuO26kqAO0Z0tN1VYdqxg/mkWC2x6yPQ66yFtJ4srH19Rsb2Uq\u002B5A5hRZy7QB0dQ\u002BkaVqymBrdvD5gKd\u002BoKoRARj1B8Tuy1J61iRXIPxAORlNL5blwFX/5TrMmypGwUZqSMmcC8oQT8VS7/Q7E1bzuUaNMXETK0HC9iGJITAnMxTe7Ngzoy1PPN/RktFhw9Hk2eLkuY/UVhyI2RWohi2VK7vfXSd9wBUYPvWRQphvYTJPpEhNQ3qECZa8qsoYp7WyO2cVgWaqZhjNy3uaQxODGHfiWOLlR\u002BdBWlSRwRVKAJY/3wYxWeDMpT0vgHj/6sWCOJFTNU7TzPSA1CYSGaUCgsrkW2QNUr\u002BXFrOktcduQXCODoiE98pIaxISsIW5uYuYLP6tG45gdebSvB\u002BbLxYtEpO2gwocfor/nO9S\u002BqE53VwnDIjJwCbhLpmisTurrDv75Z7yAjaAe65zrX6eDnpEmN7CdCONZFFs1VVwecxPVPC0VhUDR9smppDaVRKnQh8fXhld6TcYbYBNhS3hDwLhI1mO6rdkQVA="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-a8e1c191-8a9b-caa6-ada0-4e82488e283e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-01044aef5c4305dd022192170595ffcb-e8c2f9ca334eb8ca-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "3cec89dd-3c44-5d8c-e671-8ea3cf43fd2e",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA4AC3C0\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "3cec89dd-3c44-5d8c-e671-8ea3cf43fd2e",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de81d-d01e-0002-2cb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "A5zNk7MOPsWSNVEbs/JruJvolLXCrUSWjvgyuBhXaLocyFlMaoW6cg7Am6y\u002B5i4x7tZPz9CLjlVXNgW63IWsOs2W/\u002BuYHk4WLiKnAhKY2KfKAMpBCJnqkToD9TOAAJWIE2HfJ\u002BdCmdCIOaGt44tDv15d79y7ajE0rG6wlCgalS2MH\u002B6wubDAh2f5uc/4PK2uwDXUIhC5zKgvq3p5kgSnbaNzIMSckgatnWd0wbFiO2/AAtTyRnMd01JGgQ41RvViUksrhBzoES0vJ4WpRQr2zG8LuI8wtCcwVk1xVhH3d1ZxEW9mN7dT2PCnwx7tc45HT7WfKo5mMp0j\u002Bi7PdrscN68uNzOakJS3t9\u002BeiPEIQuK\u002BKQdbWE3IC97SQjyIhGE1i4tvvzxarb4g53Kux6qrG7hMEEy0wN9iZitUyE5YLzN9aP1mmYOlY3xIOnHaGUM0JieDPHMVgcqsDVgQBuRvyLg\u002BMF6sRYE1pqzPa4Zth0zoIKEn1PLAaOczuowqlF2Y2HK5nOnlh\u002BGlTpbGRRZEPoULKOZDSPTFfsd3eYr0ChFPN5IUs\u002BtjApi/goVc\u002BSLQ7nsHHmx3VZB\u002B8x0hbQ5XsEOEdw6DL4qZqCVNg8VuaYSkpooO7eul1\u002BIClsDNQpWKaNFC14EUTb7xbXZGKdHKD4qYfMaDSMJX36ArgJnKy2WQwxv0LJEDkFjLHYB1Xq0QN4Y1NcbOBh8O6vjh6cwlJqERtma21uP4lexutypC4oDyGkkTlJafwbz75UGZIqaLpvbeZKhGWmGiPJ/ZYE/0zAd37s6DEZEKcfSqu/GhX3NF4hEzY37YrMDncVj3xmFtBhg6ITTYCJVl0/KznJ9vANwslH4\u002BwGiJn0IOm6A5E6uTPLTYZz4\u002Bbdp7zo\u002BLJQ8geHB7yjLiL0WwsILyymz0K8BHH1/ql5me7SakwvLY/noy7SMwvkh5sA1vJ7a8TKNth6PPQwWvNuDW3N0LPm1T17IIv91IxG13zm9Se2/i4qCDNjpOCLp1g7ZDWeFrbnGgHFADs43FJcM1WHWVXbpw9Po9hwgyBM74kzsmBGqMDGD9sV8f3i4SvRB3GLBE3yX802XmLeZpbheBCyBRnyBYqUsVl6tbUBXLKsn3uuses7MWKjEFpd55lENHntMNwR7vH29kL0d6oIJPGwMccbMsYlhtO3XvUgRtmwNoFLJCvmmrCJp8uYNsnImvtonbXCOPGzt7oIWoAM1q95NDEYzQDFyacWkZsKnUAJ/rP5t6kT7g2fl2xx3jAgfNEcLvKIr936ktQeu6dWqSpp/lvcEy72VVYzeTWUU\u002Btm5hS57n5NgU7WDxTVBTJmOO5CB\u002B/URGmyJcmsRTaoZk7ot8WCnMq8LH0c9gQKIVAT3TBXQkwLgpG7B7ikkTwYPajF/F1s06wTletyx15VqAR5iGgGURQC3SUjx5UCB5sxBMhrNCTypvmUM7xgmLtDZW\u002B0KwjEAdyEwx8oSQwHAY5AMcKV6mPfduFuYh1XokR50GI1XdyCbPLr1nEVym39jTI\u002BEFb4vXr75LQnVZ/PPSDKvmip0bOhvdTfqgPyubxzcOTrKYH9gSLnOXkoawdTHKlAWxv1Q6uOjFJyGQNm\u002BSsHo9S65AOu3T1Fspg6eVLdjI1qol6Qjj05XJ0ve2gfcEBOIMcimDiVoY3er4EDRBMPpJyGDEbMZxWncYdmf2HVNjJX/EiLquRUxPDQwd6sJhiKH8bbiXP5ccmhexaxPzIsCXleu0fKdAmoIUdV65U3C0tu7F\u002Ba\u002BazObnp\u002B6i/Nk5XOtMhlXXrAz6u9I1g8o4Y0an/bQkLigQ/MkFzdS5nZ2o2xhzbM0b3Qriyz3cZEkbrkSn\u002Bv8lFC7DPIqM0t83QB41jKixxfZ5jB\u002BqQmLqM5d/6R\u002BQEqKeg8bqsDBCjworqosfp9ehauhNLW7fe9HL2AjzDOm/py17lwnhxhXGN/0Vf5jXyou/3n42QuU0vgj1H9cnT4IhawNdpBDOv6PTh/Zwyvs58w59My1qiWRIRtgB7Kc\u002Bnud69BSUeSZ78R/bYrruxPMMvCvJqhtVtuGeFV03zdP8lekO9dbnpHroAUIOjyapWYLl9C97dfPLJT0y9WTIQyNL3s3R4M4dJBex4KjZRye69bzbUtijgCD1Q9CYta4VIL4ewrBY2Hm0x9AYypRK8t4WeACo7PFKp16t2539hG9pm8DquoR2YR1DJooIi7WLq1HygjytbTPN0xtSq/zctkNgri/TYDdZnxbjZcVmQhuoITBMCwIyuy2NHOZoJLYgZnBHqN2GuEoZmOImyghtZpH/qonMkKtALfMBRkNQ8Xtgwv5VH5o\u002BIWnlMnMfDPEkILZVaHksVNbFBnrqhXIHyadnxgcKF0f3wYgg5l04ISEB3CaN\u002BogCM24nkBggVJz23mnLuEXqGQhuXqfwDG15jeVY6KhMec4eZZOY44cv1mzsKQj0bGjcF8IdHpzhEScBrQIyyGvzqmSarVOyUTaAPoc6BOJkhCF8e9HlLlsyPVNslzaE/A4A\u002BH\u002BkWr4VKcaMnd8UpwxEnCjhtUyaDnsJaHD/RrkA\u002B0J5OQtjvypiZ1ILWJF7HZZHJ/oNo0fCZuoDm/FOFeMMjKGdm20B4Nz\u002Bf075j7XqjUrauB6/81j6ttMhYCQ5FFFv/szv3YEoRkceDiT4yNY0GA2mdF3ETZlJouWa33\u002B4xWr8ipDp\u002B7DJsXLXoOQ0Au397EgWkp/0qrEzpjo="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-deb9482e-a769-1444-d038-a6dfe1e24509",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b70d9fecb72bd750c2a5a4efab2264b9-5c1f94bfb0a25408-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "83bd3e1a-f679-0bab-0bbc-3ade32bbd05f",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA4BADFB\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "83bd3e1a-f679-0bab-0bbc-3ade32bbd05f",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de867-d01e-0002-6bb0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "nI5mx2ZJufs\u002BRUscXN3C6\u002BystRSg953yN6Eyygjf3rVUdiwjCw86mnsGr7ehK7q03Qi\u002BBX2RmaXwc5DEF\u002B7zXmaVx\u002Baxn9/ccRqZmkflUQvnfu3/Idk4w9yGMph/doONE1BRC2PTAz4p4ZRi\u002BP9dCyGE3ZgA8z2NXQQJKmxHXfuXDIf3lEanE3qv1kBE1crdKSd2\u002B5jqjB8TxK1fytjR4YOZy\u002Bx3Znbb3MkeURz9SIg6KwBE0WJirX9n49CYSEmi3fS8qwreZsOwmh7OzDsDFnslJZ7XjBAhNh1sEIKmQpOAe3MnQJ1\u002BW8U9lDZDk\u002BFEY8xVcyOqylHkmnTscVVACliKTlDI29Xep8nZmvjZ3aI7KKy2Uc5w1rEiQqUokelv/YneuUWRfIj3dsxa0TBYC7zRsUmoirmJGnefppgwtRbfaZxv\u002BiRdqqwkv9oCFQSAyTfpV9\u002BgxnPQVZ/N8tbvx8G2emeU6BCYdAadhMrehgRzHtxhRl42P6IonqWEj7jWNfgYTJud7OAnUOLZA0Ko8c6bWtT6jYBjgDvFa0pqE\u002BVNx07SxTpp1TH7OfZ7XDtgf6zX6TTk3Kd4tctf2IGWvDz9izvz1SuTMYSi/lOJ5yP/ZeudkymwaeunWhBvCv2vZH25ftEAbKqBRLevQd1T7s2oX3KW\u002BSkTTCJQTHsbJCeH85rWz2lS//hBHE9xAScOU2xDxqqKGWtUpjKuryAvZh\u002BPKE5CfR5kVV96VN3ZoUv6QvgO1119/Nkvgik2o1DYErYv4djZy9ZN3nBLEMSNegXntG0nII7CEit0E/r1LbIPoUInqr9yIXciwfnsMewUoQckT\u002B/isfInbc\u002BtZLfbWLG\u002BO26CZtBFdJP1BF\u002BV1eA/X3Hz0d3DLPBQ/zzwxby/R2lILvV9kjs33tpc7a2TkpfubQVF6IbT\u002Bw9\u002BMmaTVa/WNrz1Tafrws02u/ICZz9CvW2lAle2eV/idDLm/l/Uo4krhbbwnUXvA6s4DiyU0JTQO3X57VJYILxcE9h1BMNtYhhp1\u002BGIUR8ntv\u002BrfmszTqSeFsPp2rU20mT6k4lsev7oyqwUKviyR\u002BlV0TdTraFRKcUz1u4Ag4hiMgR9jr6VujwAwrS\u002BHyOs7M7ZlAh\u002B4iXDqGrEOaMP6EYksfjzNbkrwBb7UurtkgqhhuogJu9/40/fuuVT0IGY8dptmm0rubcUrdPxg5A71RZgIrO578FWpc2oFHvU2O\u002BVYmEPf/icds0zC3kbjWC/o\u002BTO867O3wEZFvWfg6U7QNXkXCAuLFYdw6zlheRHOxdt6HCWBeVBx4Ng9mgD/fMn98qkNjFAkXeOsS8B6Fkd0dvdMpo1pTvwo5SdzjXtGsa4vY4ZowTlLFb4CFS1P98pQySMJcpY8lKPtJOdosNBoJZoSCrLAy3X\u002BAVDPJznOmS1c4sRYPX8YMs8iu9xSImTt2e9Tfa0Xj/3tS3FFLa1qHku5y44MEChbOhfjnk\u002BZq97sIU0KexuABVLGavHNksUhuF1QmBaW4YnG\u002BENVc/GuE5\u002BSWQxgH6NwOcZ7BaV2jWdSwiXyCROIFT\u002BDQ4LYKtFhGFcSe3m4gVj6IF5QW9vkkGrcArHL/AqLykQM3NwgWA702i1OJBItmgCM\u002BCi1N/ljnvMX\u002B\u002BhflRwMhrE1q\u002BS8mYhPm4GulmxY7qixfwPiFtKKqT3oyFwmlUTRAZ2g9\u002B4b0B6gJZw3tQhG/w1/7lYYaq\u002BeqsLm05EsaMY83VTOt/a6VW7lQfF2UzP1YglOpubuuNbtwkzrdTxNc/yWOtfzuAcWxVjncyi\u002BaFfO8XGH3cIfDiS94PVpjyByV840oBgcAenCN\u002BFOB0XuL1o03EPKxZX6tuzzNZdRrTZ4tRsaicg/8q9HhaYgkQaez/FbdPKcZ5J4OilraMxSsEqrFVJqk6WSNSmUQwAv2iWmFGXmNnhDnA2Ioo\u002BelEnjNRUbdXu0dDxLiT\u002BJCCRSSCADhRRmrLoSZ7lE4jEV86Df8Q4q1KSqMeBpWm14upQpNlpvms81fIibCM3Cb1HLddWe6RcWJ3O7WZNz/RIMmazlG6vWphiRqnRFj8uW54JOniSX2dF9Ew7m9AE7wX\u002B2Tm9g3RPmNI\u002B8zX6ikJdn5LIRJV7ttP\u002BbqAic7/IXlak0zwGcdcpuqGmVGsyS2kJ3vs\u002BPKtvgiNmvhXULCUTdpXeVrcFVy26non01WFnzCI2GJXDiSGrNVAZn7PCVY18k97WVPWyBIbOg50heq3B//HynRSQT\u002BxzMiFm67d5\u002BEn7eEKDkHgtgxMO9QWDibqiWKDC0Ld560PxYiHTTBnOVItUJQJrPm55xBoAgVrm76lnxJMXtyiSgoz\u002BkS5XWTf6P6B5L2O3NxkySQuceWrpC3J3bIiFt5xjwaN1baw/IWriBUK6bMBFr4x55G4c9QgiFYa73\u002B2vdYcDFm6/Qclt8iehunMnLp6yMr37C9ItR8ubU1cmhEF9M5C6tlZRhW3CDPJHezuU\u002BuboCa0vtGm11s\u002BiJO5yRm7lI4bjbXhHYKxPOP/g5suQBlhxPnuUTX4nBN\u002BHr2B/UMaDYVe0sI1toKgA4Hxp1e8DER6VAAfzUdUHvGiYwLFLz\u002Bc5XIRz21XKA53Sk20CvS/vg51C6U\u002B\u002BkBCBrPQl1OD2tRCUMHhrkDbIyv1qIL1oBf84qDwTCOWXe8t08S5hpS\u002B93N5cbYy2hPNneh9SVHBSGaf07Cuk46wq/bWt954HZyXOrETeC5c="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-ff8ed137-7ad1-395c-3a3c-6996713952f5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7eb337088eb9593dcf0b0b7b236b827b-0b60cc21f1bfd205-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "9089378b-7985-74b4-20f8-680ad7fcee33",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:12 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA4D0D59\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "9089378b-7985-74b4-20f8-680ad7fcee33",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de8cb-d01e-0002-43b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "coEkSKyOxkQmWyHYhmy4Axn4MjFw1wmNVV8T\u002BYSnK3QNEIJrB1s2HWS4jlHWxYD6bMqTS6zZJ5t3lvJMe8zAfzCsy3bqTfy9whXNt0i4t4/eGI25E\u002BDIM\u002Bjm83Bo6qGX\u002BA8hKfoKEB7O1omWDG9Sv99jbmM/BmtP5JeNA1qLVNdzNr85l42V1Adu6z1WMSd5kzSQBXw\u002BWPKj0URjfAzEQoGxI9WwGSdRzZlb0Bsu\u002BbNvFHAm\u002B09bNd3NlsZJMlf7qqi7pQ5RyXoMPjfi4ojWddiQ82icnkcyVe344oNhCJtCYCZyclOlHkr1GbwXeVJV9iHtuD7vXgtgiU8gWeb2qjaboIJhZAKE69QdpoSLG9yaouxidE9dUgEaEukDhcVk/m\u002BFe9nQ85Ieac1q0biG1G5zhbb5lDbmPk2AR1EZgGYPuKcVBZ8Dyq9aQwqC8oFJkz17kP8Oamk5nj2LT6xABehnWhgQcc7Ob7oHn1ErZEvMN7MTnfBmAU4922dhd3sCGT0iGphoOSFurCBFBssYDTnxvxj4LWf4AVnK0pVnbPg/BIUTCEqzZP6SpPHPIPqCJc4tcLhiCuzWKhk/nWaLBj8oBQJGBATvPlsaZYh2KOBeSK3HOvxA3PqYPd4wc8aXBp2xphv4PCHJPTFcSKRkYAE44VS5w8xC6CgHrcYmvsuUgl/qxILFZQyM/v3L45RVNN3d95Jx3kLRb77y8I5aon5mx8ZFept\u002Bc3tILcTOdwSUsnnpSMY4IqQcGFTD0nV\u002BMVx/ZRvNELlBXoQXKbB\u002BA/e5XT4UcVq3LaQiKGFHu6AGyvtoTxHoxqK/p\u002BpCIfnznhVcCXQ2acABxzh3q\u002BdY\u002BqPjEV\u002B1FbPm0ZebVclvdQurL4pM6rErz2A7ZofZcRq6Z6xGXhCaPYhhdjjdmxT2klIsy3xdCxDxuEL\u002Beq4rDF984O0dKBb7EfEB6nN4TTRMRNQ1raaeXVucVabOm8PaNWrZYbom2Wk8MLqLWyGdeGoOsTXZ9l653oOSgNNwLXUtJ7QIn\u002Bx5JWpr\u002BXzrEwI6/9w7wOmNAD8MH4I2lFiVywNEXTRslNl9lIzKbv3hzcuBWIH3NGyLoCZ1/H9pQpES1i15p7XNzWoCvixdwpJCKlK3tTzWnZeXuLwN9pdZE1H7uJfPaCYVs4oX9HZALt2UM9Etso1UOziW4u75v9fSqaraYgn6csIrogGyv6kgVorfeMPFK2HDpn1eOYY4HPSyREvLZcvTmsAPAg\u002BLonuPdYtjGUYTDH1IF7yMmzk88oYN/3tdVfC\u002BC94DtilSOAQCz8P61AKtnzfNgk4PR/\u002BG0w\u002BIfaIAMSCapQ1oEFZU9t64isx1QR6EYGBDkNKirsTefeIZybphAZ2jXy70RY/heItvV7wzEJLxBB1CvaFN\u002BPdJiZJzOy0jVogu0eHvjxvQYRhGMlYHq2xQKMSdHkT8Vmc3q7v8bTxeTAA0BD6wAXQCcVuIB8WgQd0mIxJphjdDMnt6t\u002BRf1PTb6OZW06YtoCdPm63pc0\u002Bhl2nd1Uop9MXI8NLDNUmPopxnrB7eSm02\u002BYLrGeuKWr4s2CB6gf6psfMhjePUaWrdv/gQgsYwwk37p9zHPdvaPpUTl10oFSGevfsrvbyKYo8XDlnyetj3\u002BxXTf9oi4XMXRk9NwNINtKrXcsTLBQSQcURMsC\u002BC58O9G5tHVZVGe9yHE3dtPaG8ClmuGwgTLPYQQg6V1TFElV\u002BLj6U3xV4VkfboRPGNIjOjj6XW08y7qe\u002BkNhOHsKWqQn0Y4q38hUT6mYoRK\u002BcFgx/a8kWLbsKSz\u002Ba1k49LjeBQPQFzdT\u002BGpwph2zlBqn4InrPzrb5fHtS7hRPGRvK1rwypwe3lkQ3gVEs7KpKIUCRorPTbV\u002BAi8B8suO8sv2AXqystmOmQIgylE1hzJPNCMzTuXpr\u002B2Vcsh9DOudkds5XqJH5mW7g714rnNUSHrswr6oS7PWDGGdLTARAYwmkziF/DiP9129h8soYPFqQTpNkEos5UYnY0JAqsklmoIxUgtK3kxCbMtg\u002BsP4rZtgItwFw2FB\u002Ba3iXpjmT0yEh\u002B049x72L3Lt\u002BzN\u002By/pyPrW24If9L8cQ/1hdaI\u002BzbB1\u002B3GLmv7aMafNpF9g9wy2zYB/TP17El1gWGAe2mMbjOp8WD/\u002BHm48PKnaEhBf\u002B4yw6qfhv0CzOujUawJe\u002BxcE8dd05J8M\u002BO8SQ1ATYMBNAJzTbi/7Oc1pyR1W6fMrnQFSlWA46xbto/H4j3vwn5nohyqli40nSbfJyttB9c78JqZOgMugFFVF5Yo\u002BAmpReWmDbiLIhdG0a0voLuA7q\u002B4i/KjVod7OSLKVX\u002BXC6QcNeJGx/kesM6CUmlV/t\u002BW1CjmcG0XBu9dKtSWwMyYrsUIEmrZOie2mdskIAQeJTpCNIBWsJo3BS/y6Jwkh\u002B8B6qOjTOx1vZoBMNeS8ubqPwWaVIxMQv0r0Q075lGLkRHrIzZgethOzHblVIDDpRJICKiXijJjtKeleHveOddIdp7Fps6wicUsS4gVZu19Zyz68t2o9Abeh26OugJdb5OfnN7h/f5EmH7jaj6qTU66KBBP40f5n4KX5x9gIs/Cz9z0dskPnGottlpfxYnIMzkg1JLyDYxMpvxbSRbf43avIJtitteEqoymISzsmdr5z7PlP0480MFPqM/MtFJTTtLjsKTtZX1hmykGS\u002BxfXwwiYnli\u002BaMoclDaEg0Ht/Y5UtJZCek1C2k1g6Q="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-9b4907ea-b8a6-e94b-7ccc-d763e3c7e9cb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6704ae34be90d50605136e75540b91c7-4e8476a20e5da008-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "fa536ab0-3f32-08d9-2ce9-6da434fdf4b3",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:12 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA4E1EA3\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "fa536ab0-3f32-08d9-2ce9-6da434fdf4b3",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de94d-d01e-0002-39b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "JDaE1PBJw6pR2PFVL7s9UxNTcFnjM835GQVVIuxWECx1/wM8ywUiw0QNpGBhfSpNq\u002BH4FsUpwPFoi7vr86C9\u002BsjE3y\u002B4AIgNMa0V1Y5sl5zaCHYKXvlnSz8R00BKN8\u002BjUKqYnJ37lKpZ6uUYFOpj/PMfEOspspzOXZPwpi1Hw/ndcoXk1Pv\u002B33PMsHMUTjdUrtdMKybjeZ0OyT4JC\u002B19EifrOqFkfyj4IDF3XQEouQ5cm/hW\u002B5fT\u002Bfnn1gq89NSFTp5MKRSW8C\u002BuVAr1bBub5g8wrW/1JxaPGECofKkdOyxd8Q9i25D5xavJp6aN3Y3dS\u002B/6jEZkkCaIvBDU7XOGkBndmHoMOAp/NufELIBwAjqyyjG5I67m\u002BGHo2h9/Jdc4QhaNr0US0RPle1Zen2OmF7nWISNBzG1q958ZI13q/xAPjOlq4lL0oPkd06hXh1n9QsNlqQS09nWoIrem\u002BK21\u002B3tGThN6PDRm4YEpJPnFE3BGHOGahFUMW5VzwcCaTqdLaNgsEThFgwaO/8iCi9J84w9HYNzMGnYmOfN\u002BBnp0y5LZ3rshmAE4AZnbDIWNic/D992xU\u002B7Kf05hBthEx3yLGjM1qKwWWkoOD19D8Q7wmK8jug\u002BcwnikDl5tv5Io8zocT/FSV\u002BAirJyTo0OPh40/cG0oIAxt7le6kZlOqZu35RslJ6IcnkHOAQ5yCR80FIfRLU4lANMtrmCal8VG1AIB270oamDrI9IrWR/\u002B\u002BuU3hX0SfHxMkuVI93hBgQZ8hywLcS1hDKon5Ql8\u002BaazL7R6YhFINFeFtEnY33PnqqHLr9Lz8oi31XnS65dzz5g\u002BlMfDxh/0NFPUhrzkiS03PztnsErUwD0rwoyYdUnAEuWwmUqrJOOC13p\u002BHmzL00xMm6tcCx5NatSKmAOSXL8KE3PXM\u002B/iixtY5dnPVaHRX\u002B9ATNmdZAfGYi52IYvf8Hu7dAv4859caQ\u002BQAyZFfhUyuDgUUQ/lbK9sEdDAa2qPefReE\u002BCW2GxP4\u002BLJDGDggeQZRGhTyp5r1gdbjOLOnP6lAYox5mo1m\u002BDMxG4tHGBPi5DrpycCO65W8j3YO0yJgEfkJAvVr5p65KiIhwYwPrmnDABS4vTWosXc2/QsXGCTQkMmSfdVedv2ccN/erSoJbSEMC5LN51SDYFF\u002BdSmTodH9ETCCfTCUpIlW3ExVygQNLU/qCsxSAum1Dt1D4AHUCI7N4Vw5hy/wd6cJtssIbVZNMQeZqZcFaw4GzW4TEISHQtP9h\u002BioE6Zf\u002BZNlSEwerKGG9q76el83yLZN8rnBnSbiQnP3CuWt5R2hea/Dn\u002BKCKGCMjBnVzMh0hb9yGiDsXlxsQwYYJ2H72RGRGQCvNCiTy8oZdNENDLVrQoUme4r89NtTl1zcagE\u002BkPMIRLPHxZGWnk5W0ylLX3aQ7KTclZ1G1GQlW1zLt2GJGqQdxIfBY7zzj518ZiGyCHfmS71cYfsVgbBPoqo0iubsjfiFLVquj0kn6QXACm4CsxMk5WvkbLipCEMXcYESvsT2j5hpLRsdd7x0dHj1VbcCDS9XD\u002BW7CGE/3CTXV12H1SoBCXqV2YY4B22vsDg/87LL1SSRu68fO4d3KRD2BeAerF9OtAw8rDOpXsh3y5ho/\u002Bhxy4J5Nhm7Ic3zHvB1AcGNUMOY8X\u002Bmz2jxKFymp2/vDmkohDpd5XYFk1I\u002BCY1DNF0G6nqUj86oizxZSA39FLqeA9CHDH3Hb6tNU13taMWbbjP/n/01Wr5av/k\u002BBJ1oCL7XoAW8\u002B\u002BffP3rPBzywu2J2vhnaPXS9qKlSbIyEyWrOJQre1YiAHnJMIGBCJhNBqcSWx0aDTgsKWjdcKo8bWnYPwSIx0eWZtl\u002Bnjh0UO0JWEIKILgHkSpc/lLuRZDPjMIYqMmUxT5ge/REnG4AuNh70xdnMU2x0a3ZLMn1qCBJrhJ1XKckdZMEqqTDwvW7W0Z5c3F5Z1p1Ztcbuph1a9PU\u002B\u002B1cilswV16DY4eo7g63HtCCezWv0Ea4//XQCLv6jj/R78cIX9DqSBwT9QPSzXjIZJzI8\u002B\u002BdJCumo4tmYE6iiNVI1v9Gr74AlzIYm9pD5TJ9B6MfMptPM8qcYbtFhOjNcGwuivd4gbTdyFu9hIhQY75Y6Firg1Y5\u002BaI1qk0DuhJKSyttFFo7BIXuQmo/kq9BTP787JyPIuwW9JFUQ9dn2Q1Icjld4k9kHePSvEHr\u002Bmbz815PBs12uyk\u002BVx/J5sGuh2hc9h915GmvmM\u002B4vGarKvoqYVB5GNM/0rcQHosvmjYiJDTZjwNHfQ/0n23\u002Bvv7CkywknoRwNW\u002BUHSRoZcXef/2YlZcy0Zv24\u002BRAhHhlQRO4TYpeCvyyse/ERHHf3hhKFiBvZSlnkMKRLrugMLD3L9sQsBg6gHQB5uOobYwpFwTL9m5X9tvqUbzIzNxBEYE\u002BzBWWzi7/D5Wrbn5FviM1Zxa21DpCnzn/JV9ccbOYwNVhaqB3k0jWzObYrIdcpZKYk2TFijxH\u002ByzclqnPo53iEq2p41SDvdTO4AhTavOxo4DMw95P0jaYGm5zm/2fByhI9pnas8E\u002BFdWQ96o09JE5K/MpAuC/k0B3EcnlDyLXL9jgCnNa1u\u002B\u002Bja0IvtuLZCbcOm8KdQRIiGJYY6L4WQazuMjRU\u002Bkd3lQDanQyt9Rl66yiCNWzzLnUmIERAXNNxjSnVQYSuhA9v1sbBwuQFdGO83f1VVAwAOsO/btnDN3htaM/i2LOUjGcZUk="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a/test-blob-764b445b-2900-b46d-eb7f-a42d3eaea396",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-75e7a2ba0f5bf3efb140bb80b20753fd-8de7dac02f3f48d5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "6c59d838-f3a8-4500-b886-44cfea144738",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:12 GMT",
+        "x-ms-range": "bytes=0-2047",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "2048",
+        "Content-Range": "bytes 0-2047/2048",
+        "Content-Type": "application/octet-stream",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "ETag": "\u00220x8DB71C7FA508F47\u0022",
+        "Last-Modified": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "6c59d838-f3a8-4500-b886-44cfea144738",
+        "x-ms-creation-time": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "993de9a3-d01e-0002-09b0-a32f3a000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "eZfFrUSCsIIN/Fhx5HZVGgO8VNWyfjlSZ1CJb8ChRVnvB7doJmC5OLeKz\u002BRcMlsUDLNOdEeQlvtec0bz\u002BUDBbLb/gd2/7fSiAxseKK5U9TT1dWIMUtARX3C7CbIaxT92yGIuXLF9VR\u002B/q3ErcW5NCX0R/oPetRrm7SJtBONBiD3bqF9LJpiDdyBDTKZf5e0BbQA0CMe8lxNISG6PEFA8fiMzUMkOAeLljoZjmmhzhgg0a5biDX92HxBMAt4p9GfPB86CK5Uk82weT3pAWPyq1MFmWqW6WXGjvTC4wv4Du5oflJOa8FtyEHgqxL0FNccToi4dw5nBFa1d321lazFtGpTfIcRpEONm9Eksj5WznYhppR/Q5vgAXX7lPBHtDaVHvakpJRQCqpJKt89QlYUYqUHl\u002B8URnDOb38NFg9PSeOak5dLriXd0ZvuNhi8pr8j5zJLQCBHfNiB2jUZQvSe\u002BeD7oq6\u002ByLSDJcZTKgxYDci/6TLZAAXDUxK\u002BydPwxI6nUzw3xQAQYRp9yBpd9FLIJchoWVXFwfnbOFOYAALgjl03r9rQIEjIr4gUXzfvYV6/8qAHhG804Y1CXIiwdGEbmTm9JkR7\u002BAWDo6nNrWbB79bw2BFe3Qnt/spNjce8GDcq\u002BMH6MjsWR/aeh\u002BTBZzAmgGyxv5hPvLwzzyt6Lm49w4typrSky72f3pQewFUlKJeaJw1XDlie2zwFymcTmBmEXMBdUsB/gbSzFeEEMPhnDqKT4Adg6rUu1894nv1aiEJ6lmOUy9nXHqFUo/R7lqpDnrvAg7gSJ3YLLnr1AuK3WI2iiZqUzkbEuMVmCEbAtz0hOQBFlgSKZHLtjZle4hu\u002BnUdq2Q0Pqsxw/8byrBsvSnc908niccaFFCErq0CpZdqpp27/Vd4wFY4z0JpBl7hXwkcmIQ5N2CuA5cDr4AOPy5XsSQisL/CZCb47sqEsQ4Bo1\u002BT9h0DMW8tDfnAdRDGOpAkAVU6vq5ZSiRdQFimKVKI8gwwajkBRH\u002B09aK2Ae8WIrQ6UK\u002B41uShOqvopfEWdtSnN4MUhcBXErzVdbkLk0hFRx2Ue8iiwBsXjz\u002BdGJ6Onn7OHspsAazj0z3i41ErpadTo27Tcgsb9GdoDQaQygoeRudKPYSN6UVwsJiKv\u002By569mYOXU/qxxzshpS9ASWUxkzxKx54XgS1copYsFigUSKrhEtCJCU7pvaxot6KuVA2l2PVutAT/phdVO7BkhLATDV2EXjeUp4ruYAnxrsqKrU6Jhj4ypZOm4mu4M86dhTj8ValFKvXWETBrgFP6DfdNyo1i2v5y4GjJ3nvL3HS7UNvR9VkgRIJYs3UNxyRAq9R0a2hAOqo6iXRBfEx5CjS8ry94KRieLIULCieIZBhDiDKnV3ALexUwl2vk38g23qhAURj0yIK81j7iNDCDsSRc/vMZ0rLDsTMaR5GsuU291St\u002BRxMATsCw6oExKEfkreZGiOHVHAv1fJ/k2oDwEBzxJV8EBGkRW68yaOcxkYjsNZmrZTBs6LkgiMpzHHRAwNpkQALn4Kl8NS0xorMkxOsX96XnRarshT2m5HyfnT478qgNzFGFBFXwLy8COkUF/MPfXCTOWXsveLrFQfss3Zju9rALFveZkfJQ9hZ66Ur3oOi4v0AZbJgt3VSWwMNZw1GXE0SV\u002BuXMRssxfmJktI5wzaASdB1Y1IkX3TijAtAv9jLE49UGYqYD63l05\u002B42yCjFJvIiRk4zPz66fhysKUP6AocvoNG5aWv6D4ik4\u002B2b4RUQ3dveDa/kkKSWS\u002BSKVsI1euVmBihXDL2HKDfGjlxRH5wHnEtoHPTXSw8tIh2Hb7jFb2gHNNrsuNAeVuV4HgJHRCxHgrp3zV3wjroYKumf/7h/AB7zSuvCGuN6ScUPXy0N5d3xQOz9TqILFqUg043mflcs\u002BB3jVPpAhWjW/IOY4C\u002BNC0UMrb/LgbF86DNFokZWlMpu42cPKpDjsLqEJ1IfczV2kshI2tGXYHdsZmzG\u002BuIhgGi4Kf3IfeG0KPwER1pfXXX9zw9\u002BDbn514Lvo8MkHbbXY6bpZkk3rhXnk7LUkhkcDAn3yCvTo3Ouv1J72NkdkApGLOS0dfYrxSH5lnkGJURo05e5LFSLBL8zO6f3vNY7yQKnjWU1aJYTywIJ2Qz5p5kNEgRCZGS2uygkgDpPNAlLvsx3X5jfM2oApmBRgSqzOpMN6anR\u002BGWe8dI9EOdcxJf5vhs/gUgBLt\u002BZQr0DZDn9cEanQUpfesVn2G3GoiKDpOLJWMMPdLhKDLvKN7Wnm4yYP5\u002BhtINNmURV2KnaO4y8Fp7bOgt27fyOXTSOlUIQvz3gLWKD4e9ee75/upwOb9EvDiAXy2CBIVGjEldOvwQBRBhr\u002BQ0pOTSvfL9M9zNgf\u002B1jXoYi\u002BPPcXwwR4M\u002BYELu6fXWDonXEBtTraE6hNCoeQpNp62B930wkj5oBGFllFmwDknm93dx4nlixNpCkOivh8p08LyVaPJ4pXhPbw\u002B57hlHinqKxYGW28UwIy6m7gFRuHyW7KedHqFXalH7JnNtpNrA\u002BwpyJMJI4hT7YUnH1bd6\u002BbKPIwFxqm/ZM1szm7VRwnpX5fL245e\u002BTgqOpblbk5SafCi84oHVT1CelPFnFUpjpaLPb\u002B/AgBoe0NT24wCygaPGmRuIkOP0fpaiWEqmVzTALvwajCOk1fgOog2s4mhP6BdRoHwu1xC\u002B1vFZIivTeHmgMrQAl/V8HcMc="
+    },
+    {
+      "RequestUri": "https://seanmcccanada.blob.core.windows.net/test-container-36fc326b-24c9-55dc-2550-3cb5366fb49a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fbf870b42761a13769679a503b41b9c4-a710397d0387e5b5-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.17.0-alpha.20230620.1 (.NET 7.0.7; Microsoft Windows 10.0.22621)",
+        "x-ms-client-request-id": "5c6c091d-88a3-e90a-1a25-006557464969",
+        "x-ms-date": "Tue, 20 Jun 2023 19:53:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 20 Jun 2023 19:53:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5c6c091d-88a3-e90a-1a25-006557464969",
+        "x-ms-request-id": "993de9c2-d01e-0002-27b0-a32f3a000000",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1606098896",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanada\nU2FuaXRpemVk\nhttps://seanmcccanada.blob.core.windows.net\nhttps://seanmcccanada.file.core.windows.net\nhttps://seanmcccanada.queue.core.windows.net\nhttps://seanmcccanada.table.core.windows.net\n\n\n\n\nhttps://seanmcccanada-secondary.blob.core.windows.net\nhttps://seanmcccanada-secondary.file.core.windows.net\nhttps://seanmcccanada-secondary.queue.core.windows.net\nhttps://seanmcccanada-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanada.blob.core.windows.net/;QueueEndpoint=https://seanmcccanada.queue.core.windows.net/;FileEndpoint=https://seanmcccanada.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanada-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanada-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanada-secondary.file.core.windows.net/;AccountName=seanmcccanada;AccountKey=Sanitized\nseanscope1\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferSyncCopyTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferSyncCopyTests.cs
@@ -245,9 +245,7 @@ namespace Azure.Storage.DataMovement.Tests
                 waitTimeInSec: waitTimeInSec).ConfigureAwait(false);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/33003")]
-        [Test]
-        [LiveOnly]
+        [RecordedTest]
         [TestCase(2, 0, 30)]
         [TestCase(6, 0, 30)]
         [TestCase(2, 100, 30)]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
@@ -455,9 +455,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferManagerOptions: managerOptions);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/33003")]
-        [Test]
-        [LiveOnly]
+        [RecordedTest]
         [TestCase(2, 0, 30)]
         [TestCase(2, Constants.KB, 30)]
         [TestCase(6, Constants.KB, 30)]
@@ -853,9 +851,7 @@ namespace Azure.Storage.DataMovement.Tests
                 container: testContainer.Container);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/33003")]
-        [Test]
-        [LiveOnly]
+        [RecordedTest]
         [TestCase(2, Constants.KB, 10)]
         [TestCase(6, Constants.KB, 10)]
         [TestCase(2, 2 * Constants.KB, 10)]
@@ -1298,9 +1294,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferManagerOptions: managerOptions);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/33003")]
-        [Test]
-        [LiveOnly]
+        [RecordedTest]
         [TestCase(2, 0, 30)]
         [TestCase(6, 0, 30)]
         [TestCase(2, Constants.KB, 30)]


### PR DESCRIPTION
Introduces diagnostics options to the transfer manager, separate from diagnostics on resources provided to the transfer manager.

Introduces a lifetime diagnostic scope for the transfer manager to account for unpredictable order of chunks processed by the transfer manager. While the scope can be better tuned in future PRs (e.g. start when internal channels have any elements and stop when they have none) this is a good start and allows us to start recording previously unrecordable tests.