### PR TITLE
Disable deprecated track 1 SDKs from building

### DIFF
--- a/sdk/applicationinsights/ci.yml
+++ b/sdk/applicationinsights/ci.yml
@@ -1,28 +1,5 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
-trigger:
-  branches:
-    include:
-    - main
-    - hotfix/*
-    - release/*
-  paths:
-    include:
-    - sdk/applicationinsights/
-    exclude:
-    - sdk/applicationinsights/Azure.ResourceManager.ApplicationInsights/
-
-pr:
-  branches:
-    include:
-    - main
-    - feature/*
-    - hotfix/*
-    - release/*
-  paths:
-    include:
-    - sdk/applicationinsights/
-    exclude:
-    - sdk/applicationinsights/Azure.ResourceManager.ApplicationInsights/
+trigger: none
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/applicationinsights/service.projects
+++ b/sdk/applicationinsights/service.projects
@@ -1,0 +1,6 @@
+<Project>
+    <ItemGroup>
+        <!-- Remove deprecated track 1 packages from builds and live testing. -->
+        <ProjectReference Remove="$(MSBuildThisFileDirectory)Microsoft.Azure.ApplicationInsights*\**\*.csproj" />
+    </ItemGroup>
+</Project>

--- a/sdk/operationalinsights/ci.yml
+++ b/sdk/operationalinsights/ci.yml
@@ -1,29 +1,6 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 
-trigger:
-  branches:
-    include:
-    - main
-    - hotfix/*
-    - release/*
-  paths:
-    include:
-    - sdk/operationalinsights/
-    exclude:
-    - sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/
-
-pr:
-  branches:
-    include:
-    - main
-    - feature/*
-    - hotfix/*
-    - release/*
-  paths:
-    include:
-    - sdk/operationalinsights/
-    exclude:
-    - sdk/operationalinsights/Azure.ResourceManager.OperationalInsights/
+trigger: none
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/operationalinsights/service.projects
+++ b/sdk/operationalinsights/service.projects
@@ -1,0 +1,6 @@
+<Project>
+    <ItemGroup>
+        <!-- Remove deprecated track 1 packages from builds and live testing. -->
+        <ProjectReference Remove="$(MSBuildThisFileDirectory)Microsoft.Azure.OperationalInsights*\**\*.csproj" />
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
These are generating CG alerts unnecessary and are both deprecated in
favor of Azure Monitor Query SDK.
