### PR TITLE
[Azure Communication Services][CallAutomation]Create Customcontext class

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -239,7 +239,7 @@ namespace Azure.Communication.CallAutomation
         public CallInvite(Azure.Communication.CommunicationUserIdentifier targetIdentity) { }
         public CallInvite(Azure.Communication.MicrosoftTeamsUserIdentifier targetIdentity) { }
         public CallInvite(Azure.Communication.PhoneNumberIdentifier targetPhoneNumberIdentity, Azure.Communication.PhoneNumberIdentifier callerIdNumber) { }
-        public Azure.Communication.CallAutomation.Models.CustomContext CustomContext { get { throw null; } }
+        public Azure.Communication.CallAutomation.CustomContext CustomContext { get { throw null; } }
         public Azure.Communication.PhoneNumberIdentifier SourceCallerIdNumber { get { throw null; } }
         public string SourceDisplayName { get { throw null; } set { } }
         public Azure.Communication.CommunicationIdentifier Target { get { throw null; } }
@@ -525,12 +525,25 @@ namespace Azure.Communication.CallAutomation
         public CreateGroupCallOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> targets, System.Uri callbackUri) { }
         public System.Uri AzureCognitiveServicesEndpointUrl { get { throw null; } set { } }
         public System.Uri CallbackUri { get { throw null; } }
-        public Azure.Communication.CallAutomation.Models.CustomContext CustomContext { get { throw null; } set { } }
+        public Azure.Communication.CallAutomation.CustomContext CustomContext { get { throw null; } }
         public Azure.Communication.CallAutomation.MediaStreamingOptions MediaStreamingOptions { get { throw null; } set { } }
         public string OperationContext { get { throw null; } set { } }
         public Azure.Communication.PhoneNumberIdentifier SourceCallerIdNumber { get { throw null; } set { } }
         public string SourceDisplayName { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> Targets { get { throw null; } }
+    }
+    public partial class CustomContext
+    {
+        internal CustomContext() { }
+        public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } }
+        public void Add(Azure.Communication.CallAutomation.CustomContextHeader header) { }
+    }
+    public abstract partial class CustomContextHeader
+    {
+        protected CustomContextHeader(string key, string value) { }
+        public string Key { get { throw null; } }
+        public string Value { get { throw null; } }
     }
     public partial class DialogCompleted : Azure.Communication.CallAutomation.CallAutomationEventBase
     {
@@ -1172,6 +1185,14 @@ namespace Azure.Communication.CallAutomation
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
+    public partial class SIPCustomHeader : Azure.Communication.CallAutomation.CustomContextHeader
+    {
+        public SIPCustomHeader(string key, string value) : base (default(string), default(string)) { }
+    }
+    public partial class SIPUUIHeader : Azure.Communication.CallAutomation.CustomContextHeader
+    {
+        public SIPUUIHeader(string value) : base (default(string), default(string)) { }
+    }
     public partial class SpeechResult : Azure.Communication.CallAutomation.RecognizeResult
     {
         internal SpeechResult() { }
@@ -1254,7 +1275,7 @@ namespace Azure.Communication.CallAutomation
         public TransferToParticipantOptions(Azure.Communication.CommunicationUserIdentifier targetIdentity) { }
         public TransferToParticipantOptions(Azure.Communication.MicrosoftTeamsUserIdentifier targetIdentity) { }
         public TransferToParticipantOptions(Azure.Communication.PhoneNumberIdentifier targetPhoneNumberIdentity) { }
-        public Azure.Communication.CallAutomation.Models.CustomContext CustomContext { get { throw null; } }
+        public Azure.Communication.CallAutomation.CustomContext CustomContext { get { throw null; } }
         public string OperationContext { get { throw null; } set { } }
         public Azure.Communication.CommunicationIdentifier Target { get { throw null; } }
     }
@@ -1274,31 +1295,7 @@ namespace Azure.Communication.CallAutomation
         internal UserConsent() { }
         public int? Recording { get { throw null; } }
     }
-}
-namespace Azure.Communication.CallAutomation.Models
-{
-    public partial class CustomContext
-    {
-        public CustomContext(System.Collections.Generic.IDictionary<string, string> sipHeaders, System.Collections.Generic.IDictionary<string, string> voipHeaders) { }
-        public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } }
-        public void Add(Azure.Communication.CallAutomation.Models.CustomContextHeader header) { }
-    }
-    public abstract partial class CustomContextHeader
-    {
-        protected CustomContextHeader(string key, string value) { }
-        public string Key { get { throw null; } }
-        public string Value { get { throw null; } }
-    }
-    public partial class SIPCustomHeader : Azure.Communication.CallAutomation.Models.CustomContextHeader
-    {
-        public SIPCustomHeader(string key, string value) : base (default(string), default(string)) { }
-    }
-    public partial class SIPUUIHeader : Azure.Communication.CallAutomation.Models.CustomContextHeader
-    {
-        public SIPUUIHeader(string value) : base (default(string), default(string)) { }
-    }
-    public partial class VoipHeader : Azure.Communication.CallAutomation.Models.CustomContextHeader
+    public partial class VoipHeader : Azure.Communication.CallAutomation.CustomContextHeader
     {
         public VoipHeader(string key, string value) : base (default(string), default(string)) { }
     }

--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -236,14 +236,13 @@ namespace Azure.Communication.CallAutomation
     }
     public partial class CallInvite
     {
-        public CallInvite(Azure.Communication.CommunicationUserIdentifier targetIdentity, System.Collections.Generic.IDictionary<string, string> voipHeaders = null) { }
-        public CallInvite(Azure.Communication.MicrosoftTeamsUserIdentifier targetIdentity, System.Collections.Generic.IDictionary<string, string> voipHeaders = null) { }
-        public CallInvite(Azure.Communication.PhoneNumberIdentifier targetPhoneNumberIdentity, Azure.Communication.PhoneNumberIdentifier callerIdNumber, System.Collections.Generic.IDictionary<string, string> sipHeaders = null) { }
-        public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } }
+        public CallInvite(Azure.Communication.CommunicationUserIdentifier targetIdentity) { }
+        public CallInvite(Azure.Communication.MicrosoftTeamsUserIdentifier targetIdentity) { }
+        public CallInvite(Azure.Communication.PhoneNumberIdentifier targetPhoneNumberIdentity, Azure.Communication.PhoneNumberIdentifier callerIdNumber) { }
+        public Azure.Communication.CallAutomation.Models.CustomContext CustomContext { get { throw null; } }
         public Azure.Communication.PhoneNumberIdentifier SourceCallerIdNumber { get { throw null; } }
         public string SourceDisplayName { get { throw null; } set { } }
         public Azure.Communication.CommunicationIdentifier Target { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } }
     }
     public abstract partial class CallLocator : System.IEquatable<Azure.Communication.CallAutomation.CallLocator>
     {
@@ -526,13 +525,12 @@ namespace Azure.Communication.CallAutomation
         public CreateGroupCallOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> targets, System.Uri callbackUri) { }
         public System.Uri AzureCognitiveServicesEndpointUrl { get { throw null; } set { } }
         public System.Uri CallbackUri { get { throw null; } }
+        public Azure.Communication.CallAutomation.Models.CustomContext CustomContext { get { throw null; } set { } }
         public Azure.Communication.CallAutomation.MediaStreamingOptions MediaStreamingOptions { get { throw null; } set { } }
         public string OperationContext { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } set { } }
         public Azure.Communication.PhoneNumberIdentifier SourceCallerIdNumber { get { throw null; } set { } }
         public string SourceDisplayName { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Azure.Communication.CommunicationIdentifier> Targets { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } set { } }
     }
     public partial class DialogCompleted : Azure.Communication.CallAutomation.CallAutomationEventBase
     {
@@ -1253,13 +1251,12 @@ namespace Azure.Communication.CallAutomation
     }
     public partial class TransferToParticipantOptions
     {
-        public TransferToParticipantOptions(Azure.Communication.CommunicationUserIdentifier targetIdentity, System.Collections.Generic.IDictionary<string, string> voipHeaders = null) { }
-        public TransferToParticipantOptions(Azure.Communication.MicrosoftTeamsUserIdentifier targetIdentity, System.Collections.Generic.IDictionary<string, string> voipHeaders = null) { }
-        public TransferToParticipantOptions(Azure.Communication.PhoneNumberIdentifier targetPhoneNumberIdentity, System.Collections.Generic.IDictionary<string, string> sipHeaders = null) { }
+        public TransferToParticipantOptions(Azure.Communication.CommunicationUserIdentifier targetIdentity) { }
+        public TransferToParticipantOptions(Azure.Communication.MicrosoftTeamsUserIdentifier targetIdentity) { }
+        public TransferToParticipantOptions(Azure.Communication.PhoneNumberIdentifier targetPhoneNumberIdentity) { }
+        public Azure.Communication.CallAutomation.Models.CustomContext CustomContext { get { throw null; } }
         public string OperationContext { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } }
         public Azure.Communication.CommunicationIdentifier Target { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } }
     }
     public partial class UnmuteParticipantsOptions
     {
@@ -1276,5 +1273,33 @@ namespace Azure.Communication.CallAutomation
     {
         internal UserConsent() { }
         public int? Recording { get { throw null; } }
+    }
+}
+namespace Azure.Communication.CallAutomation.Models
+{
+    public partial class CustomContext
+    {
+        public CustomContext(System.Collections.Generic.IDictionary<string, string> sipHeaders, System.Collections.Generic.IDictionary<string, string> voipHeaders) { }
+        public System.Collections.Generic.IDictionary<string, string> SipHeaders { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, string> VoipHeaders { get { throw null; } }
+        public void Add(Azure.Communication.CallAutomation.Models.CustomContextHeader header) { }
+    }
+    public abstract partial class CustomContextHeader
+    {
+        protected CustomContextHeader(string key, string value) { }
+        public string Key { get { throw null; } }
+        public string Value { get { throw null; } }
+    }
+    public partial class SIPCustomHeader : Azure.Communication.CallAutomation.Models.CustomContextHeader
+    {
+        public SIPCustomHeader(string key, string value) : base (default(string), default(string)) { }
+    }
+    public partial class SIPUUIHeader : Azure.Communication.CallAutomation.Models.CustomContextHeader
+    {
+        public SIPUUIHeader(string value) : base (default(string), default(string)) { }
+    }
+    public partial class VoipHeader : Azure.Communication.CallAutomation.Models.CustomContextHeader
+    {
+        public VoipHeader(string key, string value) : base (default(string), default(string)) { }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallAutomationClient.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallAutomationClient.cs
@@ -297,8 +297,8 @@ namespace Azure.Communication.CallAutomation
                 var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 request.CustomContext = new CustomContextInternal(
-                   options.CallInvite.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.SipHeaders,
-                   options.CallInvite.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.VoipHeaders);
+                   options.CallInvite.CustomContext.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.CustomContext.SipHeaders,
+                   options.CallInvite.CustomContext.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.CustomContext.VoipHeaders);
 
                 return await AzureCommunicationServicesRestClient.RedirectCallAsync(
                     request,
@@ -346,8 +346,8 @@ namespace Azure.Communication.CallAutomation
                 var repeatabilityHeaders = new RepeatabilityHeaders();
 
                 request.CustomContext = new CustomContextInternal(
-                   options.CallInvite.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.SipHeaders,
-                   options.CallInvite.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.VoipHeaders);
+                   options.CallInvite.CustomContext.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.CustomContext.SipHeaders,
+                   options.CallInvite.CustomContext.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.CustomContext.VoipHeaders);
 
                 return AzureCommunicationServicesRestClient.RedirectCall(
                     request,
@@ -674,8 +674,8 @@ namespace Azure.Communication.CallAutomation
             };
 
             request.CustomContext = new CustomContextInternal(
-               options.CallInvite.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.SipHeaders,
-               options.CallInvite.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.VoipHeaders);
+               options.CallInvite.CustomContext.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.CustomContext.SipHeaders,
+               options.CallInvite.CustomContext.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CallInvite.CustomContext.VoipHeaders);
 
             // Add custom cognitive service domain name
             if (options.AzureCognitiveServicesEndpointUrl != null)
@@ -706,8 +706,8 @@ namespace Azure.Communication.CallAutomation
             };
 
             request.CustomContext = new CustomContextInternal(
-               options.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.SipHeaders,
-               options.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.VoipHeaders);
+               options.CustomContext.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CustomContext.SipHeaders,
+               options.CustomContext.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CustomContext.VoipHeaders);
 
             // Add custom cognitive service domain name
             if (options.AzureCognitiveServicesEndpointUrl != null)

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallConnection.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallConnection.cs
@@ -305,8 +305,8 @@ namespace Azure.Communication.CallAutomation
             TransferToParticipantRequestInternal request = new TransferToParticipantRequestInternal(CommunicationIdentifierSerializer.Serialize(options.Target));
 
             request.CustomContext = new CustomContextInternal(
-                options.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.SipHeaders,
-                options.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.VoipHeaders);
+                options.CustomContext.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CustomContext.SipHeaders,
+                options.CustomContext.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.CustomContext.VoipHeaders);
 
             if (options.OperationContext != null && options.OperationContext.Length > CallAutomationConstants.InputValidation.StringMaxLength)
             {
@@ -444,8 +444,8 @@ namespace Azure.Communication.CallAutomation
             }
 
             request.CustomContext = new CustomContextInternal(
-                options.ParticipantToAdd.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.ParticipantToAdd.SipHeaders,
-                options.ParticipantToAdd.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.ParticipantToAdd.VoipHeaders);
+                options.ParticipantToAdd.CustomContext.SipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.ParticipantToAdd.CustomContext.SipHeaders,
+                options.ParticipantToAdd.CustomContext.VoipHeaders == null ? new ChangeTrackingDictionary<string, string>() : options.ParticipantToAdd.CustomContext.VoipHeaders);
 
             return request;
         }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CallInvite.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CallInvite.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Azure.Communication.CallAutomation.Models;
 
 namespace Azure.Communication.CallAutomation
 {
@@ -15,34 +16,31 @@ namespace Azure.Communication.CallAutomation
         /// </summary>
         /// <param name="targetPhoneNumberIdentity"></param>
         /// <param name="callerIdNumber"></param>
-        /// /// <param name="sipHeaders"></param>
-        public CallInvite(PhoneNumberIdentifier targetPhoneNumberIdentity, PhoneNumberIdentifier callerIdNumber, IDictionary<string, string> sipHeaders = null)
+        public CallInvite(PhoneNumberIdentifier targetPhoneNumberIdentity, PhoneNumberIdentifier callerIdNumber)
         {
             Target = targetPhoneNumberIdentity;
             SourceCallerIdNumber = callerIdNumber;
-            SipHeaders= sipHeaders == null ? new Dictionary<string, string>() : sipHeaders;
+            CustomContext = new CustomContext(sipHeaders: new Dictionary<string, string>(), voipHeaders: null);
         }
 
         /// <summary>
         /// Creates a new CallInvite object.
         /// </summary>
         /// <param name="targetIdentity"></param>
-        /// <param name="voipHeaders"></param>
-        public CallInvite(CommunicationUserIdentifier targetIdentity, IDictionary<string, string> voipHeaders = null)
+        public CallInvite(CommunicationUserIdentifier targetIdentity)
         {
             Target = targetIdentity;
-            VoipHeaders= voipHeaders == null ? new Dictionary<string, string>() : voipHeaders;
+            CustomContext = new CustomContext(sipHeaders: null, voipHeaders: new Dictionary<string, string>());
         }
 
         /// <summary>
         /// Creates a new CallInvite object.
         /// </summary>
         /// <param name="targetIdentity"></param>
-        /// <param name="voipHeaders"></param>
-        public CallInvite(MicrosoftTeamsUserIdentifier targetIdentity, IDictionary<string, string> voipHeaders = null)
+        public CallInvite(MicrosoftTeamsUserIdentifier targetIdentity)
         {
             Target = targetIdentity;
-            VoipHeaders = voipHeaders == null ? new Dictionary<string, string>() : voipHeaders;
+            CustomContext = new CustomContext(sipHeaders: null, voipHeaders: new Dictionary<string, string>());
         }
 
         /// <summary>
@@ -57,16 +55,15 @@ namespace Azure.Communication.CallAutomation
         /// <value></value>
         public PhoneNumberIdentifier SourceCallerIdNumber { get; }
 
-        /// <summary> Dictionary of VOIP headers. </summary>
-        public IDictionary<string, string> VoipHeaders { get; }
-
-        /// <summary> Dictionary of SIP headers. </summary>
-        public IDictionary<string, string> SipHeaders { get; }
-
         /// <summary>
         /// The display name to appear on target callee.
         /// </summary>
         /// <value></value>
         public string SourceDisplayName { get; set; }
+
+        /// <summary>
+        /// The Custom Context which contains SIP and voip headers
+        /// </summary>
+        public CustomContext CustomContext { get; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CallInvite.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CallInvite.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Azure.Communication.CallAutomation.Models;
 
 namespace Azure.Communication.CallAutomation
 {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateGroupCallOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateGroupCallOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Communication.CallAutomation.Models;
 
 namespace Azure.Communication.CallAutomation
 {
@@ -57,13 +58,8 @@ namespace Azure.Communication.CallAutomation
         public Uri AzureCognitiveServicesEndpointUrl { get; set; }
 
         /// <summary>
-        /// Custom Context for PSTN targets.
+        /// The Custom Context which contains SIP and voip headers
         /// </summary>
-        public IDictionary<string, string> SipHeaders { get; set; }
-
-        /// <summary>
-        /// Custom Context for Voip targets.
-        /// </summary>
-        public IDictionary<string, string> VoipHeaders { get; set; }
+        public CustomContext CustomContext { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateGroupCallOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateGroupCallOptions.cs
@@ -19,6 +19,7 @@ namespace Azure.Communication.CallAutomation
         {
             Targets = targets;
             CallbackUri = callbackUri;
+            CustomContext = new CustomContext(sipHeaders: new Dictionary<string, string>(), voipHeaders: new Dictionary<string, string>());
         }
 
         /// <summary>

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateGroupCallOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CreateGroupCallOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Azure.Communication.CallAutomation.Models;
 
 namespace Azure.Communication.CallAutomation
 {
@@ -59,8 +58,8 @@ namespace Azure.Communication.CallAutomation
         public Uri AzureCognitiveServicesEndpointUrl { get; set; }
 
         /// <summary>
-        /// The Custom Context which contains SIP and voip headers
+        /// The Custom Context which contains SIP and voip headers.
         /// </summary>
-        public CustomContext CustomContext { get; set; }
+        public CustomContext CustomContext { get; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContext.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContext.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Communication.CallAutomation.Models
+{
+    /// <summary>
+    /// CustomContext details.
+    /// </summary>
+    public class CustomContext
+    {
+        /// <summary> Dictionary of VOIP headers. </summary>
+        public IDictionary<string, string> VoipHeaders { get; }
+
+        /// <summary> Dictionary of SIP headers. </summary>
+        public IDictionary<string, string> SipHeaders { get; }
+
+        /// <summary>
+        /// Creates a new CustomContext.
+        /// </summary>
+        public CustomContext(IDictionary<string, string> sipHeaders, IDictionary<string, string> voipHeaders)
+        {
+            SipHeaders = sipHeaders;
+            VoipHeaders = voipHeaders;
+        }
+
+        /// <summary>
+        /// Add a custom context sip or voip header.
+        /// </summary>
+        /// <param name="header">custom context sip UUI, custom header or voip header.</param>
+        public void Add(CustomContextHeader header)
+        {
+            if (header is SIPUUIHeader sipUUIHeader)
+            {
+                if (SipHeaders == null)
+                {
+                    throw new InvalidOperationException("Cannot add sip header, SipHeaders is null.");
+                }
+                SipHeaders.Add(sipUUIHeader.Key, sipUUIHeader.Value);
+            }
+            else if (header is SIPCustomHeader sipCustomHeader)
+            {
+                if (SipHeaders == null)
+                {
+                    throw new InvalidOperationException("Cannot add sip header, SipHeaders is null.");
+                }
+                SipHeaders.Add(sipCustomHeader.Key, sipCustomHeader.Value);
+            }
+            else if (header is VoipHeader voipHeader)
+            {
+                if (VoipHeaders == null)
+                {
+                    throw new InvalidOperationException("Cannot add voip header, VoipHeaders is null");
+                }
+                VoipHeaders.Add(voipHeader.Key, voipHeader.Value);
+            }
+            else
+            {
+                throw new InvalidOperationException("Unknown custom context header type.");
+            }
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContext.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContext.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Azure.Communication.CallAutomation.Models
+namespace Azure.Communication.CallAutomation
 {
     /// <summary>
     /// CustomContext details.
@@ -20,7 +20,7 @@ namespace Azure.Communication.CallAutomation.Models
         /// <summary>
         /// Creates a new CustomContext.
         /// </summary>
-        public CustomContext(IDictionary<string, string> sipHeaders, IDictionary<string, string> voipHeaders)
+        internal CustomContext(IDictionary<string, string> sipHeaders, IDictionary<string, string> voipHeaders)
         {
             SipHeaders = sipHeaders;
             VoipHeaders = voipHeaders;

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContextHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContextHeader.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Communication.CallAutomation.Models
+{
+    /// <summary>
+    /// The base class of CustomContext SipHeader and VoipHeader.
+    /// </summary>
+    public abstract class CustomContextHeader
+    {
+        /// <summary>
+        /// The CustomContext Key name.
+        /// </summary>
+        public string Key { get; }
+
+        /// <summary>
+        /// The CustomContext Key value.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Creates a new CustomContextHeader
+        /// </summary>
+        protected CustomContextHeader(string key, string value)
+        {
+            Key = key;
+            Value = value;
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContextHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CustomContextHeader.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Communication.CallAutomation.Models
+namespace Azure.Communication.CallAutomation
 {
     /// <summary>
     /// The base class of CustomContext SipHeader and VoipHeader.

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPCustomHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPCustomHeader.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Communication.CallAutomation.Models
+namespace Azure.Communication.CallAutomation
 {
     /// <summary>
     /// Custom Context Sip header.

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPCustomHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPCustomHeader.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Communication.CallAutomation.Models
+{
+    /// <summary>
+    /// Custom Context Sip header.
+    /// </summary>
+    public class SIPCustomHeader : CustomContextHeader
+    {
+        /// <summary>
+        /// Create a new Sip header.
+        /// </summary>
+        /// <param name="key">sip header key name.</param>
+        /// <param name="value">sip header value.</param>
+        public SIPCustomHeader(string key, string value) : base("X-MS-Custom-"+key, value)
+        {
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPUUIHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPUUIHeader.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Communication.CallAutomation.Models
+{
+    /// <summary>
+    /// Custom Context User-to-User Sip header.
+    /// </summary>
+    public class SIPUUIHeader : CustomContextHeader
+    {
+        /// <summary>
+        /// Create a new Sip UUI header.
+        /// </summary>
+        /// <param name="value">CustomContext Sip UUI value.</param>
+        public SIPUUIHeader(string value) : base("User-to-User", value)
+        {
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPUUIHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/SIPUUIHeader.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Communication.CallAutomation.Models
+namespace Azure.Communication.CallAutomation
 {
     /// <summary>
     /// Custom Context User-to-User Sip header.

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/TransferToParticipantOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/TransferToParticipantOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Azure.Communication.CallAutomation.Models;
 
 namespace Azure.Communication.CallAutomation
 {

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/TransferToParticipantOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/TransferToParticipantOptions.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
+using Azure.Communication.CallAutomation.Models;
 
 namespace Azure.Communication.CallAutomation
 {
@@ -15,33 +15,30 @@ namespace Azure.Communication.CallAutomation
         /// Creates a new TransferToParticipantOptions object.
         /// </summary>
         /// <param name="targetPhoneNumberIdentity"> The target to transfer the call to. </param>
-        /// <param name="sipHeaders"> Custom Context Sip headers. </param>
-        public TransferToParticipantOptions(PhoneNumberIdentifier targetPhoneNumberIdentity, IDictionary<string, string> sipHeaders = null)
+        public TransferToParticipantOptions(PhoneNumberIdentifier targetPhoneNumberIdentity)
         {
             Target = targetPhoneNumberIdentity;
-            SipHeaders = sipHeaders == null ? new Dictionary<string, string>() : sipHeaders;
+            CustomContext = new CustomContext(sipHeaders: new Dictionary<string, string>(), null);
         }
 
         /// <summary>
         /// Creates a new TransferToParticipantOptions object.
         /// </summary>
         /// <param name="targetIdentity"> The target to transfer the call to. </param>
-        /// <param name="voipHeaders"> Custom Context Voip headers. </param>
-        public TransferToParticipantOptions(CommunicationUserIdentifier targetIdentity, IDictionary<string, string> voipHeaders = null)
+        public TransferToParticipantOptions(CommunicationUserIdentifier targetIdentity)
         {
             Target = targetIdentity;
-            VoipHeaders = voipHeaders == null ? new Dictionary<string, string>() : voipHeaders;
+            CustomContext = new CustomContext(sipHeaders: null, voipHeaders: new Dictionary<string, string>());
         }
 
         /// <summary>
         /// Creates a new TransferToParticipantOptions object.
         /// </summary>
         /// <param name="targetIdentity"> The target to transfer the call to. </param>
-        /// <param name="voipHeaders"> Custom Context Voip headers. </param>
-        public TransferToParticipantOptions(MicrosoftTeamsUserIdentifier targetIdentity, IDictionary<string, string> voipHeaders = null)
+        public TransferToParticipantOptions(MicrosoftTeamsUserIdentifier targetIdentity)
         {
             Target = targetIdentity;
-            VoipHeaders = voipHeaders == null ? new Dictionary<string, string>() : voipHeaders;
+            CustomContext = new CustomContext(sipHeaders: null, voipHeaders: new Dictionary<string, string>());
         }
 
         /// <summary>
@@ -50,15 +47,14 @@ namespace Azure.Communication.CallAutomation
         /// <value></value>
         public CommunicationIdentifier Target { get; }
 
-        /// <summary> Dictionary of VOIP headers. </summary>
-        public IDictionary<string, string> VoipHeaders { get; }
-
-        /// <summary> Dictionary of SIP headers. </summary>
-        public IDictionary<string, string> SipHeaders { get; }
-
         /// <summary>
         /// The operationContext for this transfer call.
         /// </summary>
         public string OperationContext { get; set; }
+
+        /// <summary>
+        /// The Custom Context which contains SIP and voip headers
+        /// </summary>
+        public CustomContext CustomContext { get; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/VoipHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/VoipHeader.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Communication.CallAutomation.Models
+namespace Azure.Communication.CallAutomation
 {
     /// <summary>
     /// Custom Context Voip header.

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/VoipHeader.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/VoipHeader.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Communication.CallAutomation.Models
+{
+    /// <summary>
+    /// Custom Context Voip header.
+    /// </summary>
+    public class VoipHeader : CustomContextHeader
+    {
+        /// <summary>
+        /// Create a new voip header.
+        /// </summary>
+        /// <param name="key">voip header key name.</param>
+        /// <param name="value">voip header value.</param>
+        public VoipHeader(string key, string value) : base(key, value)
+        {
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Azure.Communication.CallAutomation.Models;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using System;
 
@@ -561,12 +562,13 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
         private static IEnumerable<object?[]> TestData_TransferCallToParticipant()
         {
+            var callInvite = new CallInvite(new CommunicationUserIdentifier("userId"));
+            callInvite.CustomContext.Add(new VoipHeader("key1", "value1"));
             return new[]
             {
                 new object?[]
                 {
-                    new CallInvite(new CommunicationUserIdentifier("userId")){
-                        VoipHeaders = {{ "key1", "value1" }}}
+                    callInvite
                 },
             };
         }


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

#customers' feedback:
1.	SIP UUI format: The format used by ACS (userToUser) is not aligned to  RFC format.  Developers being more familiar with the latter, I recommend we align to RFC format (User-to-User) in SDK as well as EG payload, just we like we do for custom headers.   

2.	In line with No.1, it might be a better experience to manage the strict header key format at SDK layer, so that every developer doesnt have to remember to set the correct format in the request. 
eg. Instead of callInvite.SipHeaders.Add("userToUser", "616d617a6f6e5f6368696;encoding=hex");
we do callInvite.SipHeaders.AddUserToUser("616d617a6f6e5f6368696;encoding=hex");

eg. Instead of callInvite.SipHeaders.Add("X-MS-Custom-<suffix>", "434erdr454tf"),
we do callInvite.SipHeaders.AddCustomHeader("<suffix>", "434erdr454tf");

#Design:
1.1.1	PSTN target
```
CallInvite callInvite = new CallInvite(new PhoneNumberIdentifier(targetParticipant), callerIdNumber);
callInvite.CustomContext.Add(new SIPUUIHeader(“jason”));
callInvite.CustomContext.Add(new SIPCustomHeader("Frank", "Rizzo")); // SDK will add prefix "X-MS-Custom-"
```
Then SDK will send this payload to PMA:
```
customContext: {        
        "sipHeaders":
        {
                "User-to-User": "jason",
                "X-MS-Custom-Frank": "Rizzo"
        }
}
```

1.1.2	VoiP Target
```
CallInvite callInvite = new CallInvite(new CommunicationUserIdentifier(targetParticipant))
callInvite.CustomContext.Add(new VoipHeader("Foo-1", "Bar")); //no prefix
```
	
Then SDK will send below payload to PMA:
```
customContext: {        
        "voipHeaders":
        {
                "Foo-1": "Bar"
        }
}
```


