### PR TITLE
[Core] Upgrading `System.Diagnostics.DiagnosticSource` to 5.0.0 (netcoreapp2.1)/ 6.0.1

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -68,7 +68,7 @@
     <PackageReference Update="System.Memory.Data" Version="1.0.2" />
     <PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
-    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
+    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
@@ -23,9 +23,16 @@
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 
+  <!-- Upgrade System.Diagnostics.DiagnosticSource to 6.0.1 in netcoreapp3.1+ -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' ">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Numerics.Vectors" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="System.Text.Json" />

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -23,7 +23,7 @@
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 
-  <!-- Upgrade System.Diagnostics.DiagnosticSource to 6.0.1 in netcoreapp3.1+ -->
+  <!-- Keep System.Diagnostics.DiagnosticSource 5.0.0 for netcoreapp2.1 support. -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="5.0.0" />
   </ItemGroup>

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -47,8 +47,6 @@ namespace Azure.Core.Pipeline
 
         public bool IsEnabled { get; }
 
-        public ActivitySource ActivityS { get; } = default!;
-
         public void AddAttribute(string name, string value)
         {
             _activityAdapter?.AddTag(name, value);

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -47,6 +47,8 @@ namespace Azure.Core.Pipeline
 
         public bool IsEnabled { get; }
 
+        public ActivitySource ActivityS { get; } = default!;
+
         public void AddAttribute(string name, string value)
         {
             _activityAdapter?.AddTag(name, value);

--- a/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
@@ -170,10 +170,10 @@ namespace Azure.Core.Shared
                     DiagnosticScope.ActivityKind.Producer);
                 messageScope.Start();
 
-                Activity activity = Activity.Current;
+                Activity? activity = Activity.Current;
                 if (activity != null)
                 {
-                    traceparent = activity.Id;
+                    traceparent = activity!.Id!;
                     properties[DiagnosticIdAttribute] = traceparent;
                     if (ActivityExtensions.SupportsActivitySource())
                     {


### PR DESCRIPTION
This is the first piece of resolving #33683. Unfortunately, given the dependencies between packages, I don't think it's possible to upgrade the dependency and use the new types in the same release, or at the very least in the same PR. I think we may need to release with the upgraded dependency first and then merge in the rest of the work in this PR: https://github.com/Azure/azure-sdk-for-net/pull/37149.

Initially, there were concerns about PowerShell and functions integrations when upgrading this dependency. After doing some research, the most recent versions of PowerShell 7 depend on the newest version of the `System.Diagnostics.DiagnosticSource ` (7.*), so upgrading this dependency should not impact PowerShell integration.

In order to support both netcoreapp2.1 and the new types, we need to multitarget with 5.0.0. `System.Diagnostics.DiagnosticSource` 6.0.1 has a transitive dependency that does not support netcoreapp2.1.  However, `System.Diagnostics.DiagnosticSource` 5.0.0 is deprecated, so we shouldn't take a dependency on that version anywhere else.

There are also some changes here to `MessagingClientDiagnostics`. This file was causing pipeline errors that needed some simple updates to fix.

This also contributes to: https://github.com/Azure/azure-sdk-for-net/issues/35572

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
