### PR TITLE
Save telemetry offline when TransmissionState is open

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -43,9 +43,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             _connectionVars = InitializeConnectionVars(options, platform);
 
-            _applicationInsightsRestClient = InitializeRestClient(options, _connectionVars);
-
             _transmissionStateManager = new TransmissionStateManager();
+
+            _applicationInsightsRestClient = InitializeRestClient(options, _connectionVars);
 
             _fileBlobProvider = InitializeOfflineStorage(platform, _connectionVars, options.DisableOfflineStorage, options.StorageDirectory);
 
@@ -168,22 +168,33 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             try
             {
-                using var httpMessage = async ?
+                if (_transmissionStateManager.State == TransmissionState.Closed)
+                {
+                    using var httpMessage = async ?
                     await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).ConfigureAwait(false) :
                     _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).Result;
 
-                result = HttpPipelineHelper.IsSuccess(httpMessage);
+                    result = HttpPipelineHelper.IsSuccess(httpMessage);
 
-                if (result == ExportResult.Failure && _fileBlobProvider != null)
-                {
-                    _transmissionStateManager.EnableBackOff(httpMessage.Response);
-                    result = HttpPipelineHelper.HandleFailures(httpMessage, _fileBlobProvider, _connectionVars);
+                    if (result == ExportResult.Failure && _fileBlobProvider != null)
+                    {
+                        _transmissionStateManager.EnableBackOff(httpMessage.Response);
+                        result = HttpPipelineHelper.HandleFailures(httpMessage, _fileBlobProvider, _connectionVars);
+                    }
+                    else
+                    {
+                        _transmissionStateManager.ResetConsecutiveErrors();
+                        _transmissionStateManager.CloseTransmission();
+                        AzureMonitorExporterEventSource.Log.TransmissionSuccess(_connectionVars.InstrumentationKey);
+                    }
                 }
                 else
                 {
-                    _transmissionStateManager.ResetConsecutiveErrors();
-                    _transmissionStateManager.CloseTransmission();
-                    AzureMonitorExporterEventSource.Log.TransmissionSuccess(_connectionVars.InstrumentationKey);
+                    byte[] requestContent = HttpPipelineHelper.GetSerializedContent(telemetryItems);
+                    if (_fileBlobProvider != null)
+                    {
+                        result = _fileBlobProvider.SaveTelemetry(requestContent);
+                    }
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -15,6 +15,7 @@ using Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage;
 using System.Diagnostics.CodeAnalysis;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+using System.Collections.Generic;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
@@ -82,6 +83,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             retryAfter = default;
             return false;
+        }
+
+        internal static byte[] GetSerializedContent(IEnumerable<TelemetryItem> body)
+        {
+            using var content = new NDJsonWriter();
+            foreach (var item in body)
+            {
+                content.JsonWriter.WriteObjectValue(item);
+                content.WriteNewLine();
+            }
+
+            return content.ToBytes().ToArray();
         }
 
         internal static bool TryGetRequestContent(RequestContent? content, [NotNullWhen(true)] out byte[]? requestContent)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmissionStateManager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmissionStateManager.cs
@@ -67,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// <summary>
         /// Stops transmitting data to backend.
         /// </summary>
-        private void OpenTransmission()
+        internal void OpenTransmission()
         {
             State = TransmissionState.Open;
         }


### PR DESCRIPTION
When the transmission state is set to Open, it means that we should fail fast and do not attempt to transmit for a set time period by transmission state manager. We were following this when [transmitting](https://github.com/Azure/azure-sdk-for-net/blob/2cfa587f85f734fc7da3573a7349b5f642e73e44/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs#L43) telemetry from storage. However, while transmitting telemetry received by the exporter this pattern was not followed. This change fixes that. We will only attempt when the transmission state is set to `closed` else the telemetry will be stored offline.