### PR TITLE
Ignore new sample tests

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample13_AdvancedConfiguration.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample13_AdvancedConfiguration.cs
@@ -90,6 +90,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         }
 
         [Test]
+        [Ignore("Only verifying that the code builds")]
         public async Task ConfigureMessageLockLostHandler()
         {
             #region Snippet:ServiceBusProcessorLockLostHandler
@@ -156,6 +157,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         }
 
         [Test]
+        [Ignore("Only verifying that the code builds")]
         public async Task ConfigureSessionLockLostHandler()
         {
             #region Snippet:ServiceBusSessionProcessorLockLostHandler


### PR DESCRIPTION
These samples have a Console.ReadKey which was hanging the live test runs.