### PR TITLE
[Storage] Fixed issue with parsing the stored transfer state blob tags and added tests

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
@@ -18,7 +18,7 @@ namespace Azure.Storage.DataMovement.Blobs
     public class AppendBlobStorageResource : StorageResourceSingle
     {
         internal AppendBlobClient BlobClient { get; set; }
-        private AppendBlobStorageResourceOptions _options;
+        internal AppendBlobStorageResourceOptions _options;
         private long? _length;
         private ETag? _etagDownloadLock = default;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
@@ -21,12 +21,13 @@ namespace Azure.Storage.DataMovement.Blobs
     public class BlockBlobStorageResource : StorageResourceSingle
     {
         internal BlockBlobClient BlobClient { get; set; }
+        internal BlockBlobStorageResourceOptions _options;
+
         /// <summary>
         /// In order to ensure the block list is sent in the correct order
         /// we will order them by the offset (i.e. {offset, block_id}).
         /// </summary>
         private ConcurrentDictionary<long, string> _blocks;
-        private BlockBlobStorageResourceOptions _options;
         private long? _length;
         private ETag? _etagDownloadLock = default;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -515,7 +515,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 // Get Metadata
                 int metadataIndex = DataMovementConstants.PlanFile.DstBlobMetadataLengthIndex;
                 int metadataReadLength = DataMovementConstants.PlanFile.DstBlobTagsLengthIndex - metadataIndex;
-                string metadata = await checkpointer.GetHeaderValue(
+                string metadata = await checkpointer.GetHeaderUShortValue(
                     transferId,
                     metadataIndex,
                     metadataReadLength,
@@ -526,7 +526,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 // Get blob tags
                 int tagsIndex = DataMovementConstants.PlanFile.DstBlobTagsLengthIndex;
                 int tagsReadLength = DataMovementConstants.PlanFile.DstBlobIsSourceEncrypted - tagsIndex;
-                string tags = await checkpointer.GetHeaderValue(
+                string tags = await checkpointer.GetHeaderLongValue(
                     transferId,
                     tagsIndex,
                     tagsReadLength,

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
@@ -18,7 +18,7 @@ namespace Azure.Storage.DataMovement.Blobs
     public class PageBlobStorageResource : StorageResourceSingle
     {
         internal PageBlobClient BlobClient { get; set; }
-        private PageBlobStorageResourceOptions _options;
+        internal PageBlobStorageResourceOptions _options;
         private long? _length;
         private ETag? _etagDownloadLock = default;
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/RehydrateBlobResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/RehydrateBlobResourceTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.DataMovement.Blobs;
@@ -82,14 +80,30 @@ namespace Azure.Storage.DataMovement.Tests
             return mock;
         }
 
+        private JobPlanOperation GetPlanOperation(
+            StorageResourceType sourceType,
+            StorageResourceType destinationType)
+        {
+            if (sourceType == StorageResourceType.Local)
+            {
+                return JobPlanOperation.Upload;
+            }
+            else if (destinationType == StorageResourceType.Local)
+            {
+                return JobPlanOperation.Download;
+            }
+            return JobPlanOperation.ServiceToService;
+        }
+
         private async Task AddJobPartToCheckpointer(
             TransferCheckpointer checkpointer,
             string transferId,
             StorageResourceType sourceType,
             List<string> sourcePaths,
-            StorageResourceType destinatonType,
+            StorageResourceType destinationType,
             List<string> destinationPaths,
-            int partCount = 1)
+            int partCount = 1,
+            JobPartPlanHeader header = default)
         {
             // Populate sourcePaths if not provided
             if (sourcePaths == default)
@@ -112,25 +126,13 @@ namespace Azure.Storage.DataMovement.Tests
                 }
             }
 
-            JobPlanOperation fromTo;
-            if (sourceType == StorageResourceType.Local)
-            {
-                fromTo = JobPlanOperation.Upload;
-            }
-            else if (destinatonType == StorageResourceType.Local)
-            {
-                fromTo = JobPlanOperation.Download;
-            }
-            else
-            {
-                fromTo = JobPlanOperation.ServiceToService;
-            }
+            JobPlanOperation fromTo = GetPlanOperation(sourceType, destinationType);
 
             await checkpointer.AddNewJobAsync(transferId);
 
             for (int currentPart = 0; currentPart < partCount; currentPart++)
             {
-                JobPartPlanHeader header = CreateDefaultJobPartHeader(
+                header ??= CreateDefaultJobPartHeader(
                     transferId: transferId,
                     partNumber: currentPart,
                     sourcePath: sourcePaths[currentPart],
@@ -213,6 +215,67 @@ namespace Azure.Storage.DataMovement.Tests
 
         [Test]
         [Combinatorial]
+        public async Task RehydrateBlockBlob_Options(
+            [ValueSource(nameof(GetRehydrateApis))] RehydrateApi api)
+        {
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+            TransferCheckpointer checkpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            string transferId = GetNewTransferId();
+            string sourcePath = "https://storageaccount.blob.core.windows.net/container/blobsource";
+            string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
+
+            StorageResourceType sourceType = StorageResourceType.Local;
+            StorageResourceType destinationType = StorageResourceType.BlockBlob;
+
+            DataTransferProperties transferProperties = GetProperties(
+                test.DirectoryPath,
+                transferId,
+                sourcePath,
+                destinationPath,
+                ToResourceId(sourceType),
+                ToResourceId(destinationType),
+                isContainer: false).Object;
+
+            IDictionary<string, string> metadata = BuildMetadata();
+            IDictionary<string, string> blobTags = BuildTags();
+
+            JobPartPlanHeader header = CreateDefaultJobPartHeader(
+                    transferId: transferId,
+                    partNumber: 0,
+                    sourcePath: sourcePath,
+                    destinationPath: destinationPath,
+                    fromTo: GetPlanOperation(sourceType, destinationType),
+                    blobTags: blobTags,
+                    metadata: metadata,
+                    blockBlobTier: JobPartPlanBlockBlobTier.Cool);
+
+            await AddJobPartToCheckpointer(
+                checkpointer,
+                transferId,
+                sourceType,
+                new List<string>() { sourcePath },
+                destinationType,
+                new List<string>() { destinationPath },
+                header: header);
+
+            BlockBlobStorageResource storageResource = api switch
+            {
+                RehydrateApi.ResourceStaticApi => await BlockBlobStorageResource.RehydrateResourceAsync(transferProperties, false),
+                RehydrateApi.ProviderInstance => (BlockBlobStorageResource)await new BlobStorageResourceProvider(
+                    transferProperties, false, BlobStorageResources.ResourceType.BlockBlob).MakeResourceAsync(),
+                RehydrateApi.PublicStaticApi => (BlockBlobStorageResource)await AzureBlobStorageResourcesInlineTryGet(
+                    transferProperties, false),
+                _ => throw new ArgumentException("Unrecognized test parameter"),
+            };
+
+            Assert.AreEqual(destinationPath, storageResource.Uri.AbsoluteUri);
+            Assert.AreEqual(AccessTier.Cool, storageResource._options.AccessTier);
+            Assert.AreEqual(metadata, storageResource._options.Metadata);
+            Assert.AreEqual(blobTags, storageResource._options.Tags);
+        }
+
+        [Test]
+        [Combinatorial]
         public async Task RehydratePageBlob(
             [Values(true, false)] bool isSource,
             [ValueSource(nameof(GetRehydrateApis))] RehydrateApi api)
@@ -259,6 +322,67 @@ namespace Azure.Storage.DataMovement.Tests
 
         [Test]
         [Combinatorial]
+        public async Task RehydratePageBlob_Options(
+            [ValueSource(nameof(GetRehydrateApis))] RehydrateApi api)
+        {
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+            TransferCheckpointer checkpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            string transferId = GetNewTransferId();
+            string sourcePath = "https://storageaccount.blob.core.windows.net/container/blobsource";
+            string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
+
+            StorageResourceType sourceType = StorageResourceType.Local;
+            StorageResourceType destinationType = StorageResourceType.PageBlob;
+
+            DataTransferProperties transferProperties = GetProperties(
+                test.DirectoryPath,
+                transferId,
+                sourcePath,
+                destinationPath,
+                ToResourceId(sourceType),
+                ToResourceId(destinationType),
+                isContainer: false).Object;
+
+            IDictionary<string, string> metadata = BuildMetadata();
+            IDictionary<string, string> blobTags = BuildTags();
+
+            JobPartPlanHeader header = CreateDefaultJobPartHeader(
+                    transferId: transferId,
+                    partNumber: 0,
+                    sourcePath: sourcePath,
+                    destinationPath: destinationPath,
+                    fromTo: GetPlanOperation(sourceType, destinationType),
+                    blobTags: blobTags,
+                    metadata: metadata,
+                    pageBlobTier: JobPartPlanPageBlobTier.P30);
+
+            await AddJobPartToCheckpointer(
+                checkpointer,
+                transferId,
+                sourceType,
+                new List<string>() { sourcePath },
+                destinationType,
+                new List<string>() { destinationPath },
+                header: header);
+
+            PageBlobStorageResource storageResource = api switch
+            {
+                RehydrateApi.ResourceStaticApi => await PageBlobStorageResource.RehydrateResourceAsync(transferProperties, false),
+                RehydrateApi.ProviderInstance => (PageBlobStorageResource)await new BlobStorageResourceProvider(
+                    transferProperties, false, BlobStorageResources.ResourceType.PageBlob).MakeResourceAsync(),
+                RehydrateApi.PublicStaticApi => (PageBlobStorageResource)await AzureBlobStorageResourcesInlineTryGet(
+                    transferProperties, false),
+                _ => throw new ArgumentException("Unrecognized test parameter"),
+            };
+
+            Assert.AreEqual(destinationPath, storageResource.Uri.AbsoluteUri);
+            Assert.AreEqual(AccessTier.P30, storageResource._options.AccessTier);
+            Assert.AreEqual(metadata, storageResource._options.Metadata);
+            Assert.AreEqual(blobTags, storageResource._options.Tags);
+        }
+
+        [Test]
+        [Combinatorial]
         public async Task RehydrateAppendBlob(
             [Values(true, false)] bool isSource,
             [ValueSource(nameof(GetRehydrateApis))] RehydrateApi api)
@@ -301,6 +425,65 @@ namespace Azure.Storage.DataMovement.Tests
             };
 
             Assert.AreEqual(originalPath, storageResource.Uri.AbsoluteUri);
+        }
+
+        [Test]
+        [Combinatorial]
+        public async Task RehydrateAppendBlob_Options(
+            [ValueSource(nameof(GetRehydrateApis))] RehydrateApi api)
+        {
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+            TransferCheckpointer checkpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            string transferId = GetNewTransferId();
+            string sourcePath = "https://storageaccount.blob.core.windows.net/container/blobsource";
+            string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
+
+            StorageResourceType sourceType = StorageResourceType.Local;
+            StorageResourceType destinationType = StorageResourceType.AppendBlob;
+
+            DataTransferProperties transferProperties = GetProperties(
+                test.DirectoryPath,
+                transferId,
+                sourcePath,
+                destinationPath,
+                ToResourceId(sourceType),
+                ToResourceId(destinationType),
+                isContainer: false).Object;
+
+            IDictionary<string, string> metadata = BuildMetadata();
+            IDictionary<string, string> blobTags = BuildTags();
+
+            JobPartPlanHeader header = CreateDefaultJobPartHeader(
+                    transferId: transferId,
+                    partNumber: 0,
+                    sourcePath: sourcePath,
+                    destinationPath: destinationPath,
+                    fromTo: GetPlanOperation(sourceType, destinationType),
+                    blobTags: blobTags,
+                    metadata: metadata);
+
+            await AddJobPartToCheckpointer(
+                checkpointer,
+                transferId,
+                sourceType,
+                new List<string>() { sourcePath },
+                destinationType,
+                new List<string>() { destinationPath },
+                header: header);
+
+            AppendBlobStorageResource storageResource = api switch
+            {
+                RehydrateApi.ResourceStaticApi => await AppendBlobStorageResource.RehydrateResourceAsync(transferProperties, false),
+                RehydrateApi.ProviderInstance => (AppendBlobStorageResource)await new BlobStorageResourceProvider(
+                    transferProperties, false, BlobStorageResources.ResourceType.AppendBlob).MakeResourceAsync(),
+                RehydrateApi.PublicStaticApi => (AppendBlobStorageResource)await AzureBlobStorageResourcesInlineTryGet(
+                    transferProperties, false),
+                _ => throw new ArgumentException("Unrecognized test parameter"),
+            };
+
+            Assert.AreEqual(destinationPath, storageResource.Uri.AbsoluteUri);
+            Assert.AreEqual(metadata, storageResource._options.Metadata);
+            Assert.AreEqual(blobTags, storageResource._options.Tags);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
@@ -205,7 +205,7 @@ namespace Azure.Storage.DataMovement
             return concatStr;
         }
 
-        internal static async Task<string> GetHeaderValue(
+        internal static async Task<string> GetHeaderUShortValue(
             this TransferCheckpointer checkpointer,
             string transferId,
             int startIndex,
@@ -226,6 +226,35 @@ namespace Azure.Storage.DataMovement
                 // Read Path Length
                 byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
                 ushort pathLength = pathLengthBuffer.ToUShort();
+
+                // Read Path
+                byte[] pathBuffer = reader.ReadBytes(valueLength);
+                value = pathBuffer.ToString(pathLength);
+            }
+            return value;
+        }
+
+        internal static async Task<string> GetHeaderLongValue(
+            this TransferCheckpointer checkpointer,
+            string transferId,
+            int startIndex,
+            int streamReadLength,
+            int valueLength,
+            CancellationToken cancellationToken)
+        {
+            string value;
+            using (Stream stream = await checkpointer.ReadableStreamAsync(
+                transferId: transferId,
+                partNumber: 0,
+                offset: startIndex,
+                readSize: streamReadLength,
+                cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+
+                // Read Path Length
+                byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+                long pathLength = pathLengthBuffer.ToLong();
 
                 // Read Path
                 byte[] pathBuffer = reader.ReadBytes(valueLength);


### PR DESCRIPTION
- Fixed an issue that was added in my last PR where the blob tags weren't parsed correctly due to it parsing a ushort when it should have parsed a long instead
- No need to update the changelog since this feature hasn't been released yet
- Added necessary tests