### PR TITLE
[Event Hubs] Upgrade management package

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/tests/Azure.Messaging.EventHubs.Experimental.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/tests/Azure.Messaging.EventHubs.Experimental.Tests.csproj
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/perf/Azure.Messaging.EventHubs.Processor.Perf.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/perf/Azure.Messaging.EventHubs.Processor.Perf.csproj
@@ -18,7 +18,6 @@
    <ItemGroup>
      <PackageReference Include="Azure.ResourceManager.EventHubs" />
      <PackageReference Include="CommandLineParser" />
-     <PackageReference Include="Polly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/perf/Azure.Messaging.EventHubs.Processor.Perf.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/perf/Azure.Messaging.EventHubs.Processor.Perf.csproj
@@ -16,12 +16,9 @@
   </ItemGroup>
 
    <ItemGroup>
-    <PackageReference Include="CommandLineParser" />
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
-    <PackageReference Include="Polly" />
+     <PackageReference Include="Azure.ResourceManager.EventHubs" />
+     <PackageReference Include="CommandLineParser" />
+     <PackageReference Include="Polly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
@@ -8,14 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Polly" />
     <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -7,10 +7,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Consumer;
-using Microsoft.Azure.Management.EventHub;
-using Microsoft.Azure.Management.EventHub.Models;
-using Microsoft.Azure.Management.ResourceManager;
-using Microsoft.Rest;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -25,9 +21,6 @@ namespace Azure.Messaging.EventHubs.Tests
     {
         /// <summary>The manager for common live test resource operations.</summary>
         private static readonly LiveResourceManager ResourceManager = new LiveResourceManager();
-
-        /// <summary>The location of the Azure Resource Manager for the active cloud environment.</summary>
-        private static readonly Uri AzureResourceManagerUri = new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl);
 
         /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
         private volatile bool _disposed = false;
@@ -56,6 +49,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Initializes a new instance of the <see cref="EventHubScope"/> class.
         /// </summary>
         ///
+        /// <param name="eventHubResourceId">The ARM resource identifier of the Event Hub that was created.</param>
         /// <param name="eventHubHame">The name of the Event Hub that was created.</param>
         /// <param name="consumerGroups">The set of consumer groups associated with the Event Hub; the default consumer group is not included, as it is implicitly created.</param>
         /// <param name="shouldRemoveEventHubAtScopeCompletion">Indicates whether the Event Hub should be removed when the current scope is completed.</param>
@@ -86,14 +80,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 return;
             }
 
-            var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
-            var eventHubNamespace = EventHubsTestEnvironment.Instance.EventHubsNamespace;
-            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
-            var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
-
             try
             {
-                await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.EventHubs.DeleteAsync(resourceGroup, eventHubNamespace, EventHubName)).ConfigureAwait(false);
+                await ResourceManager.DeleteEventHubAsync(EventHubName).ConfigureAwait(false);
             }
             catch
             {
@@ -103,10 +92,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 //
                 // If an Event Hub fails to be deleted, removing of the associated namespace at the end of the
                 // test run will also remove the orphan.
-            }
-            finally
-            {
-                client?.Dispose();
             }
 
             _disposed = true;
@@ -135,25 +120,6 @@ namespace Azure.Messaging.EventHubs.Tests
         public static Task<EventHubScope> CreateAsync(int partitionCount,
                                                       IEnumerable<string> consumerGroups,
                                                       [CallerMemberName] string caller = "") => BuildScope(partitionCount, consumerGroups, caller);
-
-        /// <summary>
-        ///   Performs the tasks needed to remove an ephemeral Event Hubs namespace used as a container for Event Hub instances
-        ///   for a specific test run.
-        /// </summary>
-        ///
-        /// <param name="namespaceName">The name of the namespace to delete.</param>
-        ///
-        public static async Task DeleteNamespaceAsync(string namespaceName)
-        {
-            var subscription = EventHubsTestEnvironment.Instance.SubscriptionId;
-            var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
-            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
-
-            using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = subscription })
-            {
-                await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName)).ConfigureAwait(false);
-            }
-        }
 
         /// <summary>
         ///   Builds a new scope based on the Event Hub that is named using <see cref="EventHubsTestEnvironment.Instance.EventHubName" />, if specified.  If not,
@@ -189,22 +155,11 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns>The <see cref="EventHubScope" /> that will be used in a given test run.</returns>
         ///
-        private static async Task<EventHubScope> BuildScopeFromExistingEventHub()
-        {
-            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
-
-            using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
-            {
-                var consumerGroups = client.ConsumerGroups.ListByEventHub
-                (
-                    EventHubsTestEnvironment.Instance.ResourceGroup,
-                    EventHubsTestEnvironment.Instance.EventHubsNamespace,
-                    EventHubsTestEnvironment.Instance.EventHubNameOverride
-                 );
-
-                return new EventHubScope(EventHubsTestEnvironment.Instance.EventHubNameOverride, consumerGroups.Select(c => c.Name).ToList(), shouldRemoveEventHubAtScopeCompletion: false);
-            }
-        }
+        private static Task<EventHubScope> BuildScopeFromExistingEventHub() => Task.FromResult(
+            new EventHubScope(
+                EventHubsTestEnvironment.Instance.EventHubNameOverride,
+                ResourceManager.QueryEventHubConsumerGroupNames(EventHubsTestEnvironment.Instance.EventHubNameOverride),
+                shouldRemoveEventHubAtScopeCompletion: false));
 
         /// <summary>
         ///   Performs the tasks needed to create a new Event Hub instance with the requested
@@ -221,34 +176,29 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                            IEnumerable<string> consumerGroups,
                                                                            [CallerMemberName] string caller = "")
         {
+            // Use the name of the test along with some randomization as the name of the ephemeral Event Hub.  This
+            // allows us to identify which test is associated with it, while preventing test run failures when cleanup
+            // fails.
+
             caller = (caller.Length < 16) ? caller : caller.Substring(0, 15);
 
-            var groups = (consumerGroups ?? Enumerable.Empty<string>()).ToList();
-            var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
-            var eventHubNamespace = EventHubsTestEnvironment.Instance.EventHubsNamespace;
-            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
+            var eventHubName = $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
+            var groups = consumerGroups?.ToList() ?? new List<string>();
+            var eventHub = await ResourceManager.CreateEventHubAsync(eventHubName, partitionCount, groups).ConfigureAwait(false);
 
-            string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
+            // There is a race condition in which ARM has created the new Event Hub but it is not yet visible to the Event Hubs
+            // service.  Introduce a short delay to allow for the service to get access to the new resource.
 
-            using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
-            {
-                var eventHub = new Eventhub(partitionCount: partitionCount);
-                eventHub = await ResourceManager.CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub)).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-                var consumerPolicy = ResourceManager.CreateRetryPolicy<ConsumerGroup>();
+            // The default consumer group is always present; include it as part of the scope.
 
-                await Task.WhenAll
-                (
-                    consumerGroups.Select(groupName =>
-                    {
-                        var group = new ConsumerGroup(name: groupName);
-                        return consumerPolicy.ExecuteAsync(() => client.ConsumerGroups.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, eventHub.Name, groupName, group));
-                    })
-                ).ConfigureAwait(false);
+            groups.Insert(0, EventHubConsumerClient.DefaultConsumerGroupName);
 
-                groups.Insert(0, EventHubConsumerClient.DefaultConsumerGroupName);
-                return new EventHubScope(eventHub.Name, groups, shouldRemoveEventHubAtScopeCompletion: true);
-            }
+            return new EventHubScope(
+                eventHubName,
+                groups,
+                shouldRemoveEventHubAtScopeCompletion: true);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -49,7 +49,6 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Initializes a new instance of the <see cref="EventHubScope"/> class.
         /// </summary>
         ///
-        /// <param name="eventHubResourceId">The ARM resource identifier of the Event Hub that was created.</param>
         /// <param name="eventHubHame">The name of the Event Hub that was created.</param>
         /// <param name="consumerGroups">The set of consumer groups associated with the Event Hub; the default consumer group is not included, as it is implicitly created.</param>
         /// <param name="shouldRemoveEventHubAtScopeCompletion">Indicates whether the Event Hub should be removed when the current scope is completed.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 
 namespace Azure.Messaging.EventHubs.Tests

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     EventHubsTestEnvironment.Instance.ResourceGroup,
                     EventHubsTestEnvironment.Instance.EventHubsNamespace));
 
-            var eventHubConfig = new EventHubData { PartitionCount = partitionCount, MessageRetentionInDays = 1 };
+            var eventHubConfig = new EventHubData { PartitionCount = partitionCount };
             var eventHub = await ehNamespace.GetEventHubs().CreateOrUpdateAsync(WaitUntil.Completed, eventHubName, eventHubConfig).ConfigureAwait(false);
 
             var groups = consumerGroups ?? new List<string>();

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -1,23 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Ignore Spelling: Retriable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
-using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Management.EventHub;
-using Microsoft.Azure.Management.EventHub.Models;
-using Microsoft.Azure.Management.ResourceManager;
-using Microsoft.Azure.Management.ResourceManager.Models;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using Microsoft.Rest;
-using Microsoft.Rest.Azure;
-using Polly;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.ResourceManager;
+using Azure.ResourceManager.EventHubs;
+using Azure.ResourceManager.Resources;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -30,241 +30,281 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <summary>The maximum number of attempts to retry a management operation.</summary>
         public const int RetryMaximumAttempts = 20;
 
-        /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
-        private const double RetryExponentialBackoffSeconds = 3.0;
+        /// <summary>The length of time to use as the basis for backing off on retry attempts.</summary>
+        private readonly TimeSpan RetryExponentialBackoff = TimeSpan.FromSeconds(3);
 
-        /// <summary>The number of seconds to use as the basis for applying jitter to retry back-off calculations.</summary>
-        private const double RetryBaseJitterSeconds = 60.0;
-
-        /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
-        private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);
-
-        /// <summary>The random number generator to use for each requesting thread.</summary>
-        private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
-
-        /// <summary>The seed to use for random number generation.</summary>
-        private static int s_randomSeed = Environment.TickCount;
-
-        /// <summary>The token credential to be used with the Event Hubs management client.</summary>
-        private static ManagementToken s_managementToken;
+        /// <summary>The maximum length of time allow for backing off on retry attempts.</summary>
+        private readonly TimeSpan RetryMaximumBackoff = TimeSpan.FromMinutes(20);
 
         /// <summary>
-        ///   Queries the location for the requested Azure Resource Group.
+        ///   The <see cref="ArmClient" /> instance to use for management operations.
         /// </summary>
         ///
-        /// <param name="accessToken">The access token to use for the query request.</param>
-        /// <param name="resourceGroupName">The name of the resource group to query the location of.</param>
-        /// <param name="subscriptionId">The identifier of the Azure subscription in which the resource group resides.</param>
+        public ArmClient ArmClient { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="LiveResourceManager"/> class.
+        /// </summary>
         ///
-        /// <returns>The location code for the requested <paramref name="resourceGroupName"/>.</returns>
-        ///
-        public async Task<string> QueryResourceGroupLocationAsync(string accessToken,
-                                                                  string resourceGroupName,
-                                                                  string subscriptionId)
+        public LiveResourceManager()
         {
-            using (var client = new ResourceManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl), new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
+            var options = new ArmClientOptions
             {
-                ResourceGroup resourceGroup = await CreateRetryPolicy<ResourceGroup>().ExecuteAsync(() => client.ResourceGroups.GetAsync(resourceGroupName)).ConfigureAwait(false);
-                return resourceGroup.Location;
-            }
-        }
+                Environment = new ArmEnvironment(
+                    new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl),
+                    EventHubsTestEnvironment.Instance.ServiceManagementUrl),
 
-        /// <summary>
-        ///   Acquires a JWT token for use with the Event Hubs management client.
-        /// </summary>
-        ///
-        /// <returns>The token to use for management operations against the Event Hubs Live test namespace.</returns>
-        ///
-        public async Task<string> AcquireManagementTokenAsync()
-        {
-            var token = s_managementToken;
-            var authority = new Uri(new Uri(EventHubsTestEnvironment.Instance.AuthorityHostUrl), EventHubsTestEnvironment.Instance.TenantId).ToString();
-
-            // If there was no current token, or it is within the buffer for expiration, request a new token.
-            // There is a benign race condition here, where there may be multiple requests in-flight for a new token.  Since
-            // this is test infrastructure, just allow the acquired token to replace the current one without attempting to
-            // coordinate or ensure that the most recent is kept.
-
-            if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
-            {
-                var context = new AuthenticationContext(authority);
-                var credential = new ClientCredential(EventHubsTestEnvironment.Instance.ClientId, EventHubsTestEnvironment.Instance.ClientSecret);
-                var result = await context.AcquireTokenAsync(EventHubsTestEnvironment.Instance.ServiceManagementUrl, credential).ConfigureAwait(false);
-
-                if ((string.IsNullOrEmpty(result?.AccessToken)))
-                {
-                    throw new AuthenticationException("Unable to acquire an Active Directory token for the Event Hubs management client.");
-                }
-
-                token = new ManagementToken(result.AccessToken, result.ExpiresOn);
-                Interlocked.Exchange(ref s_managementToken, token);
-            }
-
-            return token.Token;
-        }
-
-        /// <summary>
-        ///   Generates the set of common metadata tags to apply to an ephemeral cloud resource
-        ///   used for test purposes.
-        /// </summary>
-        ///
-        /// <returns>The set of metadata tags to apply.</returns>
-        ///
-        public Dictionary<string, string> GenerateTags() =>
-            new Dictionary<string, string>
-            {
-                { "source", typeof(LiveResourceManager).Assembly.GetName().Name },
-                { "platform", System.Runtime.InteropServices.RuntimeInformation.OSDescription },
-                { "framework", System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription },
-                { "created", $"{ DateTimeOffset.UtcNow.ToString("s") }Z" },
-                { "cleanup-after", $"{ DateTimeOffset.UtcNow.AddDays(1).ToString("s") }Z" }
+                RetryPolicy = new EventHubsManagementRetryPolicy(
+                    RetryMaximumAttempts,
+                    DelayStrategy.CreateExponentialDelayStrategy(RetryExponentialBackoff, RetryMaximumBackoff))
             };
 
-        /// <summary>
-        ///   Creates the retry policy to apply to a management operation.
-        /// </summary>
-        ///
-        /// <typeparam name="T">The expected type of response from the management operation.</typeparam>
-        ///
-        /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
-        /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
-        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry back-off calculations.</param>
-        ///
-        /// <returns>The retry policy in which to execute the management operation.</returns>
-        ///
-        public IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttempts,
-                                                    double exponentialBackoffSeconds = RetryExponentialBackoffSeconds,
-                                                    double baseJitterSeconds = RetryBaseJitterSeconds) =>
-           Policy<T>
-               .Handle<Exception>(ex => ShouldRetry(ex))
-               .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
-
-        /// <summary>
-        ///   Creates the retry policy to apply to a management operation.
-        /// </summary>
-        ///
-        /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
-        /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
-        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry back-off calculations.</param>
-        ///
-        /// <returns>The retry policy in which to execute the management operation.</returns>
-        ///
-        public IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttempts,
-                                              double exponentialBackoffSeconds = RetryExponentialBackoffSeconds,
-                                              double baseJitterSeconds = RetryBaseJitterSeconds) =>
-            Policy
-                .Handle<Exception>(ex => ShouldRetry(ex))
-                .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
-
-        /// <summary>
-        ///   Determines whether the specified HTTP status code is considered eligible to retry
-        ///   the associated operation.
-        /// </summary>
-        ///
-        /// <param name="statusCode">The status code to consider.</param>
-        ///
-        /// <returns><c>true</c> if the status code is eligible for retries; otherwise, <c>false</c>.</returns>
-        ///
-        private static bool IsRetriableStatus(HttpStatusCode statusCode) =>
-            ((statusCode == HttpStatusCode.Unauthorized)
-                || (statusCode == ((HttpStatusCode)408))
-                || (statusCode == HttpStatusCode.Conflict)
-                || (statusCode == ((HttpStatusCode)429))
-                || (statusCode == HttpStatusCode.InternalServerError)
-                || (statusCode == HttpStatusCode.ServiceUnavailable)
-                || (statusCode == HttpStatusCode.GatewayTimeout));
-
-        /// <summary>
-        ///   Determines whether the specified exception is considered eligible to retry the associated
-        ///   operation.
-        /// </summary>
-        ///
-        /// <param name="ex">The exception to consider.</param>
-        ///
-        /// <returns><c>true</c> if the exception is eligible for retries; otherwise, <c>false</c>.</returns>
-        ///
-        private static bool ShouldRetry(Exception ex) =>
-            ((IsRetriableException(ex)) || (IsRetriableException(ex?.InnerException)));
-
-        /// <summary>
-        ///   Determines whether the type of the specified exception is considered eligible to retry
-        ///   the associated operation.
-        /// </summary>
-        ///
-        /// <param name="ex">The exception to consider.</param>
-        ///
-        /// <returns><c>true</c> if the exception type is eligible for retries; otherwise, <c>false</c>.</returns>
-        ///
-        private static bool IsRetriableException(Exception ex)
-        {
-            if (ex == null)
-            {
-                return false;
-            }
-
-            switch (ex)
-            {
-                case ErrorResponseException erEx:
-                    return IsRetriableStatus(erEx.Response.StatusCode);
-
-                case CloudException clEx:
-                    return IsRetriableStatus(clEx.Response.StatusCode);
-
-                case TimeoutException _:
-                case TaskCanceledException _:
-                case OperationCanceledException _:
-                case HttpRequestException _:
-                case WebException _:
-                case SocketException _:
-                case IOException _:
-                    return true;
-
-                default:
-                    return false;
-            };
+            ArmClient = new ArmClient(
+                EventHubsTestEnvironment.Instance.Credential,
+                EventHubsTestEnvironment.Instance.SubscriptionId,
+                options);
         }
 
         /// <summary>
-        ///   Calculates the retry delay to use for management-related operations.
+        ///   Gets the identifier for an existing Event Hub under the active namespace used for the test run.
         /// </summary>
         ///
-        /// <param name="attempt">The current attempt number.</param>
-        /// <param name="exponentialBackoffSeconds">The exponential back-off amount,, in seconds.</param>
-        /// <param name="baseJitterSeconds">The amount of base jitter to include, in seconds.</param>
+        /// <param name="eventHubName">The name of the Event Hub.</param>
         ///
-        /// <returns>The interval to wait before retrying the attempted operation.</returns>
+        /// <returns>The resource identifier of the Event Hub.</returns>
         ///
-        private static TimeSpan CalculateRetryDelay(int attempt,
-                                                    double exponentialBackoffSeconds,
-                                                    double baseJitterSeconds) =>
-            TimeSpan.FromSeconds((Math.Pow(2, attempt) * exponentialBackoffSeconds) + (RandomNumberGenerator.Value.NextDouble() * baseJitterSeconds));
+        public ResourceIdentifier GetEventHubResourceIdentifier(string eventHubName) =>
+            EventHubResource.CreateResourceIdentifier(
+                EventHubsTestEnvironment.Instance.SubscriptionId,
+                EventHubsTestEnvironment.Instance.ResourceGroup,
+                EventHubsTestEnvironment.Instance.EventHubsNamespace,
+                eventHubName);
 
         /// <summary>
-        ///   An internal type for tracking the management access token and
-        ///   its associated expiration.
+        ///   Queries the consumer groups for an Event Hub under the active namespace used for the test run.
         /// </summary>
         ///
-        private class ManagementToken
-        {
-            /// <summary>The value bearer token to use for authorization.</summary>
-            public readonly string Token;
+        /// <param name="eventHubName">The name of the Event Hub to query.</param>
+        ///
+        /// <returns>A list containing the names of the consumer groups belonging to the Event Hub.</returns>
+        ///
+        public List<string> QueryEventHubConsumerGroupNames(string eventHubName) =>
+            ArmClient
+                .GetEventHubResource(GetEventHubResourceIdentifier(eventHubName))
+                .GetEventHubsConsumerGroups()
+                .Select(c => c.Data.Name)
+                .ToList();
 
-            /// <summary>The date and time, in UTC, that the token expires.</summary>
-            public readonly DateTimeOffset ExpiresOn;
+        /// <summary>
+        ///   Creates a new Event Hub under the active namespace used for the test run.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name to assign the Event Hub.</param>
+        /// <param name="partitionCount">The number of partitions that the Event Hub should have.</param>
+        /// <param name="consumerGroups">The consumer groups to create for the Event Hub.  If not provided, only the default consumer group will exist.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        ///
+        /// <returns>The newly created Event Hub.</returns>
+        ///
+        public async Task<EventHubResource> CreateEventHubAsync(string eventHubName,
+                                                                int partitionCount,
+                                                                IList<string> consumerGroups = default,
+                                                                CancellationToken cancellationToken = default)
+        {
+            var ehNamespace = ArmClient.GetEventHubsNamespaceResource(
+                EventHubsNamespaceResource.CreateResourceIdentifier(
+                    EventHubsTestEnvironment.Instance.SubscriptionId,
+                    EventHubsTestEnvironment.Instance.ResourceGroup,
+                    EventHubsTestEnvironment.Instance.EventHubsNamespace));
+
+            var eventHubConfig = new EventHubData { PartitionCount = partitionCount, MessageRetentionInDays = 1 };
+            var eventHub = await ehNamespace.GetEventHubs().CreateOrUpdateAsync(WaitUntil.Completed, eventHubName, eventHubConfig).ConfigureAwait(false);
+
+            var groups = consumerGroups ?? new List<string>();
+            var consumerGroupCollection = eventHub.Value.GetEventHubsConsumerGroups();
+
+            if ((groups != default) && (groups.Count > 0))
+            {
+                var groupData = new EventHubsConsumerGroupData();
+
+                await Task.WhenAll
+                (
+                    groups.Select(groupName =>
+                    {
+                        return consumerGroupCollection.CreateOrUpdateAsync(WaitUntil.Completed, groupName, groupData);
+                    })
+                ).ConfigureAwait(false);
+            }
+
+            return eventHub.Value;
+        }
+
+        /// <summary>
+        ///   Deletes an Event Hub under the active namespace used for the test run.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub to delete.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        ///
+        public async Task DeleteEventHubAsync(string eventHubName,
+                                              CancellationToken cancellationToken = default) =>
+            await ArmClient.GetEventHubResource(GetEventHubResourceIdentifier(eventHubName)).DeleteAsync(WaitUntil.Completed, cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        ///   A retry policy that extends the common retry scenarios to include
+        ///   additional response types specific to Event Hubs management operations.
+        /// </summary>
+        ///
+        /// <seealso cref="Azure.Core.Pipeline.RetryPolicy" />
+        ///
+        private class EventHubsManagementRetryPolicy : RetryPolicy
+        {
+            /// <summary>The classifier to use when considering retries for management operations.</summary>
+            private static readonly ResponseClassifier Classifier = new EventHubsManagementClassifier();
 
             /// <summary>
-            ///   Initializes a new instance of the <see cref="ManagementToken"/> class.
+            ///   Initializes a new instance of the <see cref="EventHubsManagementRetryPolicy"/> class.
             /// </summary>
             ///
-            /// <param name="token">The value of the bearer token.</param>
-            /// <param name="expiresOn">The date and time, in UTC, that the token expires on.</param>
+            /// <param name="maximumRetryAttempts">The maximum number of retry attempts for a single operation.</param>
+            /// <param name="delayStrategy">The delay strategy.</param>
             ///
-            public ManagementToken(string token,
-                                   DateTimeOffset expiresOn)
+            public EventHubsManagementRetryPolicy(int maximumRetryAttempts, DelayStrategy delayStrategy) : base(maximumRetryAttempts, delayStrategy)
             {
-                Token = token;
-                ExpiresOn = expiresOn;
             }
+
+            /// <summary>
+            ///   Determines whether a retry should be performed for the associated operation.
+            /// </summary>
+            ///
+            /// <param name="message">The <see cref="HttpMessage" /> for the operation.</param>
+            /// <param name="exception">The exception, if any, thrown by the operation.</param>
+            ///
+            /// <returns><c>true</c> if the operation should be retried; otherwise, <c>false</c>.</returns>
+            ///
+            protected override bool ShouldRetry(HttpMessage message, Exception exception)
+            {
+                var originalClassifier = message.ResponseClassifier;
+
+                try
+                {
+                    message.ResponseClassifier = Classifier;
+                    return base.ShouldRetry(message, exception);
+                }
+                finally
+                {
+                    message.ResponseClassifier = originalClassifier;
+                }
+            }
+
+            /// <summary>
+            ///   Determines whether a retry should be performed for the associated operation.
+            /// </summary>
+            ///
+            /// <param name="message">The <see cref="HttpMessage" /> for the operation.</param>
+            /// <param name="exception">The exception, if any, thrown by the operation.</param>
+            ///
+            /// <returns><c>true</c> if the operation should be retried; otherwise, <c>false</c>.</returns>
+            ///
+            protected override ValueTask<bool> ShouldRetryAsync(HttpMessage message, Exception exception)
+            {
+                var originalClassifier = message.ResponseClassifier;
+
+                try
+                {
+                    message.ResponseClassifier = Classifier;
+                    return base.ShouldRetryAsync(message, exception);
+                }
+                finally
+                {
+                    message.ResponseClassifier = originalClassifier;
+                }
+            }
+
+            /// <summary>
+            ///   A custom response classifier that extends the common retry scenarios to include
+            ///   additional response types specific to Event Hubs management operations.
+            /// </summary>
+            ///
+            /// <seealso cref="Azure.Core.ResponseClassifier" />
+            ///
+            private class EventHubsManagementClassifier : ResponseClassifier
+            {
+                /// <summary>
+                ///   Determines whether the specified HTTP message is considered eligible to retry for
+                ///   the associated operation.
+                /// </summary>
+                ///
+                /// <param name="message">The <see cref="HttpMessage" /> to consider.</param>
+                ///
+                /// <returns><c>true</c> if the message is eligible for retries; otherwise, <c>false</c>.</returns>
+                ///
+                public override bool IsRetriableResponse(HttpMessage message)
+                {
+                    if (message == null)
+                    {
+                        return false;
+                    }
+
+                    return IsRetriableStatus(message.Response.Status);
+                }
+
+                /// <summary>
+                ///   Determines whether the type of the specified exception is considered eligible to retry
+                ///   the associated operation.
+                /// </summary>
+                ///
+                /// <param name="exception">The exception to consider.</param>
+                ///
+                /// <returns><c>true</c> if the exception type is eligible for retries; otherwise, <c>false</c>.</returns>
+                ///
+                public override bool IsRetriableException(Exception exception)
+                {
+                    if (exception == null)
+                    {
+                        return false;
+                    }
+
+                    switch (exception)
+                    {
+                        case RequestFailedException erEx:
+                            return IsRetriableStatus(erEx.Status);
+
+                        case TimeoutException _:
+                        case TaskCanceledException _:
+                        case OperationCanceledException _:
+                        case HttpRequestException _:
+                        case WebException _:
+                        case SocketException _:
+                        case IOException _:
+                            return true;
+
+                        default:
+                            return false;
+                    };
+                }
+
+                /// <summary>
+                ///   Determines whether the specified HTTP status code is considered eligible to retry for
+                ///   the associated operation.
+                /// </summary>
+                ///
+                /// <param name="message">The status code to consider.</param>
+                ///
+                /// <returns><c>true</c> if the message is eligible for retries; otherwise, <c>false</c>.</returns>
+                ///
+                private bool IsRetriableStatus(int statusCode) => statusCode switch
+                {
+                   (int)HttpStatusCode.Unauthorized => true,
+                   (int)HttpStatusCode.Conflict => true,
+                   (int)HttpStatusCode.InternalServerError => true,
+                   (int)HttpStatusCode.ServiceUnavailable => true,
+                   (int)HttpStatusCode.GatewayTimeout => true,
+                   408 => true,
+                   429 => true,
+                   _ => false
+                };
+        };
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Ignore Spelling: Retriable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -14,10 +12,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Messaging.EventHubs.Consumer;
 using Azure.ResourceManager;
 using Azure.ResourceManager.EventHubs;
-using Azure.ResourceManager.Resources;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -123,7 +119,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var groups = consumerGroups ?? new List<string>();
             var consumerGroupCollection = eventHub.Value.GetEventHubsConsumerGroups();
 
-            if ((groups != default) && (groups.Count > 0))
+            if (groups?.Count > 0)
             {
                 var groupData = new EventHubsConsumerGroupData();
 
@@ -184,17 +180,8 @@ namespace Azure.Messaging.EventHubs.Tests
             ///
             protected override bool ShouldRetry(HttpMessage message, Exception exception)
             {
-                var originalClassifier = message.ResponseClassifier;
-
-                try
-                {
-                    message.ResponseClassifier = Classifier;
-                    return base.ShouldRetry(message, exception);
-                }
-                finally
-                {
-                    message.ResponseClassifier = originalClassifier;
-                }
+                message.ResponseClassifier = Classifier;
+                return base.ShouldRetry(message, exception);
             }
 
             /// <summary>
@@ -208,17 +195,8 @@ namespace Azure.Messaging.EventHubs.Tests
             ///
             protected override ValueTask<bool> ShouldRetryAsync(HttpMessage message, Exception exception)
             {
-                var originalClassifier = message.ResponseClassifier;
-
-                try
-                {
-                    message.ResponseClassifier = Classifier;
-                    return base.ShouldRetryAsync(message, exception);
-                }
-                finally
-                {
-                    message.ResponseClassifier = originalClassifier;
-                }
+                message.ResponseClassifier = Classifier;
+                return base.ShouldRetryAsync(message, exception);
             }
 
             /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -14,9 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf.csproj
@@ -17,12 +17,8 @@
 
    <ItemGroup>
     <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
-    <PackageReference Include="Polly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/ReadPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/ReadPerfTest.cs
@@ -58,7 +58,7 @@ namespace Azure.Messaging.EventHubs.Perf
         ///
         public async override Task GlobalSetupAsync()
         {
-            await base.GlobalCleanupAsync().ConfigureAwait(false);
+            await base.GlobalSetupAsync().ConfigureAwait(false);
 
             // The limit for concurrent readers in a consumer group is 5; create
             // enough consumer groups to support the requested parallelism.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -12,16 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="Microsoft.Azure.Amqp" />
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Polly" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="System.ValueTuple" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
@@ -6,14 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Azure.ResourceManager.EventHubs" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" VersionOverride="3.0.27" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
-    <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ScaleHostEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ScaleHostEndToEndTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests
                             ""targetUnprocessedEventThreshold"": 1
                         }
                     }
-                }   
+                }
             }";
 
             // Function1Name uses connection string


### PR DESCRIPTION
# Summary

The focus of these changes is to update the management package used by test infrastructure to manage ephemeral resources for test isolation. The current generation management package has reached GA and the legacy package is now deprecated.

# References and Related

- [Project Azure.Messaging.EventHubs.Perf needs to use track 2 management SDK (#37499)](https://github.com/Azure/azure-sdk-for-net/issues/37499)
- [[Core] RetryPolicy improvements (#37564)](https://github.com/Azure/azure-sdk-for-net/issues/37564)