### PR TITLE
[AzureMonitorExporter] cleanup statsbeat logging

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -149,7 +149,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
                 catch (Exception ex)
                 {
-                    AzureMonitorExporterEventSource.Log.ErrorInitializingStatsbeat(connectionVars.InstrumentationKey, ex);
+                    AzureMonitorExporterEventSource.Log.ErrorInitializingStatsbeat(connectionVars, ex);
                 }
             }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -241,16 +241,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         public void StatsbeatDisabled() => WriteEvent(30);
 
         [NonEvent]
-        public void ErrorInitializingStatsbeat(string instrumentationKey, Exception ex)
+        public void ErrorInitializingStatsbeat(ConnectionVars connectionVars, Exception ex)
         {
-            if (IsEnabled(EventLevel.Error))
+            if (IsEnabled(EventLevel.Informational))
             {
-                ErrorInitializingStatsbeat(instrumentationKey, ex.FlattenException().ToInvariantString());
+                ErrorInitializingStatsbeat(connectionVars.InstrumentationKey, connectionVars.IngestionEndpoint, ex.FlattenException().ToInvariantString());
             }
         }
 
-        [Event(31, Message = "Failed to initialize Statsbeat due to an exception. Instrumentation Key: {0}. {1}", Level = EventLevel.Error)]
-        public void ErrorInitializingStatsbeat(string instrumentationKey, string exceptionMessage) => WriteEvent(31, instrumentationKey, exceptionMessage);
+        [Event(31, Message = "Failed to initialize Statsbeat due to an exception. This is only for internal telemetry and can safely be ignored. Instrumentation Key: {0}. Configured Endpoint: {1}. {2}", Level = EventLevel.Informational)]
+        public void ErrorInitializingStatsbeat(string instrumentationKey, string configuredEndpoint, string exceptionMessage) => WriteEvent(31, instrumentationKey, configuredEndpoint, exceptionMessage);
 
         [Event(32, Message = "Successfully transmitted a batch of telemetry Items. Instrumentation Key: {0}", Level = EventLevel.Verbose)]
         public void TransmissionSuccess(string instrumentationKey) => WriteEvent(32, instrumentationKey);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -52,7 +52,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
             // Initialize only if we are able to determine the correct region to send the data to.
             if (_statsbeat_ConnectionString == null)
             {
-                throw new InvalidOperationException("Cannot initialize statsbeat");
+                throw new InvalidOperationException("Could not find a matching endpoint to initialize Statsbeat.");
             }
 
             _customer_Ikey = connectionStringVars?.InstrumentationKey;


### PR DESCRIPTION
Towards #34581

Our demo app is logging this error:

```
2023-06-30T18:09:25.7236334Z:Failed to initialize Statsbeat due to an exception. Instrumentation Key: {0}. {1}{00000000-0000-0000-0000-000000000000}{System.InvalidOperationException: Cannot initialize statsbeat
   at Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat.AzureMonitorStatsbeat..ctor(ConnectionVars connectionStringVars, IPlatform platform) in C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\Statsbeat\AzureMonitorStatsbeat.cs:line 55
   at Azure.Monitor.OpenTelemetry.Exporter.Internals.AzureMonitorTransmitter.InitializeStatsbeat(AzureMonitorExporterOptions options, ConnectionVars connectionVars, IPlatform platform) in C:\REPOS\AzureSDK\sdk\monitor\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\AzureMonitorTransmitter.cs:line 148}
```
   
The reason is the default connection string uses the global ingestion endpoint, which doesn't have a matching Statsbeat endpoint (this is by design).
In this case, Statsbeat should log a more informative message.

### Changes
- log a more informative message when Stastbeat fails to match the endpoint
- Include IngestionEndpoint in Statsbeat log (this is a vital parameter for initialization).
- downgraded the LogLevel to `Informational`. This is in line with other Statsbeat messages.