### PR TITLE
Workload Identity Support for AzureComponentFactory

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -94,7 +94,7 @@
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.15.0" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.2.0" />
     <PackageReference Update="Azure.Monitor.Query" Version="1.1.0" />
-    <PackageReference Update="Azure.Identity" Version="1.7.0" />
+    <PackageReference Update="Azure.Identity" Version="1.9.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.2.0" />
@@ -194,7 +194,7 @@
   <ItemGroup Condition="('$(IsTestProject)' == 'true') OR ('$(IsTestSupportProject)' == 'true') OR ('$(IsPerfProject)' == 'true') OR ('$(IsStressProject)' == 'true') OR ('$(IsSamplesProject)' == 'true')">
     <PackageReference Update="ApprovalTests" Version="3.0.22" />
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
-    <PackageReference Update="Azure.Identity" Version="1.7.0" />
+    <PackageReference Update="Azure.Identity" Version="1.9.0" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.14.1" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.15.0" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.0.0" />

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Other Changes
 
-- Updated dependency `Azure.Identity` to version `1.9.0`
+- Updated dependency `Azure.Identity` to version `1.9.0`.
 
 ## 1.6.3 (2023-03-10)
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Features Added
 
+- Added support for creating `WorkloadIdentityCredential` objects from the configuration using the `"credential": "workloadidentity"`. Users must provide values for the `tenentId`, `clientId`, and newly added `tokenFilePath` keys in the configuration, or they must set the environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`.
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- Updated dependency `Azure.Identity` to version `1.9.0`
 
 ## 1.6.3 (2023-03-10)
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Extensions.Azure
             var certificateStoreName = configuration["clientCertificateStoreName"];
             var certificateStoreLocation = configuration["clientCertificateStoreLocation"];
             var additionallyAllowedTenants = configuration["additionallyAllowedTenants"];
+            var tokenFilePath = configuration["tokenFilePath"];
             IEnumerable<string> additionallyAllowedTenantsList = null;
             if (!string.IsNullOrWhiteSpace(additionallyAllowedTenants))
             {
@@ -117,6 +118,34 @@ namespace Microsoft.Extensions.Azure
                 }
 
                 return new ManagedIdentityCredential(clientId);
+            }
+
+            if (string.Equals(credentialType, "workloadidentity", StringComparison.OrdinalIgnoreCase))
+            {
+                var workloadIdentityOptions = new WorkloadIdentityCredentialOptions();
+                if (!string.IsNullOrWhiteSpace(tenantId))
+                {
+                    workloadIdentityOptions.TenantId = tenantId;
+                }
+
+                if (!string.IsNullOrWhiteSpace(clientId))
+                {
+                    workloadIdentityOptions.ClientId = clientId;
+                }
+
+                if (!string.IsNullOrWhiteSpace(tokenFilePath))
+                {
+                    workloadIdentityOptions.TokenFilePath = tokenFilePath;
+                }
+
+                if (!string.IsNullOrWhiteSpace(workloadIdentityOptions.TenantId) &&
+                    !string.IsNullOrWhiteSpace(workloadIdentityOptions.ClientId) &&
+                    !string.IsNullOrWhiteSpace(workloadIdentityOptions.TokenFilePath))
+                {
+                    return new WorkloadIdentityCredential(workloadIdentityOptions);
+                }
+
+                throw new ArgumentException("For workload identity, 'tenantId', 'clientId', and 'tokenFilePath' must be specified via environment variables or the configuration.");
             }
 
             if (!string.IsNullOrWhiteSpace(tenantId) &&

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -122,6 +122,8 @@ namespace Microsoft.Extensions.Azure
 
             if (string.Equals(credentialType, "workloadidentity", StringComparison.OrdinalIgnoreCase))
             {
+                // The WorkloadIdentityCredentialOptions object initialization populates its instance members
+                // from the environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE
                 var workloadIdentityOptions = new WorkloadIdentityCredentialOptions();
                 if (!string.IsNullOrWhiteSpace(tenantId))
                 {


### PR DESCRIPTION
Resolves #37943

- Allow `AzureCredentialFactory` to create instances of `WorkloadIdentityCredential` based on the new `"workloadidentity"` `credential` value
  - Workload Identity credentials must have a Tenant Id, Client Id, and a Token File Path specified
  - Add new `tokenFilePath` field to the configuration expected by `ClientFactory.CreateCredential`
- Update `Azure.Identity` version to `1.9.0` across the repository to support `WorkloadIdentityCredential`