### PR TITLE
[Core] Disable otel tracing in netcoreapp2.1

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
@@ -179,7 +179,7 @@ namespace Azure.Core.Pipeline
         private bool ShouldCreateActivity =>
             _isDistributedTracingEnabled &&
 #if NETCOREAPP2_1 // Activity Source support is not available on netcoreapp2.1
-            false;
+            s_diagnosticSource.IsEnabled();
 #else
             (s_diagnosticSource.IsEnabled() || s_activitySource.HasListeners());
 #endif

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -16,6 +16,8 @@ namespace Azure.Core.Pipeline
 {
     internal readonly struct DiagnosticScope : IDisposable
     {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
         private const string AzureSdkScopeLabel = "az.sdk.scope";
         internal const string OpenTelemetrySchemaAttribute = "az.schema_url";
         internal const string OpenTelemetrySchemaVersion = "https://opentelemetry.io/schemas/1.17.0";
@@ -24,26 +26,14 @@ namespace Azure.Core.Pipeline
         private readonly ActivityAdapter? _activityAdapter;
         private readonly bool _suppressNestedClientActivities;
 
-#if NETCOREAPP2_1
-        internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, object? activitySource, ActivityKind kind, bool suppressNestedClientActivities)
-#else
         internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, ActivitySource? activitySource, System.Diagnostics.ActivityKind kind, bool suppressNestedClientActivities)
-#endif
         {
             // ActivityKind.Internal and Client both can represent public API calls depending on the SDK
-#if NETCOREAPP2_1
-            _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == ActivityKind.Internal) ? suppressNestedClientActivities : false;
-#else
             _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == System.Diagnostics.ActivityKind.Internal) ? suppressNestedClientActivities : false;
-#endif
 
             // outer scope presence is enough to suppress any inner scope, regardless of inner scope configuation.
             bool hasListeners;
-#if NETCOREAPP2_1
-            hasListeners = ActivityExtensions.ActivitySourceHasListeners(activitySource);
-#else
             hasListeners = activitySource?.HasListeners() ?? false;
-#endif
             IsEnabled = source.IsEnabled() || hasListeners;
 
             if (_suppressNestedClientActivities)
@@ -58,17 +48,24 @@ namespace Azure.Core.Pipeline
                                                     kind: kind,
                                                     diagnosticSourceArgs: diagnosticSourceArgs) : null;
         }
+#endif
 
         public bool IsEnabled { get; }
 
         public void AddAttribute(string name, string value)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             _activityAdapter?.AddTag(name, value);
+#endif
         }
 
         public void AddIntegerAttribute(string name, int value)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             _activityAdapter?.AddTag(name, value);
+#endif
         }
 
         public void AddAttribute<T>(string name,
@@ -82,11 +79,14 @@ namespace Azure.Core.Pipeline
 
         public void AddAttribute<T>(string name, T value, Func<T, string> format)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             if (_activityAdapter != null)
             {
                 var formattedValue = format(value);
                 _activityAdapter.AddTag(name, formattedValue);
             }
+#endif
         }
 
         /// <summary>
@@ -97,23 +97,35 @@ namespace Azure.Core.Pipeline
         /// <param name="attributes">Optional attributes to associate with the link.</param>
         public void AddLink(string traceparent, string? tracestate, IDictionary<string, string>? attributes = null)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             _activityAdapter?.AddLink(traceparent, tracestate, attributes);
+#endif
         }
 
         public void Start()
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             Activity? started = _activityAdapter?.Start();
             started?.SetCustomProperty(AzureSdkScopeLabel, AzureSdkScopeValue);
+#endif
         }
 
         public void SetDisplayName(string displayName)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             _activityAdapter?.SetDisplayName(displayName);
+#endif
         }
 
         public void SetStartTime(DateTime dateTime)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             _activityAdapter?.SetStartTime(dateTime);
+#endif
         }
 
         /// <summary>
@@ -123,13 +135,19 @@ namespace Azure.Core.Pipeline
         /// <param name="tracestate">The trace state to set for the current scope.</param>
         public void SetTraceContext(string traceparent, string? tracestate = default)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             _activityAdapter?.SetTraceContext(traceparent, tracestate);
+#endif
         }
 
         public void Dispose()
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             // Reverse the Start order
             _activityAdapter?.Dispose();
+#endif
         }
 
         /// <summary>
@@ -138,42 +156,11 @@ namespace Azure.Core.Pipeline
         /// <param name="exception">The exception to associate with the failed scope.</param>
         public void Failed(Exception? exception = default)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             _activityAdapter?.MarkFailed(exception);
-        }
-
-#if NETCOREAPP2_1
-        /// <summary>
-        /// Kind describes the relationship between the Activity, its parents, and its children in a Trace.
-        /// </summary>
-        public enum ActivityKind
-        {
-            /// <summary>
-            /// Default value.
-            /// Indicates that the Activity represents an internal operation within an application, as opposed to an operations with remote parents or children.
-            /// </summary>
-            Internal = 0,
-
-            /// <summary>
-            /// Server activity represents request incoming from external component.
-            /// </summary>
-            Server = 1,
-
-            /// <summary>
-            /// Client activity represents outgoing request to the external component.
-            /// </summary>
-            Client = 2,
-
-            /// <summary>
-            /// Producer activity represents output provided to external components.
-            /// </summary>
-            Producer = 3,
-
-            /// <summary>
-            /// Consumer activity represents output received from an external component.
-            /// </summary>
-            Consumer = 4,
-        }
 #endif
+        }
 
         private class DiagnosticActivity : Activity
         {
@@ -186,41 +173,27 @@ namespace Azure.Core.Pipeline
             }
         }
 
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
         private class ActivityAdapter : IDisposable
         {
-#if NETCOREAPP2_1
-            private readonly object? _activitySource;
-#else
             private readonly ActivitySource? _activitySource;
-#endif
             private readonly DiagnosticSource _diagnosticSource;
             private readonly string _activityName;
-#if NETCOREAPP2_1
-            private readonly ActivityKind _kind;
-#else
             private readonly System.Diagnostics.ActivityKind _kind;
-#endif
             private readonly object? _diagnosticSourceArgs;
 
             private Activity? _currentActivity;
             private Activity? _sampleOutActivity;
 
-#if NETCOREAPP2_1
-            private ICollection<KeyValuePair<string,object>>? _tagCollection;
-#else
             private ActivityTagsCollection? _tagCollection;
-#endif
             private DateTimeOffset _startTime;
             private List<Activity>? _links;
             private string? _traceparent;
             private string? _tracestate;
             private string? _displayName;
 
-#if NETCOREAPP2_1
-            public ActivityAdapter(object? activitySource, DiagnosticSource diagnosticSource, string activityName, ActivityKind kind, object? diagnosticSourceArgs)
-#else
             public ActivityAdapter(ActivitySource? activitySource, DiagnosticSource diagnosticSource, string activityName, System.Diagnostics.ActivityKind kind, object? diagnosticSourceArgs)
-#endif
             {
                 _activitySource = activitySource;
                 _diagnosticSource = diagnosticSource;
@@ -235,63 +208,26 @@ namespace Azure.Core.Pipeline
                 {
                     // Activity is not started yet, add the value to the collection
                     // that is going to be passed to StartActivity
-#if NETCOREAPP2_1
-                    _tagCollection ??= ActivityExtensions.CreateTagsCollection() ?? new List<KeyValuePair<string, object>>();
-                    _tagCollection?.Add(new KeyValuePair<string, object>(name, value!));
-#else
                     _tagCollection ??= new ActivityTagsCollection();
                     _tagCollection.Add(name, value!);
-#endif
                 }
                 else
                 {
-#if NETCOREAPP2_1
-                    _currentActivity?.AddObjectTag(name, value);
-#else
                     _currentActivity?.AddTag(name, value);
-#endif
                 }
             }
 
-#if NETCOREAPP2_1
-            private IList? GetActivitySourceLinkCollection()
-#else
             private List<ActivityLink>? GetActivitySourceLinkCollection()
-#endif
             {
                 if (_links == null)
                 {
                     return null;
                 }
 
-#if NETCOREAPP2_1
-                var linkCollection = ActivityExtensions.CreateLinkCollection();
-                if (linkCollection == null)
-                {
-                    return null;
-                }
-#else
                 var linkCollection = new List<ActivityLink>();
-#endif
 
                 foreach (var activity in _links)
                 {
-#if NETCOREAPP2_1
-                    ICollection<KeyValuePair<string,object>>? linkTagsCollection =  ActivityExtensions.CreateTagsCollection();
-                    if (linkTagsCollection != null)
-                    {
-                        foreach (var tag in activity.Tags)
-                        {
-                            linkTagsCollection.Add(new KeyValuePair<string, object>(tag.Key, tag.Value!));
-                        }
-                    }
-
-                    var link = ActivityExtensions.CreateActivityLink(activity.ParentId!, activity.GetTraceState(), linkTagsCollection);
-                    if (link != null)
-                    {
-                        linkCollection.Add(link);
-                    }
-#else
                     ActivityTagsCollection linkTagsCollection = new();
                     foreach (var tag in activity.Tags)
                     {
@@ -304,7 +240,6 @@ namespace Azure.Core.Pipeline
                         var link = new ActivityLink(context, linkTagsCollection);
                         linkCollection.Add(link);
                     }
-#endif
             }
 
                 return linkCollection;
@@ -314,13 +249,8 @@ namespace Azure.Core.Pipeline
             {
                 var linkedActivity = new Activity("LinkedActivity");
                 linkedActivity.SetParentId(traceparent);
-#if NETCOREAPP2_1
-                linkedActivity.SetW3CFormat();
-                linkedActivity.SetTraceState(tracestate);
-#else
                 linkedActivity.SetIdFormat(ActivityIdFormat.W3C);
                 linkedActivity.TraceStateString = tracestate;
-#endif
 
                 if (attributes != null)
                 {
@@ -339,11 +269,7 @@ namespace Azure.Core.Pipeline
                 _currentActivity = StartActivitySourceActivity();
                 if (_currentActivity != null)
                 {
-#if NETCOREAPP2_1
-                    if (!_currentActivity.GetIsAllDataRequested())
-#else
                     if (!_currentActivity.IsAllDataRequested)
-#endif
                     {
                         _sampleOutActivity = _currentActivity;
                         _currentActivity = null;
@@ -383,11 +309,7 @@ namespace Azure.Core.Pipeline
                     {
                         Links = (IEnumerable<Activity>?)_links ?? Array.Empty<Activity>(),
                     };
-#if NETCOREAPP2_1
-                    _currentActivity.SetW3CFormat();
-#else
                     _currentActivity.SetIdFormat(ActivityIdFormat.W3C);
-#endif
 
                     if (_startTime != default)
                     {
@@ -398,11 +320,7 @@ namespace Azure.Core.Pipeline
                     {
                         foreach (var tag in _tagCollection)
                         {
-#if NETCOREAPP2_1
-                            _currentActivity.AddObjectTag(tag.Key, tag.Value);
-#else
                             _currentActivity.AddTag(tag.Key, tag.Value);
-#endif
                         }
                     }
 
@@ -413,11 +331,7 @@ namespace Azure.Core.Pipeline
 
                     if (_tracestate != null)
                     {
-#if NETCOREAPP2_1
-                        _currentActivity.SetTraceState(_tracestate);
-#else
                         _currentActivity.TraceStateString = _tracestate;
-#endif
                     }
 
                     _currentActivity.Start();
@@ -427,11 +341,7 @@ namespace Azure.Core.Pipeline
 
                 if (_displayName != null)
                 {
-#if NETCOREAPP2_1
-                    _currentActivity?.SetDisplayName(_displayName);
-#else
                     _currentActivity.DisplayName = _displayName;
-#endif
                 }
 
                 return _currentActivity;
@@ -442,27 +352,12 @@ namespace Azure.Core.Pipeline
                 _displayName = displayName;
                 if (_currentActivity != null)
                 {
-#if NETCOREAPP2_1
-                    _currentActivity.SetDisplayName(_displayName);
-#else
                     _currentActivity.DisplayName = _displayName;
-#endif
                 }
             }
 
             private Activity? StartActivitySourceActivity()
             {
-#if NETCOREAPP2_1
-                return ActivityExtensions.ActivitySourceStartActivity(
-                    _activitySource,
-                    _activityName,
-                    (int)_kind,
-                    startTime: _startTime,
-                    tags: _tagCollection,
-                    links: GetActivitySourceLinkCollection(),
-                    traceparent: _traceparent,
-                    tracestate: _tracestate);
-#else
                 if (_activitySource == null)
                 {
                     return null;
@@ -478,7 +373,6 @@ namespace Azure.Core.Pipeline
                 }
                 var activity = _activitySource.StartActivity(_activityName, _kind, context, _tagCollection, GetActivitySourceLinkCollection()!, _startTime);
                 return activity;
-#endif
             }
 
             public void SetStartTime(DateTime startTime)
@@ -494,12 +388,6 @@ namespace Azure.Core.Pipeline
                     _diagnosticSource?.Write(_activityName + ".Exception", exception);
                 }
 
-#if NETCOREAPP2_1
-                if (ActivityExtensions.SupportsActivitySource())
-                {
-                    _currentActivity?.SetErrorStatus(exception?.ToString());
-                }
-#endif
 #if NET6_0_OR_GREATER
                 _currentActivity?.SetStatus(ActivityStatusCode.Error, exception?.ToString());
 #endif
@@ -527,515 +415,13 @@ namespace Azure.Core.Pipeline
                     activity.SetEndTime(DateTime.UtcNow);
 
                 _diagnosticSource.Write(_activityName + ".Stop", _diagnosticSourceArgs);
-
-#if NETCOREAPP2_1
-                if (!activity.TryDispose())
-                {
-                    activity.Stop();
-                }
-#else
                 activity.Dispose();
+            }
+        }
 #endif
-            }
-        }
     }
 
-#if NETCOREAPP2_1
-#pragma warning disable SA1507 // File can not contain multiple types
-    /// <summary>
-    /// Until we can reference the 5.0 of System.Diagnostics.DiagnosticSource
-    /// </summary>
-    internal static class ActivityExtensions
-    {
-        static ActivityExtensions()
-        {
-            ResetFeatureSwitch();
-        }
-
-        private static bool SupportsActivitySourceSwitch;
-
-        private static readonly Type? ActivitySourceType = Type.GetType("System.Diagnostics.ActivitySource, System.Diagnostics.DiagnosticSource");
-        private static readonly Type? ActivityKindType = Type.GetType("System.Diagnostics.ActivityKind, System.Diagnostics.DiagnosticSource");
-        private static readonly Type? ActivityTagsCollectionType = Type.GetType("System.Diagnostics.ActivityTagsCollection, System.Diagnostics.DiagnosticSource");
-        private static readonly Type? ActivityLinkType = Type.GetType("System.Diagnostics.ActivityLink, System.Diagnostics.DiagnosticSource");
-        private static readonly Type? ActivityContextType = Type.GetType("System.Diagnostics.ActivityContext, System.Diagnostics.DiagnosticSource");
-        private static readonly Type? ActivityStatusCodeType = Type.GetType("System.Diagnostics.ActivityStatusCode, System.Diagnostics.DiagnosticSource");
-
-        private static Action<Activity, int>? SetIdFormatMethod;
-        private static Func<Activity, string?>? GetTraceStateStringMethod;
-        private static Action<Activity, string?>? SetTraceStateStringMethod;
-        private static Action<Activity, int, string?>? SetErrorStatusMethod;
-        private static Func<Activity, int>? GetIdFormatMethod;
-        private static Func<Activity, bool>? GetAllDataRequestedMethod;
-        private static Action<Activity, string, object?>? ActivityAddTagMethod;
-        private static Func<object, string, int, object?, ICollection<KeyValuePair<string, object>>?, IList?, DateTimeOffset, Activity?>? ActivitySourceStartActivityMethod;
-        private static Func<object, bool>? ActivitySourceHasListenersMethod;
-        private static Func<string, string?, ICollection<KeyValuePair<string, object>>?, object?>? CreateActivityLinkMethod;
-        private static Func<ICollection<KeyValuePair<string,object>>?>? CreateTagsCollectionMethod;
-        private static Func<Activity, string, object?>? GetCustomPropertyMethod;
-        private static Action<Activity, string, object>? SetCustomPropertyMethod;
-        private static readonly ParameterExpression ActivityParameter = Expression.Parameter(typeof(Activity));
-        private static MethodInfo? ParseActivityContextMethod;
-        private static Action<Activity, string>? SetDisplayNameMethod;
-
-        public static object? GetCustomProperty(this Activity activity, string propertyName)
-        {
-            if (GetCustomPropertyMethod == null)
-            {
-                var method = typeof(Activity).GetMethod("GetCustomProperty");
-                if (method == null)
-                {
-                    GetCustomPropertyMethod = (_, _) => null;
-                }
-                else
-                {
-                    var nameParameter = Expression.Parameter(typeof(string));
-
-                    GetCustomPropertyMethod = Expression.Lambda<Func<Activity, string, object>>(
-                        Expression.Convert(Expression.Call(ActivityParameter, method, nameParameter), typeof(object)),
-                        ActivityParameter, nameParameter).Compile();
-                }
-            }
-
-            return GetCustomPropertyMethod(activity, propertyName);
-        }
-
-        public static void SetCustomProperty(this Activity activity, string propertyName, object propertyValue)
-        {
-            if (SetCustomPropertyMethod == null)
-            {
-                var method = typeof(Activity).GetMethod("SetCustomProperty");
-                if (method == null)
-                {
-                    SetCustomPropertyMethod = (_, _, _) => { };
-                }
-                else
-                {
-                    var nameParameter = Expression.Parameter(typeof(string));
-                    var valueParameter = Expression.Parameter(typeof(object));
-
-                    SetCustomPropertyMethod = Expression.Lambda<Action<Activity, string, object>>(
-                        Expression.Call(ActivityParameter, method, nameParameter, valueParameter),
-                        ActivityParameter, nameParameter, valueParameter).Compile();
-                }
-            }
-
-            SetCustomPropertyMethod(activity, propertyName, propertyValue);
-        }
-
-        public static void SetW3CFormat(this Activity activity)
-        {
-            if (SetIdFormatMethod == null)
-            {
-                var method = typeof(Activity).GetMethod("SetIdFormat");
-                if (method == null)
-                {
-                    SetIdFormatMethod = (_, _) => { };
-                }
-                else
-                {
-                    var idParameter = Expression.Parameter(typeof(int));
-                    var convertedId = Expression.Convert(idParameter, method.GetParameters()[0].ParameterType);
-
-                    SetIdFormatMethod = Expression.Lambda<Action<Activity, int>>(
-                        Expression.Call(ActivityParameter, method, convertedId),
-                        ActivityParameter, idParameter).Compile();
-                }
-            }
-
-            SetIdFormatMethod(activity, 2 /* ActivityIdFormat.W3C */);
-        }
-
-        public static bool IsW3CFormat(this Activity activity)
-        {
-            if (GetIdFormatMethod == null)
-            {
-                var method = typeof(Activity).GetProperty("IdFormat")?.GetMethod;
-                if (method == null)
-                {
-                    GetIdFormatMethod = _ => -1;
-                }
-                else
-                {
-                    GetIdFormatMethod = Expression.Lambda<Func<Activity, int>>(
-                        Expression.Convert(Expression.Call(ActivityParameter, method), typeof(int)),
-                        ActivityParameter).Compile();
-                }
-            }
-
-
-            int result = GetIdFormatMethod(activity);
-
-            return result == 2 /* ActivityIdFormat.W3C */;
-        }
-
-        public static string? GetTraceState(this Activity activity)
-        {
-            if (GetTraceStateStringMethod == null)
-            {
-                var method = typeof(Activity).GetProperty("TraceStateString")?.GetMethod;
-                if (method == null)
-                {
-                    GetTraceStateStringMethod = _ => null;
-                }
-                else
-                {
-                    GetTraceStateStringMethod = Expression.Lambda<Func<Activity, string?>>(
-                        Expression.Call(ActivityParameter, method),
-                        ActivityParameter).Compile();
-                }
-            }
-
-            return GetTraceStateStringMethod(activity);
-        }
-
-        public static bool GetIsAllDataRequested(this Activity activity)
-        {
-            if (GetAllDataRequestedMethod == null)
-            {
-                var method = typeof(Activity).GetProperty("IsAllDataRequested")?.GetMethod;
-                if (method == null)
-                {
-                    GetAllDataRequestedMethod = _ => true;
-                }
-                else
-                {
-                    GetAllDataRequestedMethod = Expression.Lambda<Func<Activity, bool>>(
-                        Expression.Call(ActivityParameter, method),
-                        ActivityParameter).Compile();
-                }
-            }
-            return GetAllDataRequestedMethod(activity);
-        }
-
-        public static void SetDisplayName(this Activity activity, string displayName)
-        {
-            if (displayName != null)
-            {
-                if (SetDisplayNameMethod == null)
-                {
-                    var method = typeof(Activity).GetProperty("DisplayName")?.SetMethod;
-                    if (method == null)
-                    {
-                        SetDisplayNameMethod = (_, _) => { };
-                    }
-                    else
-                    {
-                        var displayNameParameter = Expression.Parameter(typeof(string));
-                        var convertedParameter = Expression.Convert(displayNameParameter, method.GetParameters()[0].ParameterType);
-                        SetDisplayNameMethod = Expression.Lambda<Action<Activity, string>>(
-                            Expression.Call(ActivityParameter, method, convertedParameter),
-                            ActivityParameter, displayNameParameter).Compile();
-                    }
-                }
-                SetDisplayNameMethod(activity, displayName);
-            }
-        }
-
-        public static void SetTraceState(this Activity activity, string? tracestate)
-        {
-            if (SetTraceStateStringMethod == null)
-            {
-                var method = typeof(Activity).GetProperty("TraceStateString")?.SetMethod;
-                if (method == null)
-                {
-                    SetTraceStateStringMethod = (_, _) => { };
-                }
-                else
-                {
-                    var tracestateParameter = Expression.Parameter(typeof(string));
-                    var convertedParameter = Expression.Convert(tracestateParameter, method.GetParameters()[0].ParameterType);
-                    SetTraceStateStringMethod = Expression.Lambda<Action<Activity, string?>>(
-                        Expression.Call(ActivityParameter, method, convertedParameter),
-                        ActivityParameter, tracestateParameter).Compile();
-                }
-            }
-
-            SetTraceStateStringMethod(activity, tracestate);
-        }
-
-        public static void SetErrorStatus(this Activity activity, string? errorDescription)
-        {
-            if (SetErrorStatusMethod == null)
-            {
-                if (ActivityStatusCodeType == null)
-                {
-                    SetErrorStatusMethod = (_, _, _) => { };
-                }
-                else
-                {
-                    var method = typeof(Activity).GetMethod("SetStatus", BindingFlags.Instance | BindingFlags.Public, null, new Type[]
-                    {
-                        ActivityStatusCodeType,
-                        typeof(string)
-                    }, null);
-                    if (method == null)
-                    {
-                        SetErrorStatusMethod = (_, _, _) => { };
-                    }
-                    else
-                    {
-                        var methodParameters = method.GetParameters();
-
-                        var statusParameter = Expression.Parameter(typeof(int));
-                        var descriptionParameter = Expression.Parameter(typeof(string));
-                        SetErrorStatusMethod = Expression.Lambda<Action<Activity, int, string?>>(
-                            Expression.Call(ActivityParameter, method, Expression.Convert(statusParameter, methodParameters[0].ParameterType), descriptionParameter),
-                            ActivityParameter, statusParameter, descriptionParameter).Compile();
-                    }
-                }
-            }
-            SetErrorStatusMethod(activity, 2 /* Error */, errorDescription);
-        }
-
-        public static void AddObjectTag(this Activity activity, string name, object value)
-        {
-            if (ActivityAddTagMethod == null)
-            {
-                var method = typeof(Activity).GetMethod("AddTag", BindingFlags.Instance | BindingFlags.Public, null, new Type[]
-                {
-                    typeof(string),
-                    typeof(object)
-                }, null);
-
-                if (method == null)
-                {
-                    // If the object overload is not available, fall back to the string overload. The assumption is that the object overload
-                    // not being available means that we cannot be using activity source, so the string cast should never fail because we will always
-                    // be passing a string value.
-                    ActivityAddTagMethod = (activityParameter, nameParameter, valueParameter) => activityParameter.AddTag(
-                        nameParameter,
-                        // null check is required to keep nullable reference compilation happy
-                        valueParameter == null ? null : (string)valueParameter);
-                }
-                else
-                {
-                    var nameParameter = Expression.Parameter(typeof(string));
-                    var valueParameter = Expression.Parameter(typeof(object));
-
-                    ActivityAddTagMethod = Expression.Lambda<Action<Activity, string, object?>>(
-                        Expression.Call(ActivityParameter, method, nameParameter, valueParameter),
-                        ActivityParameter, nameParameter, valueParameter).Compile();
-                }
-            }
-
-            ActivityAddTagMethod(activity, name, value);
-        }
-
-        public static bool SupportsActivitySource()
-        {
-            return SupportsActivitySourceSwitch && ActivitySourceType != null;
-        }
-
-        public static ICollection<KeyValuePair<string,object>>? CreateTagsCollection()
-        {
-            if (CreateTagsCollectionMethod == null)
-            {
-                var ctor = ActivityTagsCollectionType?.GetConstructor(Array.Empty<Type>());
-                if (ctor == null)
-                {
-                    CreateTagsCollectionMethod = () => null;
-                }
-                else
-                {
-                    CreateTagsCollectionMethod = Expression.Lambda<Func<ICollection<KeyValuePair<string,object>>?>>(
-                        Expression.New(ctor)).Compile();
-                }
-            }
-
-            return CreateTagsCollectionMethod();
-        }
-
-        public static object? CreateActivityLink(string traceparent, string? tracestate, ICollection<KeyValuePair<string,object>>? tags)
-        {
-            if (ActivityLinkType == null)
-            {
-                return null;
-            }
-
-            if (CreateActivityLinkMethod == null)
-            {
-                var parseMethod = ActivityContextType?.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public);
-                var ctor = ActivityLinkType?.GetConstructor(new[] { ActivityContextType!, ActivityTagsCollectionType! });
-
-                if (parseMethod == null ||
-                    ctor == null ||
-                    ActivityTagsCollectionType == null ||
-                    ActivityContextType == null)
-                {
-                    CreateActivityLinkMethod = (_, _, _) => null;
-                }
-                else
-                {
-                    var traceparentParameter = Expression.Parameter(typeof(string));
-                    var tracestateParameter = Expression.Parameter(typeof(string));
-                    var tagsParameter = Expression.Parameter(typeof(ICollection<KeyValuePair<string,object>>));
-
-                    CreateActivityLinkMethod = Expression.Lambda<Func<string, string?, ICollection<KeyValuePair<string, object>>?, object?>>(
-                        Expression.TryCatch(
-                                Expression.Convert(Expression.New(ctor,
-                                        Expression.Call(parseMethod, traceparentParameter, tracestateParameter),
-                                Expression.Convert(tagsParameter, ActivityTagsCollectionType)), typeof(object)),
-                        Expression.Catch(typeof(Exception), Expression.Default(typeof(object)))),
-                             traceparentParameter, tracestateParameter, tagsParameter).Compile();
-                }
-            }
-
-            return CreateActivityLinkMethod(traceparent, tracestate, tags);
-        }
-
-        public static bool ActivitySourceHasListeners(object? activitySource)
-        {
-            if (!SupportsActivitySource())
-            {
-                return false;
-            }
-
-            if (activitySource == null)
-            {
-                return false;
-            }
-
-            if (ActivitySourceHasListenersMethod == null)
-            {
-                var method = ActivitySourceType?.GetMethod("HasListeners", BindingFlags.Instance | BindingFlags.Public);
-                if (method == null ||
-                    ActivitySourceType == null)
-                {
-                    ActivitySourceHasListenersMethod = _ => false;
-                }
-                else
-                {
-                    var sourceParameter = Expression.Parameter(typeof(object));
-                    ActivitySourceHasListenersMethod = Expression.Lambda<Func<object, bool>>(
-                        Expression.Call(Expression.Convert(sourceParameter, ActivitySourceType), method),
-                        sourceParameter).Compile();
-                }
-            }
-
-            return ActivitySourceHasListenersMethod.Invoke(activitySource);
-        }
-
-        public static Activity? ActivitySourceStartActivity(
-            object? activitySource,
-            string activityName,
-            int kind,
-            DateTimeOffset startTime,
-            ICollection<KeyValuePair<string, object>>? tags,
-            IList? links,
-            string? traceparent,
-            string? tracestate)
-        {
-            if (activitySource == null)
-            {
-                return null;
-            }
-
-            object? activityContext = default;
-
-            if (ActivitySourceStartActivityMethod == null)
-            {
-                if (ActivityLinkType == null ||
-                    ActivitySourceType == null ||
-                    ActivityContextType == null ||
-                    ActivityKindType == null)
-                {
-                    ActivitySourceStartActivityMethod = (_, _, _, _, _, _, _) => null;
-                }
-                else
-                {
-                    var method = ActivitySourceType?.GetMethod("StartActivity", BindingFlags.Instance | BindingFlags.Public, null, new[]
-                    {
-                        typeof(string),
-                        ActivityKindType,
-                        ActivityContextType,
-                        typeof(IEnumerable<KeyValuePair<string, object>>),
-                        typeof(IEnumerable<>).MakeGenericType(ActivityLinkType),
-                        typeof(DateTimeOffset)
-                    }, null);
-
-                    if (method == null)
-                    {
-                        ActivitySourceStartActivityMethod = (_, _, _, _, _, _, _) => null;
-                    }
-                    else
-                    {
-                        var sourceParameter = Expression.Parameter(typeof(object));
-                        var nameParameter = Expression.Parameter(typeof(string));
-                        var kindParameter = Expression.Parameter(typeof(int));
-                        var contextParameter = Expression.Parameter(typeof(object));
-                        var startTimeParameter = Expression.Parameter(typeof(DateTimeOffset));
-                        var tagsParameter = Expression.Parameter(typeof(ICollection<KeyValuePair<string, object>>));
-                        var linksParameter = Expression.Parameter(typeof(IList));
-                        var methodParameter = method.GetParameters();
-                        ParseActivityContextMethod = ActivityContextType.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public);
-
-                        ActivitySourceStartActivityMethod = Expression.Lambda<Func<object, string, int, object?, ICollection<KeyValuePair<string, object>>?, IList?, DateTimeOffset, Activity?>>(
-                            Expression.Call(
-                                Expression.Convert(sourceParameter, method.DeclaringType!),
-                                method,
-                                nameParameter,
-                                Expression.Convert(kindParameter,  methodParameter[1].ParameterType),
-                                Expression.Convert(contextParameter, methodParameter[2].ParameterType),
-                                Expression.Convert(tagsParameter,  methodParameter[3].ParameterType),
-                                Expression.Convert(linksParameter,  methodParameter[4].ParameterType),
-                                Expression.Convert(startTimeParameter,  methodParameter[5].ParameterType)),
-                            sourceParameter, nameParameter, kindParameter, contextParameter, tagsParameter, linksParameter, startTimeParameter).Compile();
-                    }
-                }
-            }
-
-            if (ActivityContextType != null && ParseActivityContextMethod != null)
-            {
-                if (traceparent != null)
-                    activityContext = ParseActivityContextMethod.Invoke(null, new[] {traceparent, tracestate})!;
-                else
-                    // because ActivityContext is a struct, we need to create a default instance rather than allowing the argument to be null
-                    activityContext = Activator.CreateInstance(ActivityContextType);
-            }
-
-            return ActivitySourceStartActivityMethod.Invoke(activitySource, activityName, kind, activityContext, tags, links, startTime);
-        }
-
-        public static object? CreateActivitySource(string name)
-        {
-            if (ActivitySourceType == null)
-            {
-                return null;
-            }
-            return Activator.CreateInstance(ActivitySourceType,
-                name, // name
-                null // version
-            );
-        }
-
-        public static IList? CreateLinkCollection()
-        {
-            if (ActivityLinkType == null)
-            {
-                return null;
-            }
-            return Activator.CreateInstance(typeof(List<>).MakeGenericType(ActivityLinkType)) as IList;
-        }
-
-        public static bool TryDispose(this Activity activity)
-        {
-            if (activity is IDisposable disposable)
-            {
-                disposable.Dispose();
-                return true;
-            }
-
-            return false;
-        }
-
-        public static void ResetFeatureSwitch()
-        {
-            SupportsActivitySourceSwitch = AppContextSwitchHelper.GetConfigValue(
-                "Azure.Experimental.EnableActivitySource",
-                "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE");
-        }
-    }
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
 #else
 #pragma warning disable SA1507 // File can not contain multiple types
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -30,11 +30,11 @@ namespace Azure.Core.Pipeline
         internal DiagnosticScope(string scopeName, DiagnosticListener source, object? diagnosticSourceArgs, ActivitySource? activitySource, System.Diagnostics.ActivityKind kind, bool suppressNestedClientActivities)
 #endif
         {
-#if NETCOREAPP2_1 // Activity Kind support is not available on netcoreapp2.1
-            _suppressNestedClientActivities = suppressNestedClientActivities;
+#if NETCOREAPP2_1
+           _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == ActivityKind.Internal) ? suppressNestedClientActivities : false;
 #else
             // ActivityKind.Internal and Client both can represent public API calls depending on the SDK
-            _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == System.Diagnostics.ActivityKind.Internal) ? suppressNestedClientActivities : false;
+            _suppressNestedClientActivities = (kind == ActivityKind.Client || kind == ActivityKind.Internal) ? suppressNestedClientActivities : false;
 #endif
 
             // outer scope presence is enough to suppress any inner scope, regardless of inner scope configuation.

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScopeFactory.cs
@@ -15,19 +15,20 @@ namespace Azure.Core.Pipeline
     internal class DiagnosticScopeFactory
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
     {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
         private static Dictionary<string, DiagnosticListener>? _listeners;
         private readonly string? _resourceProviderNamespace;
         private readonly DiagnosticListener? _source;
         private readonly bool _suppressNestedClientActivities;
-
-#if NETCOREAPP2_1
-        private static readonly ConcurrentDictionary<string, object?> ActivitySources = new();
-#else
         private static readonly ConcurrentDictionary<string, ActivitySource?> ActivitySources = new();
 #endif
 
         public DiagnosticScopeFactory(string clientNamespace, string? resourceProviderNamespace, bool isActivityEnabled, bool suppressNestedClientActivities)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+            IsActivityEnabled = false;
+#else
             _resourceProviderNamespace = resourceProviderNamespace;
             IsActivityEnabled = isActivityEnabled;
             _suppressNestedClientActivities = suppressNestedClientActivities;
@@ -45,15 +46,18 @@ namespace Azure.Core.Pipeline
                     }
                 }
             }
+#endif
         }
 
         public bool IsActivityEnabled { get; }
 
-#if NETCOREAPP2_1
-        public DiagnosticScope CreateScope(string name, DiagnosticScope.ActivityKind kind = DiagnosticScope.ActivityKind.Internal)
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+        public DiagnosticScope CreateScope(string name, object? kind = null)
+        {
+             return default;
+        }
 #else
         public DiagnosticScope CreateScope(string name, System.Diagnostics.ActivityKind kind = ActivityKind.Internal)
-#endif
         {
             if (_source == null)
             {
@@ -74,7 +78,10 @@ namespace Azure.Core.Pipeline
             }
             return scope;
         }
+#endif
 
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
         /// <summary>
         /// This method combines client namespace and operation name into an ActivitySource name and creates the activity source.
         /// For example:
@@ -82,17 +89,9 @@ namespace Azure.Core.Pipeline
         ///     name: BlobClient.DownloadTo
         ///     result Azure.Storage.Blobs.BlobClient
         /// </summary>
-#if NETCOREAPP2_1
-        private static object? GetActivitySource(string ns, string name)
-#else
         private static ActivitySource? GetActivitySource(string ns, string name)
-#endif
         {
-#if NETCOREAPP2_1
-            if (!ActivityExtensions.SupportsActivitySource())
-#else
             if (!ActivityExtensions.SupportsActivitySource)
-#endif
             {
                 return null;
             }
@@ -103,11 +102,8 @@ namespace Azure.Core.Pipeline
             {
                 clientName += "." + name.Substring(0, indexOfDot);
             }
-#if NETCOREAPP2_1
-            return ActivitySources.GetOrAdd(clientName, static n => ActivityExtensions.CreateActivitySource(n));
-#else
             return ActivitySources.GetOrAdd(clientName, static n => new ActivitySource(n));
-#endif
         }
+#endif
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
@@ -64,6 +64,9 @@ namespace Azure.Core.Shared
             ActivityKind kind,
             MessagingDiagnosticOperation operation = default)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+            return default;
+#else
             DiagnosticScope scope = _scopeFactory.CreateScope(activityName, kind);
             if (ActivityExtensions.SupportsActivitySource)
             {
@@ -84,6 +87,7 @@ namespace Azure.Core.Shared
             }
 
             return scope;
+#endif
         }
 
         /// <summary>
@@ -96,6 +100,8 @@ namespace Azure.Core.Shared
         /// <returns><c>true</c> if the message properties contained the diagnostic id; otherwise, <c>false</c>.</returns>
         public static bool TryExtractTraceContext(IReadOnlyDictionary<string, object> properties, out string? traceparent, out string? tracestate)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             traceparent = null;
             tracestate = null;
 
@@ -115,6 +121,7 @@ namespace Azure.Core.Shared
                 traceparent = diagnosticIdString;
                 return true;
             }
+#endif
             return false;
         }
 
@@ -128,6 +135,8 @@ namespace Azure.Core.Shared
         /// <returns><c>true</c> if the message properties contained the diagnostic id; otherwise, <c>false</c>.</returns>
         public static bool TryExtractTraceContext(IDictionary<string, object> properties, out string? traceparent, out string? tracestate)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             traceparent = null;
             tracestate = null;
 
@@ -147,6 +156,7 @@ namespace Azure.Core.Shared
                 traceparent = diagnosticIdString;
                 return true;
             }
+#endif
             return false;
         }
 
@@ -160,6 +170,8 @@ namespace Azure.Core.Shared
         /// <param name="tracestate">The tracestate that was either added, or that already existed in the message properties.</param>
         public void InstrumentMessage(IDictionary<string, object> properties, string activityName, out string? traceparent, out string? tracestate)
         {
+#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
+#else
             traceparent = null;
             tracestate = null;
 
@@ -190,6 +202,7 @@ namespace Azure.Core.Shared
             {
                 TryExtractTraceContext(properties, out traceparent, out tracestate);
             }
+#endif
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/MessagingClientDiagnostics.cs
@@ -61,12 +61,13 @@ namespace Azure.Core.Shared
         /// <returns>The created diagnostic scope containing the common set of messaging attributes that are knowable upon creation.</returns>
         public DiagnosticScope CreateScope(
             string activityName,
+#if NETCOREAPP2_1
+            DiagnosticScope.ActivityKind kind,
+#else
             ActivityKind kind,
+#endif
             MessagingDiagnosticOperation operation = default)
         {
-#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
-            return default;
-#else
             DiagnosticScope scope = _scopeFactory.CreateScope(activityName, kind);
             if (ActivityExtensions.SupportsActivitySource)
             {
@@ -87,7 +88,6 @@ namespace Azure.Core.Shared
             }
 
             return scope;
-#endif
         }
 
         /// <summary>
@@ -100,8 +100,6 @@ namespace Azure.Core.Shared
         /// <returns><c>true</c> if the message properties contained the diagnostic id; otherwise, <c>false</c>.</returns>
         public static bool TryExtractTraceContext(IReadOnlyDictionary<string, object> properties, out string? traceparent, out string? tracestate)
         {
-#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
-#else
             traceparent = null;
             tracestate = null;
 
@@ -121,7 +119,6 @@ namespace Azure.Core.Shared
                 traceparent = diagnosticIdString;
                 return true;
             }
-#endif
             return false;
         }
 
@@ -135,8 +132,6 @@ namespace Azure.Core.Shared
         /// <returns><c>true</c> if the message properties contained the diagnostic id; otherwise, <c>false</c>.</returns>
         public static bool TryExtractTraceContext(IDictionary<string, object> properties, out string? traceparent, out string? tracestate)
         {
-#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
-#else
             traceparent = null;
             tracestate = null;
 
@@ -156,7 +151,6 @@ namespace Azure.Core.Shared
                 traceparent = diagnosticIdString;
                 return true;
             }
-#endif
             return false;
         }
 
@@ -170,8 +164,6 @@ namespace Azure.Core.Shared
         /// <param name="tracestate">The tracestate that was either added, or that already existed in the message properties.</param>
         public void InstrumentMessage(IDictionary<string, object> properties, string activityName, out string? traceparent, out string? tracestate)
         {
-#if NETCOREAPP2_1 // Tracing is disabled in netcoreapp2.1
-#else
             traceparent = null;
             tracestate = null;
 
@@ -179,7 +171,11 @@ namespace Azure.Core.Shared
             {
                 using DiagnosticScope messageScope = CreateScope(
                     activityName,
+#if NETCOREAPP2_1
+                    DiagnosticScope.ActivityKind.Producer);
+#else
                     ActivityKind.Producer);
+#endif
                 messageScope.Start();
 
                 Activity? activity = Activity.Current;
@@ -202,7 +198,6 @@ namespace Azure.Core.Shared
             {
                 TryExtractTraceContext(properties, out traceparent, out tracestate);
             }
-#endif
         }
     }
 }


### PR DESCRIPTION
A few days ago I opened the following PR to remove reflection code for all non netcoreapp2.1 targets: https://github.com/Azure/azure-sdk-for-net/pull/37661 (which includes additional context if needed).

After having a discussion with @JoshLove-msft and @lmolkova they reminded me that the otel support in the repo is all still considered experimental. Since it is considered experimental, this means we can break customers who are using tracing in netcoreapp2.1 applications. This PR removes tracing support for netcoreapp2.1 applications.

There are a few reasons that we should do this:
1. Josh pointed out that as we make changes to otel tracing in the future it will be unclear whether we should also add these features via reflection to the netcoreapp2.1 pieces of the code. Since netcoreapp2.1 is deprecated, it is not worth the engineering effort needed to implement these features. On the flip side if we do not implement these features, it will make netcoreapp2.1 support an arbitrary "snapshot in time", which could create confusion.
2. Tracing was only ever supported in netcoreapp2.1 if using a direct reference on `System.Diagnostics.DiagnosticSource 5.0.0` which is also deprecated. `System.Diagnostics.DiagnosticSource 6.x` doesn't support netcoreapp2.1.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
