### PR TITLE
[EventGrid] Moving from ActivityExtensions to System.Diagnostics.DiagnosticSource

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEventRequestContent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEventRequestContent.cs
@@ -61,10 +61,10 @@ namespace Azure.Messaging.EventGrid
                 string currentActivityId = null;
                 string traceState = null;
                 Activity currentActivity = Activity.Current;
-                if (currentActivity != null && currentActivity.IsW3CFormat())
+                if (currentActivity != null && (currentActivity.IdFormat == ActivityIdFormat.W3C))
                 {
                     currentActivityId = currentActivity.Id;
-                    traceState = currentActivity.GetTraceState();
+                    traceState = currentActivity.TraceStateString;
                 }
 
                 foreach (CloudEvent cloudEvent in _cloudEvents)

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/CloudEventTests.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/CloudEventTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Messaging.EventGrid.Tests
 
             // simulating some other activity already being started before doing operations with the client
             var activity = new Activity("ParentEvent");
-            activity.SetW3CFormat();
+            activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.Start();
             activity.TraceStateString = "tracestatevalue";
             List<CloudEvent> eventsList = new List<CloudEvent>();
@@ -135,7 +135,7 @@ namespace Azure.Messaging.EventGrid.Tests
 
             // simulating some other activity already being started before doing operations with the client
             var activity = new Activity("ParentEvent");
-            activity.SetW3CFormat();
+            activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.Start();
 
             CloudEvent cloudEvent = new CloudEvent(
@@ -195,7 +195,7 @@ namespace Azure.Messaging.EventGrid.Tests
 
             // simulating some other activity already being started before doing operations with the client
             var activity = new Activity("ParentEvent");
-            activity.SetW3CFormat();
+            activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.Start();
             activity.TraceStateString = "tracestatevalue";
             List<CloudEvent> eventsList = new List<CloudEvent>();

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/EventGridPublisherClientExtensions.cs
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/EventGridPublisherClientExtensions.cs
@@ -81,10 +81,10 @@ namespace Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents
             string activityId = null;
             string traceState = null;
             Activity currentActivity = Activity.Current;
-            if (currentActivity != null && currentActivity.IsW3CFormat())
+            if (currentActivity != null && (currentActivity.IdFormat == ActivityIdFormat.W3C))
             {
                 activityId = currentActivity.Id;
-                traceState = currentActivity.GetTraceState();
+                traceState = currentActivity.TraceStateString;
             }
 
             using var stream = new MemoryStream();

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/tests/CloudEventTests.cs
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/tests/CloudEventTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.Tests
                    new AzureKeyCredential("fakeKey"),
                    options);
             var activity = new Activity($"{nameof(EventGridPublisherClient)}.{nameof(EventGridPublisherClient.SendEvents)}");
-            activity.SetW3CFormat();
+            activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.Start();
             List<CloudEvent> inputEvents = new List<CloudEvent>();
             for (int i = 0; i < 10; i++)


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/37593

The ActivityExtensions were accessing these API's via reflection, so this doesn't change anything behaviorally.

There is more information in the following issues/PRs:
- https://github.com/Azure/azure-sdk-for-net/issues/33683
- https://github.com/Azure/azure-sdk-for-net/pull/37418

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
