### PR TITLE
Don't pass cancelled token to TryExecute when draining

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusExtensionConfigProvider.cs
@@ -7,6 +7,7 @@ using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Primitives;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Extensions.ServiceBus.Config;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -33,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
         private readonly IConverterManager _converterManager;
         private readonly ServiceBusClientFactory _clientFactory;
         private readonly ConcurrencyManager _concurrencyManager;
+        private readonly IDrainModeManager _drainModeManager;
 
         /// <summary>
         /// Creates a new <see cref="ServiceBusExtensionConfigProvider"/> instance.
@@ -45,7 +47,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
             ILoggerFactory loggerFactory,
             IConverterManager converterManager,
             ServiceBusClientFactory clientFactory,
-            ConcurrencyManager concurrencyManager)
+            ConcurrencyManager concurrencyManager,
+            IDrainModeManager drainModeManager)
         {
             _options = options.Value;
             _messagingProvider = messagingProvider;
@@ -54,6 +57,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
             _converterManager = converterManager;
             _clientFactory = clientFactory;
             _concurrencyManager = concurrencyManager;
+            _drainModeManager = drainModeManager;
         }
 
         /// <summary>
@@ -101,7 +105,16 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
                 .AddOpenConverter<ServiceBusReceivedMessage, OpenType.Poco>(typeof(MessageToPocoConverter<>), _options.JsonSerializerSettings);
 
             // register our trigger binding provider
-            ServiceBusTriggerAttributeBindingProvider triggerBindingProvider = new ServiceBusTriggerAttributeBindingProvider(_nameResolver, _options, _messagingProvider, _loggerFactory, _converterManager, _clientFactory, _concurrencyManager);
+            ServiceBusTriggerAttributeBindingProvider triggerBindingProvider = new ServiceBusTriggerAttributeBindingProvider(
+                _nameResolver,
+                _options,
+                _messagingProvider,
+                _loggerFactory,
+                _converterManager,
+                _clientFactory,
+                _concurrencyManager,
+                _drainModeManager);
+
             context.AddBindingRule<ServiceBusTriggerAttribute>()
                 .BindToTrigger(triggerBindingProvider);
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             _batchReceiveRegistration.Dispose();
             _concurrencyUpdateManager?.Dispose();
 
-            // No need to dispose the _disposingCancellationTokenSource since we don't create it as a linked token and
+            // No need to dispose the _functionExecutionCancellationTokenSource since we don't create it as a linked token and
             // it won't use a timer, so the Dispose method is essentially a no-op. The downside to disposing it is that
             // any customers who are trying to use it to cancel their own operations would get an ObjectDisposedException.
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -331,6 +331,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             _batchReceiveRegistration.Dispose();
             _concurrencyUpdateManager?.Dispose();
 
+            // No need to dispose the _disposingCancellationTokenSource since we don't create it as a linked token and
+            // it won't use a timer, so the Dispose method is essentially a no-op. The downside to disposing it is that
+            // any customers who are trying to use it to cancel their own operations would get an ObjectDisposedException.
+
             Disposed = true;
 
             _logger.LogDebug($"ServiceBus listener disposed({_details.Value})");

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -302,17 +302,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
 #pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
             }
 
-            // Only close the processor if it is not processing. If it is still processing, then calling CloseAsync would wait
-            // for the processing to complete, which is not what we want to do here since this is the final step of shutdown.
-            // The connection will still be closed when the client is disposed.
-            if (_messageProcessor.IsValueCreated && !_messageProcessor.Value.Processor.IsProcessing)
+            if (_messageProcessor.IsValueCreated)
             {
 #pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
                 _messageProcessor.Value.Processor.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
 #pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult().
             }
 
-            if (_sessionMessageProcessor.IsValueCreated && !_sessionMessageProcessor.Value.Processor.IsProcessing)
+            if (_sessionMessageProcessor.IsValueCreated)
             {
 #pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
                 _sessionMessageProcessor.Value.Processor.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         private readonly ServiceBusClientFactory _clientFactory;
         private readonly ILogger<ServiceBusTriggerAttributeBindingProvider> _logger;
         private readonly ConcurrencyManager _concurrencyManager;
+        private readonly IDrainModeManager _drainModeManager;
 
         public ServiceBusTriggerAttributeBindingProvider(
             INameResolver nameResolver,
@@ -36,7 +37,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             ILoggerFactory loggerFactory,
             IConverterManager converterManager,
             ServiceBusClientFactory clientFactory,
-            ConcurrencyManager concurrencyManager)
+            ConcurrencyManager concurrencyManager,
+            IDrainModeManager drainModeManager)
         {
             _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
             _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -46,6 +48,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             _clientFactory = clientFactory;
             _logger = _loggerFactory.CreateLogger<ServiceBusTriggerAttributeBindingProvider>();
             _concurrencyManager = concurrencyManager;
+            _drainModeManager = drainModeManager;
         }
 
         public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
@@ -84,7 +87,21 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             (factoryContext, singleDispatch) =>
             {
                 var autoCompleteMessagesOptionEvaluatedValue = GetAutoCompleteMessagesOptionToUse(attribute, factoryContext.Descriptor.ShortName);
-                IListener listener = new ServiceBusListener(factoryContext.Descriptor.Id, serviceBusEntityType, entityPath, attribute.IsSessionsEnabled, autoCompleteMessagesOptionEvaluatedValue, factoryContext.Executor, _options, attribute.Connection, _messagingProvider, _loggerFactory, singleDispatch, _clientFactory, _concurrencyManager);
+                IListener listener = new ServiceBusListener(
+                    factoryContext.Descriptor.Id,
+                    serviceBusEntityType,
+                    entityPath,
+                    attribute.IsSessionsEnabled,
+                    autoCompleteMessagesOptionEvaluatedValue,
+                    factoryContext.Executor,
+                    _options,
+                    attribute.Connection,
+                    _messagingProvider,
+                    _loggerFactory,
+                    singleDispatch,
+                    _clientFactory,
+                    _concurrencyManager,
+                    _drainModeManager);
 
                 return Task.FromResult(listener);
             };

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Mock<IConverterManager> convertManager = new Mock<IConverterManager>(MockBehavior.Default);
             var provider = new MessagingProvider(new OptionsWrapper<ServiceBusOptions>(options));
             var factory = new ServiceBusClientFactory(configuration, new Mock<AzureComponentFactory>().Object, provider, new AzureEventSourceLogForwarder(new NullLoggerFactory()), new OptionsWrapper<ServiceBusOptions>(options));
-            _provider = new ServiceBusTriggerAttributeBindingProvider(mockResolver.Object, options, provider, NullLoggerFactory.Instance, convertManager.Object, factory, concurrencyManager);
+            _provider = new ServiceBusTriggerAttributeBindingProvider(mockResolver.Object, options, provider, NullLoggerFactory.Instance, convertManager.Object, factory, concurrencyManager, default);
         }
 
         [Test]

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -120,7 +120,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
                 _loggerFactory,
                 false,
                 _mockClientFactory.Object,
-                concurrencyManager);
+                concurrencyManager,
+                default);
 
             _scaleMonitor = (ServiceBusScaleMonitor)_listener.GetMonitor();
         }
@@ -539,7 +540,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
                 _loggerFactory,
                 false,
                 _mockClientFactory.Object,
-                concurrencyManager);
+                concurrencyManager,
+                default);
         }
 
         [Test]

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -251,7 +251,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             bool result = _waitHandle1.WaitOne(SBTimeoutMills);
             Assert.True(result);
             host.Dispose();
-            _waitHandle2.Set();
         }
 
         [Test]
@@ -1614,14 +1613,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public class TestSingleDispose
         {
-            public static void RunAsync(
+            public static async Task RunAsync(
                 [ServiceBusTrigger(FirstQueueNameKey)]
                 ServiceBusReceivedMessage message,
                 CancellationToken cancellationToken)
             {
                 _waitHandle1.Set();
-                bool result = _waitHandle2.WaitOne(SBTimeoutMills);
-                Assert.IsTrue(result);
+                // wait a small amount of time for the host to call dispose
+                await Task.Delay(2000, CancellationToken.None);
                 Assert.IsTrue(cancellationToken.IsCancellationRequested);
             }
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -686,7 +686,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             bool result = _waitHandle1.WaitOne(SBTimeoutMills);
             Assert.True(result);
             host.Dispose();
-            _waitHandle2.Set();
         }
 
         [Test]
@@ -1182,14 +1181,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public class TestSingleDispose
         {
-            public static void RunAsync(
+            public static async Task RunAsync(
                 [ServiceBusTrigger(FirstQueueNameKey, IsSessionsEnabled = true)]
                 ServiceBusReceivedMessage message,
                 CancellationToken cancellationToken)
             {
                 _waitHandle1.Set();
-                bool result = _waitHandle2.WaitOne(SBTimeoutMills);
-                Assert.IsTrue(result);
+                // wait a small amount of time for the host to call dispose
+                await Task.Delay(2000, CancellationToken.None);
                 Assert.IsTrue(cancellationToken.IsCancellationRequested);
             }
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -689,6 +689,17 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        public async Task TestSingle_StopWithoutDrain()
+        {
+            await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}", "sessionId1");
+            var host = BuildHost<TestSingleDispose>();
+
+            bool result = _waitHandle1.WaitOne(SBTimeoutMills);
+            Assert.True(result);
+            await host.StopAsync();
+        }
+
+        [Test]
         public async Task TestBatch_Dispose()
         {
             await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}", "sessionId1");
@@ -697,7 +708,17 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             bool result = _waitHandle1.WaitOne(SBTimeoutMills);
             Assert.True(result);
             host.Dispose();
-            _waitHandle2.Set();
+        }
+
+        [Test]
+        public async Task TestBatch_StopWithoutDrain()
+        {
+            await WriteQueueMessage("{'Name': 'Test1', 'Value': 'Value'}", "sessionId1");
+            var host = BuildHost<TestBatchDispose>();
+
+            bool result = _waitHandle1.WaitOne(SBTimeoutMills);
+            Assert.True(result);
+            await host.StopAsync();
         }
 
         private async Task TestMultiple<T>(bool isXml = false)
@@ -1195,14 +1216,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public class TestBatchDispose
         {
-            public static void RunAsync(
+            public static async Task RunAsync(
                 [ServiceBusTrigger(FirstQueueNameKey, IsSessionsEnabled = true)]
                 ServiceBusReceivedMessage[] message,
                 CancellationToken cancellationToken)
             {
                 _waitHandle1.Set();
-                bool result = _waitHandle2.WaitOne(SBTimeoutMills);
-                Assert.IsTrue(result);
+                // wait a small amount of time for the host to call dispose
+                await Task.Delay(2000, CancellationToken.None);
                 Assert.IsTrue(cancellationToken.IsCancellationRequested);
             }
         }


### PR DESCRIPTION
Replaces https://github.com/Azure/azure-sdk-for-net/pull/36792