### PR TITLE
Prepend "/" to ResourceIdentifier input if missing

### DIFF
--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -80,6 +80,10 @@ namespace Azure.Core
         public ResourceIdentifier(string resourceId)
         {
             Argument.AssertNotNullOrEmpty(resourceId, nameof(resourceId));
+            if (!resourceId.StartsWith("/"))
+            {
+                resourceId = $"/{resourceId}";
+            }
 
             _stringValue = resourceId;
 

--- a/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
@@ -546,7 +546,7 @@ namespace Azure.Core.Tests
             Assert.AreEqual(resourceId, subscription.ToString());
         }
 
-        [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Microsoft.CognitiveServices/locations/westus/resourceGroups/myResourceGroup/deletedAccounts/myDeletedAccount", "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts")]
+        [TestCase("subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Microsoft.CognitiveServices/locations/westus/resourceGroups/myResourceGroup/deletedAccounts/myDeletedAccount", "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts")]
         public void CanCalculateResourceType(string id, string resourceType)
         {
             ResourceIdentifier resourceId = GetResourceIdentifier(id);
@@ -807,7 +807,6 @@ namespace Azure.Core.Tests
 
         [TestCase("/providers/MicrosoftSomething/billingAccounts/")]
         [TestCase("/MicrosoftSomething/billingAccounts/")]
-        [TestCase("providers/subscription/MicrosoftSomething/billingAccounts/")]
         [TestCase("/subscription/providersSomething")]
         [TestCase("/providers")]
         public void InvalidTenantID(string id)


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/37481
