### PR TITLE
Specify internal properties to include

### DIFF
--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryKeyVaultSecretReference.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryKeyVaultSecretReference.cs
@@ -10,7 +10,7 @@ using System;
 namespace Azure.Core.Expressions.DataFactory
 {
     /// <summary> Azure Key Vault secret reference. </summary>
-    [TypeReferenceType]
+    [TypeReferenceType(false, new[]{ nameof(SecretBaseType)})]
     public partial class DataFactoryKeyVaultSecretReference : DataFactorySecretBaseDefinition
     {
         /// <summary> Initializes a new instance of AzureKeyVaultSecretReference. </summary>

--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactorySecretBaseDefinition.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactorySecretBaseDefinition.cs
@@ -8,7 +8,7 @@ namespace Azure.Core.Expressions.DataFactory
     /// Please note <see cref="DataFactorySecretBaseDefinition"/> is the base class. According to the scenario, a derived class of the base class might need to be assigned here, or this property needs to be casted to one of the possible derived classes.
     /// The available derived classes include <see cref="DataFactorySecretString"/> and <see cref="DataFactoryKeyVaultSecretReference"/>.
     /// </summary>
-    [TypeReferenceType]
+    [TypeReferenceType(false, new[]{ nameof(SecretBaseType)})]
     public abstract partial class DataFactorySecretBaseDefinition
     {
         /// <summary> Initializes a new instance of DataFactorySecretBaseDefinition. </summary>

--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactorySecretString.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactorySecretString.cs
@@ -6,7 +6,7 @@ using System;
 namespace Azure.Core.Expressions.DataFactory
 {
     /// <summary> Azure Data Factory secure string definition. The string value will be masked with asterisks '*' during Get or List API calls. </summary>
-    [TypeReferenceType]
+    [TypeReferenceType(false, new[]{ nameof(SecretBaseType)})]
     public partial class DataFactorySecretString : DataFactorySecretBaseDefinition
     {
         /// <summary> Initializes a new instance of DataFactorySecretString. </summary>

--- a/sdk/core/Azure.Core/src/Shared/TypeReferenceTypeAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/TypeReferenceTypeAttribute.cs
@@ -23,8 +23,8 @@ namespace Azure.Core
         /// Constructs a new instance of <see cref="TypeReferenceTypeAttribute"/>.
         /// </summary>
         /// <param name="ignoreExtraProperties">Whether to allow replacement to occur when the type to be replaced
-        /// contains extra properties as compared to the type attributed with <see cref="TypeReferenceTypeAttribute"/> that it will be replaced with. Defaults
-        /// to false.</param>
+        /// contains extra properties as compared to the type attributed with <see cref="TypeReferenceTypeAttribute"/> that it will be replaced with.
+        /// Defaults to false.</param>
         /// <param name="internalPropertiesToInclude">An array of internal properties to include for the reference type when evaluating whether type
         /// replacement should occur. When evaluating a type for replacement, internal properties are considered on the type to be replaced.</param>
         public TypeReferenceTypeAttribute(bool ignoreExtraProperties, string[] internalPropertiesToInclude)

--- a/sdk/core/Azure.Core/src/Shared/TypeReferenceTypeAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/TypeReferenceTypeAttribute.cs
@@ -11,11 +11,22 @@ namespace Azure.Core
     [AttributeUsage(AttributeTargets.Class)]
     internal class TypeReferenceTypeAttribute : Attribute
     {
+        /// <summary>
+        /// Constructs a new instance of <see cref="TypeReferenceTypeAttribute"/>.
+        /// </summary>
         public TypeReferenceTypeAttribute()
            : this(false, Array.Empty<string>())
         {
         }
 
+        /// <summary>
+        /// Constructs a new instance of <see cref="TypeReferenceTypeAttribute"/>.
+        /// </summary>
+        /// <param name="ignoreExtraProperties">Whether to allow replacement to occur when the type to be replaced
+        /// contains extra properties as compared to the type attributed with <see cref="TypeReferenceTypeAttribute"/> that it will be replaced with. Defaults
+        /// to false.</param>
+        /// <param name="internalPropertiesToInclude">An array of internal properties to include for the reference type when evaluating whether type
+        /// replacement should occur. When evaluating a type for replacement, internal properties are considered on the type to be replaced.</param>
         public TypeReferenceTypeAttribute(bool ignoreExtraProperties, string[] internalPropertiesToInclude)
         {
             IgnoreExtraProperties = ignoreExtraProperties;

--- a/sdk/core/Azure.Core/src/Shared/TypeReferenceTypeAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/TypeReferenceTypeAttribute.cs
@@ -23,10 +23,12 @@ namespace Azure.Core
         /// Constructs a new instance of <see cref="TypeReferenceTypeAttribute"/>.
         /// </summary>
         /// <param name="ignoreExtraProperties">Whether to allow replacement to occur when the type to be replaced
-        /// contains extra properties as compared to the type attributed with <see cref="TypeReferenceTypeAttribute"/> that it will be replaced with.
-        /// Defaults to false.</param>
+        /// contains extra properties as compared to the reference type attributed with <see cref="TypeReferenceTypeAttribute"/> that it will
+        /// be replaced with. Defaults to false.</param>
         /// <param name="internalPropertiesToInclude">An array of internal properties to include for the reference type when evaluating whether type
-        /// replacement should occur. When evaluating a type for replacement, internal properties are considered on the type to be replaced.</param>
+        /// replacement should occur. When evaluating a type for replacement with a reference type, all internal properties are considered on the
+        /// type to be replaced. Thus this parameter can be used to specify internal properties to allow replacement to occur on a type with internal
+        /// properties.</param>
         public TypeReferenceTypeAttribute(bool ignoreExtraProperties, string[] internalPropertiesToInclude)
         {
             IgnoreExtraProperties = ignoreExtraProperties;


### PR DESCRIPTION
The SecretBaseType internal property needs to be included in the TypeReferenceTypeAttribute constructor for the DataFactory types to avoid false positives where these DataFactory types would replace other unrelated types during code gen. After these changes, only the relevant secret types from Azure.ResourceManager.DataFactory will be replaced by the core types from Azure.Core.Expressions.DataFactory (the types being modified in this PR).