### PR TITLE
[AzureMonitorDistro] update readme: Configure method

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -23,7 +23,7 @@ The Azure Monitor Distro is a distribution of the .NET OpenTelemetry SDK and rel
   * [ASP.NET Core Instrumentation Library](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore/) provides automatic collection of common ASP.NET Core metrics.
   * [HTTP Client Instrumentation Library](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http/) provides automatic collection of HTTP client metrics.
 
-* [Logs](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/logs/getting-started/README.md)
+* [Logs](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/logs/getting-started-console)
 
 * [Azure Monitor Exporter](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Exporter/) allows sending traces, metrics, and logs data to Azure Monitor.
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -161,14 +161,14 @@ builder.Services.AddOpenTelemetry().UseAzureMonitor(o =>
 
 ```C#
 builder.Services.AddOpenTelemetry().UseAzureMonitor();
-builder.Services.ConfigureOpenTelemetryTracerProvider((sp, builder) => builder.AddSource("MyCompany.MyProduct.MyLibrary"));
+builder.Services.ConfigureOpenTelemetryTracerProvider(builder => builder.AddSource("MyCompany.MyProduct.MyLibrary"));
 ```
 
 #### Adding Custom Meter to Metrics
 
 ```C#
 builder.Services.AddOpenTelemetry().UseAzureMonitor();
-builder.Services.ConfigureOpenTelemetryMeterProvider((sp, builder) => builder.AddMeter("MyCompany.MyProduct.MyLibrary"));
+builder.Services.ConfigureOpenTelemetryMeterProvider(builder => builder.AddMeter("MyCompany.MyProduct.MyLibrary"));
 ```
 
 #### Adding Additional Instrumentation
@@ -177,7 +177,7 @@ If you need to instrument a library or framework that isn't included in the Azur
 
 ```C#
 builder.Services.AddOpenTelemetry().UseAzureMonitor();
-builder.Services.ConfigureOpenTelemetryTracerProvider((sp, builder) => builder.AddGrpcClientInstrumentation());
+builder.Services.ConfigureOpenTelemetryTracerProvider(builder => builder.AddGrpcClientInstrumentation());
 ```
 
 #### Enable Azure SDK Instrumentation
@@ -204,7 +204,7 @@ Azure Monitor Distro uses the Azure Monitor exporter to send data to Application
 
 ```C#
 builder.Services.AddOpenTelemetry().UseAzureMonitor();
-builder.Services.ConfigureOpenTelemetryMeterProvider((sp, builder) => builder.AddConsoleExporter());
+builder.Services.ConfigureOpenTelemetryMeterProvider(builder => builder.AddConsoleExporter());
 ```
 
 #### Adding Custom Resource
@@ -213,7 +213,7 @@ To modify the resource, use the following code.
 
 ```C#
 builder.Services.AddOpenTelemetry().UseAzureMonitor();
-builder.Services.ConfigureOpenTelemetryTracerProvider((sp, builder) => builder.ConfigureResource(resourceBuilder => resourceBuilder.AddService("service-name")));
+builder.Services.ConfigureOpenTelemetryTracerProvider(builder => builder.ConfigureResource(resourceBuilder => resourceBuilder.AddService("service-name")));
 ```
 
 It is also possible to configure the `Resource` by using following


### PR DESCRIPTION
replace `builder.Services.ConfigureOpenTelemetryTracerProvider((sp, builder) =>` with `builder.Services.ConfigureOpenTelemetryTracerProvider(builder) =>` in all examples