### PR TITLE
Update Microsoft.Rest.ClientRuntime

### DIFF
--- a/sdk/applicationinsights/ci.yml
+++ b/sdk/applicationinsights/ci.yml
@@ -1,5 +1,6 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 trigger: none
+pr: none
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/perf/Azure.Containers.ContainerRegistry.Perf/Azure.Containers.ContainerRegistry.Perf.csproj
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/perf/Azure.Containers.ContainerRegistry.Perf/Azure.Containers.ContainerRegistry.Perf.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ContainerRegistry" VersionOverride="4.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerRegistry.Fluent"/>
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Microsoft.Azure.EventHubs.Perf.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/perf/Microsoft.Azure.EventHubs.Perf.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
     <PackageReference Include="Polly" />
   </ItemGroup>
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/OptionsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/OptionsTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.True(testReceiver.ReceiveTimeout.Equals(testReceiveTimeout),
                 $"Unexpected receive timeout {testReceiver.ReceiveTimeout}");
             Assert.NotNull(testReceiver.Options);
-            Assert.Equal(testReceiver.Options.Identifier, tag);
+            Assert.Equal(tag, testReceiver.Options.Identifier);
 
             // EnableReceiverRuntimeMetric is false by default. This case is a convenient opportunity to
             // verify that RuntimeInformation was not updated when the option is false.

--- a/sdk/operationalinsights/ci.yml
+++ b/sdk/operationalinsights/ci.yml
@@ -1,6 +1,7 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
 trigger: none
+pr: none
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
Updates a couple perf projects to use the newest
Microsoft.Rest.ClientRuntime for CVE-2022-26907.
