### PR TITLE
Use sparse checkout in Compliance job

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -247,6 +247,27 @@ jobs:
 
         - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 
+        # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
+        # as we require the GitHub service connection to be loaded.
+        - ${{ if not(contains(variables['Build.DefinitionName'], 'net-pr')) }}:
+          # For PullRequests CredScan will be run against the files changed in the PR.
+          # For non-pull requests CredScan runs against the service directory.
+          - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+            - pwsh: |
+                $changedFiles = & "eng/common/scripts/get-changedfiles.ps1"
+                $tmp = ConvertTo-Json @($changedFiles | Sort-Object | Get-Unique) -Compress
+                Write-Host "##vso[task.setvariable variable=SparseCheckoutDirectories;]$tmp"
+
+            - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+              parameters:
+                Paths: $(SparseCheckoutDirectories)
+
+          - ${{ else }}:
+            - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+              parameters:
+                Paths: 
+                  - "sdk/${{ parameters.ServiceDirectory }}"
+
         - template: /eng/common/pipelines/templates/steps/credscan.yml
           parameters:
             BaselineFilePath: $(Build.sourcesdirectory)/eng/dotnet.gdnbaselines

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -233,9 +233,10 @@ jobs:
         - ${{ if not(contains(variables['Build.DefinitionName'], 'net-pr')) }}:
           # First checkout the eng folder to get the common scripts
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-            Paths:
-              - '**/*.md'
-              - '.vscode/cspell.json'
+            parameters:
+              Paths:
+                - '**/*.md'
+                - '.vscode/cspell.json'
 
           # For PullRequests CredScan will be run against the files changed in the PR.
           # For non-pull requests CredScan runs against the service directory.

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -227,26 +227,7 @@ jobs:
           displayName: "Use Python 3.9"
           inputs:
             versionSpec: "3.9"
-
-        - template: /eng/common/pipelines/templates/steps/validate-filename.yml
-
-        - template: /eng/common/pipelines/templates/steps/check-spelling.yml
-
-        - template: /eng/common/pipelines/templates/steps/verify-links.yml
-          parameters:
-            ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: ''
-              Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-            ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: sdk/${{ parameters.ServiceDirectory }}
-            CheckLinkGuidance: $true
-
-        - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
-          parameters:
-            SourceDirectory: $(Build.SourcesDirectory)
-
-        - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
-
+            
         # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
         # as we require the GitHub service connection to be loaded.
         - ${{ if not(contains(variables['Build.DefinitionName'], 'net-pr')) }}:
@@ -267,6 +248,25 @@ jobs:
               parameters:
                 Paths: 
                   - "sdk/${{ parameters.ServiceDirectory }}"
+
+        - template: /eng/common/pipelines/templates/steps/validate-filename.yml
+
+        - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+
+        - template: /eng/common/pipelines/templates/steps/verify-links.yml
+          parameters:
+            ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+              Directory: ''
+              Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
+            ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+              Directory: sdk/${{ parameters.ServiceDirectory }}
+            CheckLinkGuidance: $true
+
+        - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
+          parameters:
+            SourceDirectory: $(Build.SourcesDirectory)
+
+        - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 
         - template: /eng/common/pipelines/templates/steps/credscan.yml
           parameters:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -233,6 +233,9 @@ jobs:
         - ${{ if not(contains(variables['Build.DefinitionName'], 'net-pr')) }}:
           # First checkout the eng folder to get the common scripts
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+            Paths:
+              - '**/*.md'
+              - '.vscode/cspell.json'
 
           # For PullRequests CredScan will be run against the files changed in the PR.
           # For non-pull requests CredScan runs against the service directory.

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -227,10 +227,13 @@ jobs:
           displayName: "Use Python 3.9"
           inputs:
             versionSpec: "3.9"
-            
+
         # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
         # as we require the GitHub service connection to be loaded.
         - ${{ if not(contains(variables['Build.DefinitionName'], 'net-pr')) }}:
+          # First checkout the eng folder to get the common scripts
+          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+
           # For PullRequests CredScan will be run against the files changed in the PR.
           # For non-pull requests CredScan runs against the service directory.
           - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -242,12 +245,14 @@ jobs:
             - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
               parameters:
                 Paths: $(SparseCheckoutDirectories)
+                SkipCheckoutNone: true
 
           - ${{ else }}:
             - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
               parameters:
                 Paths: 
                   - "sdk/${{ parameters.ServiceDirectory }}"
+                SkipCheckoutNone: true
 
         - template: /eng/common/pipelines/templates/steps/validate-filename.yml
 


### PR DESCRIPTION
_Replication of https://github.com/Azure/azure-sdk-for-java/pull/35835 and https://github.com/Azure/azure-sdk-for-java/pull/35867 from the `azure-sdk-for-java` repository._

Updates the `Compliance` CI job to use sparse checkout instead of full repository checkout when running compliance for non-private repository jobs. When running `Compliance` for pull requests sparse checkout will only checkout the files changed by the PR, replicating what CredScan validates, and for scheduled or manually triggered jobs it will checkout all files in the service directory specified by the CI configuration, again replicating what CredScan validates.

This reduces the amount of files, and time, the CredScan job spends checking out code from about a few minutes to a few seconds. In the Java repository, and likely similar in this repository, the checkout time reduced from about 3-5 minutes to 20-30 seconds.