### PR TITLE
Fix code generation for EmailAttachment serialization

### DIFF
--- a/sdk/communication/Azure.Communication.Email/src/Generated/Models/EmailAttachment.Serialization.cs
+++ b/sdk/communication/Azure.Communication.Email/src/Generated/Models/EmailAttachment.Serialization.cs
@@ -20,7 +20,7 @@ namespace Azure.Communication.Email
             writer.WritePropertyName("contentType"u8);
             writer.WriteStringValue(ContentType);
             writer.WritePropertyName("contentInBase64"u8);
-            writer.WriteStringValue(ContentInBase64);
+            writer.WriteBase64StringValue(Content.ToArray(), "D");
             writer.WriteEndObject();
         }
     }

--- a/sdk/communication/Azure.Communication.Email/src/Models/EmailAttachment.cs
+++ b/sdk/communication/Azure.Communication.Email/src/Models/EmailAttachment.cs
@@ -37,20 +37,6 @@ namespace Azure.Communication.Email
             }
         }
 
-        internal string ContentInBase64
-        {
-            get
-            {
-                string valueToReturn = Convert.ToBase64String(Content.ToArray());
-                if (string.IsNullOrWhiteSpace(valueToReturn))
-                {
-                    throw new ArgumentException(ErrorMessages.InvalidAttachmentContent);
-                }
-
-                return valueToReturn;
-            }
-        }
-
         /// <summary>
         /// Contents of the attachment as BinaryData.
         /// </summary>

--- a/sdk/communication/Azure.Communication.Email/src/autorest.md
+++ b/sdk/communication/Azure.Communication.Email/src/autorest.md
@@ -8,4 +8,10 @@ input-file:
 generation1-convenience-client: true
 payload-flattening-threshold: 3
 model-namespace: false
+
+directive:
+  from: swagger-document
+  where: "$.definitions.EmailAttachment.properties.contentInBase64"
+  transform: >
+    $["x-ms-client-name"] = "content";
 ```

--- a/sdk/communication/Azure.Communication.Email/src/autorest.md
+++ b/sdk/communication/Azure.Communication.Email/src/autorest.md
@@ -4,7 +4,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 
 ``` yaml
 input-file:
-    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/ac29c822ecd5f6054cd17c46839e7c04a1114c6d/specification/communication/data-plane/Email/stable/2023-03-31/CommunicationServicesEmail.json
+    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/512e966e15cd8e6ffd756279971c478702f4e19e/specification/communication/data-plane/Email/stable/2023-03-31/CommunicationServicesEmail.json
 generation1-convenience-client: true
 payload-flattening-threshold: 3
 model-namespace: false


### PR DESCRIPTION
Currently, code generated for EmailAttachment serialization is not efficient from memory usage perspective.

Below, there is an example of memory profiling for 5 MB attachment.
![image](https://github.com/Azure/azure-sdk-for-net/assets/106100749/9e46e27d-74f6-4c3c-b3f5-01c4f93d7594)

Those are the lines of code causing it:

        writer.WritePropertyName("contentInBase64"u8);
        writer.WriteStringValue(ContentInBase64);
Where ContentInBase64 is just a wrapper around Content property:

    internal string ContentInBase64
    {
        get
        {
            string valueToReturn = Convert.ToBase64String(Content.ToArray());
            if (string.IsNullOrWhiteSpace(valueToReturn))
            {
                throw new ArgumentException(ErrorMessages.InvalidAttachmentContent);
            }

            return valueToReturn;
        }
    }
With updated specification generator produces the following code:

        writer.WritePropertyName("contentInBase64"u8);
        writer.WriteBase64StringValue(Content.ToArray(), "D");
which is significantly more efficient (~20MB vs ~170MB):
![image](https://github.com/Azure/azure-sdk-for-net/assets/106100749/3ca1060e-0159-4b38-a688-8b66cfd8726b)

This PR is intended to fix this issue by using updated specification for code generation.