### PR TITLE
[Core] Updating System.Diagnostics.DiagnosticSource types usage

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
@@ -143,13 +143,20 @@ namespace Azure.Core.Pipeline
             if (currentActivity != null)
             {
                 var currentActivityId = currentActivity.Id ?? string.Empty;
-
+#if NETCOREAPP2_1
                 if (currentActivity.IsW3CFormat())
+#else
+                if (currentActivity.IdFormat == ActivityIdFormat.W3C)
+#endif
                 {
                     if (!message.Request.Headers.Contains(TraceParentHeaderName))
                     {
                         message.Request.Headers.Add(TraceParentHeaderName, currentActivityId);
+#if NETCOREAPP2_1
                         if (currentActivity.GetTraceState() is string traceStateString)
+#else
+                        if (currentActivity.TraceStateString is string traceStateString)
+#endif
                         {
                             message.Request.Headers.Add(TraceStateHeaderName, traceStateString);
                         }
@@ -177,8 +184,16 @@ namespace Azure.Core.Pipeline
 
         private bool ShouldCreateActivity =>
             _isDistributedTracingEnabled &&
+#if NETCOREAPP2_1
             (s_diagnosticSource.IsEnabled() || ActivityExtensions.ActivitySourceHasListeners(s_activitySource));
+#else
+            (s_diagnosticSource.IsEnabled() || s_activitySource.HasListeners());
+#endif
 
+#if NETCOREAPP2_1
         private bool IsActivitySourceEnabled => _isDistributedTracingEnabled && ActivityExtensions.ActivitySourceHasListeners(s_activitySource);
+#else
+        private bool IsActivitySourceEnabled => _isDistributedTracingEnabled && s_activitySource.HasListeners();
+#endif
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -530,16 +530,12 @@ namespace Azure.Core.Pipeline
 
 #if NETCOREAPP2_1
                 if (!activity.TryDispose())
-#else
-                if (activity is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
-                else
-#endif
                 {
                     activity.Stop();
                 }
+#else
+                activity.Dispose();
+#endif
             }
         }
     }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -31,10 +31,20 @@ namespace Azure.Core.Pipeline
 #endif
         {
             // ActivityKind.Internal and Client both can represent public API calls depending on the SDK
+#if NETCOREAPP2_1
             _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == ActivityKind.Internal) ? suppressNestedClientActivities : false;
+#else
+            _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == System.Diagnostics.ActivityKind.Internal) ? suppressNestedClientActivities : false;
+#endif
 
             // outer scope presence is enough to suppress any inner scope, regardless of inner scope configuation.
-            IsEnabled = source.IsEnabled() || ActivityExtensions.ActivitySourceHasListeners(activitySource);
+            bool hasListeners;
+#if NETCOREAPP2_1
+            hasListeners = ActivityExtensions.ActivitySourceHasListeners(activitySource);
+#else
+            hasListeners = activitySource?.HasListeners() ?? false;
+#endif
+            IsEnabled = source.IsEnabled() || hasListeners;
 
             if (_suppressNestedClientActivities)
             {
@@ -178,23 +188,39 @@ namespace Azure.Core.Pipeline
 
         private class ActivityAdapter : IDisposable
         {
+#if NETCOREAPP2_1
             private readonly object? _activitySource;
+#else
+            private readonly ActivitySource? _activitySource;
+#endif
             private readonly DiagnosticSource _diagnosticSource;
             private readonly string _activityName;
+#if NETCOREAPP2_1
             private readonly ActivityKind _kind;
+#else
+            private readonly System.Diagnostics.ActivityKind _kind;
+#endif
             private readonly object? _diagnosticSourceArgs;
 
             private Activity? _currentActivity;
             private Activity? _sampleOutActivity;
 
+#if NETCOREAPP2_1
             private ICollection<KeyValuePair<string,object>>? _tagCollection;
+#else
+            private ActivityTagsCollection? _tagCollection;
+#endif
             private DateTimeOffset _startTime;
             private List<Activity>? _links;
             private string? _traceparent;
             private string? _tracestate;
             private string? _displayName;
 
+#if NETCOREAPP2_1
             public ActivityAdapter(object? activitySource, DiagnosticSource diagnosticSource, string activityName, ActivityKind kind, object? diagnosticSourceArgs)
+#else
+            public ActivityAdapter(ActivitySource? activitySource, DiagnosticSource diagnosticSource, string activityName, System.Diagnostics.ActivityKind kind, object? diagnosticSourceArgs)
+#endif
             {
                 _activitySource = activitySource;
                 _diagnosticSource = diagnosticSource;
@@ -209,30 +235,48 @@ namespace Azure.Core.Pipeline
                 {
                     // Activity is not started yet, add the value to the collection
                     // that is going to be passed to StartActivity
+#if NETCOREAPP2_1
                     _tagCollection ??= ActivityExtensions.CreateTagsCollection() ?? new List<KeyValuePair<string, object>>();
                     _tagCollection?.Add(new KeyValuePair<string, object>(name, value!));
+#else
+                    _tagCollection ??= new ActivityTagsCollection();
+                    _tagCollection.Add(name, value!);
+#endif
                 }
                 else
                 {
+#if NETCOREAPP2_1
                     _currentActivity?.AddObjectTag(name, value);
+#else
+                    _currentActivity?.AddTag(name, value);
+#endif
                 }
             }
 
+#if NETCOREAPP2_1
             private IList? GetActivitySourceLinkCollection()
+#else
+            private List<ActivityLink>? GetActivitySourceLinkCollection()
+#endif
             {
                 if (_links == null)
                 {
                     return null;
                 }
 
+#if NETCOREAPP2_1
                 var linkCollection = ActivityExtensions.CreateLinkCollection();
                 if (linkCollection == null)
                 {
                     return null;
                 }
+#else
+                var linkCollection = new List<ActivityLink>();
+#endif
 
                 foreach (var activity in _links)
                 {
+#if NETCOREAPP2_1
                     ICollection<KeyValuePair<string,object>>? linkTagsCollection =  ActivityExtensions.CreateTagsCollection();
                     if (linkTagsCollection != null)
                     {
@@ -247,6 +291,23 @@ namespace Azure.Core.Pipeline
                     {
                         linkCollection.Add(link);
                     }
+#else
+                    ActivityTagsCollection linkTagsCollection = new();
+                    foreach (var tag in activity.Tags)
+                    {
+                        linkTagsCollection.Add(tag.Key, tag.Value!);
+                    }
+
+                    try
+                    {
+                        var context = ActivityContext.Parse(activity.ParentId!, activity.TraceStateString);
+                        var link = new ActivityLink(context, linkTagsCollection);
+                        linkCollection.Add(link);
+                    }
+                    catch (Exception)
+                    {
+                    }
+#endif
                 }
 
                 return linkCollection;
@@ -255,9 +316,14 @@ namespace Azure.Core.Pipeline
             public void AddLink(string traceparent, string? tracestate, IDictionary<string, string>? attributes)
             {
                 var linkedActivity = new Activity("LinkedActivity");
-                linkedActivity.SetW3CFormat();
                 linkedActivity.SetParentId(traceparent);
+#if NETCOREAPP2_1
+                linkedActivity.SetW3CFormat();
                 linkedActivity.SetTraceState(tracestate);
+#else
+                linkedActivity.SetIdFormat(ActivityIdFormat.W3C);
+                linkedActivity.TraceStateString = tracestate;
+#endif
 
                 if (attributes != null)
                 {
@@ -276,7 +342,11 @@ namespace Azure.Core.Pipeline
                 _currentActivity = StartActivitySourceActivity();
                 if (_currentActivity != null)
                 {
+#if NETCOREAPP2_1
                     if (!_currentActivity.GetIsAllDataRequested())
+#else
+                    if (!_currentActivity.IsAllDataRequested)
+#endif
                     {
                         _sampleOutActivity = _currentActivity;
                         _currentActivity = null;
@@ -316,7 +386,11 @@ namespace Azure.Core.Pipeline
                     {
                         Links = (IEnumerable<Activity>?)_links ?? Array.Empty<Activity>(),
                     };
+#if NETCOREAPP2_1
                     _currentActivity.SetW3CFormat();
+#else
+                    _currentActivity.SetIdFormat(ActivityIdFormat.W3C);
+#endif
 
                     if (_startTime != default)
                     {
@@ -327,7 +401,11 @@ namespace Azure.Core.Pipeline
                     {
                         foreach (var tag in _tagCollection)
                         {
+#if NETCOREAPP2_1
                             _currentActivity.AddObjectTag(tag.Key, tag.Value);
+#else
+                            _currentActivity.AddTag(tag.Key, tag.Value);
+#endif
                         }
                     }
 
@@ -338,7 +416,11 @@ namespace Azure.Core.Pipeline
 
                     if (_tracestate != null)
                     {
+#if NETCOREAPP2_1
                         _currentActivity.SetTraceState(_tracestate);
+#else
+                        _currentActivity.TraceStateString = _tracestate;
+#endif
                     }
 
                     _currentActivity.Start();
@@ -348,7 +430,11 @@ namespace Azure.Core.Pipeline
 
                 if (_displayName != null)
                 {
+#if NETCOREAPP2_1
                     _currentActivity?.SetDisplayName(_displayName);
+#else
+                    _currentActivity.DisplayName = _displayName;
+#endif
                 }
 
                 return _currentActivity;
@@ -357,11 +443,19 @@ namespace Azure.Core.Pipeline
             public void SetDisplayName(string displayName)
             {
                 _displayName = displayName;
-                _currentActivity?.SetDisplayName(displayName);
+                if (_currentActivity != null)
+                {
+#if NETCOREAPP2_1
+                    _currentActivity.SetDisplayName(_displayName);
+#else
+                    _currentActivity.DisplayName = _displayName;
+#endif
+                }
             }
 
             private Activity? StartActivitySourceActivity()
             {
+#if NETCOREAPP2_1
                 return ActivityExtensions.ActivitySourceStartActivity(
                     _activitySource,
                     _activityName,
@@ -371,6 +465,23 @@ namespace Azure.Core.Pipeline
                     links: GetActivitySourceLinkCollection(),
                     traceparent: _traceparent,
                     tracestate: _tracestate);
+#else
+                if (_activitySource == null)
+                {
+                    return null;
+                }
+                ActivityContext context;
+                if (_traceparent != null)
+                {
+                    context = ActivityContext.Parse(_traceparent, _tracestate);
+                }
+                else
+                {
+                    context = new ActivityContext();
+                }
+                var activity = _activitySource.StartActivity(_activityName, _kind, context, _tagCollection, GetActivitySourceLinkCollection()!, _startTime);
+                return activity;
+#endif
             }
 
             public void SetStartTime(DateTime startTime)
@@ -386,10 +497,15 @@ namespace Azure.Core.Pipeline
                     _diagnosticSource?.Write(_activityName + ".Exception", exception);
                 }
 
+#if NETCOREAPP2_1
                 if (ActivityExtensions.SupportsActivitySource())
                 {
                     _currentActivity?.SetErrorStatus(exception?.ToString());
                 }
+#endif
+#if NET6_0_OR_GREATER
+                _currentActivity?.SetStatus(ActivityStatusCode.Error, exception?.ToString());
+#endif
             }
 
             public void SetTraceContext(string traceparent, string? tracestate)
@@ -415,7 +531,15 @@ namespace Azure.Core.Pipeline
 
                 _diagnosticSource.Write(_activityName + ".Stop", _diagnosticSourceArgs);
 
+#if NETCOREAPP2_1
                 if (!activity.TryDispose())
+#else
+                if (activity is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+                else
+#endif
                 {
                     activity.Stop();
                 }
@@ -423,6 +547,7 @@ namespace Azure.Core.Pipeline
         }
     }
 
+#if NETCOREAPP2_1
 #pragma warning disable SA1507 // File can not contain multiple types
     /// <summary>
     /// Until we can reference the 5.0 of System.Diagnostics.DiagnosticSource
@@ -918,4 +1043,26 @@ namespace Azure.Core.Pipeline
                 "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE");
         }
     }
+#else
+#pragma warning disable SA1507 // File can not contain multiple types
+    /// <summary>
+    /// Until Activity Source is no longer considered experimental.
+    /// </summary>
+    internal static class ActivityExtensions
+    {
+        private static bool SupportsActivitySourceSwitch;
+
+        public static bool SupportsActivitySource()
+        {
+            return SupportsActivitySourceSwitch;
+        }
+
+        public static void ResetFeatureSwitch()
+        {
+            SupportsActivitySourceSwitch = AppContextSwitchHelper.GetConfigValue(
+                "Azure.Experimental.EnableActivitySource",
+                "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE");
+        }
+    }
+#endif
 }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -298,17 +298,14 @@ namespace Azure.Core.Pipeline
                         linkTagsCollection.Add(tag.Key, tag.Value!);
                     }
 
-                    try
+                    var contextWasParsed = ActivityContext.TryParse(activity.ParentId!, activity.TraceStateString, out var context);
+                    if (contextWasParsed)
                     {
-                        var context = ActivityContext.Parse(activity.ParentId!, activity.TraceStateString);
                         var link = new ActivityLink(context, linkTagsCollection);
                         linkCollection.Add(link);
                     }
-                    catch (Exception)
-                    {
-                    }
 #endif
-                }
+            }
 
                 return linkCollection;
             }
@@ -1050,16 +1047,11 @@ namespace Azure.Core.Pipeline
     /// </summary>
     internal static class ActivityExtensions
     {
-        private static bool SupportsActivitySourceSwitch;
-
-        public static bool SupportsActivitySource()
-        {
-            return SupportsActivitySourceSwitch;
-        }
+        public static bool SupportsActivitySource { get; private set; }
 
         public static void ResetFeatureSwitch()
         {
-            SupportsActivitySourceSwitch = AppContextSwitchHelper.GetConfigValue(
+            SupportsActivitySource = AppContextSwitchHelper.GetConfigValue(
                 "Azure.Experimental.EnableActivitySource",
                 "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE");
         }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -88,7 +88,11 @@ namespace Azure.Core.Pipeline
         private static ActivitySource? GetActivitySource(string ns, string name)
 #endif
         {
+#if NETCOREAPP2_1
             if (!ActivityExtensions.SupportsActivitySource())
+#else
+            if (!ActivityExtensions.SupportsActivitySource)
+#endif
             {
                 return null;
             }

--- a/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
@@ -65,7 +65,7 @@ namespace Azure.Core.Shared
             MessagingDiagnosticOperation operation = default)
         {
             DiagnosticScope scope = _scopeFactory.CreateScope(activityName, kind);
-            if (ActivityExtensions.SupportsActivitySource())
+            if (ActivityExtensions.SupportsActivitySource)
             {
                 scope.AddAttribute(MessagingSystem, _messagingSystem);
                 if (operation != default)
@@ -99,7 +99,7 @@ namespace Azure.Core.Shared
             traceparent = null;
             tracestate = null;
 
-            if (ActivityExtensions.SupportsActivitySource() && properties.TryGetValue(TraceParent, out var traceParent) && traceParent is string traceParentString)
+            if (ActivityExtensions.SupportsActivitySource && properties.TryGetValue(TraceParent, out var traceParent) && traceParent is string traceParentString)
             {
                 traceparent = traceParentString;
                 if (properties.TryGetValue(TraceState, out object state) && state is string stateString)
@@ -131,7 +131,7 @@ namespace Azure.Core.Shared
             traceparent = null;
             tracestate = null;
 
-            if (ActivityExtensions.SupportsActivitySource() && properties.TryGetValue(TraceParent, out var traceParent) && traceParent is string traceParentString)
+            if (ActivityExtensions.SupportsActivitySource && properties.TryGetValue(TraceParent, out var traceParent) && traceParent is string traceParentString)
             {
                 traceparent = traceParentString;
                 if (properties.TryGetValue(TraceState, out object state) && state is string stateString)
@@ -175,7 +175,7 @@ namespace Azure.Core.Shared
                 {
                     traceparent = activity.Id!;
                     properties[DiagnosticIdAttribute] = traceparent;
-                    if (ActivityExtensions.SupportsActivitySource())
+                    if (ActivityExtensions.SupportsActivitySource)
                     {
                         properties[TraceParent] = traceparent;
                         if (activity.TraceStateString != null)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -629,7 +629,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             {
                 var isBatch = (EventBatchMaximumCount > 1);
 
-                if (isBatch && ActivityExtensions.SupportsActivitySource())
+                if (isBatch && ActivityExtensions.SupportsActivitySource)
                     diagnosticScope.AddIntegerAttribute(MessagingClientDiagnostics.BatchCount, eventBatch.Count);
 
                 foreach (var eventData in eventBatch)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -1304,7 +1304,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 {
                     scope.AddLink(context.TraceParent, context.TraceState);
                 }
-                if (eventCount > 1 && ActivityExtensions.SupportsActivitySource())
+                if (eventCount > 1 && ActivityExtensions.SupportsActivitySource)
                 {
                     scope.AddIntegerAttribute(MessagingClientDiagnostics.BatchCount, eventCount);
                 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
@@ -71,7 +71,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                     AddLinkedDiagnostics(scope, message.ApplicationProperties);
                 }
 
-                if (messages.Count > 1 && ActivityExtensions.SupportsActivitySource())
+                if (messages.Count > 1 && ActivityExtensions.SupportsActivitySource)
                 {
                     scope.AddIntegerAttribute(MessagingClientDiagnostics.BatchCount, messages.Count);
                 }
@@ -87,7 +87,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                     AddLinkedDiagnostics(scope, message.ApplicationProperties.Map);
                 }
 
-                if (messages.Count > 1 && ActivityExtensions.SupportsActivitySource())
+                if (messages.Count > 1 && ActivityExtensions.SupportsActivitySource)
                 {
                     scope.AddIntegerAttribute(MessagingClientDiagnostics.BatchCount, messages.Count);
                 }
@@ -111,7 +111,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                     AddLinkedDiagnostics(scope, message.ApplicationProperties);
                 }
 
-                if (messages.Count > 1 && ActivityExtensions.SupportsActivitySource())
+                if (messages.Count > 1 && ActivityExtensions.SupportsActivitySource)
                 {
                     scope.AddIntegerAttribute(MessagingClientDiagnostics.BatchCount, messages.Count);
                 }


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/37593

This pull request updates the types used from `System.Diagnostics.DiagnosticSource` in order to remove as much of the `ActivityExtensions` class as possible. Right now, ActivitySource is still considered experimental. Because of this, it's easiest to leave the two methods in the ActivityExtensions class to keep track of if ActivitySource is enabled. Once ActivitySource is no longer considered experimental, then we can remove this class entirely.

In addition, rather than deleting the previously used code, it is wrapped in preprocessor directives to keep the NETCOREAPP2.1 build target from breaking. Once the NETCOREAPP2.1 target is removed, then all of this code can be removed.

This work was prepped by the following PRs:
- https://github.com/Azure/azure-sdk-for-net/pull/37600
- https://github.com/Azure/azure-sdk-for-net/pull/37597

Additional Information and context is here:
- https://github.com/Azure/azure-sdk-for-net/issues/33683
- https://github.com/Azure/azure-sdk-for-net/pull/37418

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
