### PR TITLE
Update format to have J and W and implement json always on xml models

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -1133,7 +1133,8 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelJsonConverter : System.Text.Json.Serialization.JsonConverter<Azure.Core.Serialization.IModelSerializable>
     {
-        public ModelJsonConverter(string format = "D") { }
+        public ModelJsonConverter() { }
+        public ModelJsonConverter(Azure.Core.Serialization.ModelSerializerFormat format) { }
         public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public override bool CanConvert(System.Type typeToConvert) { throw null; }
         public override Azure.Core.Serialization.IModelSerializable Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
@@ -1149,7 +1150,7 @@ namespace Azure.Core.Serialization
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public static readonly Azure.Core.Serialization.ModelSerializerFormat Data;
+        public static readonly Azure.Core.Serialization.ModelSerializerFormat Json;
         public static readonly Azure.Core.Serialization.ModelSerializerFormat Wire;
         public ModelSerializerFormat(string value) { throw null; }
         public bool Equals(Azure.Core.Serialization.ModelSerializerFormat other) { throw null; }
@@ -1165,8 +1166,9 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelSerializerOptions
     {
-        public Azure.Core.Serialization.ModelSerializerFormat Format;
-        public ModelSerializerOptions(string format = "D") { }
+        public ModelSerializerOptions() { }
+        public ModelSerializerOptions(Azure.Core.Serialization.ModelSerializerFormat format) { }
+        public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public System.Collections.Generic.Dictionary<System.Type, Azure.Core.Serialization.ObjectSerializer> Serializers { get { throw null; } }
     }
     public abstract partial class ObjectSerializer

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -1133,7 +1133,8 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelJsonConverter : System.Text.Json.Serialization.JsonConverter<Azure.Core.Serialization.IModelSerializable>
     {
-        public ModelJsonConverter(string format = "D") { }
+        public ModelJsonConverter() { }
+        public ModelJsonConverter(Azure.Core.Serialization.ModelSerializerFormat format) { }
         public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public override bool CanConvert(System.Type typeToConvert) { throw null; }
         public override Azure.Core.Serialization.IModelSerializable Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
@@ -1149,7 +1150,7 @@ namespace Azure.Core.Serialization
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public static readonly Azure.Core.Serialization.ModelSerializerFormat Data;
+        public static readonly Azure.Core.Serialization.ModelSerializerFormat Json;
         public static readonly Azure.Core.Serialization.ModelSerializerFormat Wire;
         public ModelSerializerFormat(string value) { throw null; }
         public bool Equals(Azure.Core.Serialization.ModelSerializerFormat other) { throw null; }
@@ -1165,8 +1166,9 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelSerializerOptions
     {
-        public Azure.Core.Serialization.ModelSerializerFormat Format;
-        public ModelSerializerOptions(string format = "D") { }
+        public ModelSerializerOptions() { }
+        public ModelSerializerOptions(Azure.Core.Serialization.ModelSerializerFormat format) { }
+        public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public System.Collections.Generic.Dictionary<System.Type, Azure.Core.Serialization.ObjectSerializer> Serializers { get { throw null; } }
     }
     public abstract partial class ObjectSerializer

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -1133,7 +1133,8 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelJsonConverter : System.Text.Json.Serialization.JsonConverter<Azure.Core.Serialization.IModelSerializable>
     {
-        public ModelJsonConverter(string format = "D") { }
+        public ModelJsonConverter() { }
+        public ModelJsonConverter(Azure.Core.Serialization.ModelSerializerFormat format) { }
         public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public override bool CanConvert(System.Type typeToConvert) { throw null; }
         public override Azure.Core.Serialization.IModelSerializable Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
@@ -1149,7 +1150,7 @@ namespace Azure.Core.Serialization
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public static readonly Azure.Core.Serialization.ModelSerializerFormat Data;
+        public static readonly Azure.Core.Serialization.ModelSerializerFormat Json;
         public static readonly Azure.Core.Serialization.ModelSerializerFormat Wire;
         public ModelSerializerFormat(string value) { throw null; }
         public bool Equals(Azure.Core.Serialization.ModelSerializerFormat other) { throw null; }
@@ -1165,8 +1166,9 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelSerializerOptions
     {
-        public Azure.Core.Serialization.ModelSerializerFormat Format;
-        public ModelSerializerOptions(string format = "D") { }
+        public ModelSerializerOptions() { }
+        public ModelSerializerOptions(Azure.Core.Serialization.ModelSerializerFormat format) { }
+        public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public System.Collections.Generic.Dictionary<System.Type, Azure.Core.Serialization.ObjectSerializer> Serializers { get { throw null; } }
     }
     public abstract partial class ObjectSerializer

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -1133,7 +1133,8 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelJsonConverter : System.Text.Json.Serialization.JsonConverter<Azure.Core.Serialization.IModelSerializable>
     {
-        public ModelJsonConverter(string format = "D") { }
+        public ModelJsonConverter() { }
+        public ModelJsonConverter(Azure.Core.Serialization.ModelSerializerFormat format) { }
         public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public override bool CanConvert(System.Type typeToConvert) { throw null; }
         public override Azure.Core.Serialization.IModelSerializable Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
@@ -1149,7 +1150,7 @@ namespace Azure.Core.Serialization
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public static readonly Azure.Core.Serialization.ModelSerializerFormat Data;
+        public static readonly Azure.Core.Serialization.ModelSerializerFormat Json;
         public static readonly Azure.Core.Serialization.ModelSerializerFormat Wire;
         public ModelSerializerFormat(string value) { throw null; }
         public bool Equals(Azure.Core.Serialization.ModelSerializerFormat other) { throw null; }
@@ -1165,8 +1166,9 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelSerializerOptions
     {
-        public Azure.Core.Serialization.ModelSerializerFormat Format;
-        public ModelSerializerOptions(string format = "D") { }
+        public ModelSerializerOptions() { }
+        public ModelSerializerOptions(Azure.Core.Serialization.ModelSerializerFormat format) { }
+        public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public System.Collections.Generic.Dictionary<System.Type, Azure.Core.Serialization.ObjectSerializer> Serializers { get { throw null; } }
     }
     public abstract partial class ObjectSerializer

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1133,7 +1133,8 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelJsonConverter : System.Text.Json.Serialization.JsonConverter<Azure.Core.Serialization.IModelSerializable>
     {
-        public ModelJsonConverter(string format = "D") { }
+        public ModelJsonConverter() { }
+        public ModelJsonConverter(Azure.Core.Serialization.ModelSerializerFormat format) { }
         public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public override bool CanConvert(System.Type typeToConvert) { throw null; }
         public override Azure.Core.Serialization.IModelSerializable Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
@@ -1149,7 +1150,7 @@ namespace Azure.Core.Serialization
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public static readonly Azure.Core.Serialization.ModelSerializerFormat Data;
+        public static readonly Azure.Core.Serialization.ModelSerializerFormat Json;
         public static readonly Azure.Core.Serialization.ModelSerializerFormat Wire;
         public ModelSerializerFormat(string value) { throw null; }
         public bool Equals(Azure.Core.Serialization.ModelSerializerFormat other) { throw null; }
@@ -1165,8 +1166,9 @@ namespace Azure.Core.Serialization
     }
     public partial class ModelSerializerOptions
     {
-        public Azure.Core.Serialization.ModelSerializerFormat Format;
-        public ModelSerializerOptions(string format = "D") { }
+        public ModelSerializerOptions() { }
+        public ModelSerializerOptions(Azure.Core.Serialization.ModelSerializerFormat format) { }
+        public Azure.Core.Serialization.ModelSerializerFormat Format { get { throw null; } }
         public System.Collections.Generic.Dictionary<System.Type, Azure.Core.Serialization.ObjectSerializer> Serializers { get { throw null; } }
     }
     public abstract partial class ObjectSerializer

--- a/sdk/core/Azure.Core/src/Serialization/ModelJsonConverter.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelJsonConverter.cs
@@ -22,9 +22,16 @@ namespace Azure.Core.Serialization
         public ModelSerializerFormat Format { get; }
 
         /// <summary>
-        /// String that determines Format of serialized model. "D" = data format which means both properties are false, "W" = wire format which means both properties are true Default is "D".
+        /// Initializes a new instance of <see cref="ModelJsonConverter"/> with a default format of <see cref="ModelSerializerFormat.Json"/>.
         /// </summary>
-        public ModelJsonConverter(string format = "D")
+        public ModelJsonConverter()
+            : this(ModelSerializerFormat.Json) { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ModelJsonConverter"/>.
+        /// </summary>
+        /// <param name="format"> The format to serialize to and deserialize from. </param>
+        public ModelJsonConverter(ModelSerializerFormat format)
         {
             Format = format;
         }

--- a/sdk/core/Azure.Core/src/Serialization/ModelSerializerFormat.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelSerializerFormat.cs
@@ -11,13 +11,13 @@ namespace Azure.Core.Serialization
     /// </summary>
     public readonly partial struct ModelSerializerFormat : IEquatable<ModelSerializerFormat>
     {
-        internal const string DataValue = "D";
+        internal const string JsonValue = "J";
         internal const string WireValue = "W";
 
         /// <summary>
         /// Specifies the data format where IgnoreReadOnly and IgnoreAdditionalProperties are false.
         /// </summary>
-        public static readonly ModelSerializerFormat Data = new ModelSerializerFormat(DataValue);
+        public static readonly ModelSerializerFormat Json = new ModelSerializerFormat(JsonValue);
 
         /// <summary>
         /// Specifies the wire format IgnoreReadOnly and IgnoreAdditionalProperties are true.

--- a/sdk/core/Azure.Core/src/Serialization/ModelSerializerOptions.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelSerializerOptions.cs
@@ -12,32 +12,28 @@ namespace Azure.Core.Serialization
     public class ModelSerializerOptions
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ModelSerializerOptions" /> class. Takes in a string that determines Format of serialized model. "D" = data format which means IgnoreReadOnly and IgnoreAdditionalProperties are false, "W" = wire format which means both properties are true. Default is "D".
+        /// Initializes a new instance of the <see cref="ModelSerializerOptions" /> class using a default for of <see cref="ModelSerializerFormat.Json"/>.
         /// </summary>
-        /// <param name="format"></param>
-        public ModelSerializerOptions(string format = "D")
+        public ModelSerializerOptions()
+            : this(ModelSerializerFormat.JsonValue) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelSerializerOptions" /> class.
+        /// </summary>
+        /// <param name="format"> The format to serialize to and deserialize from. </param>
+        public ModelSerializerOptions(ModelSerializerFormat format)
         {
-            //throw ArgumentException if not "D" or "W"
-            Format = ValidateFormat(format);
+            Format = format;
         }
 
         /// <summary>
-        /// ModelSerializerFormat that determines Format of serialized model. "D" = data format which means IgnoreReadOnly and IgnoreAdditionalProperties are false, "W" = wire format which means both properties are true. Default is "D".
+        /// Gets the <see cref="ModelSerializerFormat"/> that determines Format of serialized model.
         /// </summary>
-        public ModelSerializerFormat Format;
+        public ModelSerializerFormat Format { get; }
 
         /// <summary>
         /// Dictionary that holds all the serializers for the different model types.
         /// </summary>
         public Dictionary<Type, ObjectSerializer> Serializers { get; } = new Dictionary<Type, ObjectSerializer>();
-
-        private string ValidateFormat(string x)
-        {
-            if (x != ModelSerializerFormat.Data && x != ModelSerializerFormat.Wire)
-            {
-                throw new ArgumentException($"Format must be either '{ModelSerializerFormat.Data}' or '{ModelSerializerFormat.Wire}'.");
-            }
-            return x;
-        }
     }
 }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/CombinedInterfaceTests.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/CombinedInterfaceTests.cs
@@ -13,23 +13,26 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 {
     internal class CombinedInterfaceTests
     {
-        [TestCase("D")]
-        [TestCase("W")]
-        public void CanRoundTripFutureVersionWithoutLossXml(string format)
+        private const string _xmlServiceResponse =
+        "<Tag>" +
+        "<Key>Color</Key>" +
+        "<Value>Red</Value>" +
+        "<ReadOnlyProperty>ReadOnly</ReadOnlyProperty>" +
+        "</Tag>";
+
+        private const string _jsonServiceResponse = "{\"key\":\"Color\",\"value\":\"Red\",\"readOnlyProperty\":\"ReadOnly\"}";
+
+        [Test]
+        public void RoundTripXmlModelWithWire() => CanRoundTripFutureVersionWithoutLossXml(ModelSerializerFormat.Wire, _xmlServiceResponse);
+
+        [Test]
+        public void RoundTripXmlModelWithJson() => CanRoundTripFutureVersionWithoutLossXml(ModelSerializerFormat.Json, _jsonServiceResponse);
+
+        private void CanRoundTripFutureVersionWithoutLossXml(ModelSerializerFormat format, string serviceResponse)
         {
             ModelSerializerOptions options = new ModelSerializerOptions(format);
 
-            string serviceResponse =
-                "<Tag>" +
-                "<Key>Color</Key>" +
-                "<Value>Red</Value>" +
-                "<ReadOnlyProperty>ReadOnly</ReadOnlyProperty>" +
-                "</Tag>";
-
-            var expectedSerializedString = "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Tag><Key>Color</Key><Value>Red</Value>";
-            if (format.Equals(ModelSerializerFormat.Data))
-                expectedSerializedString += "<ReadOnlyProperty>ReadOnly</ReadOnlyProperty>";
-            expectedSerializedString += "</Tag>";
+            var expectedSerializedString = GetExpectedResult(format);
 
             XmlModelForCombinedInterface model = ModelSerializer.Deserialize<XmlModelForCombinedInterface>(new BinaryData(Encoding.UTF8.GetBytes(serviceResponse)), options);
 
@@ -45,7 +48,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             VerifyModelXmlModelForCombinedInterface(model, model2, format);
         }
 
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void CanRoundTripFutureVersionWithoutLossJson(string format)
         {
@@ -54,7 +57,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             string serviceResponse = "{\"key\":\"Color\",\"value\":\"Red\",\"readOnlyProperty\":\"ReadOnly\",\"x\":\"extra\"}";
 
             var expectedSerializedString = "{\"key\":\"Color\",\"value\":\"Red\"";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 expectedSerializedString += ",\"readOnlyProperty\":\"ReadOnly\"";
                 expectedSerializedString += ",\"x\":\"extra\"";
@@ -68,7 +71,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             Assert.AreEqual("ReadOnly", model.ReadOnlyProperty);
             var additionalProperties = typeof(JsonModelForCombinedInterface).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(model) as Dictionary<string, BinaryData>;
             Assert.IsNotNull(additionalProperties);
-            Assert.AreEqual(format.Equals(ModelSerializerFormat.Data), additionalProperties.ContainsKey("x"));
+            Assert.AreEqual(format.Equals(ModelSerializerFormat.Json), additionalProperties.ContainsKey("x"));
             var data = ModelSerializer.Serialize(model, options);
             string roundTrip = data.ToString();
 
@@ -82,7 +85,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
         {
             Assert.AreEqual(expected.Key, actual.Key);
             Assert.AreEqual(expected.Value, actual.Value);
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 Assert.AreEqual(expected.ReadOnlyProperty, actual.ReadOnlyProperty);
         }
 
@@ -90,14 +93,35 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
         {
             Assert.AreEqual(expected.Key, actual.Key);
             Assert.AreEqual(expected.Value, actual.Value);
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 Assert.AreEqual(expected.ReadOnlyProperty, actual.ReadOnlyProperty);
             var rawDataProperty = typeof(JsonModelForCombinedInterface).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var expectedRawData = rawDataProperty.GetValue(expected) as Dictionary<string, BinaryData>;
             var actualRawData = rawDataProperty.GetValue(actual) as Dictionary<string, BinaryData>;
             Assert.AreEqual(expectedRawData.Count, actualRawData.Count);
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 Assert.AreEqual(expectedRawData["x"].ToString(), actualRawData["x"].ToString());
+        }
+
+        private string GetExpectedResult(ModelSerializerFormat format)
+        {
+            if (format == ModelSerializerFormat.Wire)
+            {
+                var expectedSerializedString = "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Tag><Key>Color</Key><Value>Red</Value>";
+                if (format.Equals(ModelSerializerFormat.Json))
+                    expectedSerializedString += "<ReadOnlyProperty>ReadOnly</ReadOnlyProperty>";
+                expectedSerializedString += "</Tag>";
+                return expectedSerializedString;
+            }
+            if (format == ModelSerializerFormat.Json)
+            {
+                var expectedSerializedString = "{\"key\":\"Color\",\"value\":\"Red\"";
+                if (format.Equals(ModelSerializerFormat.Json))
+                    expectedSerializedString += ",\"readOnlyProperty\":\"ReadOnly\"";
+                expectedSerializedString += "}";
+                return expectedSerializedString;
+            }
+            throw new InvalidOperationException($"Unknown format used in test {format}");
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Envelope.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Envelope.cs
@@ -54,7 +54,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             MemoryStream stream = new MemoryStream();
             Utf8JsonWriter writer = new Utf8JsonWriter(stream);
             writer.WriteStartObject();
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 writer.WritePropertyName("readOnlyProperty"u8);
                 writer.WriteStringValue(ReadOnlyProperty);
@@ -70,7 +70,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             writer.WritePropertyName("modelC"u8);
             SerializeT(writer, options);
 
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)
@@ -114,7 +114,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
                     continue;
                 }
 
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means it's an modelC property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/EnvelopeTests.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/EnvelopeTests.cs
@@ -12,7 +12,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 {
     internal class EnvelopeTests
     {
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void CanRoundTripFutureVersionWithoutLoss(string format)
         {
@@ -23,12 +23,12 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
                 "}";
 
             StringBuilder expectedSerialized = new StringBuilder("{");
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 expectedSerialized.Append("\"readOnlyProperty\":\"read\",");
             }
             expectedSerialized.Append("\"modelA\":{");
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 expectedSerialized.Append("\"latinName\":\"Felis catus\",\"hasWhiskers\":false,");
             }
@@ -52,7 +52,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 
             Envelope<ModelC> model = ModelSerializer.Deserialize<Envelope<ModelC>>(new BinaryData(Encoding.UTF8.GetBytes(serviceResponse)), options: options);
 
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 Assert.That(model.ReadOnlyProperty, Is.EqualTo("read"));
             }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/ModelJsonConverterTests.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/ModelJsonConverterTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 {
     public class ModelJsonConverterTests
     {
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void SerializeTest(string format)
         {
@@ -23,7 +23,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             options.Converters.Add(new ModelJsonConverter(format));
 
             string expected = "{";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 expected += "\"latinName\":\"Animalia\",";
             expected += "\"name\":\"Doggo\",\"isHungry\":false,";
             expected += "\"weight\":1.5,";
@@ -39,7 +39,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void DeserializeTest(string format)
         {
@@ -58,17 +58,17 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 
             var additionalProperties = typeof(Animal).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(dog) as Dictionary<string, BinaryData>;
             Assert.IsNotNull(additionalProperties);
-            Assert.AreEqual(format.Equals(ModelSerializerFormat.Data), additionalProperties.ContainsKey("numberOfLegs"));
-            if (format.Equals(ModelSerializerFormat.Data))
+            Assert.AreEqual(format.Equals(ModelSerializerFormat.Json), additionalProperties.ContainsKey("numberOfLegs"));
+            if (format.Equals(ModelSerializerFormat.Json))
                 Assert.AreEqual("4", additionalProperties["numberOfLegs"].ToString());
 
             string expected = "{";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 expected += "\"latinName\":\"Animalia\",";
             expected += "\"name\":\"Doggo\",\"isHungry\":false,";
             expected += "\"weight\":1.5,";
             expected += "\"foodConsumed\":[\"kibble\",\"egg\",\"peanut butter\"]";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 expected += ",\"numberOfLegs\":4,\"DogListPropertyConverterMarker\":true"; //validate marker exists to ensure we are using the class converter if it exists
             }
@@ -99,7 +99,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             Assert.AreEqual("", actual);
         }
 
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void CanSerializeDerivedModel(string format)
         {
@@ -114,21 +114,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             Assert.AreEqual("X", modelX.Kind);
             var additionalProperties = typeof(ModelX).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(modelX) as Dictionary<string, BinaryData>;
             Assert.IsNotNull(additionalProperties);
-            Assert.AreEqual(format.Equals(ModelSerializerFormat.Data), additionalProperties.ContainsKey("extra"));
-            if (format.Equals(ModelSerializerFormat.Data))
+            Assert.AreEqual(format.Equals(ModelSerializerFormat.Json), additionalProperties.ContainsKey("extra"));
+            if (format.Equals(ModelSerializerFormat.Json))
                 Assert.AreEqual("\"stuff\"", additionalProperties["extra"].ToString());
 
             string expected = "{\"kind\":\"X\",\"name\":\"xmodel\"";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 expected += ",\"xProperty\":100";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 expected += ",\"extra\":\"stuff\"";
             expected += "}";
             var actual = JsonSerializer.Serialize(modelX, options);
             Assert.AreEqual(expected, actual);
         }
 
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void CanSerializeBaseModel(string format)
         {
@@ -145,12 +145,12 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             Assert.AreEqual("X", modelX.Kind);
             var additionalProperties = typeof(ModelX).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(modelX) as Dictionary<string, BinaryData>;
             Assert.IsNotNull(additionalProperties);
-            Assert.AreEqual(format.Equals(ModelSerializerFormat.Data), additionalProperties.ContainsKey("extra"));
-            if (format.Equals(ModelSerializerFormat.Data))
+            Assert.AreEqual(format.Equals(ModelSerializerFormat.Json), additionalProperties.ContainsKey("extra"));
+            if (format.Equals(ModelSerializerFormat.Json))
                 Assert.AreEqual("\"stuff\"", additionalProperties["extra"].ToString());
 
             string expected = "{\"kind\":\"X\",\"name\":\"xmodel\"";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 expected += ",\"xProperty\":100";
                 expected += ",\"extra\":\"stuff\"";
@@ -160,7 +160,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             Assert.AreEqual(expected, actual);
         }
 
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void CanSerializeUnknown(string format)
         {
@@ -176,16 +176,16 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             Assert.AreEqual("Z", baseModel.Kind);
             var additionalProperties = typeof(UnknownBaseModel).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(baseModel) as Dictionary<string, BinaryData>;
             Assert.IsNotNull(additionalProperties);
-            Assert.AreEqual(format.Equals(ModelSerializerFormat.Data), additionalProperties.ContainsKey("extra"));
-            Assert.AreEqual(format.Equals(ModelSerializerFormat.Data), additionalProperties.ContainsKey("zProperty"));
-            if (format.Equals(ModelSerializerFormat.Data))
+            Assert.AreEqual(format.Equals(ModelSerializerFormat.Json), additionalProperties.ContainsKey("extra"));
+            Assert.AreEqual(format.Equals(ModelSerializerFormat.Json), additionalProperties.ContainsKey("zProperty"));
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 Assert.AreEqual("\"stuff\"", additionalProperties["extra"].ToString());
                 Assert.AreEqual("1.5", additionalProperties["zProperty"].ToString());
             }
 
             string expected = "{\"kind\":\"Z\",\"name\":\"zmodel\"";
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 expected += ",\"zProperty\":1.5";
                 expected += ",\"extra\":\"stuff\"";

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/ModelXmlTests.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/ModelXmlTests.cs
@@ -7,30 +7,53 @@ using NUnit.Framework;
 using Azure.Core.Tests.Public.ModelSerializationTests.Models;
 using Azure.Core.Serialization;
 using System;
+using System.Text.Json;
+using System.Xml;
 
 namespace Azure.Core.Tests.Public.ModelSerializationTests
 {
     internal class ModelXmlTests
     {
-        [TestCase("D")]
-        [TestCase("W")]
-        public void CanRoundTripFutureVersionWithoutLoss(string format)
-        {
-            ModelSerializerOptions options = new ModelSerializerOptions(format);
-
-            Stream stream = new MemoryStream();
-
-            string serviceResponse =
-                "<Tag>"+
-                "<Key>Color</Key>"+
-                "<Value>Red</Value>"+
+        private const string _xmlServiceResponse =
+                "<Tag>" +
+                "<Key>Color</Key>" +
+                "<Value>Red</Value>" +
                 "<ReadOnlyProperty>ReadOnly</ReadOnlyProperty>" +
                 "</Tag>";
 
-            var expectedSerializedString = "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Tag><Key>Color</Key><Value>Red</Value>";
-            if (format.Equals(ModelSerializerFormat.Data))
-                expectedSerializedString += "<ReadOnlyProperty>ReadOnly</ReadOnlyProperty>";
-            expectedSerializedString += "</Tag>";
+        private const string _jsonServiceResponse = "{\"key\":\"Color\",\"value\":\"Red\",\"readOnlyProperty\":\"ReadOnly\"}";
+
+        [Test]
+        public void RoundTripWithWire() => CanRoundTripFutureVersionWithoutLoss(ModelSerializerFormat.Wire, _xmlServiceResponse);
+
+        [Test]
+        public void RoundTripWithJson() => CanRoundTripFutureVersionWithoutLoss(ModelSerializerFormat.Json, _jsonServiceResponse);
+
+        [Test]
+        public void ThrowsIfUnknownFormat()
+        {
+            ModelSerializerOptions options = new ModelSerializerOptions("x");
+            Assert.Throws<InvalidOperationException>(() => ModelSerializer.Serialize(new ModelXml(), options));
+            Assert.Throws<InvalidOperationException>(() => ModelSerializer.Deserialize<ModelXml>(new BinaryData("x"), options));
+        }
+
+        [Test]
+        public void ThrowsIfMismatch()
+        {
+            ModelSerializerOptions jsonOptions = new ModelSerializerOptions(ModelSerializerFormat.Json);
+            ModelXml model = ModelSerializer.Deserialize<ModelXml>(new BinaryData(Encoding.UTF8.GetBytes(_jsonServiceResponse)), jsonOptions);
+
+            Assert.Throws(Is.InstanceOf<JsonException>(), () => ModelSerializer.Deserialize<ModelXml>(new BinaryData(Encoding.UTF8.GetBytes(_xmlServiceResponse)), jsonOptions));
+
+            ModelSerializerOptions wireOptions = new ModelSerializerOptions(ModelSerializerFormat.Wire);
+            Assert.Throws<XmlException>(() => ModelSerializer.Deserialize<ModelXml>(new BinaryData(Encoding.UTF8.GetBytes(_jsonServiceResponse)), wireOptions));
+        }
+
+        private void CanRoundTripFutureVersionWithoutLoss(ModelSerializerFormat format, string serviceResponse)
+        {
+            ModelSerializerOptions options = new ModelSerializerOptions(format);
+
+            var expectedSerializedString = GetExpectedResult(format);
 
             ModelXml model = ModelSerializer.Deserialize<ModelXml>(new BinaryData(Encoding.UTF8.GetBytes(serviceResponse)), options);
 
@@ -46,11 +69,32 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             VerifyModelXml(model, model2, format);
         }
 
+        private string GetExpectedResult(ModelSerializerFormat format)
+        {
+            if (format == ModelSerializerFormat.Wire)
+            {
+                var expectedSerializedString = "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Tag><Key>Color</Key><Value>Red</Value>";
+                if (format.Equals(ModelSerializerFormat.Json))
+                    expectedSerializedString += "<ReadOnlyProperty>ReadOnly</ReadOnlyProperty>";
+                expectedSerializedString += "</Tag>";
+                return expectedSerializedString;
+            }
+            if (format == ModelSerializerFormat.Json)
+            {
+                var expectedSerializedString = "{\"key\":\"Color\",\"value\":\"Red\"";
+                if (format.Equals(ModelSerializerFormat.Json))
+                    expectedSerializedString += ",\"readOnlyProperty\":\"ReadOnly\"";
+                expectedSerializedString += "}";
+                return expectedSerializedString;
+            }
+            throw new InvalidOperationException($"Unknown format used in test {format}");
+        }
+
         internal static void VerifyModelXml(ModelXml correctModelXml, ModelXml model2, string format)
         {
             Assert.AreEqual(correctModelXml.Key, model2.Key);
             Assert.AreEqual(correctModelXml.Value, model2.Value);
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
                 Assert.AreEqual(correctModelXml.ReadOnlyProperty, model2.ReadOnlyProperty);
         }
     }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/Animal.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/Animal.cs
@@ -61,7 +61,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             MemoryStream stream = new MemoryStream();
             Utf8JsonWriter writer = new Utf8JsonWriter(stream);
             writer.WriteStartObject();
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 writer.WritePropertyName("latinName"u8);
                 writer.WriteStringValue(LatinName);
@@ -73,7 +73,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             writer.WritePropertyName("weight"u8);
             writer.WriteNumberValue(Weight);
 
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)
@@ -123,7 +123,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
                     continue;
                 }
 
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means it's an unknown property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/CatReadOnlyProperty.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/CatReadOnlyProperty.cs
@@ -45,7 +45,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             MemoryStream stream = new MemoryStream();
             Utf8JsonWriter writer = new Utf8JsonWriter(stream);
             writer.WriteStartObject();
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 writer.WritePropertyName("latinName"u8);
                 writer.WriteStringValue(LatinName);
@@ -60,7 +60,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             writer.WritePropertyName("weight"u8);
             writer.WriteNumberValue(Weight);
 
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)
@@ -116,7 +116,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
                     hasWhiskers = property.Value.GetBoolean();
                     continue;
                 }
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means its an unknown property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/BaseModel.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/BaseModel.cs
@@ -41,7 +41,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/ModelX.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/ModelX.cs
@@ -53,12 +53,12 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 writer.WritePropertyName("xProperty"u8);
                 writer.WriteNumberValue(XProperty);
             }
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)
@@ -104,7 +104,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
                     xProperty = property.Value.GetInt32();
                     continue;
                 }
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means it's an unknown property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/ModelY.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/ModelY.cs
@@ -49,7 +49,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
             writer.WriteStartObject();
             writer.WritePropertyName("kind"u8);
             writer.WriteStringValue(Kind);
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 if (Optional.IsDefined(Name))
                 {
@@ -59,7 +59,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
             }
             writer.WritePropertyName("yProperty"u8);
             writer.WriteStringValue(YProperty);
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)
@@ -105,7 +105,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
                     yProperty = property.Value.GetString();
                     continue;
                 }
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means it's an unknown property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/UnknownBaseModel.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DiscriminatorSet/UnknownBaseModel.cs
@@ -51,7 +51,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)
@@ -91,7 +91,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
                     name = property.Value.GetString();
                     continue;
                 }
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means it's an unknown property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DogListProperty.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/DogListProperty.cs
@@ -37,7 +37,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
         public static explicit operator DogListProperty(Response response)
         {
             using JsonDocument jsonDocument = JsonDocument.Parse(response.ContentStream);
-            var serializationOptions = new ModelSerializerOptions(ModelSerializerFormat.Data);
+            var serializationOptions = new ModelSerializerOptions(ModelSerializerFormat.Json);
             return DeserializeDogListProperty(jsonDocument.RootElement, serializationOptions);
         }
 
@@ -66,7 +66,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             MemoryStream stream = new MemoryStream();
             Utf8JsonWriter writer = new Utf8JsonWriter(stream);
             writer.WriteStartObject();
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 writer.WritePropertyName("latinName"u8);
                 writer.WriteStringValue(LatinName);
@@ -89,7 +89,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
                 writer.WriteEndArray();
             }
 
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)
@@ -147,7 +147,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
                     }
                     continue;
                 }
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means its an unknown property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/JsonModelForCombinedInterface.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/JsonModelForCombinedInterface.cs
@@ -79,7 +79,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
                     readOnlyProperty = property.Value.GetString();
                     continue;
                 }
-                if (options.Format == ModelSerializerFormat.Data)
+                if (options.Format == ModelSerializerFormat.Json)
                 {
                     //this means its an unknown property we got
                     rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
@@ -97,12 +97,12 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
             writer.WriteStringValue(Key);
             writer.WritePropertyName("value"u8);
             writer.WriteStringValue(Value);
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 writer.WritePropertyName("readOnlyProperty"u8);
                 writer.WriteStringValue(ReadOnlyProperty);
             }
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 //write out the raw data
                 foreach (var property in RawData)

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXml.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXml.cs
@@ -53,13 +53,28 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
             writer.WriteStartElement("Value");
             writer.WriteValue(Value);
             writer.WriteEndElement();
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 writer.WriteStartElement("ReadOnlyProperty");
                 writer.WriteValue(ReadOnlyProperty);
                 writer.WriteEndElement();
             }
             writer.WriteEndElement();
+        }
+
+        private void Serialize(Utf8JsonWriter writer, ModelSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("key"u8);
+            writer.WriteStringValue(Key);
+            writer.WritePropertyName("value"u8);
+            writer.WriteStringValue(Value);
+            if (options.Format == ModelSerializerFormat.Json)
+            {
+                writer.WritePropertyName("readOnlyProperty"u8);
+                writer.WriteStringValue(ReadOnlyProperty);
+            }
+            writer.WriteEndObject();
         }
 
         internal static ModelXml DeserializeModelXml(XElement element, ModelSerializerOptions options = default)
@@ -84,17 +99,65 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
 
         BinaryData IModelSerializable.Serialize(ModelSerializerOptions options)
         {
-            MemoryStream stream = new MemoryStream();
-            XmlWriter writer = XmlWriter.Create(stream);
-            Serialize(writer, options);
-            writer.Flush();
-            stream.Position = 0;
-            return new BinaryData(stream.ToArray());
+            if (options.Format == ModelSerializerFormat.Json)
+            {
+                MemoryStream stream = new MemoryStream();
+                using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
+                Serialize(writer, options);
+                writer.Flush();
+                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+            }
+            if (options.Format == ModelSerializerFormat.Wire)
+            {
+                MemoryStream stream = new MemoryStream();
+                using XmlWriter writer = XmlWriter.Create(stream);
+                Serialize(writer, options);
+                writer.Flush();
+                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+            }
+            throw new InvalidOperationException($"Unsupported format '{options.Format}' request for '{GetType().Name}'");
+        }
+
+        internal static ModelXml DeserializeModelXml(JsonElement element, ModelSerializerOptions options)
+        {
+            string key = default;
+            string value = default;
+            string readOnlyProperty = default;
+
+            Dictionary<string, BinaryData> rawData = new Dictionary<string, BinaryData>();
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("key"u8))
+                {
+                    key = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("value"u8))
+                {
+                    value = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("readOnlyProperty"u8))
+                {
+                    readOnlyProperty = property.Value.GetString();
+                    continue;
+                }
+            }
+            return new ModelXml(key, value, readOnlyProperty);
         }
 
         object IModelSerializable.Deserialize(BinaryData data, ModelSerializerOptions options)
         {
-            return DeserializeModelXml(XElement.Load(data.ToStream()), options);
+            if (options.Format == ModelSerializerFormat.Json)
+            {
+                using var doc = JsonDocument.Parse(data);
+                return DeserializeModelXml(doc.RootElement, options);
+            }
+            if (options.Format == ModelSerializerFormat.Wire)
+            {
+                return DeserializeModelXml(XElement.Load(data.ToStream()), options);
+            }
+            throw new InvalidOperationException($"Unsupported format '{options.Format}' request for '{GetType().Name}'");
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/NewtonSoftTests.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/NewtonSoftTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 {
     internal class NewtonSoftTests
     {
-        [TestCase("D")]
+        [TestCase("J")]
         [TestCase("W")]
         public void CanRoundTripFutureVersionWithoutLoss(string format)
         {
@@ -26,7 +26,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
             StringBuilder expectedSerialized = new StringBuilder("{");
             expectedSerialized.Append("\"IsHungry\":false,");
             expectedSerialized.Append("\"Weight\":2.5,");
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 expectedSerialized.Append("\"LatinName\":\"Animalia\",");
             }
@@ -49,7 +49,7 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 
             var model = ModelSerializer.Deserialize<Animal>(new BinaryData(Encoding.UTF8.GetBytes(serviceResponse)), options: options);
 
-            if (format.Equals(ModelSerializerFormat.Data))
+            if (format.Equals(ModelSerializerFormat.Json))
             {
                 Assert.That(model.LatinName, Is.EqualTo("Animalia"));
             }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/VerifyModels.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/VerifyModels.cs
@@ -17,12 +17,12 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 
         private static void VerifyProperties(Animal x, Animal y, ModelSerializerOptions options)
         {
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
                 Assert.That(x.LatinName, Is.EqualTo(y.LatinName));
             Assert.That(x.Name, Is.EqualTo(y.Name));
             Assert.That(x.Weight, Is.EqualTo(y.Weight));
 
-            if (options.Format == ModelSerializerFormat.Data)
+            if (options.Format == ModelSerializerFormat.Json)
             {
                 var additionalPropertiesX = typeof(Animal).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(x) as Dictionary<string, BinaryData>;
                 var additionalPropertiesY = typeof(Animal).GetProperty("RawData", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(y) as Dictionary<string, BinaryData>;


### PR DESCRIPTION
Addresses this comment https://apiview.dev/Assemblies/Review/52b58c3eb11144e383612c92c69f1f74/6f9d249df11249928f1caf8b7226151f?diffRevisionId=c53fffb104884669addf0e6c1fdfd4d2&doc=False&diffOnly=True#b771bc223886485ea538173f1b1b8794

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
