### PR TITLE
[AzureMonitorDistro] update resource detector

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -129,7 +129,7 @@
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
     <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.5.1-beta.1" />
     <PackageReference Update="OpenTelemetry.PersistentStorage.FileSystem" Version="1.0.0-beta.2" />
-    <PackageReference Update="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.1" />
+    <PackageReference Update="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.2" />
   </ItemGroup>
 
   <!--

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -17,11 +17,13 @@
 
 * Update OpenTelemetry dependencies
   ([#37837](https://github.com/Azure/azure-sdk-for-net/pull/37837))
+  ([#37881](https://github.com/Azure/azure-sdk-for-net/pull/37881))
   - OpenTelemetry 1.5.1
   - OpenTelemetry.Extensions.Hosting 1.5.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.5.1-beta.1
   - OpenTelemetry.Instrumentation.Http 1.5.1-beta.1
   - OpenTelemetry.Instrumentation.SqlClient 1.5.1-beta.1
+  - OpenTelemetry.ResourceDetectors.Azure 1.0.0-beta2
 
 ## 1.0.0-beta.5 (2023-07-13)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Update OpenTelemetry dependencies
   ([#37837](https://github.com/Azure/azure-sdk-for-net/pull/37837))
-  ([]())
+  ([#37881](https://github.com/Azure/azure-sdk-for-net/pull/37881))
   - OpenTelemetry 1.5.1
   - OpenTelemetry.Extensions.Hosting 1.5.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.5.1-beta.1

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -17,11 +17,12 @@
 
 * Update OpenTelemetry dependencies
   ([#37837](https://github.com/Azure/azure-sdk-for-net/pull/37837))
+  ([]())
   - OpenTelemetry 1.5.1
   - OpenTelemetry.Extensions.Hosting 1.5.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.5.1-beta.1
   - OpenTelemetry.Instrumentation.Http 1.5.1-beta.1
-  - OpenTelemetry.Instrumentation.SqlClient 1.5.1-beta.1
+  - OpenTelemetry.Instrumentation.SqlClient 1.5.1-beta.2
 
 ## 1.0.0-beta.5 (2023-07-13)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -17,12 +17,11 @@
 
 * Update OpenTelemetry dependencies
   ([#37837](https://github.com/Azure/azure-sdk-for-net/pull/37837))
-  ([#37881](https://github.com/Azure/azure-sdk-for-net/pull/37881))
   - OpenTelemetry 1.5.1
   - OpenTelemetry.Extensions.Hosting 1.5.1
   - OpenTelemetry.Instrumentation.AspNetCore 1.5.1-beta.1
   - OpenTelemetry.Instrumentation.Http 1.5.1-beta.1
-  - OpenTelemetry.Instrumentation.SqlClient 1.5.1-beta.2
+  - OpenTelemetry.Instrumentation.SqlClient 1.5.1-beta.1
 
 ## 1.0.0-beta.5 (2023-07-13)
 


### PR DESCRIPTION
ResourceDetector.Azure beta2 released late last night. 
Getting that updated in our distro.

https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.Azure/1.0.0-beta.2 