### PR TITLE
Update StorageRequestFailedDetailsParser to handle inexact type

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageRequestFailedDetailsParser.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageRequestFailedDetailsParser.cs
@@ -54,7 +54,8 @@ namespace Azure.Core.Pipeline
                         using JsonDocument json = JsonDocument.Parse(contentStream);
                         JsonElement errorElement = json.RootElement.GetProperty(Constants.ErrorPropertyKey);
 
-                        if (errorElement.TryGetProperty(Constants.DetailPropertyKey, out JsonElement detail) && detail.ValueKind == JsonValueKind.Object)
+                        if (errorElement.TryGetProperty(Constants.DetailPropertyKey, out JsonElement detail)
+                            && detail.ValueKind == JsonValueKind.Object)
                         {
                             data = new Dictionary<string, string>();
                             foreach (JsonProperty property in detail.EnumerateObject())

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageRequestFailedDetailsParser.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageRequestFailedDetailsParser.cs
@@ -54,7 +54,7 @@ namespace Azure.Core.Pipeline
                         using JsonDocument json = JsonDocument.Parse(contentStream);
                         JsonElement errorElement = json.RootElement.GetProperty(Constants.ErrorPropertyKey);
 
-                        if (errorElement.TryGetProperty(Constants.DetailPropertyKey, out JsonElement detail))
+                        if (errorElement.TryGetProperty(Constants.DetailPropertyKey, out JsonElement detail) && detail.ValueKind == JsonValueKind.Object)
                         {
                             data = new Dictionary<string, string>();
                             foreach (JsonProperty property in detail.EnumerateObject())


### PR DESCRIPTION
Update StorageRequestFailedDetailsParser to handle inexact type, this can happen if the error response is returned by a proxy.