### PR TITLE
[Storage] Moved `DataTransferOptions.ProgressHandler` to `ProgressHandlerOptions`

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -60,6 +60,8 @@
 - [BREAKING CHANGE] Renamed `StorageTransferEventArgs` to `DataTransferEventArgs`.
 - [BREAKING CHANGE] Removed `position` parameter from `StorageResourceSingle.WriteFromStreamAsync`. Use `StorageResourceWriteToOffsetOptions.Position` instead.
 - [BREAKING CHANGE] Made parameter `completeLength` from `StorageResourceSingle.CopyBlockFromUriAsync` mandatory.
+- [BREAKING CHANGE] Moved `DataTransferOptions.ProgressHandler` to `DataTransferOptions.ProgressHandlerOptions`.
+- [BREAKING CHANGE] Removed default constructor for `ProgressHandlerOptions`. Use `ProgressHandlerOptions(IProgress<DataTransferProgress>, bool)` instead.
 
 ### Bugs Fixed
 

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -28,7 +28,6 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageResourceCreationPreference CreationPreference { get { throw null; } set { } }
         public long? InitialTransferSize { get { throw null; } set { } }
         public long? MaximumTransferChunkSize { get { throw null; } set { } }
-        public System.IProgress<Azure.Storage.DataMovement.DataTransferProgress> ProgressHandler { get { throw null; } set { } }
         public Azure.Storage.DataMovement.ProgressHandlerOptions ProgressHandlerOptions { get { throw null; } set { } }
         public event Azure.Core.SyncAsyncEventHandler<Azure.Storage.DataMovement.TransferItemCompletedEventArgs> ItemTransferCompleted { add { } remove { } }
         public event Azure.Core.SyncAsyncEventHandler<Azure.Storage.DataMovement.TransferItemFailedEventArgs> ItemTransferFailed { add { } remove { } }
@@ -122,7 +121,8 @@ namespace Azure.Storage.DataMovement
     }
     public partial class ProgressHandlerOptions
     {
-        public ProgressHandlerOptions() { }
+        public ProgressHandlerOptions(System.IProgress<Azure.Storage.DataMovement.DataTransferProgress> progressHandler, bool trackBytesTransferred = false) { }
+        public System.IProgress<Azure.Storage.DataMovement.DataTransferProgress> ProgressHandler { get { throw null; } set { } }
         public bool TrackBytesTransferred { get { throw null; } set { } }
     }
     public abstract partial class StorageResource

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -28,7 +28,6 @@ namespace Azure.Storage.DataMovement
         public Azure.Storage.DataMovement.StorageResourceCreationPreference CreationPreference { get { throw null; } set { } }
         public long? InitialTransferSize { get { throw null; } set { } }
         public long? MaximumTransferChunkSize { get { throw null; } set { } }
-        public System.IProgress<Azure.Storage.DataMovement.DataTransferProgress> ProgressHandler { get { throw null; } set { } }
         public Azure.Storage.DataMovement.ProgressHandlerOptions ProgressHandlerOptions { get { throw null; } set { } }
         public event Azure.Core.SyncAsyncEventHandler<Azure.Storage.DataMovement.TransferItemCompletedEventArgs> ItemTransferCompleted { add { } remove { } }
         public event Azure.Core.SyncAsyncEventHandler<Azure.Storage.DataMovement.TransferItemFailedEventArgs> ItemTransferFailed { add { } remove { } }
@@ -122,7 +121,8 @@ namespace Azure.Storage.DataMovement
     }
     public partial class ProgressHandlerOptions
     {
-        public ProgressHandlerOptions() { }
+        public ProgressHandlerOptions(System.IProgress<Azure.Storage.DataMovement.DataTransferProgress> progressHandler, bool trackBytesTransferred = false) { }
+        public System.IProgress<Azure.Storage.DataMovement.DataTransferProgress> ProgressHandler { get { throw null; } set { } }
         public bool TrackBytesTransferred { get { throw null; } set { } }
     }
     public abstract partial class StorageResource

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferOptions.cs
@@ -31,12 +31,6 @@ namespace Azure.Storage.DataMovement
         public long? InitialTransferSize { get; set; }
 
         /// <summary>
-        /// Optional. An <see cref="IProgress{StorageTransferProgress}"/> for tracking progress of the transfer.
-        /// See <see cref="DataTransferProgress"/> for details on what is tracked.
-        /// </summary>
-        public IProgress<DataTransferProgress> ProgressHandler { get; set; }
-
-        /// <summary>
         /// Optional. Options for changing behavior of the ProgressHandler.
         /// </summary>
         public ProgressHandlerOptions ProgressHandlerOptions { get; set; }

--- a/sdk/storage/Azure.Storage.DataMovement/src/ProgressHandlerOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ProgressHandlerOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Azure.Storage.DataMovement
 {
     /// <summary>
@@ -9,8 +11,25 @@ namespace Azure.Storage.DataMovement
     public class ProgressHandlerOptions
     {
         /// <summary>
-        /// Set to true to populate BytesTransferred of <see cref="DataTransferProgress"/> in
-        /// progress reports. Set to false to not track BytesTransferred (value will be null).
+        /// Constructor for ProgressHandlerOptions.
+        /// </summary>
+        /// <param name="progressHandler"></param>
+        /// <param name="trackBytesTransferred"></param>
+        public ProgressHandlerOptions(IProgress<DataTransferProgress> progressHandler, bool trackBytesTransferred = false)
+        {
+            ProgressHandler = progressHandler;
+            TrackBytesTransferred = trackBytesTransferred;
+        }
+
+        /// <summary>
+        /// Optional. An <see cref="IProgress{StorageTransferProgress}"/> for tracking progress of the transfer.
+        /// See <see cref="DataTransferProgress"/> for details on what is tracked.
+        /// </summary>
+        public IProgress<DataTransferProgress> ProgressHandler { get; set; }
+
+        /// <summary>
+        /// Set to true to populate BytesTransferred of <see cref="DataTransferProgress.BytesTransferred"/> of <see cref="ProgressHandler"/>
+        /// in progress reports. Set to false to not track BytesTransferred (value will be null).
         /// Default value is false.
         /// </summary>
         public bool TrackBytesTransferred { get; set; } = false;

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -215,7 +215,7 @@ namespace Azure.Storage.DataMovement
             _isSingleResource = true;
             _initialTransferSize = transferOptions?.InitialTransferSize;
             _maximumTransferChunkSize = transferOptions?.MaximumTransferChunkSize;
-            _progressTracker = new TransferProgressTracker(transferOptions?.ProgressHandler, transferOptions?.ProgressHandlerOptions);
+            _progressTracker = new TransferProgressTracker(transferOptions?.ProgressHandlerOptions);
         }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Azure.Storage.DataMovement
             _isSingleResource = false;
             _initialTransferSize = transferOptions?.InitialTransferSize;
             _maximumTransferChunkSize = transferOptions?.MaximumTransferChunkSize;
-            _progressTracker = new TransferProgressTracker(transferOptions?.ProgressHandler, transferOptions?.ProgressHandlerOptions);
+            _progressTracker = new TransferProgressTracker(transferOptions?.ProgressHandlerOptions);
         }
 
         public void Dispose()

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
@@ -84,7 +84,7 @@ namespace Azure.Storage.DataMovement
         {
             if (_options != default)
             {
-                if (_options.TrackBytesTransferred)
+                if (_options?.TrackBytesTransferred)
                 {
                     lock (_bytesTransferredLock)
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
@@ -84,7 +84,7 @@ namespace Azure.Storage.DataMovement
         {
             if (_options != default)
             {
-                if (_options?.TrackBytesTransferred)
+                if ((bool)(_options?.TrackBytesTransferred))
                 {
                     lock (_bytesTransferredLock)
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferProgressTracker.cs
@@ -12,7 +12,6 @@ namespace Azure.Storage.DataMovement
     /// </summary>
     internal class TransferProgressTracker
     {
-        private readonly IProgress<DataTransferProgress> _progressHandler;
         private readonly ProgressHandlerOptions _options;
 
         private long _completedCount = 0;
@@ -23,10 +22,9 @@ namespace Azure.Storage.DataMovement
         private long _bytesTransferred = 0;
         private object _bytesTransferredLock = new();
 
-        public TransferProgressTracker(IProgress<DataTransferProgress> progressHandler, ProgressHandlerOptions options)
+        public TransferProgressTracker(ProgressHandlerOptions options)
         {
-            _progressHandler = progressHandler;
-            _options = options ?? new ProgressHandlerOptions();
+            _options = options;
         }
 
         /// <summary>
@@ -36,7 +34,7 @@ namespace Azure.Storage.DataMovement
         {
             Interlocked.Decrement(ref _inProgressCount);
             Interlocked.Increment(ref _completedCount);
-            _progressHandler?.Report(GetTransferProgress());
+            _options?.ProgressHandler?.Report(GetTransferProgress());
         }
 
         /// <summary>
@@ -46,7 +44,7 @@ namespace Azure.Storage.DataMovement
         {
             Interlocked.Decrement(ref _inProgressCount);
             Interlocked.Increment(ref _skippedCount);
-            _progressHandler?.Report(GetTransferProgress());
+            _options?.ProgressHandler?.Report(GetTransferProgress());
         }
 
         /// <summary>
@@ -56,7 +54,7 @@ namespace Azure.Storage.DataMovement
         {
             Interlocked.Decrement(ref _inProgressCount);
             Interlocked.Increment(ref _failedCount);
-            _progressHandler?.Report(GetTransferProgress());
+            _options?.ProgressHandler?.Report(GetTransferProgress());
         }
 
         /// <summary>
@@ -66,7 +64,7 @@ namespace Azure.Storage.DataMovement
         {
             Interlocked.Decrement(ref _queuedCount);
             Interlocked.Increment(ref _inProgressCount);
-            _progressHandler?.Report(GetTransferProgress());
+            _options?.ProgressHandler?.Report(GetTransferProgress());
         }
 
         /// <summary>
@@ -75,7 +73,7 @@ namespace Azure.Storage.DataMovement
         public void IncrementQueuedFiles()
         {
             Interlocked.Increment(ref _queuedCount);
-            _progressHandler?.Report(GetTransferProgress());
+            _options?.ProgressHandler?.Report(GetTransferProgress());
         }
 
         /// <summary>
@@ -84,12 +82,15 @@ namespace Azure.Storage.DataMovement
         /// <param name="bytesTransferred"></param>
         public void IncrementBytesTransferred(long bytesTransferred)
         {
-            if (_options.TrackBytesTransferred)
+            if (_options != default)
             {
-                lock (_bytesTransferredLock)
+                if (_options.TrackBytesTransferred)
                 {
-                    _bytesTransferred += bytesTransferred;
-                    _progressHandler?.Report(GetTransferProgress());
+                    lock (_bytesTransferredLock)
+                    {
+                        _bytesTransferred += bytesTransferred;
+                        _options?.ProgressHandler?.Report(GetTransferProgress());
+                    }
                 }
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/ProgressHandlerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/ProgressHandlerTests.cs
@@ -115,7 +115,7 @@ namespace Azure.Storage.DataMovement.Tests
             int failedCount = 0,
             TransferManagerOptions transferManagerOptions = default,
             DataTransferOptions transferOptions = default,
-            ProgressHandlerOptions progressHandlerOptions = default,
+            bool trackBytes = true,
             StorageResourceCreationPreference createMode = StorageResourceCreationPreference.OverwriteIfExists,
             int waitTime = 30)
         {
@@ -128,11 +128,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             TestProgressHandler progressHandler = new TestProgressHandler();
             transferOptions ??= new DataTransferOptions();
-            transferOptions.ProgressHandler = progressHandler;
-            transferOptions.ProgressHandlerOptions = progressHandlerOptions ?? new ProgressHandlerOptions()
-            {
-                TrackBytesTransferred = true
-            };
+            transferOptions.ProgressHandlerOptions = new ProgressHandlerOptions(progressHandler, trackBytes);
             transferOptions.CreationPreference = createMode;
 
             DataTransfer transfer = await transferManager.StartTransferAsync(source, destination, transferOptions);
@@ -327,11 +323,7 @@ namespace Azure.Storage.DataMovement.Tests
             TestProgressHandler progressHandler = new TestProgressHandler();
             DataTransferOptions transferOptions = new DataTransferOptions()
             {
-                ProgressHandler = progressHandler,
-                ProgressHandlerOptions = new ProgressHandlerOptions()
-                {
-                    TrackBytesTransferred = true
-                }
+                ProgressHandlerOptions = new ProgressHandlerOptions(progressHandler, true)
             };
 
             // Act - Start transfer


### PR DESCRIPTION
Based on arch board review Moved `DataTransferOptions.ProgressHandler` to `DataTransferOptions.ProgressHandlerOptions`.

Also removed default constructor for `ProgressHandlerOptions`. Use `ProgressHandlerOptions(IProgress<DataTransferProgress>, bool)` instead.

Updated changelogs
