### PR TITLE
[AzureMonitorExporter] api feedback (part2)

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -17,7 +17,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// The Connection String provides users with a single configuration setting to identify the Azure Monitor resource and endpoint.
         /// </summary>
         /// <remarks>
-        /// (https://docs.microsoft.com/azure/azure-monitor/app/sdk-connection-string).
+        /// <see href="https://docs.microsoft.com/azure/azure-monitor/app/sdk-connection-string"/>.
         /// </remarks>
         public string ConnectionString { get; set; }
 
@@ -27,7 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// and Instrumentation Key from the Connection String will be used.
         /// </summary>
         /// <remarks>
-        /// https://learn.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string?tabs=net#is-the-connection-string-a-secret
+        /// <see href="https://learn.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string?tabs=net#is-the-connection-string-a-secret"/>.
         /// </remarks>
         public TokenCredential Credential { get; set; }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#37707](https://github.com/Azure/azure-sdk-for-net/pull/37707))
 * Removing `ServiceVersion.V2020_09_15_Preview`. This is no longer in use and
   the exporter has already defaulted to the latest `ServiceVersion.v2_1`.
-  ([]())
+  ([#37993](https://github.com/Azure/azure-sdk-for-net/pull/37993))
 
 ### Bugs Fixed
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Location ip on server spans will now be set using `client.address` tag key on
   activity instead of `http.client_ip`.
   ([#37707](https://github.com/Azure/azure-sdk-for-net/pull/37707))
+* Removing `ServiceVersion.V2020_09_15_Preview`. This is no longer in use and
+  the exporter has already defaulted to the latest `ServiceVersion.v2_1`.
+  ([]())
 
 ### Bugs Fixed
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -21,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// The Connection String provides users with a single configuration setting to identify the Azure Monitor resource and endpoint.
         /// </summary>
         /// <remarks>
-        /// (https://docs.microsoft.com/azure/azure-monitor/app/sdk-connection-string).
+        /// <see href="https://docs.microsoft.com/azure/azure-monitor/app/sdk-connection-string"/>.
         /// </remarks>
         public string? ConnectionString { get; set; }
 
@@ -65,12 +65,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public enum ServiceVersion
         {
             /// <summary>
-            /// (https://github.com/Azure/azure-rest-api-specs/blob/master/specification/applicationinsights/data-plane/Monitor.Exporters/preview/2020-09-15_Preview/swagger.json).
-            /// </summary>
-            V2020_09_15_Preview = 1,
-
-            /// <summary>
-            /// (https://github.com/Azure/azure-rest-api-specs/blob/master/specification/applicationinsights/data-plane/Monitor.Exporters/preview/v2.1/swagger.json).
+            /// <see href="https://github.com/Azure/azure-rest-api-specs/blob/master/specification/applicationinsights/data-plane/Monitor.Exporters/preview/v2.1/swagger.json" />.
             /// </summary>
             v2_1 = 2,
         }


### PR DESCRIPTION
Responding to feedback on our public api.

### Changes
- update Options class
  - remove preview service version.
  - update http link in comments.
    Note in the screenshots how the link is displayed.
    <details>
      <summary>Screenshots</summary>
     
      Before:
      ![image](https://github.com/Azure/azure-sdk-for-net/assets/28785781/3f713444-5500-40a3-9820-787ab2eb91ac)
      
      After:
      ![image](https://github.com/Azure/azure-sdk-for-net/assets/28785781/bb9911a9-5454-4444-9a78-337ed02a7b3b)
    
    </details>


## TODO
- waiting for feedback on the Options ctor.