### PR TITLE
Don't close the receiver/processor when StopAsync is called

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -233,11 +233,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 {
                     if (_isSessionsEnabled)
                     {
-                        await _sessionMessageProcessor.Value.Processor.CloseAsync(cancellationToken).ConfigureAwait(false);
+                        await _sessionMessageProcessor.Value.Processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        await _messageProcessor.Value.Processor.CloseAsync(cancellationToken).ConfigureAwait(false);
+                        await _messageProcessor.Value.Processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
                     }
                 }
                 else
@@ -254,8 +254,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 
                     // Try to dispatch any already received messages.
                     await DispatchRemainingMessages(_monitoringCycleReceiver, _monitoringCycleMessageActions, _monitoringCycleReceiveActions, cancellationToken).ConfigureAwait(false);
-
-                    await _batchReceiver.Value.CloseAsync(cancellationToken).ConfigureAwait(false);
                 }
 
                 Started = false;
@@ -305,6 +303,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             {
 #pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
                 _messageProcessor.Value.Processor.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
+            }
+
+            if (_sessionMessageProcessor.IsValueCreated)
+            {
+#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
+                _sessionMessageProcessor.Value.Processor.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
 #pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
             }
 


### PR DESCRIPTION
This will enable the scenario of stopping and subsequently restarting processing by the functions host.