### PR TITLE
Make AzureBlobXmlRepository to be public

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureBlobXmlRepository.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/AzureBlobXmlRepository.cs
@@ -26,7 +26,7 @@ namespace Azure.Extensions.AspNetCore.DataProtection.Blobs
     /// <remarks>
     /// Instances of this type are thread-safe.
     /// </remarks>
-    internal sealed class AzureBlobXmlRepository : IXmlRepository
+    public sealed class AzureBlobXmlRepository : IXmlRepository
     {
         private const int ConflictMaxRetries = 5;
         private static readonly TimeSpan ConflictBackoffPeriod = TimeSpan.FromMilliseconds(200);


### PR DESCRIPTION
We need to have the opportunity to instantiate AzureBlobXmlRepository when copying keys from one repository to another one (FileSystemXmlRepository -> AzureBlobXmlRepository).  FileSystemXmlRepository is public, but AzureBlobXmlRepository is internal. I suggest making AzureBlobXmlRepository to be public too.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
