### PR TITLE
[Service Bus] ReadMe DI Snippets

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -198,16 +198,16 @@
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.15.0" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.0.0" />
     <PackageReference Update="Azure.ResourceManager.CognitiveServices" Version="1.1.0" />
-		<PackageReference Update="Azure.ResourceManager.KeyVault" Version="1.0.0" />
-		<PackageReference Update="Azure.ResourceManager.ManagedServiceIdentities" Version="1.0.0" />
+    <PackageReference Update="Azure.ResourceManager.KeyVault" Version="1.0.0" />
+    <PackageReference Update="Azure.ResourceManager.ManagedServiceIdentities" Version="1.0.0" />
     <PackageReference Update="Azure.ResourceManager.Network" Version="1.1.0" />
     <PackageReference Update="Azure.ResourceManager.OperationalInsights" Version="1.0.0" />
-		<PackageReference Update="Azure.ResourceManager.PrivateDns" Version="1.0.0" />
+    <PackageReference Update="Azure.ResourceManager.PrivateDns" Version="1.0.0" />
     <PackageReference Update="Azure.ResourceManager.Resources" Version="1.4.0" />
     <PackageReference Update="Azure.ResourceManager.Storage" Version="1.1.0" />
     <PackageReference Update="Azure.ResourceManager.EventHubs" Version="1.0.0" />
     <PackageReference Update="Azure.Search.Documents" Version="11.2.0" />
-		<PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.4.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.4.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0-beta.4" />
     <PackageReference Update="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.8.0" />
@@ -249,13 +249,13 @@
     <PackageReference Update="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
     <PackageReference Update="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.6.3" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.10" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.32" />
     <PackageReference Update="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-		<PackageReference Update="Microsoft.Graph" Version="4.52.0" />
+    <PackageReference Update="Microsoft.Graph" Version="4.52.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Update="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Update="Microsoft.Rest.ClientRuntime" Version="[2.3.24, 3.0.0)" />

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -401,6 +401,13 @@ string fullyQualifiedNamespace = "yournamespace.servicebus.windows.net";
 await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 ```
 
+### Working with Sessions
+
+[Sessions](https://docs.microsoft.com/azure/service-bus-messaging/message-sessions) provide a mechanism for grouping related messages. In order to use sessions, you need to be working with a session-enabled entity.
+
+- [Sending and receiving session messages](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md)
+- [Using the session processor](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md)
+
 ### Registering with ASP.NET Core dependency injection
 
 To inject `ServiceBusClient` as a dependency in an ASP.NET Core app, install the Azure client library integration for ASP.NET Core package.
@@ -409,60 +416,95 @@ To inject `ServiceBusClient` as a dependency in an ASP.NET Core app, install the
 dotnet add package Microsoft.Extensions.Azure
 ```
 
-Then register the client in the `Startup.ConfigureServices` method:
+Then register the client where your services are configured.  For ASP.NET Core applications, this is often directly in `Program.cs` or the  `StartupConfigureServices` method:
 
-```csharp
+```C# Snippet:DependencyInjectionRegisterClient
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddAzureClients(builder =>
     {
-        builder.AddServiceBusClient(Configuration.GetConnectionString("ServiceBus"));
+        builder.AddServiceBusClient("<< SERVICE BUS CONNECTION STRING >>");
     });
 
-    services.AddControllers();
-}
-```
-
-To use the preceding code, add this to the configuration for your application:
-
-```json
-{
-  "ConnectionStrings": {
-    "ServiceBus": "<connection_string>"
-  }
+    // Register other services, controllers, and other infrastructure.
 }
 ```
 
 For applications that prefer using a shared `Azure.Identity` credential for their clients, registration looks slightly different:
 
-```csharp
-var fullyQualifiedNamespace = "yournamespace.servicebus.windows.net";
-
+```C# Snippet:DependencyInjectionRegisterClientWithIdentity
 public void ConfigureServices(IServiceCollection services)
+ {
+     services.AddAzureClients(builder =>
+     {
+         // This will register the ServiceBusClient using an Azure Identity credential.
+         builder.AddServiceBusClientWithNamespace("<< YOUR NAMESPACE >>.servicebus.windows.net");
+
+         // By default, DefaultAzureCredential is used, which is likely desired for most
+         // scenarios. If you need to restrict to a specific credential instance, you could
+         // register that instance as the default credential instead.
+         builder.UseCredential(new ManagedIdentityCredential());
+     });
+
+     // Register other services, controllers, and other infrastructure.
+ }
+```
+
+It is also possible to register sub-clients, such as `ServiceBusSender` and `ServiceBusReceiver` with DI using the registered `ServiceBusClient` instance.  For example, to register a sender for each queue that belongs to the namespace:
+
+```C# Snippet:DependencyInjectionRegisterSubClients
+public async Task ConfigureServicesAsync(IServiceCollection services)
 {
+    // Query the available queues for the Service Bus namespace.
+    var adminClient = new ServiceBusAdministrationClient("<< SERVICE BUS CONNECTION STRING >>");
+    var queueNames = new List<string>();
+
+    // Because the result is async, they need to be captured to a standard list to avoid async
+    // calls when registering.  Failure to do so results in an error with the services collection.
+    await foreach (var queue in adminClient.GetQueuesAsync())
+    {
+        queueNames.Add(queue.Name);
+    }
+
+    // After registering the ServiceBusClient, register a named factory for each
+    // queue.  This allows them to be lazily created and managed as singleton instances.
+
     services.AddAzureClients(builder =>
     {
-        // This will register the ServiceBusClient using the default credential.
-        builder.AddServiceBusClientWithNamespace(fullyQualifiedNamespace);
+        builder.AddServiceBusClient("<< SERVICE BUS CONNECTION STRING >>");
 
-        // By default, DefaultAzureCredential is used, which is likely desired for most
-        // scenarios. If you need to restrict to a specific credential instance, you could
-        // register that instance as the default credential instead.
-        builder.UseCredential(new ManagedIdentityCredential());
+        foreach (var queueName in queueNames)
+        {
+            builder.AddClient<ServiceBusSender, ServiceBusClientOptions>((_, _, provider) =>
+                provider
+                    .GetService<ServiceBusClient>()
+                    .CreateSender(queueName)
+            )
+            .WithName(queueName);
+        }
     });
 
-    services.AddControllers();
+    // Register other services, controllers, and other infrastructure.
 }
 ```
 
-For more details, see [Dependency injection with the Azure SDK for .NET](https://docs.microsoft.com/dotnet/azure/sdk/dependency-injection).
+Because the senders are named for their associated queue, when injecting, you don't bind to them directly.  Instead, you'll bind to a factory that can be used to retrieve the named sender:
 
-### Working with Sessions
+```C# Snippet:DependencyInjectionBindToNamedSubClients
+public class ServiceBusSendingController : ControllerBase
+{
+    private readonly ServiceBusSender _sender;
 
-[Sessions](https://docs.microsoft.com/azure/service-bus-messaging/message-sessions) provide a mechanism for grouping related messages. In order to use sessions, you need to be working with a session-enabled entity.
+    public ServiceBusSendingController(IAzureClientFactory<ServiceBusSender> serviceBusSenderFactory)
+    {
+        // Though the method is called "CreateClient", the factory will manage the sender as a
+        // singleton, creating a new instance only on the first use.
+        _sender = serviceBusSenderFactory.CreateClient("<< QUEUE NAME >>");
+    }
+}
+```
 
-- [Sending and receiving session messages](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md)
-- [Using the session processor](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md)
+For more details and examples, see [Dependency injection with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/dependency-injection).
 
 ## Troubleshooting
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Azure.Messaging.ServiceBus.Tests.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Azure.Messaging.ServiceBus.Tests.csproj
@@ -18,6 +18,9 @@
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Microsoft.Extensions.Azure" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="NUnit" />
@@ -28,7 +31,7 @@
     <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="Azure.Storage.Blobs" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)EventSourceEventFormatting.cs" LinkBase="SharedSource\Azure.Core" />
   </ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Compatibility/DependencyInjectionSnippets.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Compatibility/DependencyInjectionSnippets.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Identity;
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Azure.Messaging.ServiceBus.Tests
+{
+    [TestFixture]
+    public class DependencyInjectionSnippets
+    {
+        public class ClientRegistrationConnectionString
+        {
+            #region Snippet:DependencyInjectionRegisterClient
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddAzureClients(builder =>
+                {
+                    builder.AddServiceBusClient("<< SERVICE BUS CONNECTION STRING >>");
+                });
+
+                // Register other services, controllers, and other infrastructure.
+            }
+            #endregion
+        }
+
+        public class ClientRegistrationIdentity
+        {
+            #region Snippet:DependencyInjectionRegisterClientWithIdentity
+           public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddAzureClients(builder =>
+                {
+                    // This will register the ServiceBusClient using an Azure Identity credential.
+                    builder.AddServiceBusClientWithNamespace("<< YOUR NAMESPACE >>.servicebus.windows.net");
+
+                    // By default, DefaultAzureCredential is used, which is likely desired for most
+                    // scenarios. If you need to restrict to a specific credential instance, you could
+                    // register that instance as the default credential instead.
+                    builder.UseCredential(new ManagedIdentityCredential());
+                });
+
+                // Register other services, controllers, and other infrastructure.
+            }
+            #endregion
+        }
+
+        public class SubClientRegistration
+        {
+            #region Snippet:DependencyInjectionRegisterSubClients
+            public async Task ConfigureServicesAsync(IServiceCollection services)
+            {
+                // Query the available queues for the Service Bus namespace.
+                var adminClient = new ServiceBusAdministrationClient("<< SERVICE BUS CONNECTION STRING >>");
+                var queueNames = new List<string>();
+
+                // Because the result is async, they need to be captured to a standard list to avoid async
+                // calls when registering.  Failure to do so results in an error with the services collection.
+                await foreach (var queue in adminClient.GetQueuesAsync())
+                {
+                    queueNames.Add(queue.Name);
+                }
+
+                // After registering the ServiceBusClient, register a named factory for each
+                // queue.  This allows them to be lazily created and managed as singleton instances.
+
+                services.AddAzureClients(builder =>
+                {
+                    builder.AddServiceBusClient("<< SERVICE BUS CONNECTION STRING >>");
+
+                    foreach (var queueName in queueNames)
+                    {
+                        builder.AddClient<ServiceBusSender, ServiceBusClientOptions>((_, _, provider) =>
+                            provider
+                                .GetService<ServiceBusClient>()
+                                .CreateSender(queueName)
+                        )
+                        .WithName(queueName);
+                    }
+                });
+
+                // Register other services, controllers, and other infrastructure.
+            }
+            #endregion
+
+            #region Snippet:DependencyInjectionBindToNamedSubClients
+            public class ServiceBusSendingController : ControllerBase
+            {
+                private readonly ServiceBusSender _sender;
+
+                public ServiceBusSendingController(IAzureClientFactory<ServiceBusSender> serviceBusSenderFactory)
+                {
+                    // Though the method is called "CreateClient", the factory will manage the sender as a
+                    // singleton, creating a new instance only on the first use.
+                    _sender = serviceBusSenderFactory.CreateClient("<< QUEUE NAME >>");
+                }
+            }
+            #endregion
+        }
+
+        // This is a dummy class pretending to be an ASP.NET controller. It is intended
+        // to allow the snippet to compile.
+        public class ControllerBase
+        {
+        }
+    }
+}

--- a/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/Readme.cs
+++ b/sdk/servicebus/Azure.ResourceManager.ServiceBus/tests/Samples/Readme.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#region Snippet:Managing_ServiceBus_AuthClient_Usings
 using Azure.Identity;
-#endregion
-
 using NUnit.Framework;
 
 namespace Azure.ResourceManager.ServiceBus.Tests.Samples
@@ -15,9 +12,7 @@ namespace Azure.ResourceManager.ServiceBus.Tests.Samples
         [Ignore("Only verifying that the sample builds")]
         public void ClientAuth()
         {
-            #region Snippet:Managing_ServiceBus_AuthClient
             ArmClient armClient = new ArmClient(new DefaultAzureCredential());
-            #endregion
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to convert the dependency injection examples in the README to be snippet-driven.  In addition, an example for registering SubClients was also added, as this has been a frequent inquiry.   Unused snippets in the management project were also removed, as they were causing failures for generation.

# References and Related

- [Convert DI code sample in Service Bus readme into a snippet (#21599)](https://github.com/Azure/azure-sdk-for-net/issues/21599)