### PR TITLE
Use TrySetCanceled and TrySetResult to avoid finalizing the task twice

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Helpers/AsyncAutoResetEvent.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Helpers/AsyncAutoResetEvent.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.OpenAI
                 else
                 {
                     var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    cancellationToken.Register(() => tcs?.SetCanceled());
+                    cancellationToken.Register(() => tcs?.TrySetCanceled());
                     _waits.Enqueue(tcs);
                     return tcs.Task;
                 }
@@ -42,7 +42,7 @@ namespace Azure.AI.OpenAI
                 else if (!_signaled)
                     _signaled = true;
             }
-            toRelease?.SetResult(true);
+            toRelease?.TrySetResult(true);
         }
     }
 }


### PR DESCRIPTION
This should fix https://github.com/Azure/azure-sdk-for-net/issues/37163

The exception is thrown because `SetResult(true)` is called on a `TaskCompletionSource` for which we have already called `SetCanceled()`.