### PR TITLE
Changed default cloudmachine.json location

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
@@ -3,7 +3,7 @@ namespace Azure
     public partial class CloudMachine
     {
         public CloudMachine(System.IO.Stream configurationContent) { }
-        public CloudMachine(string configurationFile = "cloudmachine.json") { }
+        public CloudMachine(string? configurationFile = null) { }
         public string DisplayName { get { throw null; } set { } }
         public string Id { get { throw null; } }
         public string Region { get { throw null; } }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
@@ -3,7 +3,7 @@ namespace Azure
     public partial class CloudMachine
     {
         public CloudMachine(System.IO.Stream configurationContent) { }
-        public CloudMachine(string configurationFile = "cloudmachine.json") { }
+        public CloudMachine(string? configurationFile = null) { }
         public string DisplayName { get { throw null; } set { } }
         public string Id { get { throw null; } }
         public string Region { get { throw null; } }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -3,7 +3,7 @@ namespace Azure
     public partial class CloudMachine
     {
         public CloudMachine(System.IO.Stream configurationContent) { }
-        public CloudMachine(string configurationFile = "cloudmachine.json") { }
+        public CloudMachine(string? configurationFile = null) { }
         public string DisplayName { get { throw null; } set { } }
         public string Id { get { throw null; } }
         public string Region { get { throw null; } }

--- a/sdk/core/Azure.Core.Experimental/src/CloudMachine.cs
+++ b/sdk/core/Azure.Core.Experimental/src/CloudMachine.cs
@@ -150,7 +150,7 @@ namespace Azure
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Save(string filepath)
         {
-            var directory = Path.GetDirectoryName(filepath);
+            string directory = Path.GetDirectoryName(filepath);
             if (directory != null && !Directory.Exists(directory)) Directory.CreateDirectory(directory);
             using var stream = File.OpenWrite(filepath);
             Save(stream);

--- a/sdk/core/Azure.Core.Experimental/src/CloudMachine.cs
+++ b/sdk/core/Azure.Core.Experimental/src/CloudMachine.cs
@@ -56,10 +56,15 @@ namespace Azure
         /// <summary>
         /// Loads CloudMachine settings from configurationFile
         /// </summary>
-        /// <param name="configurationFile"></param>
+        /// <param name="configurationFile">Default value is .azure\cloudmachine.json</param>
         /// <exception cref="InvalidCloudMachineConfigurationException"></exception>
-        public CloudMachine(string configurationFile = "cloudmachine.json")
+        public CloudMachine(string? configurationFile = default)
         {
+            if (configurationFile == null)
+            {
+                configurationFile = Path.Combine(".azure", "cloudmachine.json");
+            }
+
             try
             {
                 byte[] configurationContent = File.ReadAllBytes(configurationFile);
@@ -145,6 +150,8 @@ namespace Azure
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Save(string filepath)
         {
+            var directory = Path.GetDirectoryName(filepath);
+            if (directory != null && !Directory.Exists(directory)) Directory.CreateDirectory(directory);
             using var stream = File.OpenWrite(filepath);
             Save(stream);
         }

--- a/sdk/core/Azure.Core.Experimental/src/CloudMachine.cs
+++ b/sdk/core/Azure.Core.Experimental/src/CloudMachine.cs
@@ -60,10 +60,7 @@ namespace Azure
         /// <exception cref="InvalidCloudMachineConfigurationException"></exception>
         public CloudMachine(string? configurationFile = default)
         {
-            if (configurationFile == null)
-            {
-                configurationFile = Path.Combine(".azure", "cloudmachine.json");
-            }
+            configurationFile ??= Path.Combine(".azure", "cloudmachine.json");
 
             try
             {
@@ -150,9 +147,9 @@ namespace Azure
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Save(string filepath)
         {
-            string directory = Path.GetDirectoryName(filepath);
+            string? directory = Path.GetDirectoryName(filepath);
             if (directory != null && !Directory.Exists(directory)) Directory.CreateDirectory(directory);
-            using var stream = File.OpenWrite(filepath);
+            using FileStream stream = File.OpenWrite(filepath);
             Save(stream);
         }
 

--- a/sdk/core/Azure.Core.Experimental/tests/CloudMachineTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/CloudMachineTests.cs
@@ -27,10 +27,11 @@ namespace Azure
         [Test]
         public void DefaultCtor()
         {
+            var path = Path.Combine(".azure", "cloudmachine.json");
             try
             {
                 var cm = CloudMachine.Create(Guid.NewGuid().ToString(), "westus2");
-                cm.Save("cloudmachine.json");
+                cm.Save(path);
                 var deserialized = new CloudMachine();
                 Assert.AreEqual(cm.Id, deserialized.Id);
                 Assert.AreEqual(cm.DisplayName, deserialized.DisplayName);
@@ -39,7 +40,7 @@ namespace Azure
             }
             finally
             {
-                File.Delete("cloudmachine.json");
+                File.Delete(path);
             }
         }
     }


### PR DESCRIPTION
CloudMachine assumed its configuration file is in the application root. This worked when the app was hosted in azure (as the cwd is set to the folder with the binaries), but it did not work when debugging locally when by default the project folder is the cwd. 

This change works for both debugging, hosting, and azd. 
