### PR TITLE
[AzureMonitorExporter] Add Truncation to ContextTags

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -71,7 +71,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                         this(name, FormatUtcTimestamp(activityEventTimeStamp.DateTime))
         {
             Tags[ContextTagKeys.AiOperationParentId.ToString()] = activitySpanId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationParentId_MaxLength);
-            Tags[ContextTagKeys.AiOperationId.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString().Truncate(SchemaConstants.Tags_AiOperationId_MaxLength)];
+            Tags[ContextTagKeys.AiOperationId.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()].Truncate(SchemaConstants.Tags_AiOperationId_MaxLength);
 
             if (telemetryItem.Tags.TryGetValue("ai.user.userAgent", out string? userAgent))
             {
@@ -79,8 +79,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 Tags["ai.user.userAgent"] = userAgent;
             }
 
-            Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString().Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength)];
-            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString().Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength)];
+            Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()].Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
+            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()].Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
             InstrumentationKey = telemetryItem.InstrumentationKey;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -18,24 +18,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         {
             if (activity.ParentSpanId != default)
             {
-                Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.ParentSpanId.ToHexString();
+                Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.ParentSpanId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationParentId_MaxLength);
             }
 
-            Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
+            Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationId_MaxLength);
 
             if (activity.GetTelemetryType() == TelemetryType.Request)
             {
                 if (activityTagsProcessor.activityType.HasFlag(OperationType.V2))
                 {
-                    Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationNameV2(activity, ref activityTagsProcessor.MappedTags);
+                    Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationNameV2(activity, ref activityTagsProcessor.MappedTags).Truncate(SchemaConstants.Tags_AiOperationName_MaxLength);
                 }
                 else if (activityTagsProcessor.activityType.HasFlag(OperationType.Http))
                 {
-                    Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationName(activity, ref activityTagsProcessor.MappedTags);
+                    Tags[ContextTagKeys.AiOperationName.ToString()] = TraceHelper.GetOperationName(activity, ref activityTagsProcessor.MappedTags).Truncate(SchemaConstants.Tags_AiOperationName_MaxLength);
                 }
                 else
                 {
-                    Tags[ContextTagKeys.AiOperationName.ToString()] = activity.DisplayName;
+                    Tags[ContextTagKeys.AiOperationName.ToString()] = activity.DisplayName.Truncate(SchemaConstants.Tags_AiOperationName_MaxLength);
                 }
 
                 // Set ip in case of server spans only.
@@ -70,8 +70,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         public TelemetryItem(string name, TelemetryItem telemetryItem, ActivitySpanId activitySpanId, ActivityKind kind, DateTimeOffset activityEventTimeStamp) :
                         this(name, FormatUtcTimestamp(activityEventTimeStamp.DateTime))
         {
-            Tags[ContextTagKeys.AiOperationParentId.ToString()] = activitySpanId.ToHexString();
-            Tags[ContextTagKeys.AiOperationId.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()];
+            Tags[ContextTagKeys.AiOperationParentId.ToString()] = activitySpanId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationParentId_MaxLength);
+            Tags[ContextTagKeys.AiOperationId.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString().Truncate(SchemaConstants.Tags_AiOperationId_MaxLength)];
 
             if (telemetryItem.Tags.TryGetValue("ai.user.userAgent", out string? userAgent))
             {
@@ -79,8 +79,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
                 Tags["ai.user.userAgent"] = userAgent;
             }
 
-            Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()];
-            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()];
+            Tags[ContextTagKeys.AiCloudRole.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString().Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength)];
+            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString().Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength)];
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
             InstrumentationKey = telemetryItem.InstrumentationKey;
 
@@ -95,12 +95,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         {
             if (logRecord.TraceId != default)
             {
-                Tags[ContextTagKeys.AiOperationId.ToString()] = logRecord.TraceId.ToHexString();
+                Tags[ContextTagKeys.AiOperationId.ToString()] = logRecord.TraceId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationId_MaxLength);
             }
 
             if (logRecord.SpanId != default)
             {
-                Tags[ContextTagKeys.AiOperationParentId.ToString()] = logRecord.SpanId.ToHexString();
+                Tags[ContextTagKeys.AiOperationParentId.ToString()] = logRecord.SpanId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationParentId_MaxLength);
             }
 
             InstrumentationKey = instrumentationKey;
@@ -116,8 +116,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         private void SetResourceSdkVersionAndIkey(AzureMonitorResource? resource, string instrumentationKey)
         {
             InstrumentationKey = instrumentationKey;
-            Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName;
-            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance;
+            Tags[ContextTagKeys.AiCloudRole.ToString()] = resource?.RoleName.Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
+            Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance.Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
         }
 
@@ -131,7 +131,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         {
             if (activityTagsProcessor.EndUserId != null)
             {
-                Tags[ContextTagKeys.AiUserAuthUserId.ToString()] = activityTagsProcessor.EndUserId;
+                Tags[ContextTagKeys.AiUserAuthUserId.ToString()] = activityTagsProcessor.EndUserId.Truncate(SchemaConstants.Tags_AiUserAuthUserId_MaxLength);
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -18,10 +18,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         {
             if (activity.ParentSpanId != default)
             {
-                Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.ParentSpanId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationParentId_MaxLength);
+                Tags[ContextTagKeys.AiOperationParentId.ToString()] = activity.ParentSpanId.ToHexString();
             }
 
-            Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationId_MaxLength);
+            Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
 
             if (activity.GetTelemetryType() == TelemetryType.Request)
             {
@@ -70,8 +70,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         public TelemetryItem(string name, TelemetryItem telemetryItem, ActivitySpanId activitySpanId, ActivityKind kind, DateTimeOffset activityEventTimeStamp) :
                         this(name, FormatUtcTimestamp(activityEventTimeStamp.DateTime))
         {
-            Tags[ContextTagKeys.AiOperationParentId.ToString()] = activitySpanId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationParentId_MaxLength);
-            Tags[ContextTagKeys.AiOperationId.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()].Truncate(SchemaConstants.Tags_AiOperationId_MaxLength);
+            Tags[ContextTagKeys.AiOperationParentId.ToString()] = activitySpanId.ToHexString();
+            Tags[ContextTagKeys.AiOperationId.ToString()] = telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()];
 
             if (telemetryItem.Tags.TryGetValue("ai.user.userAgent", out string? userAgent))
             {
@@ -95,12 +95,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         {
             if (logRecord.TraceId != default)
             {
-                Tags[ContextTagKeys.AiOperationId.ToString()] = logRecord.TraceId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationId_MaxLength);
+                Tags[ContextTagKeys.AiOperationId.ToString()] = logRecord.TraceId.ToHexString();
             }
 
             if (logRecord.SpanId != default)
             {
-                Tags[ContextTagKeys.AiOperationParentId.ToString()] = logRecord.SpanId.ToHexString().Truncate(SchemaConstants.Tags_AiOperationParentId_MaxLength);
+                Tags[ContextTagKeys.AiOperationParentId.ToString()] = logRecord.SpanId.ToHexString();
             }
 
             InstrumentationKey = instrumentationKey;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -116,33 +116,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const int TelemetryEnvelope_Time_MaxLength = 64;
         public const int TelemetryEnvelope_InstrumentationKey_MaxLength = 40;
 
-        public const int Tags_AiApplicationVer_MaxLength = 1024;
-        public const int Tags_AiDeviceId_MaxLength = 1024;
-        public const int Tags_AiDeviceLocale_MaxLength = 64;
-        public const int Tags_AiDeviceModel_MaxLength = 256;
-        public const int Tags_AiDeviceOemName_MaxLength = 256;
-        public const int Tags_AiDeviceOsVersion_MaxLength = 256;
-        public const int Tags_AiDeviceType_MaxLength = 64;
-        public const int Tags_AiLocationIp_MaxLength = 46;
-        public const int Tags_AiLocationCountry_MaxLength = 256;
-        public const int Tags_AiLocationProvince_MaxLength = 256;
-        public const int Tags_AiLocationCity_MaxLength = 256;
         public const int Tags_AiOperationId_MaxLength = 128;
         public const int Tags_AiOperationName_MaxLength = 1024;
         public const int Tags_AiOperationParentId_MaxLength = 512;
-        public const int Tags_AiOperationSyntheticSource_MaxLength = 1024;
-        public const int Tags_AiOperationCorrelationVector_MaxLength = 64;
-        public const int Tags_AiSessionId_MaxLength = 64;
-        public const int Tags_AiSessionIsFirst_MaxLength = 5;
-        public const int Tags_AiUserAccountId_MaxLength = 1024;
-        public const int Tags_AiUserId_MaxLength = 128;
         public const int Tags_AiUserAuthUserId_MaxLength = 1024;
         public const int Tags_AiCloudRole_MaxLength = 256;
-        public const int Tags_AiCloudRoleVer_MaxLength = 256;
         public const int Tags_AiCloudRoleInstance_MaxLength = 256;
-        public const int Tags_AiCloudLocation_MaxLength = 256;
         public const int Tags_AiInternalSdkVersion_MaxLength = 64;
-        public const int Tags_AiInternalAgentVersion_MaxLength = 64;
-        public const int Tags_AiInternalNodeName_MaxLength = 256;
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -116,6 +116,33 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const int TelemetryEnvelope_Time_MaxLength = 64;
         public const int TelemetryEnvelope_InstrumentationKey_MaxLength = 40;
 
+        public const int Tags_AiApplicationVer_MaxLength = 1024;
+        public const int Tags_AiDeviceId_MaxLength = 1024;
+        public const int Tags_AiDeviceLocale_MaxLength = 64;
+        public const int Tags_AiDeviceModel_MaxLength = 256;
+        public const int Tags_AiDeviceOemName_MaxLength = 256;
+        public const int Tags_AiDeviceOsVersion_MaxLength = 256;
+        public const int Tags_AiDeviceType_MaxLength = 64;
+        public const int Tags_AiLocationIp_MaxLength = 46;
+        public const int Tags_AiLocationCountry_MaxLength = 256;
+        public const int Tags_AiLocationProvince_MaxLength = 256;
+        public const int Tags_AiLocationCity_MaxLength = 256;
+        public const int Tags_AiOperationId_MaxLength = 128;
+        public const int Tags_AiOperationName_MaxLength = 1024;
+        public const int Tags_AiOperationParentId_MaxLength = 512;
+        public const int Tags_AiOperationSyntheticSource_MaxLength = 1024;
+        public const int Tags_AiOperationCorrelationVector_MaxLength = 64;
+        public const int Tags_AiSessionId_MaxLength = 64;
+        public const int Tags_AiSessionIsFirst_MaxLength = 5;
+        public const int Tags_AiUserAccountId_MaxLength = 1024;
+        public const int Tags_AiUserId_MaxLength = 128;
+        public const int Tags_AiUserAuthUserId_MaxLength = 1024;
+        public const int Tags_AiCloudRole_MaxLength = 256;
+        public const int Tags_AiCloudRoleVer_MaxLength = 256;
+        public const int Tags_AiCloudRoleInstance_MaxLength = 256;
+        public const int Tags_AiCloudLocation_MaxLength = 256;
         public const int Tags_AiInternalSdkVersion_MaxLength = 64;
+        public const int Tags_AiInternalAgentVersion_MaxLength = 64;
+        public const int Tags_AiInternalNodeName_MaxLength = 256;
     }
 }


### PR DESCRIPTION
Follow up to: https://github.com/Azure/azure-sdk-for-net/pull/37508#discussion_r1260551676

We're currently setting ContextTags without enforcing max lengths.
This PR will enforce those max lengths.


## Changes
- Add MaxLength constants for all ContextTags.
  Note that more ContextTags are defined than are currently used. I've added the constants for all ContextTags
- Add Truncation to all ContextTags currently in use.