### PR TITLE
{Azure Functions} Nuget package for Azure Functions used in Isolated Process should be mentioned. 

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -12,6 +12,8 @@ Install the Storage Blobs extension with [NuGet][nuget]:
 dotnet add package Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 ```
 
+For isolated worker process functions, use [Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs nuget package](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs).
+
 ### Prerequisites
 
 You need an [Azure subscription][azure_sub] and a

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -1,6 +1,6 @@
 # Azure WebJobs Storage Blobs client library for .NET
 
-This extension provides functionality for accessing Azure Storage Blobs in Azure Functions.
+This extension provides functionality for accessing Azure Storage Blobs in Azure Functions within the process.
 
 ## Getting started
 
@@ -11,8 +11,6 @@ Install the Storage Blobs extension with [NuGet][nuget]:
 ```dotnetcli
 dotnet add package Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 ```
-
-For isolated worker process functions, use [Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs nuget package](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs).
 
 ### Prerequisites
 


### PR DESCRIPTION
Docs: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.webjobs.extensions.storage.blobs-readme?view=azure-dotnet
This document should perhaps say at the top that the package is not compatible with Azure Functions used in Isolated Process mode; this can only be used with an in-process Azure Functions app. This will avoid confusion mong our customers.
As the isolated functions use : [Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs NuGet package](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs), version 5.x.

fixes https://github.com/Azure/azure-sdk-for-net/issues/37957

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

