### PR TITLE
[AzureMonitorExporter] cleanup Todos (part3): extra logging

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 {
@@ -355,5 +356,32 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 
         [Event(36, Message = "Version string exceeds expected length. This is only for internal telemetry and can safely be ignored. Type Name: {0}. Version: {1}", Level = EventLevel.Verbose)]
         public void VersionStringUnexpectedLength(string typeName, string value) => WriteEvent(36, typeName, value);
+
+        [Event(37, Message = "Failed to delete telemetry from storage. This may result in duplicate telemetry if the file is processed again. Not user actionable.", Level = EventLevel.Warning)]
+        public void DeletedFailed() => WriteEvent(37);
+
+        [NonEvent]
+        public void PartialContentResponseInvalid(int totalTelemetryItems, TelemetryErrorDetails error)
+        {
+            if (IsEnabled(EventLevel.Warning))
+            {
+                PartialContentResponseInvalid(totalTelemetryItems, error.Index?.ToString() ?? "N/A", error.StatusCode?.ToString() ?? "N/A", error.Message);
+            }
+        }
+
+        [Event(38, Message = "Received a partial success from ingestion that does not match telemetry that was sent. Total telemetry items sent: {0}. Error Index: {1}. Error StatusCode: {2}. Error Message: {3}", Level = EventLevel.Warning)]
+        public void PartialContentResponseInvalid(int totalTelemetryItems, string errorIndex, string errorStatusCode, string errorMessage) => WriteEvent(38, totalTelemetryItems, errorIndex, errorStatusCode, errorMessage);
+
+        [NonEvent]
+        public void PartialContentResponseUnhandled(TelemetryErrorDetails error)
+        {
+            if (IsEnabled(EventLevel.Warning))
+            {
+                PartialContentResponseUnhandled(error.StatusCode?.ToString() ?? "N/A", error.Message);
+            }
+        }
+
+        [Event(39, Message = "Received a partial success from ingestion. This status code is not handled and telemetry will be lost. Error StatusCode: {0}. Error Message: {1}", Level = EventLevel.Warning)]
+        public void PartialContentResponseUnhandled(string errorStatusCode, string errorMessage) => WriteEvent(39, errorStatusCode, errorMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -61,8 +61,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                             // In case if the delete fails, there is a possibility
                             // that the current batch will be transmitted more than once resulting in duplicates.
-                            // TODO: TryDelete returns a boolean, should we log when this occurs?
-                            blob.TryDelete();
+                            var deleteSucceeded = blob.TryDelete();
+                            if (!deleteSucceeded)
+                            {
+                                AzureMonitorExporterEventSource.Log.DeletedFailed();
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
Follow up: https://github.com/Azure/azure-sdk-for-net/pull/37913

Changes
- Add logging to `TransmitFromStorageHandler` to record when a file delete fails. 
- Add logging to `HttpPipelineHelper`'s handling of Partial Success from ingestion.
  I made some minor refactor here to make this easier to read.