### PR TITLE
Update PostLedgerEntryOperation retry logic

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.2.0 (2023-08-03)
+
+### Bugs Fixed
+
+- Allow some `HttpStatusCode.NotFound` occurrences in `PostLedgerEntryOperation` to account for unexpected loss of session stickiness. These errors may occur when the connected node changes and transactions have not been fully replicated.
+
 ## 1.2.0-beta.1 (Unreleased)
 
 ### Features Added

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/assets.json
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/confidentialledger/Azure.Security.ConfidentialLedger",
-  "Tag": "net/confidentialledger/Azure.Security.ConfidentialLedger_48488df791"
+  "Tag": "net/confidentialledger/Azure.Security.ConfidentialLedger_5657482b45"
 }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Client SDK for the Azure Confidential Ledger service</Description>
     <AssemblyTitle>Azure Confidential Ledger</AssemblyTitle>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <PackageTags>Azure ConfidentialLedger</PackageTags>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
@@ -55,12 +55,36 @@ namespace Azure.Security.ConfidentialLedger
 
         async ValueTask<OperationState> IOperation.UpdateStateAsync(bool async, CancellationToken cancellationToken)
         {
-            var statusResponse = async
-                ? await _client.GetTransactionStatusAsync(
-                        Id,
-                        new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow })
-                    .ConfigureAwait(false)
-                : _client.GetTransactionStatus(Id, new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow });
+            int retryCount = 0;
+            Azure.Response statusResponse = null;
+            while (retryCount < 3)
+            {
+                 statusResponse = async
+                    ? await _client.GetTransactionStatusAsync(
+                            Id,
+                            new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow })
+                        .ConfigureAwait(false)
+                    : _client.GetTransactionStatus(Id, new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow });
+
+                // The transaction may not be found due to unexpected loss of session stickiness.
+                // This may occur when the connected node changes and transactions have not been fully replicated.
+                // We will perform retry logic to ensure that we have waited for the transactions to fully replicate before throwing an error.
+                if (statusResponse.Status == (int)HttpStatusCode.NotFound)
+                {
+                    ++retryCount;
+                }
+                else
+                {
+                    break;
+                }
+
+                // Add a 0.5 second delay between retries.
+                if (async) {
+                    await Task.Delay(500).ConfigureAwait(false);
+                } else {
+                    Thread.Sleep(500);
+                }
+            }
 
             if (statusResponse.Status != (int)HttpStatusCode.OK)
             {
@@ -76,6 +100,7 @@ namespace Azure.Security.ConfidentialLedger
             {
                 return OperationState.Success(statusResponse);
             }
+
             return OperationState.Pending(statusResponse);
         }
 


### PR DESCRIPTION
# Contributing to the Azure SDK

Fixes a bug for `PostLedgerEntryOperation` in both sync and async clients when using `waitUntil.Complete`. Azure Confidential Ledger generally has client IP-based stickiness so that users observe session consistency. Occasionally this affinity is lost unexpectedly, which can lead to errors when waiting for a commit (write is made to Node A but the read is on Node B, which doesn't know about the write yet). This can be disruptive, so we introduce a small change to retry some HttpStatusCode.NotFound errors.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
