### PR TITLE
WebJobs Extension: Allow binding to BlobContainerClient without blob

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.2.0-beta.1 (Unreleased)
 - Fixed bug where the blob container would scan from the beginning due not correctly updating the latest scan time. (#35145)
+- Loosen parameter binding data parsing and validation to allow binding BlobContainerClient without blob name. (#37124)
 
 ## 5.1.1 (2023-03-24)
 - Bumped Azure.Core dependency from 1.28 and 1.30, fixing issue with headers being non-resilient to double dispose of the request.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobPath.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobPath.cs
@@ -43,12 +43,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             return result;
         }
 
-        public static BlobPath ParseAndValidate(string value, bool isContainerBinding = false)
+        public static BlobPath ParseAndValidate(string value, bool isContainerBinding = false, bool isParameterBindingData = false)
         {
             string errorMessage;
             BlobPath path;
 
-            if (!TryParseAndValidate(value, out errorMessage, out path, isContainerBinding))
+            if (!TryParseAndValidate(value, out errorMessage, out path, isContainerBinding, isParameterBindingData))
             {
                 throw new FormatException(errorMessage);
             }
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             return false;
         }
 
-        public static bool TryParse(string value, bool isContainerBinding, out BlobPath path)
+        public static bool TryParse(string value, bool isContainerBinding, bool isParameterBindingData, out BlobPath path)
         {
             path = null;
 
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             }
 
             int slashIndex = value.IndexOf('/');
-            if (!isContainerBinding && slashIndex <= 0)
+            if (!isParameterBindingData && !isContainerBinding && slashIndex <= 0)
             {
                 return false;
             }
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             return true;
         }
 
-        private static bool TryParseAndValidate(string value, out string errorMessage, out BlobPath path, bool isContainerBinding = false)
+        private static bool TryParseAndValidate(string value, out string errorMessage, out BlobPath path, bool isContainerBinding = false, bool isParameterBindingData = false)
         {
             BlobPath possiblePath;
 
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
                 return true;
             }
 
-            if (!TryParse(value, isContainerBinding, out possiblePath))
+            if (!TryParse(value, isContainerBinding, isParameterBindingData, out possiblePath))
             {
                 errorMessage = $"Invalid blob path specified : '{value}'. Blob identifiers must be in the format 'container/blob'.";
                 path = null;
@@ -136,9 +136,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
                 return false;
             }
 
-            // for container bindings, we allow an empty blob name/path
+            // for container bindings or parameter binding data, we allow an empty blob name/path
             string possibleErrorMessage;
-            if (!(isContainerBinding && string.IsNullOrEmpty(possiblePath.BlobName)) &&
+            if (!((isContainerBinding || isParameterBindingData) && string.IsNullOrEmpty(possiblePath.BlobName)) &&
                 !BlobClientExtensions.IsValidBlobName(possiblePath.BlobName, out possibleErrorMessage))
             {
                 errorMessage = possibleErrorMessage;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Config
 
         private ParameterBindingData ConvertToParameterBindingData(BlobAttribute blobAttribute)
         {
-            var blobPath = BlobPath.ParseAndValidate(blobAttribute.BlobPath);
+            var blobPath = BlobPath.ParseAndValidate(blobAttribute.BlobPath, isParameterBindingData: true);
             return CreateParameterBindingData(blobAttribute.Connection, blobPath.BlobName, blobPath.ContainerName);
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/StorageAnalyticsLogEntry.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/StorageAnalyticsLogEntry.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             }
 
             BlobPath blobPath;
-            if (!BlobPath.TryParse(path, false, out blobPath))
+            if (!BlobPath.TryParse(path, false, false, out blobPath))
             {
                 return null;
             }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobPathSourceTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobPathSourceTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
         {
             var pathA = BlobPathSource.Create(a);
             BlobPath pathB = null;
-            BlobPath.TryParse(b, false, out pathB);
+            BlobPath.TryParse(b, false, false, out pathB);
 
             IReadOnlyDictionary<string, object> bindingData = pathA.CreateBindingData(pathB);
 


### PR DESCRIPTION
# Contributing to the Azure SDK
resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/1337

For binding `BlobContainerClient` as an input binding, we are required to provide blob name in the result such as `BlobInput("input-container/blob-name")`. We should be allowed to do this without providing the blob name, and currently we run into an error if you try to just put down the container name:
`Invalid blob path specified : 'input-container'. Blob identifiers must be in the format 'container/blob'`

This PR loosens the parsing and validating checks by adding a new parameter to `BlobPath.ParseAndValidate` called `isParameterBindingData`. This value is only set to true if we are binding to a parameter binding data type and then skips some of the checks which caused this to fail initially.

We have added a check in the dotnet worker to ensure that blob name cannot be null if we are not binding to a `BlobContainerClient`, which is the check we are skipping on the webjobs extension.
