### PR TITLE
[FormRecognizer] Updated tests after recent service deployment

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
@@ -617,7 +617,14 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             Assert.True(style.IsHandwritten);
 
-            Assert.AreEqual(38, result.Paragraphs.Count);
+            if (_serviceVersion >= DocumentAnalysisClientOptions.ServiceVersion.V2023_02_28_Preview)
+            {
+                Assert.AreEqual(52, result.Paragraphs.Count);
+            }
+            else
+            {
+                Assert.AreEqual(38, result.Paragraphs.Count);
+            }
 
             DocumentParagraph sampleParagraph = result.Paragraphs[1];
 
@@ -918,9 +925,9 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             var expectedItems = new List<(double Amount, DateTimeOffset Date, string Description, string ProductCode, double Quantity, string Unit, double UnitPrice)>()
             {
-                (60f, DateTimeOffset.Parse("2021-04-03 00:00:00+00:00"), "Consulting Services", "A123", 2, "hours", 30),
-                (30f, DateTimeOffset.Parse("2021-05-03 00:00:00+00:00"), "Document Fee", "B456", 3, null, 10),
-                (10f, DateTimeOffset.Parse("2021-06-03 00:00:00+00:00"), "Printing Fee", "C789", 10, "pages", 1)
+                (60f, DateTimeOffset.Parse("2021-03-04 00:00:00+00:00"), "Consulting Services", "A123", 2, "hours", 30),
+                (30f, DateTimeOffset.Parse("2021-03-05 00:00:00+00:00"), "Document Fee", "B456", 3, null, 10),
+                (10f, DateTimeOffset.Parse("2021-03-06 00:00:00+00:00"), "Printing Fee", "C789", 10, "pages", 1)
             };
 
             // Include a bit of tolerance when comparing double types.
@@ -1432,7 +1439,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
                 if (documentIndex == 0)
                 {
-                    Assert.AreEqual("$14,50", sampleField.Content);
+                    Assert.AreEqual("$14.50", sampleField.Content);
                 }
                 else if (documentIndex == 1)
                 {
@@ -1474,7 +1481,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
                 if (pageIndex == 0 || pageIndex == 2)
                 {
-                    var expectedContent = pageIndex == 0 ? "$14,50" : "1203.39";
+                    var expectedContent = pageIndex == 0 ? "$14.50" : "1203.39";
 
                     Assert.True(page.Words.Any(w => w.Content == expectedContent));
                 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationLiveTests.cs
@@ -69,9 +69,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             if (buildMode == DocumentBuildMode.Neural && Recording.Mode == RecordedTestMode.Live)
             {
                 // Test takes too long to finish running, and seems to cause multiple failures in our
-                // live test pipeline. Until we find a way to run it without flakiness, this test will
-                // be ignored when running in Live mode.
-                Assert.Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27042");
+                // live test pipeline. For this reason, this test is ignored when running in Live mode.
+                Assert.Ignore();
             }
 
             var client = CreateDocumentModelAdministrationClient();
@@ -118,14 +117,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             }
             else
             {
-                // We have changed the following validation because of a service bug. This needs to be updated once the bug is fixed.
-                // More information: https://github.com/Azure/azure-sdk-for-net/issues/35809
-
-                // The expected behavior. This must be added back once the service bug is fixed.
-                // Assert.IsNull(model.ExpiresOn);
-
-                // The current behavior. This assertion must be removed once the service bug is fixed.
-                Assert.Greater(model.ExpiresOn, model.CreatedOn);
+                Assert.IsNull(model.ExpiresOn);
             }
 
             CollectionAssert.AreEquivalent(options.Tags, model.Tags);
@@ -272,7 +264,15 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             Assert.AreEqual(description, model.Description);
             Assert.AreEqual(ServiceVersionString, model.ApiVersion);
             Assert.Greater(model.CreatedOn, startTime);
-            Assert.Greater(model.ExpiresOn, model.CreatedOn);
+
+            if (_serviceVersion >= DocumentAnalysisClientOptions.ServiceVersion.V2023_02_28_Preview)
+            {
+                Assert.Greater(model.ExpiresOn, model.CreatedOn);
+            }
+            else
+            {
+                Assert.IsNull(model.ExpiresOn);
+            }
 
             CollectionAssert.AreEquivalent(tags, model.Tags);
 
@@ -323,13 +323,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             Assert.AreEqual(expected.Description, model.Description);
             Assert.AreEqual(expected.ApiVersion, model.ApiVersion);
             Assert.AreEqual(expected.CreatedOn, model.CreatedOn);
-
-            // (TODO) This assertion should not need a conditional block but we need it because of a service issue.
-            // Remove the condition once this issue is fixed: https://github.com/Azure/azure-sdk-for-net/issues/35809
-            if (_serviceVersion > DocumentAnalysisClientOptions.ServiceVersion.V2022_08_31)
-            {
-                Assert.AreEqual(expected.ExpiresOn, model.ExpiresOn);
-            }
+            Assert.AreEqual(expected.ExpiresOn, model.ExpiresOn);
 
             CollectionAssert.AreEquivalent(expected.Tags, model.Tags);
 
@@ -397,13 +391,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
                 Assert.AreEqual(expected.Description, model.Description);
                 Assert.AreEqual(expected.ApiVersion, model.ApiVersion);
                 Assert.AreEqual(expected.CreatedOn, model.CreatedOn);
-
-                // (TODO) This assertion should not need a conditional block but we need it because of a service issue.
-                // Remove the condition once this issue is fixed: https://github.com/Azure/azure-sdk-for-net/issues/35809
-                if (_serviceVersion > DocumentAnalysisClientOptions.ServiceVersion.V2022_08_31)
-                {
-                    Assert.AreEqual(expected.ExpiresOn, model.ExpiresOn);
-                }
+                Assert.AreEqual(expected.ExpiresOn, model.ExpiresOn);
 
                 CollectionAssert.AreEquivalent(expected.Tags, model.Tags);
             }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/MiscellaneousOperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/MiscellaneousOperationsLiveTests.cs
@@ -176,18 +176,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             }
             else
             {
-                // We have changed the following validation because of a service bug. This needs to be updated once the bug is fixed.
-                // More information: https://github.com/Azure/azure-sdk-for-net/issues/35809
-
-                /* The expected behavior. This must be added back once the service bug is fixed.
                 Assert.Null(model.ExpiresOn);
-                */
-
-                // The current behavior. This 'if' block must be completely removed once the service bug is fixed.
-                if (model.ExpiresOn.HasValue)
-                {
-                    Assert.Greater(model.ExpiresOn, model.CreatedOn);
-                }
             }
 
             // TODO add validation for Doctypes https://github.com/Azure/azure-sdk-for-net-pr/issues/1432

--- a/sdk/formrecognizer/assets.json
+++ b/sdk/formrecognizer/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/formrecognizer",
-  "Tag": "net/formrecognizer_3c6efa38b9"
+  "Tag": "net/formrecognizer_2475157f2c"
 }


### PR DESCRIPTION
A recent service deployment introduced a couple of behavior changes that deterministically broke some of our tests. This PR updates tests, aligning them with the new service behavior, to make our pipeline greener.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/35809 as the corresponding service bug has been fixed.