### PR TITLE
[Messaging] Mocking sample annotation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_MockingClientTypes.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_MockingClientTypes.md
@@ -5,6 +5,8 @@ Event Hubs is built to support unit testing with mocks, as described in the [Azu
 
 The following examples focus on scenarios likely to occur in applications, and demonstrate how to mock the Event Hubs types typically used in each scenario. The code snippets utilize the mock object framework, Moq, in order to provide practical examples. However, many mocking frameworks exist and can be used with the same approach in mind.
 
+For more general information and examples on mocking with the Azure SDK, please see [Unit testing and mocking with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/unit-testing-mocking).
+
 ## Table of contents
 
 - **Publishing events**

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample15_MockingClientTypes.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample15_MockingClientTypes.md
@@ -5,6 +5,8 @@ The Service Bus client library is built to support unit testing with mocks, as d
 
 The following examples focus on scenarios likely to occur in applications, and demonstrate how to mock the Service Bus types typically used in each scenario. The code snippets utilize the mock object framework, Moq, in order to provide practical examples. However, many mocking frameworks exist and can be used with the same approach in mind.
 
+For more general information and examples on mocking with the Azure SDK, please see [Unit testing and mocking with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/unit-testing-mocking).
+
 ## Table of contents
 
 - **Sending and receiving messages**


### PR DESCRIPTION
# Summary

The focus of these changes is to annotate the mocking samples for Event Hubs and Service Bus with a call-out to the general Azure SDK unit testing and mocking article.  While the article is focused on HTTP services and does not replace these dedicated samples, the additional context and examples may be helpful to developers.