### PR TITLE
[Event Grid] [Event Hubs] [Service Bus] [Storage] Adding ActivitySource and migrating all DiagnosticScope.ActivityKind references

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
@@ -136,7 +136,7 @@ namespace Azure.Core.TestFramework.Tests
                     new DiagnosticListener("Azure.Core"),
                     null,
                     ActivityExtensions.CreateActivitySource("Azure.Core.Http"),
-                    DiagnosticScope.ActivityKind.Client,
+                    ActivityKind.Client,
                     false);
                 coreScope.Start();
             }

--- a/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
+++ b/sdk/core/Azure.Core.TestFramework/tests/ClientTestBaseDiagnosticScopeTests.cs
@@ -135,7 +135,7 @@ namespace Azure.Core.TestFramework.Tests
                     "Azure.Core.Http.Request",
                     new DiagnosticListener("Azure.Core"),
                     null,
-                    ActivityExtensions.CreateActivitySource("Azure.Core.Http"),
+                    new ActivitySource("Azure.Core.Http"),
                     ActivityKind.Client,
                     false);
                 coreScope.Start();

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
@@ -19,7 +19,11 @@ namespace Azure.Core.Pipeline
         private const string RequestIdHeaderName = "Request-Id";
 
         private static readonly DiagnosticListener s_diagnosticSource = new DiagnosticListener("Azure.Core");
+#if NETCOREAPP2_1
         private static readonly object? s_activitySource = ActivityExtensions.CreateActivitySource("Azure.Core.Http");
+#else
+        private static readonly ActivitySource s_activitySource = new ActivitySource("Azure.Core.Http");
+#endif
 
         public RequestActivityPolicy(bool isDistributedTracingEnabled, string? resourceProviderNamespace, HttpMessageSanitizer httpMessageSanitizer)
         {

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
@@ -54,7 +54,11 @@ namespace Azure.Core.Pipeline
 
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
+#if NETCOREAPP2_1
             using var scope = new DiagnosticScope("Azure.Core.Http.Request", s_diagnosticSource, message, s_activitySource, DiagnosticScope.ActivityKind.Client, false);
+#else
+            using var scope = new DiagnosticScope("Azure.Core.Http.Request", s_diagnosticSource, message, s_activitySource, System.Diagnostics.ActivityKind.Client, false);
+#endif
 
             bool isActivitySourceEnabled = IsActivitySourceEnabled;
 

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -27,7 +27,7 @@ namespace Azure.Core.Pipeline
 #if NETCOREAPP2_1
         internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, object? activitySource, ActivityKind kind, bool suppressNestedClientActivities)
 #else
-        internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, object? activitySource, System.Diagnostics.ActivityKind kind, bool suppressNestedClientActivities)
+        internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, ActivitySource? activitySource, System.Diagnostics.ActivityKind kind, bool suppressNestedClientActivities)
 #endif
         {
             // ActivityKind.Internal and Client both can represent public API calls depending on the SDK

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -24,7 +24,11 @@ namespace Azure.Core.Pipeline
         private readonly ActivityAdapter? _activityAdapter;
         private readonly bool _suppressNestedClientActivities;
 
+#if NETCOREAPP2_1
         internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, object? activitySource, ActivityKind kind, bool suppressNestedClientActivities)
+#else
+        internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, object? activitySource, System.Diagnostics.ActivityKind kind, bool suppressNestedClientActivities)
+#endif
         {
             // ActivityKind.Internal and Client both can represent public API calls depending on the SDK
             _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == ActivityKind.Internal) ? suppressNestedClientActivities : false;
@@ -127,6 +131,7 @@ namespace Azure.Core.Pipeline
             _activityAdapter?.MarkFailed(exception);
         }
 
+#if NETCOREAPP2_1
         /// <summary>
         /// Kind describes the relationship between the Activity, its parents, and its children in a Trace.
         /// </summary>
@@ -158,6 +163,7 @@ namespace Azure.Core.Pipeline
             /// </summary>
             Consumer = 4,
         }
+#endif
 
         private class DiagnosticActivity : Activity
         {

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -20,7 +20,11 @@ namespace Azure.Core.Pipeline
         private readonly DiagnosticListener? _source;
         private readonly bool _suppressNestedClientActivities;
 
+#if NETCOREAPP2_1
         private static readonly ConcurrentDictionary<string, object?> ActivitySources = new();
+#else
+        private static readonly ConcurrentDictionary<string, ActivitySource?> ActivitySources = new();
+#endif
 
         public DiagnosticScopeFactory(string clientNamespace, string? resourceProviderNamespace, bool isActivityEnabled, bool suppressNestedClientActivities)
         {
@@ -78,7 +82,11 @@ namespace Azure.Core.Pipeline
         ///     name: BlobClient.DownloadTo
         ///     result Azure.Storage.Blobs.BlobClient
         /// </summary>
+#if NETCOREAPP2_1
         private static object? GetActivitySource(string ns, string name)
+#else
+        private static ActivitySource? GetActivitySource(string ns, string name)
+#endif
         {
             if (!ActivityExtensions.SupportsActivitySource())
             {
@@ -91,7 +99,11 @@ namespace Azure.Core.Pipeline
             {
                 clientName += "." + name.Substring(0, indexOfDot);
             }
+#if NETCOREAPP2_1
             return ActivitySources.GetOrAdd(clientName, static n => ActivityExtensions.CreateActivitySource(n));
+#else
+            return ActivitySources.GetOrAdd(clientName, static n => new ActivitySource(n));
+#endif
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -45,7 +45,11 @@ namespace Azure.Core.Pipeline
 
         public bool IsActivityEnabled { get; }
 
+#if NETCOREAPP2_1
         public DiagnosticScope CreateScope(string name, DiagnosticScope.ActivityKind kind = DiagnosticScope.ActivityKind.Internal)
+#else
+        public DiagnosticScope CreateScope(string name, System.Diagnostics.ActivityKind kind = ActivityKind.Internal)
+#endif
         {
             if (_source == null)
             {

--- a/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
@@ -61,7 +61,7 @@ namespace Azure.Core.Shared
         /// <returns>The created diagnostic scope containing the common set of messaging attributes that are knowable upon creation.</returns>
         public DiagnosticScope CreateScope(
             string activityName,
-            DiagnosticScope.ActivityKind kind,
+            ActivityKind kind,
             MessagingDiagnosticOperation operation = default)
         {
             DiagnosticScope scope = _scopeFactory.CreateScope(activityName, kind);
@@ -167,7 +167,7 @@ namespace Azure.Core.Shared
             {
                 using DiagnosticScope messageScope = CreateScope(
                     activityName,
-                    DiagnosticScope.ActivityKind.Producer);
+                    ActivityKind.Producer);
                 messageScope.Start();
 
                 Activity? activity = Activity.Current;

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -183,21 +183,21 @@ namespace Azure.Core.Tests
             CollectionAssert.DoesNotContain(Activity.Current.Tags, new KeyValuePair<string, string>(DiagnosticScope.OpenTelemetrySchemaAttribute, DiagnosticScope.OpenTelemetrySchemaVersion));
         }
 
-        [TestCase(DiagnosticScope.ActivityKind.Internal, true)]
-        [TestCase(DiagnosticScope.ActivityKind.Server, false)]
-        [TestCase(DiagnosticScope.ActivityKind.Client, true)]
-        [TestCase(DiagnosticScope.ActivityKind.Producer, false)]
-        [TestCase(DiagnosticScope.ActivityKind.Consumer, false)]
+        [TestCase(ActivityKind.Internal, true)]
+        [TestCase(ActivityKind.Server, false)]
+        [TestCase(ActivityKind.Client, true)]
+        [TestCase(ActivityKind.Producer, false)]
+        [TestCase(ActivityKind.Consumer, false)]
         [NonParallelizable]
         public void NestedClientActivitiesSuppressed(int kind, bool expectSuppression)
         {
             using var testListener = new TestDiagnosticListener("Azure.Clients");
             DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, true);
 
-            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", (DiagnosticScope.ActivityKind)kind);
+            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", (ActivityKind)kind);
             scope.Start();
 
-            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName", (DiagnosticScope.ActivityKind)kind);
+            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName", (ActivityKind)kind);
             nestedScope.Start();
             if (expectSuppression)
             {
@@ -214,11 +214,11 @@ namespace Azure.Core.Tests
             CollectionAssert.DoesNotContain(Activity.Current.Tags, new KeyValuePair<string, string>(DiagnosticScope.OpenTelemetrySchemaAttribute, DiagnosticScope.OpenTelemetrySchemaVersion));
         }
 
-        [TestCase(DiagnosticScope.ActivityKind.Internal, true)]
-        [TestCase(DiagnosticScope.ActivityKind.Server, false)]
-        [TestCase(DiagnosticScope.ActivityKind.Client, true)]
-        [TestCase(DiagnosticScope.ActivityKind.Producer, false)]
-        [TestCase(DiagnosticScope.ActivityKind.Consumer, false)]
+        [TestCase(ActivityKind.Internal, true)]
+        [TestCase(ActivityKind.Server, false)]
+        [TestCase(ActivityKind.Client, true)]
+        [TestCase(ActivityKind.Producer, false)]
+        [TestCase(ActivityKind.Consumer, false)]
         [NonParallelizable]
         public void NestedClientActivitiesSuppressionActivitySource(int kind, bool expectSuppression)
         {
@@ -227,10 +227,10 @@ namespace Azure.Core.Tests
 
             DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, true);
 
-            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", (DiagnosticScope.ActivityKind)kind);
+            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", (ActivityKind)kind);
             scope.Start();
 
-            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName", (DiagnosticScope.ActivityKind)kind);
+            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName", (ActivityKind)kind);
             nestedScope.Start();
             if (expectSuppression)
             {

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -305,22 +305,22 @@ namespace Azure.Core.Tests
             Assert.AreEqual(2, testListener.Sources.Count);
         }
 
-        [TestCase(DiagnosticScope.ActivityKind.Internal)]
-        [TestCase(DiagnosticScope.ActivityKind.Server)]
-        [TestCase(DiagnosticScope.ActivityKind.Client)]
-        [TestCase(DiagnosticScope.ActivityKind.Producer)]
-        [TestCase(DiagnosticScope.ActivityKind.Consumer)]
+        [TestCase(ActivityKind.Internal)]
+        [TestCase(ActivityKind.Server)]
+        [TestCase(ActivityKind.Client)]
+        [TestCase(ActivityKind.Producer)]
+        [TestCase(ActivityKind.Consumer)]
         [NonParallelizable]
         public void NestedClientActivitiesNotSuppressed(int kind)
         {
             using var testListener = new TestDiagnosticListener("Azure.Clients");
             DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
 
-            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", (DiagnosticScope.ActivityKind)kind);
+            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", (ActivityKind)kind);
             scope.SetDisplayName("Activity Display Name");
             scope.Start();
 
-            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName", (DiagnosticScope.ActivityKind)kind);
+            DiagnosticScope nestedScope = clientDiagnostics.CreateScope("ClientName.NestedActivityName", (ActivityKind)kind);
             nestedScope.SetDisplayName("Nested Activity Display Name");
             nestedScope.Start();
 
@@ -339,7 +339,7 @@ namespace Azure.Core.Tests
             using var testListener = new TestDiagnosticListener("Azure.Clients");
 
             DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
-            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", DiagnosticScope.ActivityKind.Server);
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", ActivityKind.Server);
             Assert.IsTrue(scope.IsEnabled);
             scope.Start();
             Assert.AreEqual("ClientName.ActivityName", Activity.Current.OperationName);
@@ -365,7 +365,7 @@ namespace Azure.Core.Tests
             using var testListener = new TestDiagnosticListener("Azure.Clients");
             DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, false);
             ;
-            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", DiagnosticScope.ActivityKind.Server);
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName", ActivityKind.Server);
             scope.Start();
 
             using var activityListener2 = new TestDiagnosticListener("Azure.Clients2");

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -375,7 +375,7 @@ namespace Azure.Core.Tests
 
             using var clientListener = new TestActivitySourceListener("Azure.Clients.ClientName");
             DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true, true);
-            using DiagnosticScope outerScope = clientDiagnostics.CreateScope("ClientName.ActivityName", DiagnosticScope.ActivityKind.Internal);
+            using DiagnosticScope outerScope = clientDiagnostics.CreateScope("ClientName.ActivityName", ActivityKind.Internal);
             outerScope.Start();
 
             try

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -21,6 +21,6 @@
 <!-- This is required to prevent version conflict stemming from The CloudNative.CloudEvents.SystemTestJson depending on -->
 <!-- version 5.0.0.-->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="5.0.0" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource"/>
+		<PackageReference Include="Azure.Core"/>
   </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -21,5 +21,6 @@
 <!-- This is required to prevent version conflict stemming from The CloudNative.CloudEvents.SystemTestJson depending on -->
 <!-- version 5.0.0.-->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="5.0.0" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource"/>
   </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridExtensionConfigProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridExtensionConfigProvider.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Config
 
         private async Task<FunctionResult> ExecuteWithTracingAsync(string functionName, TriggeredFunctionData triggerData)
         {
-            using DiagnosticScope scope = _diagnosticScopeFactory.CreateScope(DiagnosticScopeName, DiagnosticScope.ActivityKind.Consumer);
+            using DiagnosticScope scope = _diagnosticScopeFactory.CreateScope(DiagnosticScopeName, ActivityKind.Consumer);
             if (scope.IsEnabled)
             {
                 if (triggerData.TriggerValue is JArray evntArray)

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridExtensionConfigProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Config/EventGridExtensionConfigProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="Microsoft.Azure.WebJobs" />
 		<PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.Azure.WebJobs" />
 		<PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
+		<PackageReference Include="Azure.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -890,7 +891,7 @@ namespace Azure.Messaging.EventHubs
 
             Logger.UpdateCheckpointStart(partitionId, Identifier, EventHubName, ConsumerGroup);
 
-            using var scope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorCheckpointActivityName, DiagnosticScope.ActivityKind.Internal);
+            using var scope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorCheckpointActivityName, ActivityKind.Internal);
             scope.Start();
 
             try

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -622,7 +623,7 @@ namespace Azure.Messaging.EventHubs.Primitives
 
             // Create the diagnostics scope used for distributed tracing and instrument the events in the batch.
 
-            using var diagnosticScope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorProcessingActivityName, DiagnosticScope.ActivityKind.Consumer, MessagingDiagnosticOperation.Process);
+            using var diagnosticScope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorProcessingActivityName, ActivityKind.Consumer, MessagingDiagnosticOperation.Process);
 
             if ((diagnosticScope.IsEnabled) && (eventBatch.Any()))
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -1295,7 +1296,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         private DiagnosticScope CreateDiagnosticScope(IEnumerable<(string TraceParent, string TraceState)> traceContexts, int eventCount)
         {
-            DiagnosticScope scope = ClientDiagnostics.CreateScope(DiagnosticProperty.ProducerActivityName, DiagnosticScope.ActivityKind.Client, MessagingDiagnosticOperation.Publish);
+            DiagnosticScope scope = ClientDiagnostics.CreateScope(DiagnosticProperty.ProducerActivityName, ActivityKind.Client, MessagingDiagnosticOperation.Publish);
 
             if (scope.IsEnabled)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
@@ -138,7 +139,7 @@ namespace Azure.Messaging.ServiceBus
 
         protected async Task ProcessOneMessageWithinScopeAsync(ServiceBusReceivedMessage message, string activityName, CancellationToken cancellationToken)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope(activityName, DiagnosticScope.ActivityKind.Consumer, MessagingDiagnosticOperation.Process);
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope(activityName, ActivityKind.Consumer, MessagingDiagnosticOperation.Process);
             scope.SetMessageAsParent(message);
             scope.Start();
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -320,7 +320,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.ReceiveActivityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 MessagingDiagnosticOperation.Receive);
 
             IReadOnlyList<ServiceBusReceivedMessage> messages = null;
@@ -492,7 +492,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.PeekMessageStart(Identifier, sequenceNumber, maxMessages);
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.PeekActivityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 MessagingDiagnosticOperation.Receive);
 
             IReadOnlyList<ServiceBusReceivedMessage> messages;
@@ -574,7 +574,7 @@ namespace Azure.Messaging.ServiceBus
                 message.LockTokenGuid);
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.CompleteActivityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 MessagingDiagnosticOperation.Settle);
             scope.SetMessageData(message);
             scope.Start();
@@ -643,7 +643,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.AbandonActivityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 MessagingDiagnosticOperation.Settle);
 
             scope.SetMessageData(message);
@@ -890,7 +890,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.DeadLetterActivityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 MessagingDiagnosticOperation.Settle);
 
             scope.SetMessageData(message);
@@ -963,7 +963,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.DeferActivityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 MessagingDiagnosticOperation.Settle);
 
             scope.SetMessageData(message);
@@ -1067,7 +1067,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.ReceiveDeferredActivityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 MessagingDiagnosticOperation.Receive);
 
             scope.Start();
@@ -1147,7 +1147,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.RenewMessageLockActivityName,
-                DiagnosticScope.ActivityKind.Client);
+                ActivityKind.Client);
             scope.Start();
 
             DateTimeOffset lockedUntil;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -149,7 +150,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.GetSessionStateStart(Identifier, SessionId);
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.GetSessionStateActivityName,
-                DiagnosticScope.ActivityKind.Client);
+                ActivityKind.Client);
             scope.Start();
 
             BinaryData sessionState;
@@ -193,7 +194,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.SetSessionStateStart(Identifier, SessionId);
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.SetSessionStateActivityName,
-                DiagnosticScope.ActivityKind.Client);
+                ActivityKind.Client);
             scope.Start();
 
             try
@@ -237,7 +238,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.RenewSessionLockStart(Identifier, SessionId);
             using DiagnosticScope scope = ClientDiagnostics.CreateScope(
                 DiagnosticProperty.RenewSessionLockActivityName,
-                DiagnosticScope.ActivityKind.Client);
+                ActivityKind.Client);
             scope.Start();
 
             try

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/RuleManager/ServiceBusRuleManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/RuleManager/ServiceBusRuleManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -237,7 +238,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope(
                 DiagnosticProperty.CreateRuleActivityName,
-                DiagnosticScope.ActivityKind.Client);
+                ActivityKind.Client);
             scope.Start();
 
             try
@@ -304,7 +305,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope(
                 DiagnosticProperty.DeleteRuleActivityName,
-                DiagnosticScope.ActivityKind.Client);
+                ActivityKind.Client);
             scope.Start();
 
             try
@@ -341,7 +342,7 @@ namespace Azure.Messaging.ServiceBus
                 List<RuleProperties> ruleProperties;
                 using (DiagnosticScope scope = _clientDiagnostics.CreateScope(
                     DiagnosticProperty.GetRulesActivityName,
-                    DiagnosticScope.ActivityKind.Client))
+                    ActivityKind.Client))
                 {
                     scope.Start();
                     try

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -272,7 +273,7 @@ namespace Azure.Messaging.ServiceBus
             // create a new scope for the specified operation
             DiagnosticScope scope = _clientDiagnostics.CreateScope(
                 activityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 operation);
 
             scope.SetMessageData(messages);
@@ -289,7 +290,7 @@ namespace Azure.Messaging.ServiceBus
             // create a new scope for the specified operation
             DiagnosticScope scope = _clientDiagnostics.CreateScope(
                 activityName,
-                DiagnosticScope.ActivityKind.Client,
+                ActivityKind.Client,
                 operation);
 
             scope.SetMessageData(messages);
@@ -564,7 +565,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope(
                 DiagnosticProperty.CancelActivityName,
-                DiagnosticScope.ActivityKind.Client);
+                ActivityKind.Client);
             scope.Start();
 
             try

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -631,7 +632,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         {
             using DiagnosticScope scope = _clientDiagnostics.Value.CreateScope(
                             _isSessionsEnabled ? Constants.ProcessSessionMessagesActivityName : Constants.ProcessMessagesActivityName,
-                            DiagnosticScope.ActivityKind.Consumer,
+                            ActivityKind.Consumer,
                             MessagingDiagnosticOperation.Process);
 
             scope.SetMessageData(messagesArray);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
+		<PackageReference Include ="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
-		<PackageReference Include ="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include ="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
-    <PackageReference Include ="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include ="Azure.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.Tests
         private readonly UploadTransferValidationOptions s_validationOptions = new UploadTransferValidationOptions();
         private readonly CancellationToken s_cancellation = new CancellationToken();
 
-        private static readonly object s_activitySource = ActivityExtensions.CreateActivitySource("Azure.Storage.Tests");
+        private static readonly ActivitySource s_activitySource = new ActivitySource("Azure.Storage.Tests");
 
         public PartitionedUploaderTests(bool async)
         {
@@ -47,7 +47,7 @@ namespace Azure.Storage.Tests
         {
             var mock = new Mock<PartitionedUploader<object, object>.CreateScope>(MockBehavior.Strict);
             mock.Setup(del => del(s_operationName))
-                .Returns(new Core.Pipeline.DiagnosticScope("Azure.Storage.Tests", new DiagnosticListener("Azure.Storage.Tests"), null, s_activitySource, DiagnosticScope.ActivityKind.Client, false));
+                .Returns(new Core.Pipeline.DiagnosticScope("Azure.Storage.Tests", new DiagnosticListener("Azure.Storage.Tests"), null, s_activitySource, ActivityKind.Client, false));
             return mock;
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);net6.0</TargetFrameworks>
   </PropertyGroup>
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="Azure.Core" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/37593

Now that we have upgraded the global dependency on System.Diagnostics.DiagnosticSource to 6.0.1, we can use ActivityKind directly. [DiagnosticScope.ActivityKind](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs#L131) is the same as [Diagnostics.ActivityKind](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitykind?view=net-7.0#fields)

There is more information in the following issues/PRs:
- https://github.com/Azure/azure-sdk-for-net/issues/33683
- https://github.com/Azure/azure-sdk-for-net/pull/37418

Also, I needed to add direct dependencies on Azure.Core for some packages that are pulling in older Azure.Core references. 

These older references still have the previous version of System.Diagnostics.DiagnosticSource which is breaking the shared source build. The shared source is unique because when it is built the most up to date files are loaded directly from the repository. This means that the dependency (transitive or direct) on Azure.Core needs to be up to date as well. If it's not, you need a direct reference until you can get it. 

For example, I believe it is needed in Azure.Storage.DataMovement because Azure.Storage.Common is referencing Azure.Core 1.33 (https://www.nuget.org/packages/Azure.Storage.Common). Once Azure.Storage.Common releases with Azure.Core 1.34+. then this reference should be able to be safely removed, if needed. 

Happy to explain a little more if anyone needs/wants more information.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
