### PR TITLE
Add Azure.* activity sources to distro

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -90,8 +91,29 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             }
 
             builder.WithTracing(b => b
+                            .AddSource("Azure.*")
                             .AddAspNetCoreInstrumentation()
-                            .AddHttpClientInstrumentation()
+                            .AddHttpClientInstrumentation(o => o.FilterHttpRequestMessage = (_) =>
+                            {
+                                // Azure SDKs create their own client span before calling the service using HttpClient
+                                // In this case, we would see two spans corresponding to the same operation
+                                // 1) created by Azure SDK 2) created by HttpClient
+                                // To prevent this duplication we are filtering the span from HttpClient
+                                // as span from Azure SDK contains all relevant information needed.
+                                if (AppContext.TryGetSwitch("Azure.Experimental.EnableActivitySource", out var enabled))
+                                {
+                                    if (enabled)
+                                    {
+                                        var parentActivity = Activity.Current?.Parent;
+                                        if (parentActivity != null && parentActivity.Source.Name.StartsWith("Azure.Core"))
+                                        {
+                                            return false;
+                                        }
+                                    }
+                                }
+
+                                return true;
+                            })
                             .AddSqlClientInstrumentation()
                             .AddAzureMonitorTraceExporter());
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -100,16 +100,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                                 // 1) created by Azure SDK 2) created by HttpClient
                                 // To prevent this duplication we are filtering the span from HttpClient
                                 // as span from Azure SDK contains all relevant information needed.
-                                if (AppContext.TryGetSwitch("Azure.Experimental.EnableActivitySource", out var enabled))
+                                var parentActivity = Activity.Current?.Parent;
+                                if (parentActivity != null && parentActivity.Source.Name.StartsWith("Azure.Core"))
                                 {
-                                    if (enabled)
-                                    {
-                                        var parentActivity = Activity.Current?.Parent;
-                                        if (parentActivity != null && parentActivity.Source.Name.StartsWith("Azure.Core"))
-                                        {
-                                            return false;
-                                        }
-                                    }
+                                    return false;
                                 }
 
                                 return true;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -101,7 +101,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                                 // To prevent this duplication we are filtering the span from HttpClient
                                 // as span from Azure SDK contains all relevant information needed.
                                 var parentActivity = Activity.Current?.Parent;
-                                if (parentActivity != null && parentActivity.Source.Name.StartsWith("Azure.Core.Http"))
+                                if (parentActivity != null && parentActivity.Source.Name.Equals("Azure.Core.Http"))
                                 {
                                     return false;
                                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -101,7 +101,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                                 // To prevent this duplication we are filtering the span from HttpClient
                                 // as span from Azure SDK contains all relevant information needed.
                                 var parentActivity = Activity.Current?.Parent;
-                                if (parentActivity != null && parentActivity.Source.Name.StartsWith("Azure.Core"))
+                                if (parentActivity != null && parentActivity.Source.Name.StartsWith("Azure.Core.Http"))
                                 {
                                     return false;
                                 }


### PR DESCRIPTION
This PR adds Azure SDK activity sources by default to distro. Even though the sources are added by default, users will need to enable the collection by turning on the feature by following one of the ways listed in https://devblogs.microsoft.com/azure-sdk/introducing-experimental-opentelemetry-support-in-the-azure-sdk-for-net/