### PR TITLE
Event Hubs - Don't pass cancelled token to TryExecute when draining

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubExtensionConfigProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubExtensionConfigProvider.cs
@@ -9,6 +9,7 @@ using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.EventHubs.Listeners;
 using Microsoft.Azure.WebJobs.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Configuration;
@@ -28,19 +29,22 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         private readonly IConverterManager _converterManager;
         private readonly IWebJobsExtensionConfiguration<EventHubExtensionConfigProvider> _configuration;
         private readonly EventHubClientFactory _clientFactory;
+        private readonly IDrainModeManager _drainModeManager;
 
         public EventHubExtensionConfigProvider(
             IOptions<EventHubOptions> options,
             ILoggerFactory loggerFactory,
             IConverterManager converterManager,
             IWebJobsExtensionConfiguration<EventHubExtensionConfigProvider> configuration,
-            EventHubClientFactory clientFactory)
+            EventHubClientFactory clientFactory,
+            IDrainModeManager drainModeManager)
         {
             _options = options;
             _loggerFactory = loggerFactory;
             _converterManager = converterManager;
             _configuration = configuration;
             _clientFactory = clientFactory;
+            _drainModeManager = drainModeManager;
         }
 
         internal Action<ExceptionReceivedEventArgs> ExceptionHandler { get; set; }
@@ -71,7 +75,12 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 .AddOpenConverter<OpenType.Poco, EventData>(ConvertPocoToEventData);
 
             // register our trigger binding provider
-            var triggerBindingProvider = new EventHubTriggerAttributeBindingProvider(_converterManager, _options, _loggerFactory, _clientFactory);
+            var triggerBindingProvider = new EventHubTriggerAttributeBindingProvider(
+                _converterManager,
+                _options,
+                _loggerFactory,
+                _clientFactory,
+                _drainModeManager);
             context.AddBindingRule<EventHubTriggerAttribute>()
                 .BindToTrigger(triggerBindingProvider);
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -148,10 +148,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                         try
                         {
                             // Try to acquire the semaphore. This protects the cached events.
-                            if (!_cachedEventsGuard.Wait(0, _functionExecutionToken))
+                            if (!_cachedEventsGuard.Wait(0, linkedCts.Token))
                             {
                                 // This will throw if the cancellation token is canceled.
-                                await _cachedEventsGuard.WaitAsync(_functionExecutionToken).ConfigureAwait(false);
+                                await _cachedEventsGuard.WaitAsync(linkedCts.Token).ConfigureAwait(false);
                             }
                             acquiredSemaphore = true;
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 _logger = logger;
                 _firstFunctionInvocation = true;
                 _maxWaitTime = options.MaxWaitTime;
-                _minimumBatchesEnabled = options.MinEventBatchSize > 1; // 1 is the default'
+                _minimumBatchesEnabled = options.MinEventBatchSize > 1; // 1 is the default
                 _disposingToken = disposingToken;
 
                 // Events are only cached when building a batch of minimum size.

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -185,7 +185,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                             if (_cachedEventsBackgroundTaskCts == null && CachedEventsManager.HasCachedEvents)
                             {
                                 // If there are events waiting to be processed, and no background task running, start a monitoring cycle.
-                                _cachedEventsBackgroundTaskCts = CancellationTokenSource.CreateLinkedTokenSource(linkedCts.Token);
+                                // Don't reference linkedCts in the class level background task, as it will be disposed when the method goes out of scope.
+                                _cachedEventsBackgroundTaskCts = CancellationTokenSource.CreateLinkedTokenSource(_functionExecutionToken, partitionProcessingCancellationToken);
                                 _cachedEventsBackgroundTask = MonitorCachedEvents(context.ProcessorHost.GetLastReadCheckpoint(context.PartitionId)?.LastModified, _cachedEventsBackgroundTaskCts);
                             }
                         }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.PartitionProcessor.cs
@@ -44,14 +44,14 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             private Task _cachedEventsBackgroundTask;
             private CancellationTokenSource _cachedEventsBackgroundTaskCts;
             private SemaphoreSlim _cachedEventsGuard;
-            private readonly CancellationToken _disposingToken;
+            private readonly CancellationToken _functionExecutionToken;
 
             /// <summary>
             /// When we have a minimum batch size greater than 1, this class manages caching events.
             /// </summary>
             internal PartitionProcessorEventsManager CachedEventsManager { get; }
 
-            public PartitionProcessor(EventHubOptions options, ITriggeredFunctionExecutor executor, ILogger logger, bool singleDispatch, CancellationToken disposingToken)
+            public PartitionProcessor(EventHubOptions options, ITriggeredFunctionExecutor executor, ILogger logger, bool singleDispatch, CancellationToken functionExecutionToken)
             {
                 _executor = executor;
                 _singleDispatch = singleDispatch;
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 _firstFunctionInvocation = true;
                 _maxWaitTime = options.MaxWaitTime;
                 _minimumBatchesEnabled = options.MinEventBatchSize > 1; // 1 is the default
-                _disposingToken = disposingToken;
+                _functionExecutionToken = functionExecutionToken;
 
                 // Events are only cached when building a batch of minimum size.
                 if (_minimumBatchesEnabled)
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                             TriggerDetails = eventHubTriggerInput.GetTriggerDetails(context)
                         };
 
-                        await _executor.TryExecuteAsync(input, _disposingToken).ConfigureAwait(false);
+                        await _executor.TryExecuteAsync(input, _functionExecutionToken).ConfigureAwait(false);
                         _firstFunctionInvocation = false;
                         eventToCheckpoint = events[i];
                     }
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                                 _logger.LogDebug($"Partition Processor received events and is attempting to invoke function ({details})");
 
                                 UpdateCheckpointContext(triggerEvents, context);
-                                await TriggerExecute(triggerEvents, context, _disposingToken).ConfigureAwait(false);
+                                await TriggerExecute(triggerEvents, context, _functionExecutionToken).ConfigureAwait(false);
                                 eventToCheckpoint = triggerEvents.Last();
 
                                 // If there is a background timer task, cancel it and dispose of the cancellation token. If there
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                     else
                     {
                         UpdateCheckpointContext(events, context);
-                        await TriggerExecute(events, context, _disposingToken).ConfigureAwait(false);
+                        await TriggerExecute(events, context, _functionExecutionToken).ConfigureAwait(false);
                         eventToCheckpoint = events.LastOrDefault();
                     }
 
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                         var details = GetOperationDetails(_mostRecentPartitionContext, "MaxWaitTimeElapsed");
                         _logger.LogDebug($"Partition Processor has waited MaxWaitTime since last invocation and is attempting to invoke function on all held events ({details})");
 
-                        await TriggerExecute(triggerEvents, _mostRecentPartitionContext, _disposingToken).ConfigureAwait(false);
+                        await TriggerExecute(triggerEvents, _mostRecentPartitionContext, _functionExecutionToken).ConfigureAwait(false);
                         if (!backgroundCancellationTokenSource.Token.IsCancellationRequested)
                         {
                             await CheckpointAsync(triggerEvents.Last(), _mostRecentPartitionContext).ConfigureAwait(false);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             _disposingCancellationTokenSource.Cancel();
 
 #pragma warning disable AZC0102
-            _eventProcessorHost.DisposeAsync().GetAwaiter().GetResult();
+            _eventProcessorHost.StopProcessingAsync().GetAwaiter().GetResult();
 #pragma warning restore AZC0102
 
             // No need to dispose the _disposingCancellationTokenSource since we don't create it as a linked token and

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -84,9 +84,14 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
         void IDisposable.Dispose()
         {
             _disposingCancellationTokenSource.Cancel();
+
 #pragma warning disable AZC0102
             _eventProcessorHost.DisposeAsync().GetAwaiter().GetResult();
 #pragma warning restore AZC0102
+
+            // No need to dispose the _disposingCancellationTokenSource since we don't create it as a linked token and
+            // it won't use a timer, so the Dispose method is essentially a no-op. The downside to disposing it is that
+            // any customers who are trying to use it to cancel their own operations will get an ObjectDisposedException.
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
         private string _details;
         private CancellationTokenSource _functionExecutionCancellationTokenSource;
         private readonly IDrainModeManager _drainModeManager;
+        private volatile bool _disposed;
 
         public EventHubListener(
             string functionId,
@@ -79,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
         /// </summary>
         void IListener.Cancel()
         {
-            if (_functionExecutionCancellationTokenSource.IsCancellationRequested)
+            if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(IListener));
             }
@@ -96,6 +97,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             // No need to dispose the _disposingCancellationTokenSource since we don't create it as a linked token and
             // it won't use a timer, so the Dispose method is essentially a no-op. The downside to disposing it is that
             // any customers who are trying to use it to cancel their own operations would get an ObjectDisposedException.
+            _disposed = true;
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 
             // No need to dispose the _disposingCancellationTokenSource since we don't create it as a linked token and
             // it won't use a timer, so the Dispose method is essentially a no-op. The downside to disposing it is that
-            // any customers who are trying to use it to cancel their own operations will get an ObjectDisposedException.
+            // any customers who are trying to use it to cancel their own operations would get an ObjectDisposedException.
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             _disposingCancellationTokenSource.Cancel();
 
 #pragma warning disable AZC0102
-            _eventProcessorHost.StopProcessingAsync().GetAwaiter().GetResult();
+            StopAsync(CancellationToken.None).GetAwaiter().GetResult();
 #pragma warning restore AZC0102
 
             // No need to dispose the _disposingCancellationTokenSource since we don't create it as a linked token and

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
             return _connection;
         }
 
-        public async Task DisposeAsync()
+        public virtual async Task DisposeAsync()
         {
             if (_connection != null)
             {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -149,7 +149,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
 
         public async Task DisposeAsync()
         {
-            await _connection.DisposeAsync().ConfigureAwait(false);
+            if (_connection != null)
+            {
+                await _connection.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         public async Task StartProcessingAsync(

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
                 return Task.CompletedTask;
             }
 
-            return partition.EventProcessor.ProcessEventsAsync(partition, events, cancellationToken);
+            return partition.EventProcessor.ProcessEventsAsync(partition, events);
         }
 
         protected override async Task OnInitializingPartitionAsync(EventProcessorHostPartition partition, CancellationToken cancellationToken)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
         private BlobCheckpointStoreInternal _checkpointStore;
 
         private ConcurrentDictionary<string, CheckpointInfo> _lastReadCheckpoint = new();
+        private EventHubConnection _connection;
+        private Func<EventHubConnection> ConnectionFactory { get; }
 
         /// <summary>
         /// Mocking constructor
@@ -36,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
             int eventBatchMaximumCount,
             Action<ExceptionReceivedEventArgs> exceptionHandler) : base(eventBatchMaximumCount, consumerGroup, connectionString, eventHubName, options)
         {
+            ConnectionFactory = () => new EventHubConnection(connectionString, eventHubName, options.ConnectionOptions);
             _exceptionHandler = exceptionHandler;
         }
 
@@ -47,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
             int eventBatchMaximumCount,
             Action<ExceptionReceivedEventArgs> exceptionHandler) : base(eventBatchMaximumCount, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options)
         {
+            ConnectionFactory = () => new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, options.ConnectionOptions);
             _exceptionHandler = exceptionHandler;
         }
 
@@ -66,7 +70,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
 
             if (checkpoint is BlobCheckpointStoreInternal.BlobStorageCheckpoint blobCheckpoint && blobCheckpoint is not null)
             {
-                _lastReadCheckpoint[partitionId] = new CheckpointInfo(blobCheckpoint.Offset ?? -1, blobCheckpoint.SequenceNumber ?? -1, blobCheckpoint.LastModified);
+                _lastReadCheckpoint[partitionId] = new CheckpointInfo(blobCheckpoint.Offset ?? -1, blobCheckpoint.SequenceNumber ?? -1,
+                    blobCheckpoint.LastModified);
             }
 
             return checkpoint;
@@ -134,6 +139,17 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
         {
             _lastReadCheckpoint.TryRemove(partition.PartitionId, out _);
             return partition.EventProcessor.CloseAsync(partition, reason);
+        }
+
+        protected override EventHubConnection CreateConnection()
+        {
+            _connection = ConnectionFactory();
+            return _connection;
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _connection.DisposeAsync().ConfigureAwait(false);
         }
 
         public async Task StartProcessingAsync(

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/IEventProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/IEventProcessor.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
         Task CloseAsync(EventProcessorHostPartition context, ProcessingStoppedReason reason);
         Task OpenAsync(EventProcessorHostPartition context);
         Task ProcessErrorAsync(EventProcessorHostPartition context, Exception error);
-        Task ProcessEventsAsync(EventProcessorHostPartition context, IEnumerable<EventData> messages, CancellationToken cancellationToken);
+        Task ProcessEventsAsync(EventProcessorHostPartition context, IEnumerable<EventData> messages);
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerAttributeBindingProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Triggers/EventHubTriggerAttributeBindingProvider.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Primitives;
 using Microsoft.Azure.WebJobs.EventHubs.Listeners;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Triggers;
@@ -21,17 +22,20 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         private readonly IOptions<EventHubOptions> _options;
         private readonly EventHubClientFactory _clientFactory;
         private readonly IConverterManager _converterManager;
+        private readonly IDrainModeManager _drainModeManager;
 
         public EventHubTriggerAttributeBindingProvider(
             IConverterManager converterManager,
             IOptions<EventHubOptions> options,
             ILoggerFactory loggerFactory,
-            EventHubClientFactory clientFactory)
+            EventHubClientFactory clientFactory,
+            IDrainModeManager drainModeManager)
         {
             _converterManager = converterManager;
             _options = options;
             _clientFactory = clientFactory;
             _loggerFactory = loggerFactory;
+            _drainModeManager = drainModeManager;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
@@ -67,7 +71,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                                                 _clientFactory.GetEventHubConsumerClient(attribute.EventHubName, attribute.Connection, attribute.ConsumerGroup),
                                                 checkpointStore,
                                                 options,
-                                                _loggerFactory);
+                                                _loggerFactory,
+                                                _drainModeManager);
                  return Task.FromResult(listener);
              };
 #pragma warning disable 618

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -117,6 +117,18 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        public async Task EventHub_SingleDispatch_StopWithoutDrain()
+        {
+            await using var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, _eventHubScope.EventHubName);
+            await producer.SendAsync(new EventData[] { new EventData(new BinaryData("data")) });
+            var (_, host) = BuildHost<EventHubTestSingleDispatchJobs_Dispose>(ConfigureTestEventHub);
+
+            bool result = _eventWait.WaitOne(Timeout);
+            Assert.True(result);
+            await host.StopAsync();
+        }
+
+        [Test]
         public async Task EventHub_SingleDispatch_ConsumerGroup()
         {
             var (jobHost, host) = BuildHost<EventHubTestSingleDispatchWithConsumerGroupJobs>(builder =>
@@ -399,6 +411,18 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.True(result);
             host.Dispose();
        }
+
+        [Test]
+        public async Task EventHub_MultipleDispatch_StopWithoutDrain()
+        {
+            await using var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, _eventHubScope.EventHubName);
+            await producer.SendAsync(new EventData[] { new EventData(new BinaryData("data")) });
+            var (_, host) = BuildHost<EventHubTestMultipleDispatchJobs_Dispose>();
+
+            bool result = _eventWait.WaitOne(Timeout);
+            Assert.True(result);
+            await host.StopAsync();
+        }
 
         private static void AssertMultipleDispatchLogsMinBatch(IHost host)
         {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -650,7 +650,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 _eventWait.Set();
                 // wait a small amount of time for the host to call dispose
-                await Task.Delay(2000, CancellationToken.None);
+                await Task.Delay(3000, CancellationToken.None);
                 Assert.IsTrue(cancellationToken.IsCancellationRequested);
             }
         }
@@ -661,7 +661,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 _eventWait.Set();
                 // wait a small amount of time for the host to call dispose
-                await Task.Delay(2000, CancellationToken.None);
+                await Task.Delay(3000, CancellationToken.None);
                 Assert.IsTrue(cancellationToken.IsCancellationRequested);
             }
         }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
 
             var logs = host.GetTestLoggerProvider().GetAllLogMessages().Select(p => p.FormattedMessage);
@@ -78,7 +77,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
 
                 var logs = host.GetTestLoggerProvider().GetAllLogMessages().Select(p => p.FormattedMessage);
                 CollectionAssert.Contains(logs, $"Input(data)");
@@ -98,7 +96,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
 
             AssertSingleDispatchLogs(host);
@@ -149,7 +146,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -163,7 +159,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
 
             AssertSingleDispatchLogs(host);
@@ -179,7 +174,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -193,7 +187,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -207,7 +200,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -326,7 +318,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -341,7 +332,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
 
             AssertMultipleDispatchLogs(host);
@@ -358,7 +348,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
 
             AssertMultipleDispatchLogs(host);
@@ -394,7 +383,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
 
             AssertMultipleDispatchLogsMinBatch(host);
@@ -482,7 +470,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 bool result = _eventWait.WaitOne(Timeout);
 
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -508,7 +495,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -557,7 +543,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 try { await sendTask; } catch { /* Ignore, we're not testing sends */ }
 
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 
@@ -604,7 +589,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
-                await jobHost.StopAsync();
             }
         }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait1.WaitOne(Timeout);
                 Assert.True(result);
+                await jobHost.StopAsync();
             }
 
             AssertSingleDispatchLogs(host);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -96,6 +96,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
+
+                await StopWithDrainAsync(host);
             }
 
             AssertSingleDispatchLogs(host);
@@ -159,6 +161,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
+
+                await StopWithDrainAsync(host);
             }
 
             AssertSingleDispatchLogs(host);
@@ -332,6 +336,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
+
+                await StopWithDrainAsync(host);
             }
 
             AssertMultipleDispatchLogs(host);
@@ -348,9 +354,19 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
+
+                await StopWithDrainAsync(host);
             }
 
             AssertMultipleDispatchLogs(host);
+        }
+
+        private static async Task StopWithDrainAsync(IHost host)
+        {
+            // Enable drain mode so checkpointing occurs when stopping
+            var drainModeManager = host.Services.GetService<IDrainModeManager>();
+            await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
+            await host.StopAsync();
         }
 
         [Test]
@@ -383,6 +399,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
+
+                await StopWithDrainAsync(host);
             }
 
             AssertMultipleDispatchLogsMinBatch(host);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
     {
         private static readonly TimeSpan NoEventReadTimeout = TimeSpan.FromSeconds(5);
 
-        private static EventWaitHandle _eventWait1;
-        private static EventWaitHandle _eventWait2;
+        private static EventWaitHandle _eventWait;
         private static List<string> _results;
         private static DateTimeOffset _initialOffsetEnqueuedTimeUTC;
 
@@ -40,14 +39,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public void SetUp()
         {
             _results = new List<string>();
-            _eventWait1 = new ManualResetEvent(initialState: false);
-            _eventWait2 = new ManualResetEvent(initialState: false);
+            _eventWait = new ManualResetEvent(initialState: false);
         }
 
         [TearDown]
         public void TearDown()
         {
-            _eventWait1.Dispose();
+            _eventWait.Dispose();
         }
 
         [Test]
@@ -58,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestBindToPocoJobs.SendEvent_TestHub));
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -78,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestBindToStringJobs.SendEvent_TestHub), new { input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
 
@@ -98,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestSingleDispatchJobs.SendEvent_TestHub), new { input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -113,10 +111,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await producer.SendAsync(new EventData[] { new EventData(new BinaryData("data")) });
             var (_, host) = BuildHost<EventHubTestSingleDispatchJobs_Dispose>(ConfigureTestEventHub);
 
-            bool result = _eventWait1.WaitOne(Timeout);
+            bool result = _eventWait.WaitOne(Timeout);
             Assert.True(result);
             host.Dispose();
-            _eventWait2.Set();
         }
 
         [Test]
@@ -138,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestSingleDispatchWithConsumerGroupJobs.SendEvent_TestHub));
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -152,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestSingleDispatchJobsBinaryData.SendEvent_TestHub), new { input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -168,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestClientDispatch.SendEvents));
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -182,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestCollectorDispatch.SendEvents));
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -196,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestCollectorDispatch.SendEventsWithKey));
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -315,7 +312,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 await jobHost.CallAsync(nameof(EventHubTestSingleDispatchJobWithConnection.SendEvent_TestHub), new { input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -330,7 +327,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 int numEvents = 5;
                 await jobHost.CallAsync(nameof(EventHubTestMultipleDispatchJobs.SendEvents_TestHub), new { numEvents = numEvents, input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -347,7 +344,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 int numEvents = 5;
                 await jobHost.CallAsync(nameof(EventHubTestMultipleDispatchJobsBinaryData.SendEvents_TestHub), new { numEvents = numEvents, input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -383,7 +380,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 int numEvents = 5;
                 await jobHost.CallAsync(nameof(EventHubTestMultipleDispatchMinBatchSizeJobs.SendEvents_TestHub), new { numEvents = numEvents, input = "data" });
 
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -398,10 +395,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await producer.SendAsync(new EventData[] { new EventData(new BinaryData("data")) });
             var (_, host) = BuildHost<EventHubTestMultipleDispatchJobs_Dispose>();
 
-            bool result = _eventWait1.WaitOne(Timeout);
+            bool result = _eventWait.WaitOne(Timeout);
             Assert.True(result);
             host.Dispose();
-            _eventWait2.Set();
        }
 
         private static void AssertMultipleDispatchLogsMinBatch(IHost host)
@@ -459,7 +455,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             using (jobHost)
             {
                 await jobHost.CallAsync(nameof(EventHubPartitionKeyTestJobs.SendEvents_TestHub), new { input = "data" });
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
 
                 Assert.True(result);
                 await jobHost.StopAsync();
@@ -486,7 +482,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 });
             using (jobHost)
             {
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -514,7 +510,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             using (jobHost)
             {
                 // We don't expect to get signaled as there should be no messages received with a FromEnd initial offset
-                bool result = _eventWait1.WaitOne(NoEventReadTimeout);
+                bool result = _eventWait.WaitOne(NoEventReadTimeout);
                 Assert.False(result, "An event was received while none were expected.");
 
                 // send events which should be received.  To ensure that the test is
@@ -531,7 +527,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     }
                 });
 
-                result = _eventWait1.WaitOne(Timeout);
+                result = _eventWait.WaitOne(Timeout);
 
                 cts.Cancel();
                 try { await sendTask; } catch { /* Ignore, we're not testing sends */ }
@@ -582,7 +578,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 });
             using (jobHost)
             {
-                bool result = _eventWait1.WaitOne(Timeout);
+                bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
                 await jobHost.StopAsync();
             }
@@ -618,28 +614,28 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 Assert.AreNotEqual(default(LastEnqueuedEventProperties), triggerPartitionContext.ReadLastEnqueuedEventProperties());
                 Assert.True(triggerPartitionContext.IsCheckpointingAfterInvocation);
 
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
         public class EventHubTestSingleDispatchJobs_Dispose
         {
-            public static void SendEvent_TestHub([EventHubTrigger(TestHubName, Connection = TestHubName)] string evt, CancellationToken cancellationToken)
+            public static async Task SendEvent_TestHub([EventHubTrigger(TestHubName, Connection = TestHubName)] string evt, CancellationToken cancellationToken)
             {
-                _eventWait1.Set();
-                bool result = _eventWait2.WaitOne(Timeout);
-                Assert.IsTrue(result);
+                _eventWait.Set();
+                // wait a small amount of time for the host to call dispose
+                await Task.Delay(2000, CancellationToken.None);
                 Assert.IsTrue(cancellationToken.IsCancellationRequested);
             }
         }
 
         public class EventHubTestMultipleDispatchJobs_Dispose
         {
-            public static void SendEvent_TestHub([EventHubTrigger(TestHubName, Connection = TestHubName)] string[] evt, CancellationToken cancellationToken)
+            public static async Task SendEvent_TestHub([EventHubTrigger(TestHubName, Connection = TestHubName)] string[] evt, CancellationToken cancellationToken)
             {
-                _eventWait1.Set();
-                bool result = _eventWait2.WaitOne(Timeout);
-                Assert.IsTrue(result);
+                _eventWait.Set();
+                // wait a small amount of time for the host to call dispose
+                await Task.Delay(2000, CancellationToken.None);
                 Assert.IsTrue(cancellationToken.IsCancellationRequested);
             }
         }
@@ -671,7 +667,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     Assert.AreEqual(eventData.PartitionKey, s_partitionKey);
                 }
 
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
@@ -688,7 +684,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             public static void ProcessSingleEvent([EventHubTrigger(TestHubName, Connection = TestHubName)] EventData eventData)
             {
                 Assert.AreEqual(eventData.EventBody.ToString(), "Event 1");
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
@@ -703,7 +699,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             {
                 Assert.AreEqual(evt, nameof(EventHubTestSingleDispatchWithConsumerGroupJobs));
 
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
@@ -719,7 +715,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                        IDictionary<string, object> systemProperties)
             {
                 Assert.AreEqual("data", evt.ToString());
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
@@ -735,7 +731,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 Assert.AreEqual(input.Value, "data");
                 Assert.AreEqual(input.Name, "foo");
                 logger.LogInformation($"PocoValues(foo,data)");
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
@@ -749,7 +745,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             public static void BindToString([EventHubTrigger(TestHubName, Connection = TestHubName)] string input, ILogger logger)
             {
                 logger.LogInformation($"Input({input})");
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
@@ -795,7 +791,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 if (s_processedEventCount == s_eventCount)
                 {
                     _results.AddRange(events);
-                    _eventWait1.Set();
+                    _eventWait.Set();
                 }
             }
         }
@@ -828,7 +824,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // filter for the ID the current test is using
                 if (s_processedEventCount == s_eventCount)
                 {
-                    _eventWait1.Set();
+                    _eventWait.Set();
                 }
             }
         }
@@ -893,7 +889,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 if (s_processedEventCount >= s_eventCount)
                 {
-                    _eventWait1.Set();
+                    _eventWait.Set();
                 }
             }
         }
@@ -941,7 +937,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 if (_results.Count > 0)
                 {
-                   _eventWait1.Set();
+                   _eventWait.Set();
                 }
             }
         }
@@ -960,7 +956,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 Assert.AreEqual("value1", properties["TestProp1"]);
                 Assert.AreEqual("value2", properties["TestProp2"]);
 
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
         public class TestPoco
@@ -975,7 +971,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                        string partitionKey, DateTime enqueuedTimeUtc, IDictionary<string, object> properties,
                        IDictionary<string, object> systemProperties)
             {
-                _eventWait1.Set();
+                _eventWait.Set();
             }
         }
 
@@ -1000,7 +996,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                         {
                             Assert.GreaterOrEqual(DateTimeOffset.Parse(result), earliestAllowedOffset);
                         }
-                        _eventWait1.Set();
+                        _eventWait.Set();
                     }
                 }
             }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -361,14 +361,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             AssertMultipleDispatchLogs(host);
         }
 
-        private static async Task StopWithDrainAsync(IHost host)
-        {
-            // Enable drain mode so checkpointing occurs when stopping
-            var drainModeManager = host.Services.GetService<IDrainModeManager>();
-            await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
-            await host.StopAsync();
-        }
-
         [Test]
         public async Task EventHub_MultipleDispatch_MinBatchSize()
         {
@@ -428,54 +420,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             bool result = _eventWait.WaitOne(Timeout);
             Assert.True(result);
             await host.StopAsync();
-        }
-
-        private static void AssertMultipleDispatchLogsMinBatch(IHost host)
-        {
-            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
-                .GetAllLogMessages();
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("Trigger Details:")
-                && x.FormattedMessage.Contains("Offset:")).Any());
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("OpenAsync")).Any());
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("CheckpointAsync")
-                && x.FormattedMessage.Contains("lease")
-                && x.FormattedMessage.Contains("offset")
-                && x.FormattedMessage.Contains("sequenceNumber")).Any());
-
-            // Events are being sent in the EventHubTestMultipleDispatchMinBatchSizeJobs
-            // class directly for this test
-
-            AssertAzureSdkLogs(logMessages);
-        }
-
-        private static void AssertMultipleDispatchLogs(IHost host)
-        {
-            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
-                .GetAllLogMessages();
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("Trigger Details:")
-                && x.FormattedMessage.Contains("Offset:")).Any());
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("OpenAsync")).Any());
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("CheckpointAsync")
-                && x.FormattedMessage.Contains("lease")
-                && x.FormattedMessage.Contains("offset")
-                && x.FormattedMessage.Contains("sequenceNumber")).Any());
-
-            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
-                && x.FormattedMessage.Contains("Sending events to EventHub")).Any());
-
-            AssertAzureSdkLogs(logMessages);
         }
 
         [Test]
@@ -608,6 +552,62 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 bool result = _eventWait.WaitOne(Timeout);
                 Assert.True(result);
             }
+        }
+
+        private static void AssertMultipleDispatchLogsMinBatch(IHost host)
+        {
+            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
+                .GetAllLogMessages();
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("Trigger Details:")
+                && x.FormattedMessage.Contains("Offset:")).Any());
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("OpenAsync")).Any());
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("CheckpointAsync")
+                && x.FormattedMessage.Contains("lease")
+                && x.FormattedMessage.Contains("offset")
+                && x.FormattedMessage.Contains("sequenceNumber")).Any());
+
+            // Events are being sent in the EventHubTestMultipleDispatchMinBatchSizeJobs
+            // class directly for this test
+
+            AssertAzureSdkLogs(logMessages);
+        }
+
+        private static void AssertMultipleDispatchLogs(IHost host)
+        {
+            IEnumerable<LogMessage> logMessages = host.GetTestLoggerProvider()
+                .GetAllLogMessages();
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("Trigger Details:")
+                && x.FormattedMessage.Contains("Offset:")).Any());
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("OpenAsync")).Any());
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("CheckpointAsync")
+                && x.FormattedMessage.Contains("lease")
+                && x.FormattedMessage.Contains("offset")
+                && x.FormattedMessage.Contains("sequenceNumber")).Any());
+
+            Assert.True(logMessages.Where(x => !string.IsNullOrEmpty(x.FormattedMessage)
+                && x.FormattedMessage.Contains("Sending events to EventHub")).Any());
+
+            AssertAzureSdkLogs(logMessages);
+        }
+
+        private static async Task StopWithDrainAsync(IHost host)
+        {
+            // Enable drain mode so checkpointing occurs when stopping
+            var drainModeManager = host.Services.GetService<IDrainModeManager>();
+            await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
+            await host.StopAsync();
         }
 
         private static void AssertAzureSdkLogs(IEnumerable<LogMessage> logMessages)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -14,6 +14,7 @@ using Azure.Messaging.EventHubs.Processor;
 using Azure.Messaging.EventHubs.Tests;
 using Microsoft.Azure.WebJobs.EventHubs.Listeners;
 using Microsoft.Azure.WebJobs.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -630,7 +631,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                                     consumerClientMock.Object,
                                     Mock.Of<BlobCheckpointStoreInternal>(),
                                     new EventHubOptions(),
-                                    Mock.Of<LoggerFactory>());
+                                    Mock.Of<LoggerFactory>(),
+                                    Mock.Of<IDrainModeManager>());
 
             IScaleMonitor scaleMonitor = listener.GetMonitor();
 
@@ -667,7 +669,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 consumerClientMock.Object,
                 Mock.Of<BlobCheckpointStoreInternal>(),
                 new EventHubOptions(),
-                Mock.Of<LoggerFactory>());
+                Mock.Of<LoggerFactory>(),
+                Mock.Of<IDrainModeManager>());
 
             (listener as IListener).Dispose();
             host.Verify(h => h.StopProcessingAsync(CancellationToken.None), Times.Once);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -409,19 +409,15 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             }
 
             int execution = 0;
-            var cts = new CancellationTokenSource();
 
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
-                if (execution == 0)
-                {
-                    eventProcessor.CloseAsync(partitionContext, ProcessingStoppedReason.OwnershipLost).GetAwaiter().GetResult();
-                }
                 var result = results[execution++];
                 return result;
             });
 
-            await eventProcessor.ProcessEventsAsync(partitionContext, events, cts.Token);
+            // Pass a cancellation token that is already signaled to simulate ownership loss
+            await eventProcessor.ProcessEventsAsync(partitionContext, events, new CancellationToken(true));
 
             processor.Verify(
                 p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
@@ -457,15 +453,12 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
-                if (execution == 0)
-                {
-                    eventProcessor.CloseAsync(partitionContext, ProcessingStoppedReason.Shutdown).GetAwaiter().GetResult();
-                }
                 var result = results[execution++];
                 return result;
             });
 
-            await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
+            // Pass a cancellation token that is already signaled to simulate shutdown
+            await eventProcessor.ProcessEventsAsync(partitionContext, events, new CancellationToken(true));
 
             processor.Verify(
                 p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
@@ -501,15 +494,12 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
-                if (execution == 0)
-                {
-                    eventProcessor.CloseAsync(partitionContext, ProcessingStoppedReason.Shutdown).GetAwaiter().GetResult();
-                }
                 var result = results[execution++];
                 return result;
             });
 
-            await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
+            // Pass a cancellation token that is already signaled to simulate shutdown
+            await eventProcessor.ProcessEventsAsync(partitionContext, events, new CancellationToken(true));
 
             processor.Verify(
                 p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
 
             for (int i = 0; i < 100; i++)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
 
             for (int i = 0; i < 100; i++)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 })
                 .ReturnsAsync(new FunctionResult(true));
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, false, default);
 
             for (int i = 0; i < 60; i++)
             {
@@ -370,7 +370,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var loggerMock = new Mock<ILogger>();
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
 
             await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
 
@@ -397,7 +397,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
 
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
 
             List<EventData> events = new List<EventData>();
             List<FunctionResult> results = new List<FunctionResult>();
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             int execution = 0;
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
 
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
@@ -496,7 +496,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             int execution = 0;
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
 
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
@@ -528,7 +528,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
 
             await eventProcessor.CloseAsync(partitionContext, ProcessingStoppedReason.Shutdown);
 
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var loggerMock = new Mock<ILogger>();
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
             var mockStoredEvents = new Queue<EventData>();
             mockStoredEvents.Enqueue(new EventData("E1"));
             eventProcessor.CachedEventsManager.CachedEvents = mockStoredEvents;
@@ -567,7 +567,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var options = new EventHubOptions();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true, default);
 
             var ex = new InvalidOperationException("My InvalidOperationException!");
 
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var options = new EventHubOptions();
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var testLogger = new TestLogger("Test");
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, testLogger, true, default);
 
             var disconnectedEx = new EventHubsException(true, "My ReceiverDisconnectedException!", EventHubsException.FailureReason.ConsumerDisconnected);
 
@@ -696,7 +696,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 }
             })
             .ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true);
+            var eventProcessor = new EventHubListener.PartitionProcessor(options, executor.Object, loggerMock.Object, true, default);
             List<EventData> events = new List<EventData>() { new EventData(new byte[0]) };
             CancellationTokenSource source = new CancellationTokenSource();
             // Start another thread to cancel execution

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         }
 
         [Test]
-        public void Dispose_ClosesTheConnection()
+        public void Dispose_StopsTheProcessor()
         {
             var functionId = "FunctionId";
             var eventHubName = "EventHubName";
@@ -670,8 +670,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 Mock.Of<LoggerFactory>());
 
             (listener as IListener).Dispose();
-            host.Verify(h => h.StopProcessingAsync(CancellationToken.None), Times.Never);
-            host.Verify(h => h.DisposeAsync(), Times.Once);
+            host.Verify(h => h.StopProcessingAsync(CancellationToken.None), Times.Once);
 
             Assert.Throws<ObjectDisposedException>(() => (listener as IListener).Cancel());
         }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         }
 
         [Test]
-        public void Dispose_StopsTheProcessor()
+        public void Dispose_ClosesTheConnection()
         {
             var functionId = "FunctionId";
             var eventHubName = "EventHubName";
@@ -670,10 +670,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 Mock.Of<LoggerFactory>());
 
             (listener as IListener).Dispose();
-            host.Verify(h => h.StopProcessingAsync(CancellationToken.None), Times.Once);
+            host.Verify(h => h.StopProcessingAsync(CancellationToken.None), Times.Never);
+            host.Verify(h => h.DisposeAsync(), Times.Once);
 
-            (listener as IListener).Cancel();
-            host.Verify(h => h.StopProcessingAsync(CancellationToken.None), Times.Exactly(2));
+            Assert.Throws<ObjectDisposedException>(() => (listener as IListener).Cancel());
         }
 
         [Test]

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTriggerAttributeBindingProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTriggerAttributeBindingProviderTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs.EventHubs;
 using Microsoft.Azure.WebJobs.EventHubs.Listeners;
 using Microsoft.Azure.WebJobs.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.EventHubs.Tests;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.UnitTests
                     It.IsAny<BlobClientOptions>())).Returns(blobServiceClient.Object);
 
             var factory = ConfigurationUtilities.CreateFactory(configuration, options, componentFactory.Object);
-            _provider = new EventHubTriggerAttributeBindingProvider(convertManager.Object, Options.Create(options), NullLoggerFactory.Instance, factory);
+            _provider = new EventHubTriggerAttributeBindingProvider(convertManager.Object, Options.Create(options), NullLoggerFactory.Instance, factory, Mock.Of<IDrainModeManager>());
         }
 
         [Test]

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ScaleHostEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ScaleHostEndToEndTests.cs
@@ -26,7 +26,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
-namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
 {
     [NonParallelizable]
     [LiveOnly(true)]


### PR DESCRIPTION
Event Hubs version of https://github.com/Azure/azure-sdk-for-net/pull/38063

Also fixed up the Cancel/Dispose behavior to better align with SB (and our understanding of what the correct behavior should be).

Checkpointing behavior updated so that we will checkpoint the final event when shutting down as long as we are in drain mode. If not in drain mode, we will continue to NOT checkpoint when shutting down.