### PR TITLE
[AzureMonitorExporter] refactor logging (part7)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -90,7 +90,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 };
 
                 pipeline = HttpPipelineBuilder.Build(options, httpPipelinePolicy);
-                AzureMonitorExporterEventSource.Log.WriteInformational("SetAADCredentialsToPipeline", $"HttpPipelineBuilder is built with AAD Credentials. TokenCredential: {options.Credential.GetType().Name} Scope: {scope}");
+                AzureMonitorExporterEventSource.Log.SetAADCredentialsToPipeline(options.Credential.GetType().Name, scope);
             }
             else
             {
@@ -112,7 +112,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         configuredStorageDirectory: configuredStorageDirectory,
                         instrumentationKey: connectionVars.InstrumentationKey);
 
-                    AzureMonitorExporterEventSource.Log.WriteInformational("InitializedPersistentStorage", $"Data for ikey '{connectionVars.InstrumentationKey}' will be stored at: {storageDirectory}");
+                    AzureMonitorExporterEventSource.Log.InitializedPersistentStorage(connectionVars.InstrumentationKey, storageDirectory);
 
                     return new FileBlobProvider(storageDirectory);
                 }
@@ -122,7 +122,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     // Remove this when we add an option to disable offline storage.
                     // So if someone opts in for storage and we cannot initialize, we can throw.
                     // Change needed on persistent storage side to throw if not able to create storage directory.
-                    AzureMonitorExporterEventSource.Log.WriteError("FailedToInitializePersistentStorage", ex);
+                    AzureMonitorExporterEventSource.Log.FailedToInitializePersistentStorage(ex);
 
                     return null;
                 }
@@ -140,7 +140,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     var disableStatsbeat = platform.GetEnvironmentVariable("APPLICATIONINSIGHTS_STATSBEAT_DISABLED");
                     if (string.Equals(disableStatsbeat, "true", StringComparison.OrdinalIgnoreCase))
                     {
-                        AzureMonitorExporterEventSource.Log.WriteInformational("StatsbeatInitialization: ", "Statsbeat was disabled via environment variable");
+                        AzureMonitorExporterEventSource.Log.StatsbeatDisabled();
 
                         return null;
                     }
@@ -149,7 +149,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
                 catch (Exception ex)
                 {
-                    AzureMonitorExporterEventSource.Log.WriteWarning($"ErrorInitializingStatsbeatFor:{connectionVars.InstrumentationKey}", ex);
+                    AzureMonitorExporterEventSource.Log.ErrorInitializingStatsbeat(connectionVars.InstrumentationKey, ex);
                 }
             }
 
@@ -183,12 +183,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 {
                     _transmissionStateManager.ResetConsecutiveErrors();
                     _transmissionStateManager.CloseTransmission();
-                    AzureMonitorExporterEventSource.Log.WriteInformational("TransmissionSuccess", "Successfully transmitted a batch of telemetry Items.");
+                    AzureMonitorExporterEventSource.Log.TransmissionSuccess(_connectionVars.InstrumentationKey);
                 }
             }
             catch (Exception ex)
             {
-                AzureMonitorExporterEventSource.Log.WriteError("FailedToTransmit", ex);
+                AzureMonitorExporterEventSource.Log.TransmitterFailed(_connectionVars.InstrumentationKey, ex);
             }
 
             return result;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.New.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.New.cs
@@ -211,5 +211,53 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 
         [Event(26, Message = "Successfully transmitted a blob from storage.", Level = EventLevel.Informational)]
         public void TransmitFromStorageSuccess() => WriteEvent(26);
+
+        [Event(27, Message = "HttpPipelineBuilder is built with AAD Credentials. TokenCredential: {0} Scope: {1}", Level = EventLevel.Informational)]
+        public void SetAADCredentialsToPipeline(string credentialTypeName, string scope) => WriteEvent(27, credentialTypeName, scope);
+
+        [Event(28, Message = "Storage initialized. Data for Instrumentation Key '{0}' will be stored at: {1}", Level = EventLevel.Informational)]
+        public void InitializedPersistentStorage(string instrumentationKey, string storageDirectory) => WriteEvent(28, instrumentationKey, storageDirectory);
+
+        [NonEvent]
+        public void FailedToInitializePersistentStorage(Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                FailedToInitializePersistentStorage(ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(29, Message = "Failed to initialize PersistentStorage due to an exception: {0}", Level = EventLevel.Error)]
+        public void FailedToInitializePersistentStorage(string exceptionMessage) => WriteEvent(29, exceptionMessage);
+
+        [Event(30, Message = "Statsbeat was disabled via environment variable.", Level = EventLevel.Informational)]
+        public void StatsbeatDisabled() => WriteEvent(30);
+
+        [NonEvent]
+        public void ErrorInitializingStatsbeat(string instrumentationKey, Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ErrorInitializingStatsbeat(instrumentationKey, ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(31, Message = "Failed to initialize Statsbeat due to an exception. Instrumentation Key: {0}. {1}", Level = EventLevel.Error)]
+        public void ErrorInitializingStatsbeat(string instrumentationKey, string exceptionMessage) => WriteEvent(31, instrumentationKey, exceptionMessage);
+
+        [Event(32, Message = "Successfully transmitted a batch of telemetry Items. Instrumentation Key: {0}", Level = EventLevel.Verbose)]
+        public void TransmissionSuccess(string instrumentationKey) => WriteEvent(32, instrumentationKey);
+
+        [NonEvent]
+        public void TransmitterFailed(string instrumentationKey, Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                TransmitterFailed(instrumentationKey, ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(33, Message = "Transmitter failed due to an exception. Instrumentation Key: {0}. {1}", Level = EventLevel.Error)]
+        public void TransmitterFailed(string instrumentationKey, string exceptionMessage) => WriteEvent(33, instrumentationKey, exceptionMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -15,50 +15,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         internal static readonly AzureMonitorExporterEventSource Log = new AzureMonitorExporterEventSource();
         internal static readonly AzureMonitorExporterEventListener Listener = new AzureMonitorExporterEventListener();
 
-        [Event(1, Message = "{0} - {1}", Level = EventLevel.Critical)]
-        public void WriteCritical(string name, string message) => Write(EventLevel.Critical, 1, name, message);
-
-        [Event(2, Message = "{0} - {1}", Level = EventLevel.Error)]
-        public void WriteError(string name, string message) => Write(EventLevel.Error, 2, name, message);
-
-        [NonEvent]
-        public void WriteError(string name, Exception exception) => WriteException(EventLevel.Error, 2, name, exception);
-
-        [Event(3, Message = "{0} - {1}", Level = EventLevel.Warning)]
-        public void WriteWarning(string name, string message) => Write(EventLevel.Warning, 3, name, message);
-
-        [NonEvent]
-        public void WriteWarning(string name, Exception exception) => WriteException(EventLevel.Warning, 3, name, exception);
-
-        [Event(4, Message = "{0} - {1}", Level = EventLevel.Informational)]
-        public void WriteInformational(string name, string message) => Write(EventLevel.Informational, 4, name, message);
-
-        [NonEvent]
-        public void WriteInformational(string name, Exception exception) => WriteException(EventLevel.Warning, 4, name, exception);
-
-        [Event(5, Message = "{0} - {1}", Level = EventLevel.Verbose)]
-        public void WriteVerbose(string name, string message) => Write(EventLevel.Verbose, 5, name, message);
-
-        [NonEvent]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Write(EventLevel eventLevel, int eventId, string name, string message)
-        {
-            if (IsEnabled(eventLevel))
-            {
-                WriteEvent(eventId, name, message);
-            }
-        }
-
-        [NonEvent]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteException(EventLevel eventLevel, int eventId, string name, Exception exception)
-        {
-            if (IsEnabled(eventLevel))
-            {
-                WriteEvent(eventId, name, exception.FlattenException()?.ToInvariantString());
-            }
-        }
-
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsEnabled(EventLevel eventLevel) => IsEnabled(eventLevel, EventKeywords.All);


### PR DESCRIPTION
Towards https://github.com/Azure/azure-sdk-for-net/issues/34581

### Changes
- refactoring more messages
- remove old EventSource methods (no longer used)
- remove old EventSource tests (no longer used)

### Future work
In a follow up PR, i'll merge the "EventSource" and "EventSource.New" classes.