### PR TITLE
[Storage][DataMovement] Pass metadata in block blob sync copy

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -321,7 +321,7 @@ namespace Azure.Storage.DataMovement.Blobs
             return new BlobSyncUploadFromUriOptions()
             {
                 HttpHeaders = options?.HttpHeaders,
-                // Metadata = options?.Metadata,
+                Metadata = options?.Metadata,
                 Tags = options?.Tags,
                 AccessTier = options?.AccessTier,
                 SourceConditions = new BlobRequestConditions()

--- a/sdk/storage/Azure.Storage.DataMovement/tests/ProgressHandlerAsserts.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/ProgressHandlerAsserts.cs
@@ -79,13 +79,11 @@ namespace Azure.Storage.DataMovement.Tests
 
         private static void AssertProgressUpdates(IEnumerable<StorageTransferProgress> updates, long fileCount)
         {
-            Console.WriteLine("Asserting...");
             long completed = 0;
             long skipped = 0;
             long failed = 0;
             foreach (StorageTransferProgress update in updates)
             {
-                Console.WriteLine($"Queued - {update.QueuedCount}, InProgress - {update.InProgressCount}, Completed - {update.CompletedCount}");
                 // Queued/InProgress should never be below zero or above total
                 Assert.GreaterOrEqual(update.QueuedCount, 0);
                 Assert.LessOrEqual(update.QueuedCount, fileCount);


### PR DESCRIPTION
Now that #36952 is merged, DMLib can pass metadata to `BlobSyncUploadFromUriOptions` for single-call copy transfers.