### PR TITLE
[ACS JobRouter] Update autorest to point to new swagger specs

### DIFF
--- a/sdk/communication/Azure.Communication.JobRouter/api/Azure.Communication.JobRouter.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/api/Azure.Communication.JobRouter.netstandard2.0.cs
@@ -635,11 +635,6 @@ namespace Azure.Communication.JobRouter
         public string AssignmentId { get { throw null; } }
         public string JobId { get { throw null; } }
     }
-    public partial class UnassignJobRequest
-    {
-        public UnassignJobRequest() { }
-        public bool? SuspendMatching { get { throw null; } set { } }
-    }
     public partial class UpdateClassificationPolicyOptions
     {
         public UpdateClassificationPolicyOptions(string classificationPolicyId) { }

--- a/sdk/communication/Azure.Communication.JobRouter/src/Generated/Models/UnassignJobRequest.Serialization.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Generated/Models/UnassignJobRequest.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.Communication.JobRouter
 {
-    public partial class UnassignJobRequest : IUtf8JsonSerializable
+    internal partial class UnassignJobRequest : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/sdk/communication/Azure.Communication.JobRouter/src/Generated/Models/UnassignJobRequest.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Generated/Models/UnassignJobRequest.cs
@@ -8,7 +8,7 @@
 namespace Azure.Communication.JobRouter
 {
     /// <summary> Request payload for unassigning a job. </summary>
-    public partial class UnassignJobRequest
+    internal partial class UnassignJobRequest
     {
         /// <summary> Initializes a new instance of UnassignJobRequest. </summary>
         public UnassignJobRequest()

--- a/sdk/communication/Azure.Communication.JobRouter/src/Models/UnassignJobRequest.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Models/UnassignJobRequest.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.Communication.JobRouter
+{
+    [CodeGenModel("UnassignJobRequest")]
+    internal partial class UnassignJobRequest
+    {
+    }
+}

--- a/sdk/communication/Azure.Communication.JobRouter/src/autorest.md
+++ b/sdk/communication/Azure.Communication.JobRouter/src/autorest.md
@@ -15,7 +15,7 @@ If any of the new objects needs to be overwritten, add the required changes to t
 tag: package-jobrouter-2022-07-18-preview
 model-namespace: false
 require:
-    -  https://raw.githubusercontent.com/williamzhao87/azure-rest-api-specs/c6b35542072b325bfc07c32f5fc05fb5da6891bd/specification/communication/data-plane/JobRouter/readme.md
+    -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/29159d148372f5f61cb04b76fc87252b13c62515/specification/communication/data-plane/JobRouter/readme.md
 
 generation1-convenience-client: true
 reflect-api-versions: true


### PR DESCRIPTION
- make UnassignJobRequest internal

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
