### PR TITLE
Naive implementation of allowing env override

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/README.md
+++ b/sdk/core/Azure.Core.TestFramework/README.md
@@ -366,6 +366,8 @@ public KeyClientLiveTests(bool isAsync, KeyClientOptions.ServiceVersion serviceV
 }
 ```
 
+__Note:__ A user can set the environment variable PROXY_DEBUG_MODE to a truthy value prior to invoking, just like if they set `UseLocalDebugProxy` in their code.
+
 In order to debug the test proxy, you will need to clone the [azure-sdk-tools](https://github.com/Azure/azure-sdk-tools) repo. The best practice is to first create a fork of the repo, and then clone your fork locally.
 
 Once you have cloned the repo, open the [Test Proxy solution](https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/Azure.Sdk.Tools.TestProxy.sln) in your IDE.

--- a/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
@@ -60,7 +60,7 @@ namespace Azure.Core.TestFramework
 
         private TestProxy(string proxyPath, bool debugMode = false)
         {
-            debugMode |= !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PROXY_MANUAL_START"));
+            debugMode |= !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PROXY_DEBUG_MODE"));
 
             ProcessStartInfo testProxyProcessInfo = new ProcessStartInfo(
                 s_dotNetExe,

--- a/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
@@ -60,7 +60,7 @@ namespace Azure.Core.TestFramework
 
         private TestProxy(string proxyPath, bool debugMode = false)
         {
-            debugMode = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PROXY_MANUAL_START"));
+            debugMode |= !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PROXY_MANUAL_START"));
 
             ProcessStartInfo testProxyProcessInfo = new ProcessStartInfo(
                 s_dotNetExe,

--- a/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
@@ -60,6 +60,8 @@ namespace Azure.Core.TestFramework
 
         private TestProxy(string proxyPath, bool debugMode = false)
         {
+            debugMode = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PROXY_MANUAL_START"));
+
             ProcessStartInfo testProxyProcessInfo = new ProcessStartInfo(
                 s_dotNetExe,
                 $"\"{proxyPath}\" --storage-location=\"{TestEnvironment.RepositoryRoot}\"")

--- a/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
@@ -60,7 +60,9 @@ namespace Azure.Core.TestFramework
 
         private TestProxy(string proxyPath, bool debugMode = false)
         {
-            debugMode |= !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PROXY_DEBUG_MODE"));
+            bool.TryParse(Environment.GetEnvironmentVariable("PROXY_DEBUG_MODE"), out bool environmentDebugMode);
+
+            debugMode |= environmentDebugMode;
 
             ProcessStartInfo testProxyProcessInfo = new ProcessStartInfo(
                 s_dotNetExe,


### PR DESCRIPTION
Initial problem, I want to add the .NET azure-core-tests to the `test-proxy` nightly integration tests.

Secondary problem, the .NET test framework only hardcodes a proxy version. I can work around that, but I **don't** want to have to publish a package to an external feed just to test it.

Given both, I figure that short-circuiting the `debug` mode will allow me to run the version of the tool I expect in the test-proxy integration tests.

