### PR TITLE
[AzureMonitorExporter] include name of Exporter in log messages

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -43,7 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey);
                 if (telemetryItems.Count > 0)
                 {
-                    exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+                    exportResult = _transmitter.TrackAsync(telemetryItems, nameof(AzureMonitorLogExporter), false, CancellationToken.None).EnsureCompleted();
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -43,7 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey);
                 if (telemetryItems.Count > 0)
                 {
-                    exportResult = _transmitter.TrackAsync(telemetryItems, nameof(AzureMonitorLogExporter), false, CancellationToken.None).EnsureCompleted();
+                    exportResult = _transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.AzureMonitorLogExporter, false, CancellationToken.None).EnsureCompleted();
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -47,7 +47,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, MetricResource, _instrumentationKey);
                     if (telemetryItems.Count > 0)
                     {
-                        exportResult = _transmitter.TrackAsync(telemetryItems, nameof(AzureMonitorMetricExporter), false, CancellationToken.None).EnsureCompleted();
+                        exportResult = _transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.AzureMonitorMetricExporter, false, CancellationToken.None).EnsureCompleted();
                     }
                 }
                 else

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorMetricExporter.cs
@@ -47,7 +47,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     var telemetryItems = MetricHelper.OtelToAzureMonitorMetrics(batch, MetricResource, _instrumentationKey);
                     if (telemetryItems.Count > 0)
                     {
-                        exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+                        exportResult = _transmitter.TrackAsync(telemetryItems, nameof(AzureMonitorMetricExporter), false, CancellationToken.None).EnsureCompleted();
                     }
                 }
                 else

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -43,7 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, TraceResource, _instrumentationKey);
                 if (telemetryItems.Count > 0)
                 {
-                    exportResult = _transmitter.TrackAsync(telemetryItems, nameof(AzureMonitorTraceExporter), false, CancellationToken.None).EnsureCompleted();
+                    exportResult = _transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.AzureMonitorTraceExporter, false, CancellationToken.None).EnsureCompleted();
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -43,7 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var telemetryItems = TraceHelper.OtelToAzureMonitorTrace(batch, TraceResource, _instrumentationKey);
                 if (telemetryItems.Count > 0)
                 {
-                    exportResult = _transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+                    exportResult = _transmitter.TrackAsync(telemetryItems, nameof(AzureMonitorTraceExporter), false, CancellationToken.None).EnsureCompleted();
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
@@ -23,10 +23,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// This operation sends a sequence of telemetry events that will be monitored by Azure Monitor.
         /// </summary>
         /// <param name="body">The list of telemetry events to track.</param>
-        /// <param name="origin">Origin of the telemetry items.</param>
         /// <param name="cancellationToken">The cancellation token to use.</param>
         /// <returns></returns>
-        internal async Task<HttpMessage> InternalTrackAsync(IEnumerable<TelemetryItem> body, string origin, CancellationToken cancellationToken = default)
+        internal async Task<HttpMessage> InternalTrackAsync(IEnumerable<TelemetryItem> body, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -34,8 +33,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
 
             var message = CreateTrackRequest(body);
-
-            message.SetProperty("AzureMonitorExporter_Origin", origin);
 
             try
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
@@ -23,9 +23,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// This operation sends a sequence of telemetry events that will be monitored by Azure Monitor.
         /// </summary>
         /// <param name="body">The list of telemetry events to track.</param>
+        /// <param name="origin">Origin of the telemetry items.</param>
         /// <param name="cancellationToken">The cancellation token to use.</param>
         /// <returns></returns>
-        internal async Task<HttpMessage> InternalTrackAsync(IEnumerable<TelemetryItem> body, CancellationToken cancellationToken = default)
+        internal async Task<HttpMessage> InternalTrackAsync(IEnumerable<TelemetryItem> body, string origin, CancellationToken cancellationToken = default)
         {
             if (body == null)
             {
@@ -33,6 +34,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
 
             var message = CreateTrackRequest(body);
+
+            message.SetProperty("AzureMonitorExporter_Origin", origin);
 
             try
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -171,8 +171,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 if (_transmissionStateManager.State == TransmissionState.Closed)
                 {
                     using var httpMessage = async ?
-                        await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).ConfigureAwait(false) :
-                        _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).Result;
+                    await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).ConfigureAwait(false) :
+                    _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).Result;
 
                     result = HttpPipelineHelper.IsSuccess(httpMessage);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -171,15 +171,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 if (_transmissionStateManager.State == TransmissionState.Closed)
                 {
                     using var httpMessage = async ?
-                        await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, origin, cancellationToken).ConfigureAwait(false) :
-                        _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, origin, cancellationToken).Result;
+                        await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).ConfigureAwait(false) :
+                        _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).Result;
 
                     result = HttpPipelineHelper.IsSuccess(httpMessage);
 
                     if (result == ExportResult.Failure && _fileBlobProvider != null)
                     {
                         _transmissionStateManager.EnableBackOff(httpMessage.Response);
-                        result = HttpPipelineHelper.HandleFailures(httpMessage, _fileBlobProvider, _connectionVars);
+                        result = HttpPipelineHelper.HandleFailures(httpMessage, _fileBlobProvider, _connectionVars, origin);
                     }
                     else
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -158,7 +158,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         public string InstrumentationKey => _connectionVars.InstrumentationKey;
 
-        public async ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken)
+        public async ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, string origin, bool async, CancellationToken cancellationToken)
         {
             ExportResult result = ExportResult.Failure;
             if (cancellationToken.IsCancellationRequested)
@@ -171,8 +171,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 if (_transmissionStateManager.State == TransmissionState.Closed)
                 {
                     using var httpMessage = async ?
-                    await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).ConfigureAwait(false) :
-                    _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, cancellationToken).Result;
+                        await _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, origin, cancellationToken).ConfigureAwait(false) :
+                        _applicationInsightsRestClient.InternalTrackAsync(telemetryItems, origin, cancellationToken).Result;
 
                     result = HttpPipelineHelper.IsSuccess(httpMessage);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -158,7 +158,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         public string InstrumentationKey => _connectionVars.InstrumentationKey;
 
-        public async ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, string origin, bool async, CancellationToken cancellationToken)
+        public async ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, TelemetryItemOrigin origin, bool async, CancellationToken cancellationToken)
         {
             ExportResult result = ExportResult.Failure;
             if (cancellationToken.IsCancellationRequested)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -185,7 +185,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     {
                         _transmissionStateManager.ResetConsecutiveErrors();
                         _transmissionStateManager.CloseTransmission();
-                        AzureMonitorExporterEventSource.Log.TransmissionSuccess(_connectionVars.InstrumentationKey);
+                        AzureMonitorExporterEventSource.Log.TransmissionSuccess(origin, _connectionVars.InstrumentationKey);
                     }
                 }
                 else
@@ -199,7 +199,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
             catch (Exception ex)
             {
-                AzureMonitorExporterEventSource.Log.TransmitterFailed(_connectionVars.InstrumentationKey, ex);
+                AzureMonitorExporterEventSource.Log.TransmitterFailed(origin, _connectionVars.InstrumentationKey, ex);
             }
 
             return result;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -67,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         public void FailedToTransmit(string exceptionMessage) => WriteEvent(7, exceptionMessage);
 
         [NonEvent]
-        public void TransmissionFailed(int statusCode, bool fromStorage, bool willRetry, ConnectionVars connectionVars, string? requestEndpoint, Response? response)
+        public void TransmissionFailed(int statusCode, string origin, bool willRetry, ConnectionVars connectionVars, string? requestEndpoint, Response? response)
         {
             if (IsEnabled(EventLevel.Verbose))
             {
@@ -79,7 +79,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
                         statusCode: statusCode,
                         errorMessage: "N/A",
                         action: willRetry ? "Telemetry is stored offline for retry" : "Telemetry is dropped",
-                        origin: fromStorage ? "Storage" : "AzureMonitorExporter",
+                        origin: origin,
                         instrumentationKey: connectionVars.InstrumentationKey,
                         configuredEndpoint: connectionVars.IngestionEndpoint,
                         actualEndpoint: requestEndpoint);
@@ -92,7 +92,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
                             statusCode: statusCode,
                             errorMessage: error ?? "N/A",
                             action: willRetry ? "Telemetry is stored offline for retry" : "Telemetry is dropped",
-                            origin: fromStorage ? "Storage" : "AzureMonitorExporter",
+                            origin: origin,
                             instrumentationKey: connectionVars.InstrumentationKey,
                             configuredEndpoint: connectionVars.IngestionEndpoint,
                             actualEndpoint: requestEndpoint);
@@ -105,7 +105,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
                     statusCode: statusCode,
                     errorMessage: "(To get exact error change LogLevel to Verbose)",
                     action: willRetry ? "Telemetry is stored offline for retry" : "Telemetry is dropped",
-                    origin: fromStorage ? "Storage" : "AzureMonitorExporter",
+                    origin: origin,
                     instrumentationKey: connectionVars.InstrumentationKey,
                     configuredEndpoint: connectionVars.IngestionEndpoint,
                     actualEndpoint: requestEndpoint);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -311,20 +311,29 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         [Event(31, Message = "Failed to initialize Statsbeat due to an exception. This is only for internal telemetry and can safely be ignored. Instrumentation Key: {0}. Configured Endpoint: {1}. {2}", Level = EventLevel.Informational)]
         public void ErrorInitializingStatsbeat(string instrumentationKey, string configuredEndpoint, string exceptionMessage) => WriteEvent(31, instrumentationKey, configuredEndpoint, exceptionMessage);
 
-        [Event(32, Message = "Successfully transmitted a batch of telemetry Items. Instrumentation Key: {0}", Level = EventLevel.Verbose)]
-        public void TransmissionSuccess(string instrumentationKey) => WriteEvent(32, instrumentationKey);
-
         [NonEvent]
-        public void TransmitterFailed(string instrumentationKey, Exception ex)
+        public void TransmissionSuccess(TelemetryItemOrigin origin, string instrumentationKey)
         {
-            if (IsEnabled(EventLevel.Error))
+            if (IsEnabled(EventLevel.Verbose))
             {
-                TransmitterFailed(instrumentationKey, ex.FlattenException().ToInvariantString());
+                TransmissionSuccess(origin.ToString(), instrumentationKey);
             }
         }
 
-        [Event(33, Message = "Transmitter failed due to an exception. Instrumentation Key: {0}. {1}", Level = EventLevel.Error)]
-        public void TransmitterFailed(string instrumentationKey, string exceptionMessage) => WriteEvent(33, instrumentationKey, exceptionMessage);
+        [Event(32, Message = "Successfully transmitted a batch of telemetry Items. Origin: {0}. Instrumentation Key: {1}", Level = EventLevel.Verbose)]
+        public void TransmissionSuccess(string origin, string instrumentationKey) => WriteEvent(32, origin, instrumentationKey);
+
+        [NonEvent]
+        public void TransmitterFailed(TelemetryItemOrigin origin, string instrumentationKey, Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                TransmitterFailed(origin.ToString(), instrumentationKey, ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(33, Message = "Transmitter failed due to an exception. Origin: {0}. Instrumentation Key: {1}. {2}", Level = EventLevel.Error)]
+        public void TransmitterFailed(string origin, string instrumentationKey, string exceptionMessage) => WriteEvent(33, origin, instrumentationKey, exceptionMessage);
 
         [Event(34, Message = "Exporter encountered a transmission failure and will wait {0} milliseconds before transmitting again.", Level = EventLevel.Warning)]
         public void BackoffEnabled(double milliseconds) => WriteEvent(34, milliseconds);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -67,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         public void FailedToTransmit(string exceptionMessage) => WriteEvent(7, exceptionMessage);
 
         [NonEvent]
-        public void TransmissionFailed(int statusCode, string origin, bool willRetry, ConnectionVars connectionVars, string? requestEndpoint, Response? response)
+        public void TransmissionFailed(int statusCode, TelemetryItemOrigin origin, bool willRetry, ConnectionVars connectionVars, string? requestEndpoint, Response? response)
         {
             if (IsEnabled(EventLevel.Verbose))
             {
@@ -79,7 +79,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
                         statusCode: statusCode,
                         errorMessage: "N/A",
                         action: willRetry ? "Telemetry is stored offline for retry" : "Telemetry is dropped",
-                        origin: origin,
+                        origin: origin.ToString(),
                         instrumentationKey: connectionVars.InstrumentationKey,
                         configuredEndpoint: connectionVars.IngestionEndpoint,
                         actualEndpoint: requestEndpoint);
@@ -92,7 +92,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
                             statusCode: statusCode,
                             errorMessage: error ?? "N/A",
                             action: willRetry ? "Telemetry is stored offline for retry" : "Telemetry is dropped",
-                            origin: origin,
+                            origin: origin.ToString(),
                             instrumentationKey: connectionVars.InstrumentationKey,
                             configuredEndpoint: connectionVars.IngestionEndpoint,
                             actualEndpoint: requestEndpoint);
@@ -105,7 +105,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
                     statusCode: statusCode,
                     errorMessage: "(To get exact error change LogLevel to Verbose)",
                     action: willRetry ? "Telemetry is stored offline for retry" : "Telemetry is dropped",
-                    origin: origin,
+                    origin: origin.ToString(),
                     instrumentationKey: connectionVars.InstrumentationKey,
                     configuredEndpoint: connectionVars.IngestionEndpoint,
                     actualEndpoint: requestEndpoint);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/TelemetryItemOrigin.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/TelemetryItemOrigin.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
+{
+    /// <summary>
+    /// This is used for internal logs, to distinguish where a TelemetryItem originated from.
+    /// </summary>
+    /// <remarks>
+    /// Because each Exporter can have a unique configuration, it's possible
+    /// for one Exporter to have issues not experienced by any others in a process.
+    /// </remarks>
+    internal enum TelemetryItemOrigin
+    {
+        AzureMonitorTraceExporter,
+        AzureMonitorMetricExporter,
+        AzureMonitorLogExporter,
+        Storage,
+        UnitTest,
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -220,8 +220,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
             }
 
+            httpMessage.TryGetProperty("AzureMonitorExporter_Origin", out var origin);
+
             AzureMonitorExporterEventSource.Log.TransmissionFailed(
-                fromStorage: false,
+                origin: origin?.ToString() ?? "AzureMonitorExporter",
                 statusCode: statusCode,
                 connectionVars: connectionVars,
                 requestEndpoint: httpMessage.Request.Uri.Host,
@@ -272,7 +274,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
 
             AzureMonitorExporterEventSource.Log.TransmissionFailed(
-                fromStorage: true,
+                origin: "Storage",
                 statusCode: statusCode,
                 connectionVars: connectionVars,
                 requestEndpoint: httpMessage.Request.Uri.Host,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -168,7 +168,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return ExportResult.Failure;
         }
 
-        internal static ExportResult HandleFailures(HttpMessage httpMessage, PersistentBlobProvider blobProvider, ConnectionVars connectionVars, string origin)
+        internal static ExportResult HandleFailures(HttpMessage httpMessage, PersistentBlobProvider blobProvider, ConnectionVars connectionVars, TelemetryItemOrigin origin)
         {
             ExportResult result = ExportResult.Failure;
             int statusCode = 0;
@@ -272,7 +272,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
 
             AzureMonitorExporterEventSource.Log.TransmissionFailed(
-                origin: "Storage",
+                origin: TelemetryItemOrigin.Storage,
                 statusCode: statusCode,
                 connectionVars: connectionVars,
                 requestEndpoint: httpMessage.Request.Uri.Host,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -168,7 +168,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return ExportResult.Failure;
         }
 
-        internal static ExportResult HandleFailures(HttpMessage httpMessage, PersistentBlobProvider blobProvider, ConnectionVars connectionVars)
+        internal static ExportResult HandleFailures(HttpMessage httpMessage, PersistentBlobProvider blobProvider, ConnectionVars connectionVars, string origin)
         {
             ExportResult result = ExportResult.Failure;
             int statusCode = 0;
@@ -220,10 +220,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
             }
 
-            httpMessage.TryGetProperty("AzureMonitorExporter_Origin", out var origin);
-
             AzureMonitorExporterEventSource.Log.TransmissionFailed(
-                origin: origin?.ToString() ?? "AzureMonitorExporter",
+                origin: origin,
                 statusCode: statusCode,
                 connectionVars: connectionVars,
                 requestEndpoint: httpMessage.Request.Uri.Host,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
@@ -17,7 +17,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// <summary>
         /// Sent telemetry and return the number of items Accepted.
         /// </summary>
-        ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken);
+        ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, string origin, bool async, CancellationToken cancellationToken);
         string InstrumentationKey { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ITransmitter.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 using OpenTelemetry;
@@ -17,7 +17,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// <summary>
         /// Sent telemetry and return the number of items Accepted.
         /// </summary>
-        ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, string origin, bool async, CancellationToken cancellationToken);
+        ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, TelemetryItemOrigin origin, bool async, CancellationToken cancellationToken);
         string InstrumentationKey { get; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 using OpenTelemetry;
@@ -23,7 +24,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             this.TelemetryItems = telemetryItems;
         }
 
-        public ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, string origin, bool async, CancellationToken cancellationToken)
+        public ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, TelemetryItemOrigin origin, bool async, CancellationToken cancellationToken)
         {
             foreach (var telemetryItem in telemetryItems)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockTransmitter.cs
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             this.TelemetryItems = telemetryItems;
         }
 
-        public ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken)
+        public ValueTask<ExportResult> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, string origin, bool async, CancellationToken cancellationToken)
         {
             foreach (var telemetryItem in telemetryItems)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponse = new MockResponse(200).SetContent("Ok");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -70,7 +70,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponse = new MockResponse(500).SetContent("Internal Server Error");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -90,7 +90,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                                     .AddHeader("Retry-After", "6")
                                     .SetContent("Too Many Requests");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -116,7 +116,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                                     .AddHeader("Retry-After", "6")
                                     .SetContent("{\"itemsReceived\": 3,\"itemsAccepted\": 1,\"errors\":[{\"index\": 0,\"statusCode\": 429,\"message\": \"Throttle\"},{\"index\": 1,\"statusCode\": 429,\"message\": \"Throttle\"}]}");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -147,7 +147,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mockResponseSuccess = new MockResponse(200).SetContent("{\"itemsReceived\": 1,\"itemsAccepted\": 1,\"errors\":[]}");
             var transmitter = GetTransmitter(mockResponseError, mockResponseSuccess);
 
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -181,7 +181,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mockResponseSuccess = new MockResponse(200).SetContent("{\"itemsReceived\": 1,\"itemsAccepted\": 1,\"errors\":[]}");
             var transmitter = GetTransmitter(mockResponseError, mockResponseSuccess);
 
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -209,7 +209,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponse = new MockResponse(500).SetContent("Internal Server Error");
             var transmitter = GetTransmitter(mockResponse, mockResponse);
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -249,7 +249,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal(TransmissionState.Open, transmitter._transmissionStateManager.State);
 
             // Transmit
-            transmitter.TrackAsync(telemetryItems, false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             // Telemetry should be stored offline as the state is open.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/OfflineStorageTests.cs
@@ -11,6 +11,7 @@ using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using OpenTelemetry.PersistentStorage.Abstractions;
@@ -52,7 +53,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponse = new MockResponse(200).SetContent("Ok");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -70,7 +71,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponse = new MockResponse(500).SetContent("Internal Server Error");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -90,7 +91,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                                     .AddHeader("Retry-After", "6")
                                     .SetContent("Too Many Requests");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -116,7 +117,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                                     .AddHeader("Retry-After", "6")
                                     .SetContent("{\"itemsReceived\": 3,\"itemsAccepted\": 1,\"errors\":[{\"index\": 0,\"statusCode\": 429,\"message\": \"Throttle\"},{\"index\": 1,\"statusCode\": 429,\"message\": \"Throttle\"}]}");
             using var transmitter = GetTransmitter(mockResponse);
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -147,7 +148,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mockResponseSuccess = new MockResponse(200).SetContent("{\"itemsReceived\": 1,\"itemsAccepted\": 1,\"errors\":[]}");
             var transmitter = GetTransmitter(mockResponseError, mockResponseSuccess);
 
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -181,7 +182,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var mockResponseSuccess = new MockResponse(200).SetContent("{\"itemsReceived\": 1,\"itemsAccepted\": 1,\"errors\":[]}");
             var transmitter = GetTransmitter(mockResponseError, mockResponseSuccess);
 
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -209,7 +210,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Transmit
             var mockResponse = new MockResponse(500).SetContent("Internal Server Error");
             var transmitter = GetTransmitter(mockResponse, mockResponse);
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             Assert.NotNull(transmitter._fileBlobProvider);
@@ -249,7 +250,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal(TransmissionState.Open, transmitter._transmissionStateManager.State);
 
             // Transmit
-            transmitter.TrackAsync(telemetryItems, "unit test", false, CancellationToken.None).EnsureCompleted();
+            transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.UnitTest, false, CancellationToken.None).EnsureCompleted();
 
             //Assert
             // Telemetry should be stored offline as the state is open.


### PR DESCRIPTION
Towards https://github.com/Azure/azure-sdk-for-net/issues/34581

Edit the log to specify which signal is failing to send telemetry.
This would help in troubleshooting to identify from exactly which Exporter (Trace/Log/Metric) is telemetry failing.

### Changes
- edit method parameters for the Exporter to provide it's name when calling Transmitter.TrackAsync();
- added origin to all logs from the `TrackAsync()` method

### Resulting logs:
```
OpenTelemetry-AzureMonitor-Exporter - EventId: [8], EventName: [TransmissionFailed], Message: [Transmission failed. StatusCode: 400. Error from Ingestion: Invalid instrumentation key. Action: Telemetry is dropped. Origin: AzureMonitorTraceExporter. Instrumentation Key: 00000000-0000-0000-0000-000000000000. Configured Endpoint: https://dc.services.visualstudio.com/. Actual Endpoint: dc.services.visualstudio.com]
OpenTelemetry-AzureMonitor-Exporter - EventId: [8], EventName: [TransmissionFailed], Message: [Transmission failed. StatusCode: 400. Error from Ingestion: Invalid instrumentation key. Action: Telemetry is dropped. Origin: AzureMonitorLogExporter. Instrumentation Key: 00000000-0000-0000-0000-000000000000. Configured Endpoint: https://dc.services.visualstudio.com/. Actual Endpoint: dc.services.visualstudio.com]
```