### PR TITLE
Fix typo 'stanard' to 'standard'

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.cs
@@ -43,7 +43,7 @@ namespace Azure.AI.OpenAI
         /// <inheritdoc cref="CompletionsOptions.User"/>
         public string User { get; set; }
 
-         /// <summary> A list of functions the model may generate JSON inputs for. </summary>
+        /// <summary> A list of functions the model may generate JSON inputs for. </summary>
         public IList<FunctionDefinition> Functions { get; set; }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Azure.AI.OpenAI
         ///     </item>
         ///     <item>
         ///         <see cref="FunctionDefinition.Auto"/> represents the default behavior and will allow the model
-        ///         to freely select between issuing a stanard completions response or a call to any provided
+        ///         to freely select between issuing a standard completions response or a call to any provided
         ///         function.
         ///     </item>
         ///     <item>


### PR DESCRIPTION
This will fix a minor typo in one of the classes in `Azure.AI.OpenAI` package.
