### PR TITLE
[AzureMonitorExporter] cleanup Todos (part2): add EventSource to AspNetCore

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -19,4 +19,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
   </ItemGroup>
+
+  <!-- Shared source from Exporter -->
+  <ItemGroup>
+    <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\ExceptionExtensions.cs" LinkBase="Shared" />
+  </ItemGroup>
 </Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+
+namespace Azure.Monitor.OpenTelemetry.AspNetCore
+{
+    /// <summary>
+    /// EventSource for the AzureMonitor AspNetCore Distro.
+    /// EventSource Guid at Runtime: ????.
+    /// </summary>
+    /// <remarks>
+    /// PerfView Instructions:
+    /// <list type="bullet">
+    /// <item>To collect all events: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders=*OpenTelemetry-AzureMonitor-AspNetCore</code></item>
+    /// <item>To collect events based on LogLevel: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders:OpenTelemetry-AzureMonitor-AspNetCore::Verbose</code></item>
+    /// </list>
+    /// Dotnet-Trace Instructions:
+    /// <list type="bullet">
+    /// <item>To collect all events: <code>dotnet-trace collect --process-id PID --providers OpenTelemetry-AzureMonitor-AspNetCore</code></item>
+    /// <item>To collect events based on LogLevel: <code>dotnet-trace collect --process-id PID --providers OpenTelemetry-AzureMonitor-AspNetCore::Verbose</code></item>
+    /// </list>
+    /// Logman Instructions:
+    /// <list type="number">
+    /// <item>Create a text file containing providers: <code>echo "{????}" > providers.txt</code></item>
+    /// <item>Start collecting: <code>logman -start exporter -pf providers.txt -ets -bs 1024 -nb 100 256</code></item>
+    /// <item>Stop collecting: <code>logman -stop exporter -ets</code></item>
+    /// </list>
+    /// </remarks>
+    [EventSource(Name = EventSourceName)]
+    internal sealed class AzureMonitorAspNetCoreEventSource : EventSource
+    {
+        internal const string EventSourceName = "OpenTelemetry-AzureMonitor-AspNetCore";
+
+        internal static readonly AzureMonitorAspNetCoreEventSource Log = new AzureMonitorAspNetCoreEventSource();
+
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsEnabled(EventLevel eventLevel) => IsEnabled(eventLevel, EventKeywords.All);
+
+        [NonEvent]
+        public void ConfigureFailed(Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ConfigureFailed(ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(1, Message = "Failed to configure to an exception: {0}", Level = EventLevel.Error)]
+        public void ConfigureFailed(string exceptionMessage) => WriteEvent(1, exceptionMessage);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorAspNetCoreEventSource.cs
@@ -50,7 +50,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             }
         }
 
-        [Event(1, Message = "Failed to configure to an exception: {0}", Level = EventLevel.Error)]
+        [Event(1, Message = "Failed to configure AzureMonitorOptions using the connection string from environment variables due to an exception: {0}", Level = EventLevel.Error)]
         public void ConfigureFailed(string exceptionMessage) => WriteEvent(1, exceptionMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
@@ -38,9 +38,9 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                     options.ConnectionString = connectionString;
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // TODO: Log Error.
+                AzureMonitorAspNetCoreEventSource.Log.ConfigureFailed(ex);
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\EventSourceTestHelper.cs" LinkBase="CommonTestFramework" />
+    <Compile Include="..\..\..\Azure.Monitor.OpenTelemetry.Exporter\tests\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\TestEventListener.cs" LinkBase="CommonTestFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Workaround to fix CI build failure in macOS. This package is being used indirectly by Azure analyzers. -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="7.0.0" />
   </ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureMonitorAspNetCoreEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureMonitorAspNetCoreEventSourceTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
-using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 using Xunit;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
 
-namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 {
-    public class AzureMonitorExporterEventSourceTests
+    public class AzureMonitorAspNetCoreEventSourceTests
     {
         /// <summary>
         /// This test uses reflection to invoke every Event method in our EventSource class.
@@ -16,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void EventSourceTest_AzureMonitorExporterEventSource()
         {
-            EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(AzureMonitorExporterEventSource.Log);
+            EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(AzureMonitorAspNetCoreEventSource.Log);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\**" Link="CommonTestFramework\%(Filename)%(Extension)" />
+    <Compile Include="..\Azure.Monitor.OpenTelemetry.Exporter.Tests\CommonTestFramework\**" LinkBase="CommonTestFramework" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Follow up: #37913

### Changes
- Add new EventSource class (`AzureMonitorAspNetCoreEventSource`) to `Azure.Monitor.OpenTelemetry.AspNetCore` project
- Add new test class to verify new EventSource class.
- Edit `AspNetCore.csproj` to use shared files from `Exporter` project.
- Edit `AspNetCore.Tests.csproj` to use CommonTestFramework from `Exporter.Tests` project.
- Misc Cleanup
  - remove outdated comment from `AzureMonitorExporterEventSourceTests`
  - update `Exporter.Integration.Tests.csproj` to use cleaner syntax for CommonTestFramework.