### PR TITLE
Enable Server Busy test

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -495,7 +495,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
-        [Ignore("Waiting for service fix for https://github.com/Azure/azure-sdk-for-net/issues/25275")]
         public async Task ServerBusyRespected()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))


### PR DESCRIPTION
According to the latest comment in https://github.com/Azure/azure-sdk-for-net/issues/25275, the server side issue is fixed and we can re-enable this test.