### PR TITLE
Fix typo 'Comsmos' to 'Cosmos'

### DIFF
--- a/sdk/tables/Azure.Data.Tables/MigrationGuide.md
+++ b/sdk/tables/Azure.Data.Tables/MigrationGuide.md
@@ -63,7 +63,7 @@ var serviceClient = new TableServiceClient(
 
 ### Creating a table
 
-Previously in `Microsoft.Azure.Comsmos.Table`, we'd use a `CloudTable` instance to create a table, which is returned from the `CloudTableClient` method on
+Previously in `Microsoft.Azure.Cosmos.Table`, we'd use a `CloudTable` instance to create a table, which is returned from the `CloudTableClient` method on
 `CloudTableClient`.
 
 ```C#
@@ -155,7 +155,7 @@ var entity = new OfficeSupplyEntity
 };
 ```
 
-Previously in `Microsoft.Azure.Comsmos.Table`, we would create a `TableOperation` and execute it with the table client.
+Previously in `Microsoft.Azure.Cosmos.Table`, we would create a `TableOperation` and execute it with the table client.
 The result of the operation must be casted back to the entity type.
 
 ```c#
@@ -181,7 +181,7 @@ tableClient.UpsertEntity(tableEntity);
 
 Both clients allow for fetching a single entity from the table if the `PartitionKey` and `RowKey` are known.
 
-Previously in `Microsoft.Azure.Comsmos.Table`, we created an operation and then executed it, similar to when we added the item to the cloudTable.
+Previously in `Microsoft.Azure.Cosmos.Table`, we created an operation and then executed it, similar to when we added the item to the cloudTable.
 
 ```c#
 // Create the operation.
@@ -209,7 +209,7 @@ Console.WriteLine($"{marker.PartitionKey}, {marker.RowKey}, {marker.Product}, {m
 
 ### Querying data from the table
 
-Previously in `Microsoft.Azure.Comsmos.Table`, creating an executing a query looked as follows.
+Previously in `Microsoft.Azure.Cosmos.Table`, creating an executing a query looked as follows.
 
 ```c#
 // Create the query.


### PR DESCRIPTION
The namespace `Microsoft.Azure.Cosmos.Table` has been erroneously copied around as `Microsoft.Azure.Comsmos.Table`.

See also PR #26927.
