### PR TITLE
[AzureMonitorDistro] use IConfiguration to set ConnectionString

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
@@ -31,18 +31,18 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                     _configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
 
                     // IConfiguration can read from EnvironmentVariables or InMemoryCollection if configured to do so.
-                    var connectionString = _configuration[ConnectionStringEnvironmentVariable];
-                    if (!string.IsNullOrEmpty(connectionString))
+                    var connectionStringFromIConfig = _configuration[ConnectionStringEnvironmentVariable];
+                    if (!string.IsNullOrEmpty(connectionStringFromIConfig))
                     {
-                        options.ConnectionString = connectionString;
+                        options.ConnectionString = connectionStringFromIConfig;
                     }
+                }
 
-                    // Environment Variable should take precedence.
-                    connectionString = Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable);
-                    if (!string.IsNullOrEmpty(connectionString))
-                    {
-                        options.ConnectionString = connectionString;
-                    }
+                // Environment Variable should take precedence.
+                var connectionStringFromEnvVar = Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable);
+                if (!string.IsNullOrEmpty(connectionStringFromEnvVar))
+                {
+                    options.ConnectionString = connectionStringFromEnvVar;
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
@@ -30,7 +30,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                 {
                     _configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
 
-                    options.ConnectionString ??= _configuration[ConnectionStringEnvironmentVariable];
+                    // Environment Variable should take precedence over config file.
+                    var connectionString = _configuration[ConnectionStringEnvironmentVariable];
+                    if (!string.IsNullOrEmpty(connectionString))
+                    {
+                        options.ConnectionString = connectionString;
+                    }
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
@@ -24,19 +24,13 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
 
         public void Configure(AzureMonitorOptions options)
         {
-            if (_configuration != null)
-            {
-                _configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
-            }
-
             try
             {
-                // TODO: should we replace this with IConfiguration?
-                string connectionString = Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable);
-
-                if (!string.IsNullOrWhiteSpace(connectionString))
+                if (_configuration != null)
                 {
-                    options.ConnectionString = connectionString;
+                    _configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
+
+                    options.ConnectionString ??= _configuration[ConnectionStringEnvironmentVariable];
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
@@ -30,8 +30,15 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                 {
                     _configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
 
-                    // Environment Variable should take precedence over config file.
+                    // IConfiguration can read from EnvironmentVariables or InMemoryCollection if configured to do so.
                     var connectionString = _configuration[ConnectionStringEnvironmentVariable];
+                    if (!string.IsNullOrEmpty(connectionString))
+                    {
+                        options.ConnectionString = connectionString;
+                    }
+
+                    // Environment Variable should take precedence.
+                    connectionString = Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable);
                     if (!string.IsNullOrEmpty(connectionString))
                     {
                         options.ConnectionString = connectionString;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
+{
+    public class DefaultAzureMonitorOptionsTests
+    {
+        private const string ConnectionStringEnvironmentVariable = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+
+        [Fact]
+        public void VerifyConfigure_NoConnectionStringSet()
+        {
+            var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions();
+
+            var azureMonitorOptions = new AzureMonitorOptions();
+
+            defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+            Assert.Null(azureMonitorOptions.ConnectionString);
+        }
+
+#if !NETFRAMEWORK
+        [Fact]
+        public void VerifyConfigure_ViaJson()
+        {
+            var appSettings = @"{""AzureMonitor"":{
+                ""ConnectionString"" : ""testJsonValue""
+                }}";
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(appSettings)))
+                .Build();
+
+            var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+            var azureMonitorOptions = new AzureMonitorOptions();
+
+            defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+            Assert.Equal("testJsonValue", azureMonitorOptions.ConnectionString);
+        }
+#endif
+
+        [Fact]
+        public void VerifyConfigure_ViaIConfiguration()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { [ConnectionStringEnvironmentVariable] = "testValue" })
+                .Build();
+
+            var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+            var azureMonitorOptions = new AzureMonitorOptions();
+
+            defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+            Assert.Equal("testValue", azureMonitorOptions.ConnectionString);
+        }
+
+        [Fact]
+        public void VerifyConfigure_ViaEnvironmentVar()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, "testEnvVarValue");
+
+                var configuration = new ConfigurationBuilder()
+                    .AddEnvironmentVariables()
+                    .Build();
+
+                var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+                var azureMonitorOptions = new AzureMonitorOptions();
+
+                defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+                Assert.Equal("testEnvVarValue", azureMonitorOptions.ConnectionString);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, null);
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         private const string ConnectionStringEnvironmentVariable = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
         [Fact]
-        public void VerifyConfigure_NoConnectionStringSet()
+        public void VerifyConfigure_Default()
         {
             var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions();
 
@@ -24,6 +24,9 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             defaultAzureMonitorOptions.Configure(azureMonitorOptions);
 
             Assert.Null(azureMonitorOptions.ConnectionString);
+            Assert.False(azureMonitorOptions.DisableOfflineStorage);
+            Assert.Equal(1.0F, azureMonitorOptions.SamplingRatio);
+            Assert.Null(azureMonitorOptions.StorageDirectory);
         }
 
 #if !NETFRAMEWORK
@@ -31,7 +34,10 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         public void VerifyConfigure_ViaJson()
         {
             var appSettings = @"{""AzureMonitor"":{
-                ""ConnectionString"" : ""testJsonValue""
+                ""ConnectionString"" : ""testJsonValue"",
+                ""DisableOfflineStorage"" : ""true"",
+                ""SamplingRatio"" : 0.5,
+                ""StorageDirectory"" : ""testJsonValue""
                 }}";
 
             var configuration = new ConfigurationBuilder()
@@ -45,6 +51,9 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             defaultAzureMonitorOptions.Configure(azureMonitorOptions);
 
             Assert.Equal("testJsonValue", azureMonitorOptions.ConnectionString);
+            Assert.True(azureMonitorOptions.DisableOfflineStorage);
+            Assert.Equal(0.5F, azureMonitorOptions.SamplingRatio);
+            Assert.Equal("testJsonValue", azureMonitorOptions.StorageDirectory);
         }
 #endif
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -78,15 +78,15 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         }
 
         [Fact]
-        public void VerifyConfigure_ViaJson_EnvironmentVarTakesPrecedence()
+        public void VerifyConfigure_ViaJson_EnvironmentVarTakesPrecedence_UsingIConfiguration()
         {
             try
             {
                 Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, "testEnvVarValue");
 
                 var appSettings = @"{""AzureMonitor"":{
-                ""ConnectionString"" : ""testJsonValue""
-                }}";
+                    ""ConnectionString"" : ""testJsonValue""
+                    }}";
 
                 var configuration = new ConfigurationBuilder()
                     .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(appSettings)))
@@ -106,6 +106,36 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
                 Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, null);
             }
         }
+
+        [Fact]
+        public void VerifyConfigure_ViaJson_EnvironmentVarTakesPrecedence()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, "testEnvVarValue");
+
+                var appSettings = @"{""AzureMonitor"":{
+                    ""ConnectionString"" : ""testJsonValue""
+                    }}";
+
+                var configuration = new ConfigurationBuilder()
+                    .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(appSettings)))
+                    .Build();
+
+                var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+                var azureMonitorOptions = new AzureMonitorOptions();
+
+                defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+                Assert.Equal("testEnvVarValue", azureMonitorOptions.ConnectionString);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, null);
+            }
+        }
+
 #endif
 
         [Fact]
@@ -125,7 +155,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         }
 
         [Fact]
-        public void VerifyConfigure_ViaEnvironmentVar()
+        public void VerifyConfigure_ViaEnvironmentVar_UsingIConfiguration()
         {
             try
             {
@@ -133,6 +163,30 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
 
                 var configuration = new ConfigurationBuilder()
                     .AddEnvironmentVariables()
+                    .Build();
+
+                var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+                var azureMonitorOptions = new AzureMonitorOptions();
+
+                defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+                Assert.Equal("testEnvVarValue", azureMonitorOptions.ConnectionString);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, null);
+            }
+        }
+
+        [Fact]
+        public void VerifyConfigure_ViaEnvironmentVar()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, "testEnvVarValue");
+
+                var configuration = new ConfigurationBuilder()
                     .Build();
 
                 var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -126,5 +126,23 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             }
         }
 #endif
+
+        [Fact]
+        public void VerifyConfig_SetsConnectionString_WithoutIConfig()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, "testEnvVarValue");
+
+                var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions();
+                var azureMonitorOptions = new AzureMonitorOptions();
+                defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+                Assert.Equal("testEnvVarValue", azureMonitorOptions.ConnectionString);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, null);
+            }
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -136,6 +136,58 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             }
         }
 
+        [Fact]
+        public void VerifyConfigure_ViaEnvironmentVarInsideJson()
+        {
+            var appSettings = @"{""AzureMonitor"":{
+                ""ConnectionString"" : ""testJsonValue""
+                },
+                ""APPLICATIONINSIGHTS_CONNECTION_STRING"" :  ""testJsonEnvVarValue""
+                }";
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(appSettings)))
+                .Build();
+
+            var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+            var azureMonitorOptions = new AzureMonitorOptions();
+
+            defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+            Assert.Equal("testJsonEnvVarValue", azureMonitorOptions.ConnectionString);
+        }
+
+        [Fact]
+        public void VerifyConfigure_ViaEnvironmentVarInsideJson_EnvironmentVarTakesPrecedence()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, "testEnvVarValue");
+
+                var appSettings = @"{""AzureMonitor"":{
+                    ""ConnectionString"" : ""testJsonValue""
+                    },
+                    ""APPLICATIONINSIGHTS_CONNECTION_STRING"" :  ""testJsonEnvVarValue""
+                    }";
+
+                var configuration = new ConfigurationBuilder()
+                    .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(appSettings)))
+                    .Build();
+
+                var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+                var azureMonitorOptions = new AzureMonitorOptions();
+
+                defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+                Assert.Equal("testEnvVarValue", azureMonitorOptions.ConnectionString);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConnectionStringEnvironmentVariable, null);
+            }
+        }
 #endif
 
         [Fact]


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/37913#discussion_r1278166832.

## Changes
- DefaultAzureMonitorOptions will use IConfiguration to set the ConnectionString
- Add Tests for several configuration scenarios
  - via json
  - via Env Var
  - via IConfiguration