### PR TITLE
Make cast succeed on null

### DIFF
--- a/sdk/core/Azure.Core/tests/common/ModelSerializationTests/Models/DiscriminatorSet/BaseModel.cs
+++ b/sdk/core/Azure.Core/tests/common/ModelSerializationTests/Models/DiscriminatorSet/BaseModel.cs
@@ -14,11 +14,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
 
         public static implicit operator RequestContent(BaseModel baseModel)
         {
+            if (baseModel == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create(baseModel, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator BaseModel(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             using JsonDocument jsonDocument = JsonDocument.Parse(response.ContentStream);
             return DeserializeBaseModel(jsonDocument.RootElement, ModelSerializerOptions.DefaultWireOptions);
         }

--- a/sdk/core/Azure.Core/tests/common/ModelSerializationTests/Models/DiscriminatorSet/ModelX.cs
+++ b/sdk/core/Azure.Core/tests/common/ModelSerializationTests/Models/DiscriminatorSet/ModelX.cs
@@ -30,11 +30,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
 
         public static implicit operator RequestContent(ModelX modelX)
         {
+            if (modelX == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create(modelX, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator ModelX(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             using JsonDocument jsonDocument = JsonDocument.Parse(response.ContentStream);
             return DeserializeModelX(jsonDocument.RootElement, ModelSerializerOptions.DefaultWireOptions);
         }

--- a/sdk/core/Azure.Core/tests/common/ModelSerializationTests/ServiceModels/AvailabilitySetData.cs
+++ b/sdk/core/Azure.Core/tests/common/ModelSerializationTests/ServiceModels/AvailabilitySetData.cs
@@ -24,11 +24,21 @@ namespace Azure.Core.Tests.ResourceManager.Compute
 
         public static implicit operator RequestContent(AvailabilitySetData availabilitySetData)
         {
+            if (availabilitySetData is null)
+            {
+                return null;
+            }
+
             return RequestContent.Create(availabilitySetData, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator AvailabilitySetData(Response response)
         {
+            if (response is null)
+            {
+                return null;
+            }
+
             using JsonDocument jsonDocument = JsonDocument.Parse(response.ContentStream);
             return DeserializeAvailabilitySetData(jsonDocument.RootElement, ModelSerializerOptions.DefaultWireOptions);
         }

--- a/sdk/core/Azure.Core/tests/common/ModelSerializationTests/ServiceModels/ResourceProviderData.cs
+++ b/sdk/core/Azure.Core/tests/common/ModelSerializationTests/ServiceModels/ResourceProviderData.cs
@@ -20,11 +20,21 @@ namespace Azure.Core.Tests.ResourceManager.Resources
     {
         public static implicit operator RequestContent(ResourceProviderData resourceProviderData)
         {
+            if (resourceProviderData == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create(resourceProviderData, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator ResourceProviderData(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             using JsonDocument jsonDocument = JsonDocument.Parse(response.ContentStream);
             return DeserializeResourceProviderData(jsonDocument.RootElement, ModelSerializerOptions.DefaultWireOptions);
         }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/ModelTests.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/ModelTests.cs
@@ -213,5 +213,17 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
                 }
             }
         }
+
+        [Test]
+        public void CastNull()
+        {
+            T model = null;
+            RequestContent content = ToRequestContent(model);
+            Assert.IsNull(content);
+
+            Response response = null;
+            T model2 = FromResponse(response);
+            Assert.IsNull(model2);
+        }
     }
 }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/Envelope.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/Envelope.cs
@@ -37,11 +37,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests
 
         public static implicit operator RequestContent(Envelope<T> envelope)
         {
+            if (envelope == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create(envelope, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator Envelope<T>(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             using JsonDocument jsonDocument = JsonDocument.Parse(response.ContentStream);
             return DeserializeEnvelope(jsonDocument.RootElement, ModelSerializerOptions.DefaultWireOptions);
         }

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXml.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXml.cs
@@ -46,11 +46,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
 
         public static implicit operator RequestContent(ModelXml modelXml)
         {
+            if (modelXml == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create((IModelSerializable<ModelXml>)modelXml, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator ModelXml(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             return DeserializeModelXml(XElement.Load(response.ContentStream), ModelSerializerOptions.DefaultWireOptions);
         }
 

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXmlCrossLibrary.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXmlCrossLibrary.cs
@@ -47,11 +47,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
 
         public static implicit operator RequestContent(ModelXmlCrossLibrary modelXmlCrossLibrary)
         {
+            if (modelXmlCrossLibrary == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create((IModelSerializable<ModelXmlCrossLibrary>)modelXmlCrossLibrary, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator ModelXmlCrossLibrary(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             return DeserializeModelXmlCrossLibrary(XElement.Load(response.ContentStream), ModelSerializerOptions.DefaultWireOptions);
         }
 

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXmlOnly.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/ModelXmlOnly.cs
@@ -46,11 +46,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
 
         public static implicit operator RequestContent(ModelXmlOnly modelXml)
         {
+            if (modelXml == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create(modelXml, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator ModelXmlOnly(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             return DeserializeModelXmlOnly(XElement.Load(response.ContentStream), ModelSerializerOptions.DefaultWireOptions);
         }
 

--- a/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/XmlModelForCombinedInterface.cs
+++ b/sdk/core/Azure.Core/tests/public/ModelSerializationTests/Models/XmlModelForCombinedInterface.cs
@@ -43,11 +43,21 @@ namespace Azure.Core.Tests.Public.ModelSerializationTests.Models
 
         public static implicit operator RequestContent(XmlModelForCombinedInterface xmlModelForCombinedInterface)
         {
+            if (xmlModelForCombinedInterface == null)
+            {
+                return null;
+            }
+
             return RequestContent.Create((IModelSerializable<XmlModelForCombinedInterface>)xmlModelForCombinedInterface, ModelSerializerOptions.DefaultWireOptions);
         }
 
         public static explicit operator XmlModelForCombinedInterface(Response response)
         {
+            if (response == null)
+            {
+                return null;
+            }
+
             return DeserializeXmlModelForCombinedInterface(XElement.Load(response.ContentStream), ModelSerializerOptions.DefaultWireOptions);
         }
 


### PR DESCRIPTION
When updating the generator found out we need to add a param check and return null if either case receives null.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
