### PR TITLE
[Storage][DataMovement] Implement GetResumableTransfers

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -519,7 +519,7 @@ namespace Azure.Storage.DataMovement.Blobs
                     transferId,
                     metadataIndex,
                     metadataReadLength,
-                    DataMovementConstants.PlanFile.MetadataStrMaxLength,
+                    DataMovementConstants.PlanFile.MetadataStrNumBytes,
                     cancellationToken).ConfigureAwait(false);
                 options.Metadata = metadata.ToDictionary(nameof(metadata));
 
@@ -530,7 +530,7 @@ namespace Azure.Storage.DataMovement.Blobs
                     transferId,
                     tagsIndex,
                     tagsReadLength,
-                    DataMovementConstants.PlanFile.BlobTagsStrMaxLength,
+                    DataMovementConstants.PlanFile.BlobTagsStrNumBytes,
                     cancellationToken).ConfigureAwait(false);
                 options.Tags = tags.ToDictionary(nameof(tags));
             }

--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `TransferManager` new API `PauseAllRunningTransfersAsync`.
 - Added support for `TransferManager.GetTransfers`, to retrieve the list of transfers in the `TransferManager`.
 - Added support for tracking progress of transfers. See `TransferOptions.ProgressHandler` and `TransferOptions.ProgressHandlerOptions`.
+- Added `TransferManager.GetResumableTransfers` to get information about transfers that can be resumed.
 
 ### Breaking Changes
 - [BREAKING CHANGE] Altered API signatures on `TransferManager` and `DataTransfer` for pausing.

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -149,7 +149,7 @@ namespace Azure.Storage.DataMovement.Models
 {
     public partial class DataTransferProperties
     {
-        internal DataTransferProperties() { }
+        protected internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.Models.TransferCheckpointerOptions Checkpointer { get { throw null; } }
         public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationScheme { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -125,6 +125,7 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.Models.DataTransferProperties> GetResumableTransfersAsync() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.DataTransfer> GetTransfersAsync(params Azure.Storage.DataMovement.StorageTransferStatus[] filterByStatus) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -148,7 +149,7 @@ namespace Azure.Storage.DataMovement.Models
 {
     public partial class DataTransferProperties
     {
-        protected DataTransferProperties() { }
+        internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.Models.TransferCheckpointerOptions Checkpointer { get { throw null; } }
         public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationScheme { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -149,7 +149,7 @@ namespace Azure.Storage.DataMovement.Models
 {
     public partial class DataTransferProperties
     {
-        internal DataTransferProperties() { }
+        protected internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.Models.TransferCheckpointerOptions Checkpointer { get { throw null; } }
         public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationScheme { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -125,6 +125,7 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.Models.DataTransferProperties> GetResumableTransfersAsync() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.DataTransfer> GetTransfersAsync(params Azure.Storage.DataMovement.StorageTransferStatus[] filterByStatus) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -148,7 +149,7 @@ namespace Azure.Storage.DataMovement.Models
 {
     public partial class DataTransferProperties
     {
-        protected DataTransferProperties() { }
+        internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.Models.TransferCheckpointerOptions Checkpointer { get { throw null; } }
         public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationScheme { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
@@ -149,7 +149,7 @@ namespace Azure.Storage.DataMovement.Models
 {
     public partial class DataTransferProperties
     {
-        internal DataTransferProperties() { }
+        protected internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.Models.TransferCheckpointerOptions Checkpointer { get { throw null; } }
         public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationScheme { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.1.cs
@@ -125,6 +125,7 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.Models.DataTransferProperties> GetResumableTransfersAsync() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.DataTransfer> GetTransfersAsync(params Azure.Storage.DataMovement.StorageTransferStatus[] filterByStatus) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(Azure.Storage.DataMovement.DataTransfer transfer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferIfRunningAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -148,7 +149,7 @@ namespace Azure.Storage.DataMovement.Models
 {
     public partial class DataTransferProperties
     {
-        protected DataTransferProperties() { }
+        internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.Models.TransferCheckpointerOptions Checkpointer { get { throw null; } }
         public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationScheme { get { throw null; } }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Models/DataTransferProperties.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Models/DataTransferProperties.cs
@@ -46,6 +46,6 @@ namespace Azure.Storage.DataMovement.Models
         /// <summary>
         /// For mocking.
         /// </summary>
-        internal DataTransferProperties() { }
+        protected internal DataTransferProperties() { }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Models/DataTransferProperties.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Models/DataTransferProperties.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
-
 namespace Azure.Storage.DataMovement.Models
 {
     /// <summary>
@@ -51,6 +46,6 @@ namespace Azure.Storage.DataMovement.Models
         /// <summary>
         /// For mocking.
         /// </summary>
-        protected DataTransferProperties() { }
+        internal DataTransferProperties() { }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Models/TransferCheckpointerOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Models/TransferCheckpointerOptions.cs
@@ -10,7 +10,7 @@ namespace Azure.Storage.DataMovement.Models
     public class TransferCheckpointerOptions
     {
         /// <summary>
-        /// stub
+        /// The local folder where the checkpoint information will be stored.
         /// </summary>
         public string CheckpointerPath { get; private set; }
 
@@ -24,6 +24,11 @@ namespace Azure.Storage.DataMovement.Models
         public TransferCheckpointerOptions(string localCheckpointerPath)
         {
             CheckpointerPath = localCheckpointerPath;
+        }
+
+        internal TransferCheckpointerOptions(TransferCheckpointerOptions other)
+        {
+            CheckpointerPath = other.CheckpointerPath;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/CheckpointerExtensions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Azure.Storage.DataMovement.Models;
 
 namespace Azure.Storage.DataMovement
@@ -12,7 +9,7 @@ namespace Azure.Storage.DataMovement
     {
         public static TransferCheckpointer GetCheckpointer(this TransferCheckpointerOptions options)
         {
-            if (!string.IsNullOrEmpty(options.CheckpointerPath))
+            if (!string.IsNullOrEmpty(options?.CheckpointerPath))
             {
                 return new LocalTransferCheckpointer(options.CheckpointerPath);
             }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
@@ -216,5 +216,136 @@ namespace Azure.Storage.DataMovement.Tests
             // Assert
             Assert.AreEqual(checkpointerTransfers, result.Select(d => d.Id).ToList());
         }
+
+        [Test]
+        public async Task GetResumableTransfers_LocalCheckpointer()
+        {
+            // Arrange
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+            string parentRemotePath = "https://account.blob.core.windows.net/resume-test/";
+            string parentLocalPath1 = "/resume-test/";
+            string parentLocalPath2 = @"C:\Windows\Path\";
+
+            LocalTransferCheckpointerFactory factory = new LocalTransferCheckpointerFactory(test.DirectoryPath);
+
+            // Build expected results first to use to populate checkpointer
+            DataTransferProperties[] expectedResults = new DataTransferProperties[]
+            {
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "LocalFile", SourcePath = parentLocalPath1 + "file1", DestinationScheme = "BlockBlob", DestinationPath = parentRemotePath + "file1", IsContainer = false },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "BlockBlob", SourcePath = parentRemotePath + "file2", DestinationScheme = "LocalFile", DestinationPath = parentLocalPath1 + "file2", IsContainer = false },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "BlockBlob", SourcePath = parentRemotePath + "file3", DestinationScheme = "BlockBlob", DestinationPath = parentRemotePath + "file3", IsContainer = false },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "BlockBlob", SourcePath = parentRemotePath, DestinationScheme = "LocalFile", DestinationPath = parentLocalPath1, IsContainer = true },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "LocalFile", SourcePath = parentLocalPath2, DestinationScheme = "AppendBlob", DestinationPath = parentRemotePath, IsContainer = true },
+            };
+
+            // Add a transfer for each expected result
+            foreach (DataTransferProperties props in expectedResults)
+            {
+                AddTransferFromDataTransferProperties(factory, test.DirectoryPath, props);
+            }
+
+            // Build TransferManager with the stored transfers
+            TransferManagerOptions options = new TransferManagerOptions()
+            {
+                CheckpointerOptions = new TransferCheckpointerOptions(test.DirectoryPath)
+            };
+            TransferManager manager = new TransferManager(options);
+
+            // Act
+            IList<DataTransferProperties> result = await manager.GetResumableTransfersAsync().ToListAsync();
+
+            // Assert
+            Assert.AreEqual(5, result.Count);
+            foreach (DataTransferProperties props in result)
+            {
+                DataTransferProperties expected = expectedResults.Where(p => p.TransferId == props.TransferId).First();
+                AssertTransferProperties(expected, props);
+            }
+        }
+
+        [Test]
+        public async Task GetResumableTransfers_IgnoresCompleted()
+        {
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+            LocalTransferCheckpointerFactory factory = new LocalTransferCheckpointerFactory(test.DirectoryPath);
+
+            string transferId1 = Guid.NewGuid().ToString();
+            factory.CreateStubJobPartPlanFilesAsync(
+                test.DirectoryPath,
+                transferId1,
+                3 /* jobPartCount */,
+                StorageTransferStatus.Completed);
+
+            string transferId2 = Guid.NewGuid().ToString();
+            factory.CreateStubJobPartPlanFilesAsync(
+                test.DirectoryPath,
+                transferId2,
+                3 /* jobPartCount */,
+                StorageTransferStatus.Queued);
+
+            // Build TransferManager with the stored transfers
+            TransferManagerOptions options = new TransferManagerOptions()
+            {
+                CheckpointerOptions = new TransferCheckpointerOptions(test.DirectoryPath)
+            };
+            TransferManager manager = new TransferManager(options);
+
+            // Act
+            IList<DataTransferProperties> result = await manager.GetResumableTransfersAsync().ToListAsync();
+
+            // Assert
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(transferId2, result.First().TransferId);
+        }
+
+        private void AddTransferFromDataTransferProperties(
+            LocalTransferCheckpointerFactory factory,
+            string checkpointerPath,
+            DataTransferProperties properties)
+        {
+            if (properties.IsContainer)
+            {
+                int numParts = 3;
+                List<string> sourcePaths = new List<string>();
+                List<string> destinationPaths = new List<string>();
+                for (int i = 0; i < numParts; i++)
+                {
+                    sourcePaths.Add(properties.SourcePath + $"file{i}");
+                    destinationPaths.Add(properties.DestinationPath + $"file{i}");
+                }
+
+                factory.CreateStubJobPartPlanFilesAsync(
+                    checkpointerPath,
+                    properties.TransferId,
+                    numParts, /* jobPartCount */
+                    StorageTransferStatus.InProgress,
+                    sourcePaths,
+                    destinationPaths,
+                    sourceResourceId: properties.SourceScheme,
+                    destinationResourceId: properties.DestinationScheme);
+            }
+            else
+            {
+                factory.CreateStubJobPartPlanFilesAsync(
+                    checkpointerPath,
+                    properties.TransferId,
+                    1, /* jobPartCount */
+                    StorageTransferStatus.InProgress,
+                    new List<string> { properties.SourcePath },
+                    new List<string> { properties.DestinationPath },
+                    sourceResourceId: properties.SourceScheme,
+                    destinationResourceId: properties.DestinationScheme);
+            }
+        }
+
+        private void AssertTransferProperties(DataTransferProperties expected, DataTransferProperties actual)
+        {
+            Assert.AreEqual(expected.TransferId, actual.TransferId);
+            Assert.AreEqual(expected.SourceScheme, actual.SourceScheme);
+            Assert.AreEqual(expected.SourcePath.TrimEnd('\\', '/'), actual.SourcePath);
+            Assert.AreEqual(expected.DestinationScheme, actual.DestinationScheme);
+            Assert.AreEqual(expected.DestinationPath.TrimEnd('\\', '/'), actual.DestinationPath);
+            Assert.AreEqual(expected.IsContainer, actual.IsContainer);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
@@ -232,7 +232,7 @@ namespace Azure.Storage.DataMovement.Tests
             DataTransferProperties[] expectedResults = new DataTransferProperties[]
             {
                 new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "LocalFile", SourcePath = parentLocalPath1 + "file1", DestinationScheme = "BlockBlob", DestinationPath = parentRemotePath + "file1", IsContainer = false },
-                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "BlockBlob", SourcePath = parentRemotePath + "file2", DestinationScheme = "LocalFile", DestinationPath = parentLocalPath1 + "file2", IsContainer = false },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "BlockBlob", SourcePath = parentRemotePath + "file2/", DestinationScheme = "LocalFile", DestinationPath = parentLocalPath1 + "file2/", IsContainer = false },
                 new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "BlockBlob", SourcePath = parentRemotePath + "file3", DestinationScheme = "BlockBlob", DestinationPath = parentRemotePath + "file3", IsContainer = false },
                 new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "BlockBlob", SourcePath = parentRemotePath, DestinationScheme = "LocalFile", DestinationPath = parentLocalPath1, IsContainer = true },
                 new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceScheme = "LocalFile", SourcePath = parentLocalPath2, DestinationScheme = "AppendBlob", DestinationPath = parentRemotePath, IsContainer = true },
@@ -310,6 +310,14 @@ namespace Azure.Storage.DataMovement.Tests
                 List<string> destinationPaths = new List<string>();
                 for (int i = 0; i < numParts; i++)
                 {
+                    // Put extra slash on end of last part for testing
+                    if (i == numParts - 1)
+                    {
+                        sourcePaths.Add(properties.SourcePath + $"file{i}/");
+                        destinationPaths.Add(properties.DestinationPath + $"file{i}/");
+                        continue;
+                    }
+
                     sourcePaths.Add(properties.SourcePath + $"file{i}");
                     destinationPaths.Add(properties.DestinationPath + $"file{i}");
                 }
@@ -342,9 +350,9 @@ namespace Azure.Storage.DataMovement.Tests
         {
             Assert.AreEqual(expected.TransferId, actual.TransferId);
             Assert.AreEqual(expected.SourceScheme, actual.SourceScheme);
-            Assert.AreEqual(expected.SourcePath.TrimEnd('\\', '/'), actual.SourcePath);
+            Assert.AreEqual(expected.SourcePath.TrimEnd('\\', '/'), actual.SourcePath.TrimEnd('\\', '/'));
             Assert.AreEqual(expected.DestinationScheme, actual.DestinationScheme);
-            Assert.AreEqual(expected.DestinationPath.TrimEnd('\\', '/'), actual.DestinationPath);
+            Assert.AreEqual(expected.DestinationPath.TrimEnd('\\', '/'), actual.DestinationPath.TrimEnd('\\', '/'));
             Assert.AreEqual(expected.IsContainer, actual.IsContainer);
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
@@ -91,7 +91,9 @@ namespace Azure.Storage.DataMovement.Tests
             int jobPartCount,
             StorageTransferStatus status = StorageTransferStatus.Queued,
             List<string> sourcePaths = default,
-            List<string> destinationPaths = default)
+            List<string> destinationPaths = default,
+            string sourceResourceId = "LocalFile",
+            string destinationResourceId = "LocalFile")
         {
             // Populate sourcePaths if not provided
             if (sourcePaths == default)
@@ -121,7 +123,9 @@ namespace Azure.Storage.DataMovement.Tests
                 JobPartPlanHeader header = CreateDefaultJobPartHeader(
                     transferId: transferId,
                     partNumber: partNumber,
+                    sourceResourceId: sourceResourceId,
                     sourcePath: sourcePaths.ElementAt(partNumber),
+                    destinationResourceId: destinationResourceId,
                     destinationPath: destinationPaths.ElementAt(partNumber),
                     atomicJobStatus: status,
                     atomicPartStatus: status);


### PR DESCRIPTION
This change implements `TransferManager.GetResumableTransfers` which allows for getting a list of `DataTransferProperties` for all transfers that are not completed stored in the checkpointer. The `DataTransferProperties` objects can then be used to rehydrate the resources for resuming.