### PR TITLE
Do not cancel sending output SB messages for in-flight executions aft…

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/ServiceBusBinding.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Bindings/ServiceBusBinding.cs
@@ -45,8 +45,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 
         public async Task<IValueProvider> BindAsync(BindingContext context)
         {
-            context.CancellationToken.ThrowIfCancellationRequested();
-
             string boundQueueName = _path.Bind(context.BindingData);
             var messageSender = _messagingProvider.CreateMessageSender(_clientFactory.CreateClientFromSetting(_attribute.Connection), boundQueueName);
 


### PR DESCRIPTION
…er the SB  listener stopped

There is no need to throw the `OperationCancelledException` for output binding if we signaled that the host is stopping. Other extensions do not cancel the sending:

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerBinding.cs#L120

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Triggers/BlobTriggerBinding.cs#L169

