### PR TITLE
Azure OpenAI: Improve treatment of connection exceptions during streaming

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChatChoice.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChatChoice.cs
@@ -37,16 +37,7 @@ namespace Azure.AI.OpenAI
 
         internal ChatMessage StreamingDeltaMessage { get; set; }
 
-        internal bool StreamingDoneSignalReceived
-        {
-            get => _streamingDoneSignalReceived;
-            set
-            {
-                _streamingDoneSignalReceived = value;
-                _updateAvailableEvent.Set();
-            }
-        }
-        private bool _streamingDoneSignalReceived;
+        private bool _isFinishedStreaming { get; set; } = false;
 
         internal StreamingChatChoice(ChatChoice originalBaseChoice)
         {
@@ -59,6 +50,10 @@ namespace Azure.AI.OpenAI
             lock (_baseChoicesLock)
             {
                 _baseChoices.Add(streamingChatChoice);
+            }
+            if (streamingChatChoice.FinishReason != null)
+            {
+                EnsureFinishStreaming();
             }
             _updateAvailableEvent.Set();
         }
@@ -83,10 +78,9 @@ namespace Azure.AI.OpenAI
                     lock (_baseChoicesLock)
                     {
                         ChatChoice mostRecentChoice = _baseChoices.Last();
-                        bool choiceIsComplete = mostRecentChoice.FinishReason != null || StreamingDoneSignalReceived;
 
-                        doneWaiting = choiceIsComplete || i < _baseChoices.Count;
-                        isFinalIndex = choiceIsComplete && i >= _baseChoices.Count - 1;
+                        doneWaiting = _isFinishedStreaming || i < _baseChoices.Count;
+                        isFinalIndex = _isFinishedStreaming && i >= _baseChoices.Count - 1;
                     }
 
                     if (!doneWaiting)
@@ -110,6 +104,15 @@ namespace Azure.AI.OpenAI
                 {
                     yield return message;
                 }
+            }
+        }
+
+        internal void EnsureFinishStreaming()
+        {
+            if (!_isFinishedStreaming)
+            {
+                _isFinishedStreaming = true;
+                _updateAvailableEvent.Set();
             }
         }
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChoice.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChoice.cs
@@ -35,16 +35,7 @@ namespace Azure.AI.OpenAI
         /// </remarks>
         public CompletionsFinishReason FinishReason => GetLocked(() => _baseChoices.Last().FinishReason);
 
-        internal bool StreamingDoneSignalReceived
-        {
-            get => _streamingDoneSignalReceived;
-            set
-            {
-                _streamingDoneSignalReceived = value;
-                _updateAvailableEvent.Set();
-            }
-        }
-        private bool _streamingDoneSignalReceived;
+        private bool _isFinishedStreaming { get; set; } = false;
 
         /// <summary>
         /// Gets the log probabilities associated with tokens in this Choice.
@@ -63,6 +54,10 @@ namespace Azure.AI.OpenAI
             lock (_baseChoicesLock)
             {
                 _baseChoices.Add(streamingChoice);
+            }
+            if (streamingChoice.FinishReason != null)
+            {
+                EnsureFinishStreaming();
             }
             _updateAvailableEvent.Set();
         }
@@ -87,10 +82,9 @@ namespace Azure.AI.OpenAI
                     lock (_baseChoicesLock)
                     {
                         Choice mostRecentChoice = _baseChoices.Last();
-                        bool choiceIsComplete = mostRecentChoice.FinishReason != null || StreamingDoneSignalReceived;
 
-                        doneWaiting = choiceIsComplete || i < _baseChoices.Count;
-                        isFinalIndex = choiceIsComplete && i >= _baseChoices.Count - 1;
+                        doneWaiting = _isFinishedStreaming || i < _baseChoices.Count;
+                        isFinalIndex = _isFinishedStreaming && i >= _baseChoices.Count - 1;
                     }
 
                     if (!doneWaiting)
@@ -112,6 +106,15 @@ namespace Azure.AI.OpenAI
                 {
                     yield return newText;
                 }
+            }
+        }
+
+        internal void EnsureFinishStreaming()
+        {
+            if (!_isFinishedStreaming)
+            {
+                _isFinishedStreaming = true;
+                _updateAvailableEvent.Set();
             }
         }
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingCompletions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingCompletions.cs
@@ -95,16 +95,6 @@ namespace Azure.AI.OpenAI
                             }
                         }
                     }
-
-                    // Non-Azure OpenAI doesn't always set the FinishReason on streaming choices when multiple prompts are
-                    // provided.
-                    lock (_streamingChoicesLock)
-                    {
-                        foreach (StreamingChoice streamingChoice in _streamingChoices)
-                        {
-                            streamingChoice.StreamingDoneSignalReceived = true;
-                        }
-                    }
                 }
                 catch (Exception pumpException)
                 {
@@ -112,6 +102,16 @@ namespace Azure.AI.OpenAI
                 }
                 finally
                 {
+                    lock (_streamingChoicesLock)
+                    {
+                        // If anything went wrong and a StreamingChoice didn't naturally determine it was complete
+                        // based on a non-null finish reason, ensure that nothing's left incomplete (and potentially
+                        // hanging!) now.
+                        foreach (StreamingChoice streamingChoice in _streamingChoices)
+                        {
+                            streamingChoice.EnsureFinishStreaming();
+                        }
+                    }
                     _streamingTaskComplete = true;
                     _updateAvailableEvent.Set();
                 }


### PR DESCRIPTION
Both `Completions` and `StreamingCompletions` spawn a task that pumps a service response content stream to populate incremental responses from server-sent event 'data' chunks as they arrive.

To ensure that exceptions encountered in this Task are surfaced to the caller, they're caught, stored, and later re-thrown when there's a non-background entry point to do so.

This logic currently has a dimension of incompleteness, however: although the parent `*Completions` container properly sets its synchronization event to ensure that any ongoing enumeration or other usage is appropriately terminated, the constituent `*Choice` objects are *not* always appropriately signaled -- meaning that some calling patterns inappropriately hang until a timeout or cancellation occurs.

We already had a block of code in the non-exception path that ensures all `*Choices` are finished when overall streaming is done; fundamentally, all this change does is move that logic into the `finally` block such that we *always* guarantee `*Choices` are terminated once the response pumping operation finishes (regardless of how it finishes).

It incidentally includes a small improvement to allow choices to proactively signal "finished" based on a non-null `finish_reason` arriving, which may improve perceived responsiveness in some situations with multiple choices concurrently streaming that have substantially different timing characteristics.