### PR TITLE
[FormRecognizer] Removed IgnoreServiceError attributes and overrode IsEnvironmentReady

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisClient/DocumentAnalysisClientLiveTests.cs
@@ -20,7 +20,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public class DocumentAnalysisClientLiveTests : DocumentAnalysisLiveTestBase
     {
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisModels/OperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisModels/OperationsLiveTests.cs
@@ -16,7 +16,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public class OperationsLiveTests : DocumentAnalysisLiveTestBase
     {
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationLiveTests.cs
@@ -17,7 +17,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public class DocumentModelAdministrationLiveTests : DocumentAnalysisLiveTestBase
     {
         private static readonly DocumentBuildMode[] s_buildDocumentModelTestCases = new[]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/MiscellaneousOperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/MiscellaneousOperationsLiveTests.cs
@@ -17,7 +17,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public class MiscellaneousOperationsLiveTests : DocumentAnalysisLiveTestBase
     {
         private readonly IReadOnlyDictionary<string, string> _testingTags = new Dictionary<string, string>()

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeCustomFormsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/RecognizeCustomFormsLiveTests.cs
@@ -20,7 +20,6 @@ namespace Azure.AI.FormRecognizer.Tests
     [ClientTestFixture(
     FormRecognizerClientOptions.ServiceVersion.V2_0,
     FormRecognizerClientOptions.ServiceVersion.V2_1)]
-    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public class RecognizeCustomFormsLiveTests : FormRecognizerLiveTestBase
     {
         public RecognizeCustomFormsLiveTests(bool isAsync, FormRecognizerClientOptions.ServiceVersion serviceVersion)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -19,7 +19,6 @@ namespace Azure.AI.FormRecognizer.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public class FormTrainingClientLiveTests : FormRecognizerLiveTestBase
     {
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/DocumentAnalysisSamples.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/DocumentAnalysisSamples.cs
@@ -8,7 +8,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 {
     [LiveOnly]
     [AsyncOnly] // Ensure that each sample will only run once.
-    [IgnoreServiceError(400, "InvalidRequest", Message = "Content is not accessible: Invalid data URL", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28923")]
     public partial class DocumentAnalysisSamples : RecordedTestBase<DocumentAnalysisTestEnvironment>
     {
         public DocumentAnalysisSamples(bool isAsync) : base(isAsync, RecordedTestMode.Live)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/FormRecognizerSamples.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/FormRecognizerSamples.cs
@@ -8,7 +8,6 @@ namespace Azure.AI.FormRecognizer.Samples
 {
     [LiveOnly]
     [AsyncOnly] // Ensure that each sample will only run once.
-    [IgnoreServiceError(200, "3014", Message = "Generic error during training.", Reason = "https://github.com/Azure/azure-sdk-for-net/issues/28913")]
     public partial class FormRecognizerSamples : RecordedTestBase<FormRecognizerTestEnvironment>
     {
         public FormRecognizerSamples(bool isAsync) : base(isAsync, RecordedTestMode.Live)


### PR DESCRIPTION
This PR does two things:
- We have recently made a major cleanup in Form Recognizer tests to reduce the amount of requests we're making to the service. This definitely helped with https://github.com/Azure/azure-sdk-for-net/issues/31914 and we are now able to remove the `IgnoreServiceError` attributes that we were using to make the pipeline greener.
- We're overriding the Test Framework's `IsEnvironmentReadyAsync` method so we can wait until the Form Recognizer resource creation is completely finished before making calls to the service. Before this we were frequently seeing lots of 401 (PermissionDenied) errors. Thanks to @joseharriaga for proposing this approach after he had a similar issue in Text Analytics.