### PR TITLE
Remove ParameterBindingData support from MultiBlobContext

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
@@ -330,10 +330,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Config
                     switch (blobItem.Properties.BlobType)
                     {
                         case BlobType.Block:
-                            if (typeof(T) == typeof(ParameterBindingData))
-                            {
-                                src = blobContainerClient.GetBlobClient(blobItem.Name);
-                            }
                             if (typeof(T) == typeof(BlobClient))
                             {
                                 // BlobClient is simplified version of BlockBlobClient, i.e. upload results in creation of block blob.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobTests.cs
@@ -155,53 +155,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
         }
 
         [Test]
-        public async Task Blob_IfBoundToParameterBindingDataEnumerable_CreatesParameterBindingDataArray()
-        {
-            string connectionString = AzuriteNUnitFixture.Instance.GetAzureAccount().ConnectionString;
-            var configuration = new ConfigurationBuilder()
-                    .AddInMemoryCollection(new Dictionary<string, string>()
-                    {
-                        { "ConnectionStrings:AzureWebJobsStorage", connectionString }
-                    }).Build();
-
-            // Arrange
-            var program = new BindToParameterBindingDataEnumerable();
-            IHost host = new HostBuilder()
-                .ConfigureDefaultTestHost<BindToParameterBindingDataEnumerable>(program, builder =>
-                {
-                    builder.AddAzureStorageBlobs()
-                    .UseStorageServicesWithConfiguration(blobServiceClient, queueServiceClient, configuration);
-                })
-                .Build();
-
-            var container = CreateContainer(blobServiceClient, ContainerName);
-            var blobfile = container.GetBlockBlobClient(BlobName);
-            await blobfile.UploadTextAsync(string.Empty);
-
-            var jobHost = host.GetJobHost<BindToParameterBindingDataEnumerable>();
-
-            // Act
-            await jobHost.CallAsync(nameof(BindToParameterBindingDataEnumerable.Run));
-            IEnumerable<ParameterBindingData> result = program.Result;
-
-            Assert.NotNull(result);
-
-            // Assert
-            foreach (var blob in result)
-            {
-                var blobData = blob?.Content.ToObjectFromJson<Dictionary<string,string>>();
-
-                Assert.True(blobData.TryGetValue("Connection", out var resultConnection));
-                Assert.True(blobData.TryGetValue("ContainerName", out var resultContainerName));
-                Assert.True(blobData.TryGetValue("BlobName", out var resultBlobName));
-
-                Assert.AreEqual(ConnectionName, resultConnection);
-                Assert.AreEqual(ContainerName, resultContainerName);
-                Assert.AreEqual(BlobName, resultBlobName);
-            }
-        }
-
-        [Test]
         public async Task Blob_IfBoundToStringArray_CreatesStringArray()
         {
             string connectionString = AzuriteNUnitFixture.Instance.GetAzureAccount().ConnectionString;
@@ -237,52 +190,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             foreach (var blob in result)
             {
                 Assert.AreEqual("teststring", blob);
-            }
-        }
-
-        [Test]
-        public async Task Blob_IfBoundToParameterBindingDataArray_CreatesParameterBindingDataArray()
-        {
-            string connectionString = AzuriteNUnitFixture.Instance.GetAzureAccount().ConnectionString;
-            var configuration = new ConfigurationBuilder()
-                    .AddInMemoryCollection(new Dictionary<string, string>()
-                    {
-                        { "ConnectionStrings:AzureWebJobsStorage", connectionString }
-                    }).Build();
-
-            // Arrange
-            var program = new BindToParameterBindingDataArray();
-            IHost host = new HostBuilder()
-                .ConfigureDefaultTestHost<BindToParameterBindingDataArray>(program, builder =>
-                {
-                    builder.AddAzureStorageBlobs()
-                    .UseStorageServicesWithConfiguration(blobServiceClient, queueServiceClient, configuration);
-                })
-                .Build();
-
-            var container = CreateContainer(blobServiceClient, ContainerName);
-            var blobfile = container.GetBlockBlobClient(BlobName);
-            await blobfile.UploadTextAsync(string.Empty);
-
-            var jobHost = host.GetJobHost<BindToParameterBindingDataArray>();
-
-            // Act
-            await jobHost.CallAsync(nameof(BindToParameterBindingDataArray.Run));
-            ParameterBindingData[] result = program.Result;
-
-            Assert.NotNull(result);
-
-            foreach (var blob in result)
-            {
-                var blobData = blob?.Content.ToObjectFromJson<Dictionary<string,string>>();
-
-                Assert.True(blobData.TryGetValue("Connection", out var resultConnection));
-                Assert.True(blobData.TryGetValue("ContainerName", out var resultContainerName));
-                Assert.True(blobData.TryGetValue("BlobName", out var resultBlobName));
-
-                Assert.AreEqual(ConnectionName, resultConnection);
-                Assert.AreEqual(ContainerName, resultContainerName);
-                Assert.AreEqual(BlobName, resultBlobName);
             }
         }
 
@@ -364,34 +271,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             }
         }
 
-        private class BindToParameterBindingDataEnumerable
-        {
-            public IEnumerable<ParameterBindingData> Result { get; set; }
-
-            public void Run(
-                [Blob(ContainerName)] IEnumerable<ParameterBindingData> blobs)
-            {
-                this.Result = blobs;
-            }
-        }
-
         private class BindToStringArray
         {
             public string[] Result { get; set; }
 
             public void Run(
                 [Blob(ContainerName)] string[] blobs)
-            {
-                this.Result = blobs;
-            }
-        }
-
-        private class BindToParameterBindingDataArray
-        {
-            public ParameterBindingData[] Result { get; set; }
-
-            public void Run(
-                [Blob(ContainerName)] ParameterBindingData[] blobs)
             {
                 this.Result = blobs;
             }


### PR DESCRIPTION
This code change is undoing a change made in PR #31757 with the introduction of `ParameterBindingData`.

After further design discussions, we've decided that in the case where we are binding to `ParameterBindingData`, it makes more sense for the Worker Blob Extension to get a single ParameterBindingData object and infer IsBatched/collections using the blobPath. Therefore we no longer need to include `ParameterBindingData` in the MultiBlobContext.

This PR is removing functionality and will be a technical breaking change

- [Related GH Issue](https://github.com/Azure/azure-functions-dotnet-worker/issues/1333)
- [Internal design doc](https://eng.ms/docs/cloud-ai-platform/devdiv/serverless-paas-balam/serverless-paas-benbyrd/app-service-web-apps/app-service-team-documents/functionteamdocs/design/oopworkers/dotnetisolated/inferisbatched)