### PR TITLE
Remove api-version dependencies for resource manager tests

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/assets.json
+++ b/sdk/resourcemanager/Azure.ResourceManager/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/resourcemanager/Azure.ResourceManager",
-  "Tag": "net/resourcemanager/Azure.ResourceManager_4b6dda2451"
+  "Tag": "net/resourcemanager/Azure.ResourceManager_badeb57759"
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Scenario/ResourceManagerTestBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Scenario/ResourceManagerTestBase.cs
@@ -21,17 +21,17 @@ namespace Azure.ResourceManager.Tests
         protected ArmClient Client { get; private set; }
 
         protected ResourceManagerTestBase(bool isAsync, ResourceType resourceType, string apiVersion, RecordedTestMode? mode = null)
-            : base(isAsync, resourceType, apiVersion, mode, ignoreArmCoreDependencyVersions: true)
+            : base(isAsync, resourceType, apiVersion, mode)
         {
         }
 
         protected ResourceManagerTestBase(bool isAsync, RecordedTestMode mode)
-        : base(isAsync, mode, ignoreArmCoreDependencyVersions: true)
+        : base(isAsync, mode)
         {
         }
 
         protected ResourceManagerTestBase(bool isAsync)
-            : base(isAsync, ignoreArmCoreDependencyVersions: true)
+            : base(isAsync)
         {
         }
 

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Scenario/ResourceManagerTestBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Scenario/ResourceManagerTestBase.cs
@@ -21,17 +21,17 @@ namespace Azure.ResourceManager.Tests
         protected ArmClient Client { get; private set; }
 
         protected ResourceManagerTestBase(bool isAsync, ResourceType resourceType, string apiVersion, RecordedTestMode? mode = null)
-            : base(isAsync, resourceType, apiVersion, mode, ignoreArmCoreDependencyVersions: false)
+            : base(isAsync, resourceType, apiVersion, mode, ignoreArmCoreDependencyVersions: true)
         {
         }
 
         protected ResourceManagerTestBase(bool isAsync, RecordedTestMode mode)
-        : base(isAsync, mode, ignoreArmCoreDependencyVersions: false)
+        : base(isAsync, mode, ignoreArmCoreDependencyVersions: true)
         {
         }
 
         protected ResourceManagerTestBase(bool isAsync)
-            : base(isAsync, ignoreArmCoreDependencyVersions: false)
+            : base(isAsync, ignoreArmCoreDependencyVersions: true)
         {
         }
 


### PR DESCRIPTION
Follow-up of https://github.com/Azure/azure-sdk-for-net/issues/37429