### PR TITLE
[AzureMonitorExporter] fix SDK version

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Bugs Fixed
 
+* Fixed an issue causing no telemetry if SDK Version string exceeds spec length.
+  ([#37807](https://github.com/Azure/azure-sdk-for-net/pull/37807))
+
 ### Other Changes
 
 ## 1.0.0-beta.13 (2023-07-13)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bugs Fixed
 
-* Fixed an issue causing no telemetry if SDK Version string exceeds spec length.
+* Fixed an issue causing no telemetry if SDK Version string exceeds max length.
   ([#37807](https://github.com/Azure/azure-sdk-for-net/pull/37807))
 
 ### Other Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -80,7 +80,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
             Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()];
             Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()];
-            Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion;
+            Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
             InstrumentationKey = telemetryItem.InstrumentationKey;
             SampleRate = telemetryItem.SampleRate;
         }
@@ -113,7 +113,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             InstrumentationKey = instrumentationKey;
             Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName;
             Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance;
-            Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion;
+            Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
         }
 
         internal static DateTimeOffset FormatUtcTimestamp(System.DateTime utcTimestamp)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -352,5 +352,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 
         [Event(35, Message = "Failed to deserialize response from ingestion due to an exception. Not user actionable. {0}", Level = EventLevel.Warning)]
         public void FailedToDeserializeIngestionResponse(string exceptionMessage) => WriteEvent(35, exceptionMessage);
+
+        [Event(36, Message = "Version string exceeds expected length. This is only for internal telemetry and can safely be ignored. Type Name: {0}. Version: {1}", Level = EventLevel.Verbose)]
+        public void VersionStringUnexpectedLength(string typeName, string value) => WriteEvent(36, typeName, value);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -115,5 +115,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const int TelemetryEnvelope_Name_MaxLength = 1024;
         public const int TelemetryEnvelope_Time_MaxLength = 64;
         public const int TelemetryEnvelope_InstrumentationKey_MaxLength = 40;
+
+        public const int Tags_AiInternalSdkVersion_MaxLength = 64;
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
@@ -40,6 +40,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 // 2) "4.6.30411.01 @BuiltBy: XXXXXX @Branch: XXXXXX @srccode: XXXXXX XXXXXX" Ignoring part after '@' if it is present.
                 string shortVersion = versionString.Split('+', '@', ' ')[0];
 
+                if (shortVersion.Length > 20)
+                {
+                    AzureMonitorExporterEventSource.Log.VersionStringUnexpectedLength(type.Name, versionString);
+                    return shortVersion.Substring(0, 20);
+                }
+
                 return shortVersion;
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
@@ -30,14 +30,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             try
             {
                 string versionString = type
-                .Assembly
-                .GetCustomAttributes<AssemblyInformationalVersionAttribute>()
-                .First()
-                .InformationalVersion;
+                    .Assembly
+                    .GetCustomAttributes<AssemblyInformationalVersionAttribute>()
+                    .First()
+                    .InformationalVersion;
 
-                // Informational version will be something like 1.1.0-beta2+a25741030f05c60c85be102ce7c33f3899290d49.
-                // Ignoring part after '+' if it is present.
-                string? shortVersion = versionString?.Split('+')[0];
+                // Informational version may contain extra information.
+                // 1) "1.1.0-beta2+a25741030f05c60c85be102ce7c33f3899290d49". Ignoring part after '+' if it is present.
+                // 2) "4.6.30411.01 @BuiltBy: XXXXXX @Branch: XXXXXX @srccode: XXXXXX XXXXXX" Ignoring part after '@' if it is present.
+                string shortVersion = versionString.Split('+', '@', ' ')[0];
 
                 return shortVersion;
             }


### PR DESCRIPTION
Fixes: #37775

User reported an unusual dotnet version string. The SDK version field exceeded max length and telemetry cannot be ingested.

## Changes
- check for unusual dotnet version strings.
  - 1) split the string if extra characters are present.
  - 2) truncate individual version parts. Write a verbose log if the part exceeds character length.