### PR TITLE
Document the System.IO.DirectoryNotFoundException for BlobBaseClient.DownloadToAsync Method

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -2281,6 +2281,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
+        /// A DirectoryNotFoundException will be thrown if the file
+        /// path to download the blob to doesn't exist.
         /// </remarks>
         public virtual Response DownloadTo(Stream destination) =>
             DownloadTo(destination, CancellationToken.None);
@@ -2298,6 +2300,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
+        /// A DirectoryNotFoundException will be thrown if the file
+        /// path to download the blob to doesn't exist.
         /// </remarks>
         public virtual Response DownloadTo(string path) =>
             DownloadTo(path, CancellationToken.None);
@@ -2332,6 +2336,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
+        /// A DirectoryNotFoundException will be thrown if the file
+        /// path to download the blob to doesn't exist.
         /// </remarks>
         public virtual async Task<Response> DownloadToAsync(string path) =>
             await DownloadToAsync(path, CancellationToken.None).ConfigureAwait(false);
@@ -2381,6 +2387,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
+        /// A DirectoryNotFoundException will be thrown if the file
+        /// path to download the blob to doesn't exist.
         /// </remarks>
         public virtual Response DownloadTo(
             string path,
@@ -2436,6 +2444,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
+        /// A DirectoryNotFoundException will be thrown if the file
+        /// path to download the blob to doesn't exist.
         /// </remarks>
         public virtual async Task<Response> DownloadToAsync(
             string path,
@@ -2505,6 +2515,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
+        /// A DirectoryNotFoundException will be thrown if the file
+        /// path to download the blob to doesn't exist.
         /// </remarks>
         public virtual Response DownloadTo(
             string path,


### PR DESCRIPTION
fixes Azure/azure-sdk-for-net#37772

This PR documents the `System.IO.DirectoryNotFoundException` thrown when asked to download to a path that requires creating a folder.
For example, given a correctly configured BlobClient (that points to the desired blob to download), if the directory "C:\Base" exists and we call DownloadToAsync passing the path "C:\Base\Sub\file.txt", when the folder "C:\Base\Sub" does not exist, instead of creating it as part of the download process, the DownloadToAsync throws the exception.

Other APIs sometimes create parts of the path as needed, but this one does not (maybe this should be a bug to fix, as it makes no sense to have to do several calls for a single download), but at least this exception should be documented.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
