### PR TITLE
Update PostLedgerEntryOperation retry logic

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Allow some `HttpStatusCode.NotFound` occurrences in `PostLedgerEntryOperation` to account for unexpected loss of session stickiness. These errors may occur when the connected node changes and transactions have not been fully replicated.
+- Create a custom ResponseClassifier to allow `HttpStatusCode.NotFound` to be retriable. These errors may occur in the `PostLedgerEntryOperation` due to unexpected loss of session stickiness when the connected node changes and transactions have not been fully replicated.
 
 ## 1.2.0-beta.1 (2022-11-09)
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.2.0 (2023-08-03)
+
+### Bugs Fixed
+
+- Allow some `HttpStatusCode.NotFound` occurrences in `PostLedgerEntryOperation` to account for unexpected loss of session stickiness. These errors may occur when the connected node changes and transactions have not been fully replicated.
+
 ## 1.2.0-beta.1 (Unreleased)
 
 ### Features Added

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Allow some `HttpStatusCode.NotFound` occurrences in `PostLedgerEntryOperation` to account for unexpected loss of session stickiness. These errors may occur when the connected node changes and transactions have not been fully replicated.
 
-## 1.2.0-beta.1 (Unreleased)
+## 1.2.0-beta.1 (2022-11-09)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Create a custom ResponseClassifier to allow `HttpStatusCode.NotFound` to be retriable. These errors may occur in the `PostLedgerEntryOperation` due to unexpected loss of session stickiness when the connected node changes and transactions have not been fully replicated.
+- Create a custom ResponseClassifier to allow `HttpStatusCode.NotFound` to be retriable. These errors may occur in scenarios where there is an unexpected loss of session stickiness when the connected node changes and transactions have not been fully replicated.
 
 ## 1.2.0-beta.1 (2022-11-09)
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Create a custom ResponseClassifier to allow `HttpStatusCode.NotFound` to be retriable. These errors may occur in scenarios where there is an unexpected loss of session stickiness when the connected node changes and transactions have not been fully replicated.
+- Service calls that result in a `HttpStatusCode.NotFound` status will now be retried by default. This is to handle scenarios where there is an unexpected loss of session stickiness when the connected node changes and transactions have not been fully replicated.
 
 ## 1.2.0-beta.1 (2022-11-09)
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/assets.json
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/confidentialledger/Azure.Security.ConfidentialLedger",
-  "Tag": "net/confidentialledger/Azure.Security.ConfidentialLedger_48488df791"
+  "Tag": "net/confidentialledger/Azure.Security.ConfidentialLedger_5657482b45"
 }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Client SDK for the Azure Confidential Ledger service</Description>
     <AssemblyTitle>Azure Confidential Ledger</AssemblyTitle>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <PackageTags>Azure ConfidentialLedger</PackageTags>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
@@ -78,9 +78,17 @@ namespace Azure.Security.ConfidentialLedger
                     Array.Empty<HttpPipelinePolicy>() :
                     new HttpPipelinePolicy[] { new BearerTokenAuthenticationPolicy(_tokenCredential, AuthorizationScopes) },
                 transportOptions,
-                new ResponseClassifier());
+                new ConfidentialLedgerResponseClassifier());
             _ledgerEndpoint = ledgerEndpoint;
             _apiVersion = actualOptions.Version;
+        }
+
+        internal class ConfidentialLedgerResponseClassifier : ResponseClassifier
+        {
+            public override bool IsRetriableResponse(HttpMessage message)
+            {
+                return base.IsRetriableResponse(message) || message.Response.Status == 404;
+            }
         }
 
         /// <summary> Posts a new entry to the ledger. A collection id may optionally be specified. </summary>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
@@ -79,10 +79,11 @@ namespace Azure.Security.ConfidentialLedger
                 }
 
                 // Add a 0.5 second delay between retries.
+                int delayTimeMs = 500;
                 if (async) {
-                    await Task.Delay(500).ConfigureAwait(false);
+                    await Task.Delay(delayTimeMs).ConfigureAwait(false);
                 } else {
-                    Thread.Sleep(500);
+                    Thread.Sleep(delayTimeMs);
                 }
             }
 
@@ -100,7 +101,6 @@ namespace Azure.Security.ConfidentialLedger
             {
                 return OperationState.Success(statusResponse);
             }
-
             return OperationState.Pending(statusResponse);
         }
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/PostLedgerEntryOperation.cs
@@ -55,12 +55,36 @@ namespace Azure.Security.ConfidentialLedger
 
         async ValueTask<OperationState> IOperation.UpdateStateAsync(bool async, CancellationToken cancellationToken)
         {
-            var statusResponse = async
-                ? await _client.GetTransactionStatusAsync(
-                        Id,
-                        new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow })
-                    .ConfigureAwait(false)
-                : _client.GetTransactionStatus(Id, new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow });
+            int retryCount = 0;
+            Azure.Response statusResponse = null;
+            while (retryCount < 3)
+            {
+                 statusResponse = async
+                    ? await _client.GetTransactionStatusAsync(
+                            Id,
+                            new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow })
+                        .ConfigureAwait(false)
+                    : _client.GetTransactionStatus(Id, new RequestContext { CancellationToken = cancellationToken, ErrorOptions = ErrorOptions.NoThrow });
+
+                // The transaction may not be found due to unexpected loss of session stickiness.
+                // This may occur when the connected node changes and transactions have not been fully replicated.
+                // We will perform retry logic to ensure that we have waited for the transactions to fully replicate before throwing an error.
+                if (statusResponse.Status == (int)HttpStatusCode.NotFound)
+                {
+                    ++retryCount;
+                }
+                else
+                {
+                    break;
+                }
+
+                // Add a 0.5 second delay between retries.
+                if (async) {
+                    await Task.Delay(500).ConfigureAwait(false);
+                } else {
+                    Thread.Sleep(500);
+                }
+            }
 
             if (statusResponse.Status != (int)HttpStatusCode.OK)
             {
@@ -76,6 +100,7 @@ namespace Azure.Security.ConfidentialLedger
             {
                 return OperationState.Success(statusResponse);
             }
+
             return OperationState.Pending(statusResponse);
         }
 


### PR DESCRIPTION
# Contributing to the Azure SDK

Fixes a bug for PostLedgerEntryOperation in both sync and async clients when using waitUntil.Complete. Azure Confidential Ledger generally has client IP-based stickiness so that users observe session consistency. Occasionally this affinity is lost unexpectedly, which can lead to errors when waiting for a commit (write is made to Node A but the read is on Node B, which doesn't know about the write yet). This can be disruptive, so we introduce a small change to retry some `HttpStatusCode.NotFound` errors for all scenarios.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
