### PR TITLE
DataMovement `DataTransfer` links back to owning `TransferManager`

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -5,6 +5,7 @@ namespace Azure.Storage.DataMovement
         internal DataTransfer() { }
         public bool HasCompleted { get { throw null; } }
         public string Id { get { throw null; } }
+        public Azure.Storage.DataMovement.TransferManager TransferManager { get { throw null; } }
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -5,6 +5,7 @@ namespace Azure.Storage.DataMovement
         internal DataTransfer() { }
         public bool HasCompleted { get { throw null; } }
         public string Id { get { throw null; } }
+        public Azure.Storage.DataMovement.TransferManager TransferManager { get { throw null; } }
         public Azure.Storage.DataMovement.StorageTransferStatus TransferStatus { get { throw null; } }
         public System.Threading.Tasks.Task AwaitCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void EnsureCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransfer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransfer.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -13,7 +9,7 @@ using Azure.Core.Pipeline;
 namespace Azure.Storage.DataMovement
 {
     /// <summary>
-    /// Holds transfer information
+    /// Holds transfer information.
     /// </summary>
     public class DataTransfer
     {
@@ -33,6 +29,11 @@ namespace Azure.Storage.DataMovement
         public string Id => _state.Id;
 
         /// <summary>
+        /// The <see cref="TransferManager"/> responsible for this transfer.
+        /// </summary>
+        public TransferManager TransferManager { get; }
+
+        /// <summary>
         /// Defines the current state of the transfer.
         /// </summary>
         internal DataTransferState _state;
@@ -48,13 +49,17 @@ namespace Azure.Storage.DataMovement
         /// Constructing a DataTransfer object.
         /// </summary>
         /// <param name="id">The transfer ID of the transfer object.</param>
+        /// <param name="transferManager">Reference to the transfer manager running this transfer.</param>
         /// <param name="status">The Transfer Status of the Transfer. See <see cref="StorageTransferStatus"/>.</param>
         internal DataTransfer(
             string id,
+            TransferManager transferManager,
             StorageTransferStatus status = StorageTransferStatus.Queued)
         {
             Argument.AssertNotNullOrEmpty(id, nameof(id));
+            Argument.AssertNotNull(transferManager, nameof(transferManager));
             _state = new DataTransferState(id, status);
+            TransferManager = transferManager;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
@@ -460,7 +460,7 @@ namespace Azure.Storage.DataMovement
             bool resumeJob,
             CancellationToken cancellationToken)
         {
-            DataTransfer dataTransfer = new DataTransfer(id: transferId);
+            DataTransfer dataTransfer = new DataTransfer(id: transferId, transferManager: this);
             _dataTransfers.Add(dataTransfer.Id, dataTransfer);
 
             TransferJobInternal transferJobInternal;
@@ -805,6 +805,7 @@ namespace Azure.Storage.DataMovement
 
                 _dataTransfers.Add(transferId, new DataTransfer(
                     id: transferId,
+                    transferManager: this,
                     status: header.AtomicJobStatus));
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/DataTransferTests.cs
@@ -18,12 +18,14 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
+            TransferManager transferManager = new();
 
             // Act
-            DataTransfer transfer = new DataTransfer(id: transferId);
+            DataTransfer transfer = new DataTransfer(id: transferId, transferManager: transferManager);
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
+            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsFalse(transfer.HasCompleted);
         }
 
@@ -38,14 +40,17 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
+            TransferManager transferManager = new();
 
             // Act
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: transferManager,
                 status: status);
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
+            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsFalse(transfer.HasCompleted);
         }
 
@@ -57,14 +62,17 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
+            TransferManager transferManager = new();
 
             // Act
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: transferManager,
                 status: status);
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
+            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -73,9 +81,11 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
+            TransferManager transferManager = new();
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: transferManager,
                 status: StorageTransferStatus.Completed);
 
             // Act
@@ -83,6 +93,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
+            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -94,6 +105,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: new(),
                 status: StorageTransferStatus.Queued);
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
@@ -108,9 +120,11 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             string transferId = GetNewTransferId();
+            TransferManager transferManager = new();
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: transferManager,
                 status: StorageTransferStatus.Completed);
 
             // Act
@@ -118,6 +132,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             Assert.AreEqual(transferId, transfer.Id);
+            Assert.AreEqual(transferManager, transfer.TransferManager);
             Assert.IsTrue(transfer.HasCompleted);
         }
 
@@ -129,6 +144,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: new(),
                 status: StorageTransferStatus.Queued);
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
@@ -145,6 +161,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: new(),
                 status: StorageTransferStatus.InProgress);
 
             // Act
@@ -176,6 +193,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: new(),
                 status: status);
 
             Assert.AreEqual(status, transfer.TransferStatus);
@@ -191,6 +209,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransfer transfer = new DataTransfer(
                 id: transferId,
+                transferManager: new(),
                 status: StorageTransferStatus.InProgress);
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
@@ -43,6 +43,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             return new DataTransfer(
                 id: Guid.NewGuid().ToString(),
+                transferManager: new(),
                 status: status);
         }
 


### PR DESCRIPTION
Useful reference to have for BlobContainerClient extensions as well as future work.