### PR TITLE
Add missing service label entries to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -504,7 +504,7 @@
 /sdk/iothub/Microsoft.Azure.Management.IotHub/                     @rkmanda @chieftn
 
 # ServiceLabel: %KeyVault
-#/<NotInRepo>/          @RandalliLama @schaabs @jlichwa
+#/<NotInRepo>/          @RandalliLama @jlichwa
 
 # PRLabel: %KeyVault
 /sdk/keyvault/                                                     @heaths @schaabs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -433,7 +433,7 @@
 # ServiceLabel: %Digital Twins %Service Attention
 /sdk/digitaltwins/                                                 @johngallardo @efriesner @abhinav-ghai @Aashish93-stack @sjiherzig @Satya-Kolluri
 
-# ServiceLabel: %IoT/CLI
+# ServiceLabel: %IoT - CLI
 #/<NotInRepo>/          @Azure/azure-iot-cli-triage
 
 # PRLabel: %IoT Models Repository

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,6 +75,12 @@
 # ServiceLabel: %Alerts Management %Service Attention
 /sdk/alertsmanagement/Microsoft.Azure.Management.AlertsManagement/ @liadtal @yairgil
 
+# ServiceLabel: %App Configuration
+#/<NotInRepo>/          @shenmuxiaosen @avanigupta
+
+# ServiceLabel: %Application Insights
+#/<NotInRepo>/          @azmonapplicationinsights
+
 # ServiceLabel: %ARM %Service Attention
 #/<NotInRepo>/                                                     @armleads-azure
 
@@ -95,6 +101,9 @@
 
 # ServiceLabel: %ARM - RBAC %Service Attention
 #/<NotInRepo>/                                                     @armleads-azure
+
+# ServiceLabel: %ARO
+#/<NotInRepo>/          @mjudeikis @jim-minter @julienstroheker @amanohar
 
 # ServiceLabel: %Advisor %Service Attention
 /sdk/advisor/Microsoft.Azure.Management.Advisor/                   @mojayara @Prasanna-Padmanabhan
@@ -123,6 +132,9 @@
 
 # ServiceLabel: %AVS %Service Attention
 /sdk/avs/Microsoft.Azure.Management.Avs/                           @divka78 @amitchat @aishu
+
+# ServiceLabel: %Azure Data Explorer
+#/<NotInRepo>/          @ilayrn @orhasban @zoharHenMicrosoft @sagivf @Aviv-Yaniv
 
 # ServiceLabel: %Azure Stack %Service Attention
 /sdk/azurestack*                                                   @sijuman @sarathys @bganapa @rakku-ms
@@ -234,6 +246,9 @@
 # ServiceLabel: %Commerce %Service Attention
 #/<NotInRepo>/                                                     @ms-premp @qiaozha
 
+# ServiceLabel: %Communication
+#/<NotInRepo>/          @acsdevx-msft
+
 # PRLabel: %Communication
 /sdk/communication/                                                @acsdevx-msft
 
@@ -297,6 +312,21 @@
 # ServiceLabel: %Consumption %Service Attention
 /sdk/consumption/Microsoft.Azure.Management.Consumption/           @ms-premp
 
+# ServiceLabel: %Consumption - Billing
+#/<NotInRepo>/          @ccmbpxpcrew
+
+# ServiceLabel: %Consumption - Budget
+#/<NotInRepo>/          @ccmaxpcrew
+
+# ServiceLabel: %Consumption - Query
+#/<NotInRepo>/          @ccmixpdevs
+
+# ServiceLabel: %Consumption - RIandShowBack
+#/<NotInRepo>/          @ccmshowbackdevs
+
+# ServiceLabel: %Consumption - UsageDetailsAndExport
+#/<NotInRepo>/          @TiagoCrewGitHubIssues
+
 # ServiceLabel: %Connected Kubernetes %Service Attention
 #/<NotInRepo>/                                                     @akashkeshari
 
@@ -309,11 +339,32 @@
 # ServiceLabel: %Container Registry %Service Attention
 /sdk/containerregistry/Microsoft.*/                                @toddysm @yugangw-MSFT
 
+# ServiceLabel: %Container Service
+#/<NotInRepo>/          @qike-ms @jwilder @thomas1206 @seanmck
+
 # ServiceLabel: %Cosmos %Service Attention
 /sdk/cosmosdb/                                                     @pjohari-ms @MehaKaushik @shurd @anfeldma-ms @zfoster @kushagraThapar
 
 # ServiceLabel: %Cost Management %Service Attention
 /sdk/cost-management/Microsoft.Azure.Management.CostManagement/    @ms-premp @ramaganesan-rg
+
+# ServiceLabel: %Cost Management - Billing
+#/<NotInRepo>/          @ccmbpxpcrew
+
+# ServiceLabel: %Cost Management - Budget
+#/<NotInRepo>/          @ccmaxpcrew
+
+# ServiceLabel: %Cost Management - Query
+#/<NotInRepo>/          @ccmixpdevs
+
+# ServiceLabel: %Cost Management - RIandShowBack
+#/<NotInRepo>/          @ccmshowbackdevs
+
+# ServiceLabel: %Cost Management - UsageDetailsAndExport
+#/<NotInRepo>/          @TiagoCrewGitHubIssues
+
+# ServiceLabel: %Custom Providers
+#/<NotInRepo>/          @manoharp @MSEvanhi
 
 # ServiceLabel: %Customer Insights %Service Attention
 /sdk/customer-insights/Microsoft.Azure.Management.CustomerInsights/ @shefymk
@@ -329,6 +380,9 @@
 
 # ServiceLabel: %Data Catalog %Service Attention
 #/<NotInRepo>/                                                     @anilman
+
+# ServiceLabel: %DataBox Edge
+#/<NotInRepo>/          @a-t-mason @ganzee @manuaery
 
 # ServiceLabel: %Data Factory %Service Attention
 /sdk/datafactory/Microsoft.Azure.Management.DataFactory/           @shawnxzq @lmy269
@@ -351,15 +405,23 @@
 # ServiceLabel: %Data Migration %Service Attention
 /sdk/datamigration/Microsoft.Azure.Management.DataMigration/       @rgreenMSFT
 
+# ServiceLabel: %Data Share
+#/<NotInRepo>/          @raedJarrar @jifems
 
 # ServiceLabel: %DevCenter %Service Attention
 #/<NotInRepo>/                                                     @sebrenna @mharlan @chrissmiller
+
+# ServiceLabel: %Dev Spaces
+#/<NotInRepo>/          @yuzorMa @johnsta @greenie-msft
 
 # PRLabel: %DevCenter
 /sdk/devcenter/                                                    @sebrenna @mharlan @chrissmiller @shivangireja
 
 # ServiceLabel: %Devtestlab %Service Attention
 /sdk/devtestlabs/Microsoft.Azure.Management.DevTestLabs/           @Tanmayeekamath
+
+# ServiceLabel: %DevOps
+#/<NotInRepo>/          @narula0781 @ashishonce @romil07
 
 # ServiceLabel: %Device Provisioning Service %Service Attention
 /sdk/deviceprovisioningservices/Microsoft.Azure.Management.DeviceProvisioningServices/ @nberdy
@@ -370,6 +432,9 @@
 # PRLabel: %Digital Twins
 # ServiceLabel: %Digital Twins %Service Attention
 /sdk/digitaltwins/                                                 @johngallardo @efriesner @abhinav-ghai @Aashish93-stack @sjiherzig @Satya-Kolluri
+
+# ServiceLabel: %IoT/CLI
+#/<NotInRepo>/          @Azure/azure-iot-cli-triage
 
 # PRLabel: %IoT Models Repository
 # ServiceLabel: %IoT Models Repository %Service Attention
@@ -419,6 +484,9 @@
 # ServiceLabel: %Import Export %Service Attention
 #/<NotInRepo>/                                                     @madhurinms
 
+# ServiceLabel: %IoT
+#/<NotInRepo>/          @ethanann-ms @vighatke
+
 # PRLabel: %Iot
 /sdk/iot*                                                          @ethanann-ms @vighatke
 
@@ -434,6 +502,9 @@
 
 # ServiceLabel: %IotHub %Service Attention
 /sdk/iothub/Microsoft.Azure.Management.IotHub/                     @rkmanda @chieftn
+
+# ServiceLabel: %KeyVault
+#/<NotInRepo>/          @RandalliLama @schaabs @jlichwa
 
 # PRLabel: %KeyVault
 /sdk/keyvault/                                                     @heaths @schaabs
@@ -558,7 +629,7 @@
 # ServiceLabel: %Network - DDOS Protection %Service Attention
 #/<NotInRepo>/                                                     @ddossuppgithub
 
-# ServiceLabel: %Network - ExpressRoutes %Service Attention
+# ServiceLabel: %Network - ExpressRoute %Service Attention
 #/<NotInRepo>/                                                     @exrsuppgithub
 
 # ServiceLabel: %Network - Firewall %Service Attention
@@ -653,6 +724,9 @@
 
 # ServiceLabel: %Security %Service Attention
 #/<NotInRepo>/                                                     @chlahav
+
+# ServiceLabel: %SecurityInsights
+#/<NotInRepo>/          @amirkeren
 
 # PRLabel: %Search
 /sdk/search/                                                       @ShivangiReja @kinelski @tg-msft @heaths


### PR DESCRIPTION
The FabricBot rule for @ mentioning people based upon the service label when the Service Attention label was added should have been generated from the CODEOWNERS file for each repository. At some point and time this stopped happening and changes were made directly to FabricBot. What I'm doing is getting the last FabricBot.json file for this repository, that was removed as part of the [PR where github-event-processor was enabled](https://github.com/Azure/azure-sdk-for-net/pull/35008) and adding any entries that were in the FabricBot rule that are missing from the CODEOWNERS file. 

Also fixed one incorrect entry (Network - ExpressRoute is the label, without the 's' at the end. It was correct in the FabricBot.)