### PR TITLE
[DO NOT MERGE] ModelWriter implementation perf comparison

### DIFF
--- a/sdk/core/Azure.Core/perf/Serializations/JsonBenchmark.cs
+++ b/sdk/core/Azure.Core/perf/Serializations/JsonBenchmark.cs
@@ -96,11 +96,30 @@ namespace Azure.Core.Perf.Serializations
             return ModelSerializer.Serialize(_model, _options);
         }
 
+        [Params(4096, 8192, 16384, 32768)]
+        public int SegmentSize { get; set; }
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory("ModelSerializer")]
+        public BinaryData Serialize_ModelWriter_Current()
+        {
+            using var writer = new ModelWriter(_model, _options, SegmentSize);
+            return writer.ToBinaryData();
+        }
+
         [Benchmark]
         [BenchmarkCategory("ModelSerializer")]
-        public BinaryData Serialize_ModelWriter()
+        public BinaryData Serialize_ModelWriter_Interlocked()
         {
-            using var writer = new ModelWriter(_model, _options);
+            using var writer = new ModelWriterInterlocked(_model, _options, SegmentSize);
+            return writer.ToBinaryData();
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("ModelSerializer")]
+        public BinaryData Serialize_ModelWriter_Locks()
+        {
+            using var writer = new ModelWriterLocks(_model, _options, SegmentSize);
             return writer.ToBinaryData();
         }
 

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriter.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriter.cs
@@ -16,19 +16,11 @@ namespace Azure.Core.Serialization
     /// </summary>
     public sealed partial class ModelWriter : IDisposable
     {
+        private static readonly object _disposed = new object();
         private readonly IModelJsonSerializable<object> _model;
         private readonly ModelSerializerOptions _options;
 
-        private readonly object _writeLock = new object();
-        private readonly object _readLock = new object();
-
-        private volatile SequenceBuilder? _sequenceBuilder;
-        private volatile bool _isDisposed;
-
-        private volatile int _readCount;
-
-        private ManualResetEvent? _readersFinished;
-        private ManualResetEvent ReadersFinished => _readersFinished ??= new ManualResetEvent(true);
+        private object? _sequenceBuilder;
 
         /// <summary>
         /// Initializes a new instance of <see cref="ModelWriter"/>.
@@ -43,67 +35,86 @@ namespace Azure.Core.Serialization
 
         private SequenceBuilder GetSequenceBuilder()
         {
-            if (_sequenceBuilder is null)
-            {
-                lock (_writeLock)
-                {
-                    if (_isDisposed)
-                    {
-                        throw new ObjectDisposedException(nameof(ModelWriter));
-                    }
+            var comparand = _sequenceBuilder;
 
-                    if (_sequenceBuilder is null)
-                    {
-                        SequenceBuilder sequenceBuilder = new SequenceBuilder();
-                        using var jsonWriter = new Utf8JsonWriter(sequenceBuilder);
-                        _model.Serialize(jsonWriter, _options);
-                        jsonWriter.Flush();
-                        _sequenceBuilder = sequenceBuilder;
-                    }
-                }
+            var cached = comparand is not null && comparand != _disposed
+                ? Interlocked.CompareExchange(ref _sequenceBuilder, null, comparand)
+                : comparand;
+
+            if (cached is SequenceBuilder sequenceBuilder && cached == comparand)
+            {
+                return sequenceBuilder;
             }
-            return _sequenceBuilder;
+
+            if (cached == _disposed)
+            {
+                throw new ObjectDisposedException(nameof(ModelWriter));
+            }
+
+            sequenceBuilder = new SequenceBuilder();
+            using var jsonWriter = new Utf8JsonWriter(sequenceBuilder);
+            _model.Serialize(jsonWriter, _options);
+            jsonWriter.Flush();
+
+            return sequenceBuilder;
+        }
+
+        private void Return(SequenceBuilder sequenceBuilder)
+        {
+            if (Interlocked.CompareExchange(ref _sequenceBuilder, sequenceBuilder, null) != null)
+            {
+                // Other instance of SequenceBuilder is cached or ModelWriter is disposed
+                // Dispose our instance of sequenceBuilder
+                sequenceBuilder.Dispose();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            var cached = Interlocked.Exchange(ref _sequenceBuilder, _disposed);
+            if (cached is SequenceBuilder sequenceBuilder)
+            {
+                sequenceBuilder.Dispose();
+            }
         }
 
         internal void CopyTo(Stream stream, CancellationToken cancellation)
         {
             SequenceBuilder builder = GetSequenceBuilder();
-            IncrementRead();
             try
             {
                 builder.CopyTo(stream, cancellation);
             }
             finally
             {
-                DecrementRead();
+                Return(builder);
             }
         }
 
         internal bool TryComputeLength(out long length)
         {
             SequenceBuilder builder = GetSequenceBuilder();
-            IncrementRead();
             try
             {
                 return builder.TryComputeLength(out length);
             }
             finally
             {
-                DecrementRead();
+                Return(builder);
             }
         }
 
         internal async Task CopyToAsync(Stream stream, CancellationToken cancellation)
         {
             SequenceBuilder builder = GetSequenceBuilder();
-            IncrementRead();
             try
             {
                 await builder.CopyToAsync(stream, cancellation).ConfigureAwait(false);
             }
             finally
             {
-                DecrementRead();
+                Return(builder);
             }
         }
 
@@ -114,7 +125,6 @@ namespace Azure.Core.Serialization
         public BinaryData ToBinaryData()
         {
             SequenceBuilder builder = GetSequenceBuilder();
-            IncrementRead();
             try
             {
                 bool gotLength = builder.TryComputeLength(out long length);
@@ -125,66 +135,7 @@ namespace Azure.Core.Serialization
             }
             finally
             {
-                DecrementRead();
-            }
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            if (!_isDisposed)
-            {
-                lock (_writeLock)
-                {
-                    if (!_isDisposed)
-                    {
-                        _isDisposed = true;
-
-                        if (_readersFinished is null || _readersFinished.WaitOne())
-                        {
-                            //only dispose if no readers ever happened or if all readers are done
-                            _sequenceBuilder?.Dispose();
-                        }
-
-                        _sequenceBuilder = null;
-                        _readersFinished?.Dispose();
-                        _readersFinished = null;
-                    }
-                }
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void IncrementRead()
-        {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(ModelWriter));
-            }
-
-            lock (_readLock)
-            {
-                Interlocked.Increment(ref _readCount);
-                ReadersFinished.Reset();
-            }
-
-            if (_isDisposed)
-            {
-                DecrementRead();
-                throw new ObjectDisposedException(nameof(ModelWriter));
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void DecrementRead()
-        {
-            lock (_readLock)
-            {
-                if (Interlocked.Decrement(ref _readCount) == 0)
-                {
-                    // notify we reached zero readers in case dispose is waiting
-                    ReadersFinished.Set();
-                }
+                Return(builder);
             }
         }
     }

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.SequenceBuilder.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.SequenceBuilder.cs
@@ -158,7 +158,18 @@ namespace Azure.Core.Serialization
                 for (int i = 0; i < _count; i++)
                 {
                     Buffer buffer = _buffers[i];
-                    await stream.WriteAsync(buffer.Array, 0, buffer.Written).ConfigureAwait(false);
+                    await stream.WriteAsync(buffer.Array, 0, buffer.Written, cancellation).ConfigureAwait(false);
+                }
+            }
+
+            public void CopyToSpan(in Span<byte> bytes)
+            {
+                var span = bytes;
+                for (int i = 0; i < _count; i++)
+                {
+                    Buffer buffer = _buffers[i];
+                    buffer.Array.AsSpan(0, buffer.Written).CopyTo(span);
+                    span = span.Slice(buffer.Written);
                 }
             }
         }

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.SequenceBuilder.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.SequenceBuilder.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Core.Serialization
+{
+    public sealed partial class ModelWriterInterlocked : IDisposable
+    {
+        private sealed class SequenceBuilder : IBufferWriter<byte>, IDisposable
+        {
+            private struct Buffer
+            {
+                public byte[] Array;
+                public int Written;
+            }
+
+            private volatile Buffer[] _buffers; // this is an array so items can be accessed by ref
+            private volatile int _count;
+            private int _segmentSize;
+
+            /// <summary>
+            /// Initializes a new instance of <see cref="SequenceBuilder"/>.
+            /// </summary>
+            /// <param name="segmentSize">The size of each buffer segment.</param>
+            public SequenceBuilder(int segmentSize = 4096)
+            {
+                _segmentSize = segmentSize;
+                _buffers = Array.Empty<Buffer>();
+            }
+
+            /// <summary>
+            /// Notifies the <see cref="SequenceBuilder"/> that bytes bytes were written to the output <see cref="Span{T}"/> or <see cref="Memory{T}"/>.
+            /// You must request a new buffer after calling <see cref="Advance(int)"/> to continue writing more data; you cannot write to a previously acquired buffer.
+            /// </summary>
+            /// <param name="bytesWritten">The number of bytes written to the <see cref="Span{T}"/> or <see cref="Memory{T}"/>.</param>
+            /// <exception cref="ArgumentOutOfRangeException"></exception>
+            public void Advance(int bytesWritten)
+            {
+                ref Buffer last = ref _buffers[_count - 1];
+                last.Written += bytesWritten;
+                if (last.Written > last.Array.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(bytesWritten));
+                }
+            }
+
+            /// <summary>
+            /// Returns a <see cref="Memory{T}"/> to write to that is at least the requested size, as specified by the <paramref name="sizeHint"/> parameter.
+            /// </summary>
+            /// <param name="sizeHint">The minimum length of the returned <see cref="Memory{T}"/>. If less than 256, a buffer of size 256 will be returned.</param>
+            /// <returns>A memory buffer of at least <paramref name="sizeHint"/> bytes. If <paramref name="sizeHint"/> is less than 256, a buffer of size 256 will be returned.</returns>
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                if (sizeHint < 256)
+                {
+                    sizeHint = 256;
+                }
+
+                int sizeToRent = sizeHint > _segmentSize ? sizeHint : _segmentSize;
+
+                if (_buffers.Length == 0)
+                {
+                    ExpandBuffers(sizeToRent);
+                }
+
+                ref Buffer last = ref _buffers[_count - 1];
+                Memory<byte> free = last.Array.AsMemory(last.Written);
+                if (free.Length >= sizeHint)
+                {
+                    return free;
+                }
+
+                // else allocate a new buffer:
+                ExpandBuffers(sizeToRent);
+
+                return _buffers[_count - 1].Array;
+            }
+
+            private readonly object _lock = new object();
+            private void ExpandBuffers(int sizeToRent)
+            {
+                lock (_lock)
+                {
+                    int bufferCount = _count == 0 ? 1 : _count * 2;
+
+                    Buffer[] resized = new Buffer[bufferCount];
+                    if (_count > 0)
+                    {
+                        _buffers.CopyTo(resized, 0);
+                    }
+                    _buffers = resized;
+                    _buffers[_count].Array = ArrayPool<byte>.Shared.Rent(sizeToRent);
+                    _count = bufferCount == 1 ? bufferCount : _count + 1;
+                }
+            }
+
+            /// <summary>
+            /// Returns a <see cref="Span{T}"/> to write to that is at least the requested size, as specified by the <paramref name="sizeHint"/> parameter.
+            /// </summary>
+            /// <param name="sizeHint">The minimum length of the returned <see cref="Span{T}"/>. If less than 256, a buffer of size 256 will be returned.</param>
+            /// <returns>A buffer of at least <paramref name="sizeHint"/> bytes. If <paramref name="sizeHint"/> is less than 256, a buffer of size 256 will be returned.</returns>
+            public Span<byte> GetSpan(int sizeHint = 0)
+            {
+                Memory<byte> memory = GetMemory(sizeHint);
+                return memory.Span;
+            }
+
+            /// <summary>
+            /// Disposes the SequenceWriter and returns the underlying buffers to the pool.
+            /// </summary>
+            public void Dispose()
+            {
+                int bufferCountToFree;
+                Buffer[] buffersToFree;
+                lock (_lock)
+                {
+                    bufferCountToFree = _count;
+                    buffersToFree = _buffers;
+                    _count = 0;
+                    _buffers = Array.Empty<Buffer>();
+                }
+
+                for (int i = 0; i < bufferCountToFree; i++)
+                {
+                    ArrayPool<byte>.Shared.Return(buffersToFree[i].Array);
+                }
+            }
+
+            /// <inheritdoc cref="RequestContent.TryComputeLength(out long)"/>
+            public bool TryComputeLength(out long length)
+            {
+                length = 0;
+                for (int i = 0; i < _count; i++)
+                {
+                    length += _buffers[i].Written;
+                }
+                return true;
+            }
+
+            /// <inheritdoc cref="RequestContent.WriteTo(Stream, CancellationToken)"/>
+            public void CopyTo(Stream stream, CancellationToken cancellation)
+            {
+                for (int i = 0; i < _count; i++)
+                {
+                    Buffer buffer = _buffers[i];
+                    stream.Write(buffer.Array, 0, buffer.Written);
+                }
+            }
+
+            /// <inheritdoc cref="RequestContent.WriteToAsync(Stream, CancellationToken)"/>
+            public async Task CopyToAsync(Stream stream, CancellationToken cancellation)
+            {
+                for (int i = 0; i < _count; i++)
+                {
+                    Buffer buffer = _buffers[i];
+                    await stream.WriteAsync(buffer.Array, 0, buffer.Written).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Core.Serialization
+{
+    /// <summary>
+    /// Provides an efficient way to serialize <see cref="IModelJsonSerializable{T}"/> into a <see cref="BinaryData"/> using multiple pooled buffers.
+    /// </summary>
+    public sealed partial class ModelWriterInterlocked : IDisposable
+    {
+        private static readonly object _disposed = new object();
+        private readonly IModelJsonSerializable<object> _model;
+        private readonly ModelSerializerOptions _options;
+        private readonly int _segmentSize;
+
+        private object? _sequenceBuilder;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ModelWriter"/>.
+        /// </summary>
+        /// <param name="model">The model to serialize.</param>
+        /// <param name="options">The <see cref="ModelSerializerOptions"/> to use.</param>
+        /// <param name="segmentSize"></param>
+        public ModelWriterInterlocked(IModelJsonSerializable<object> model, ModelSerializerOptions options, int segmentSize)
+        {
+            _model = model;
+            _options = options;
+            _segmentSize = segmentSize;
+        }
+
+        private SequenceBuilder GetSequenceBuilder()
+        {
+            var comparand = _sequenceBuilder;
+
+            var cached = comparand is not null && comparand != _disposed
+                ? Interlocked.CompareExchange(ref _sequenceBuilder, null, comparand)
+                : comparand;
+
+            if (cached is SequenceBuilder sequenceBuilder && cached == comparand)
+            {
+                return sequenceBuilder;
+            }
+
+            if (cached == _disposed)
+            {
+                throw new ObjectDisposedException(nameof(ModelWriter));
+            }
+
+            sequenceBuilder = new SequenceBuilder(_segmentSize);
+            using var jsonWriter = new Utf8JsonWriter(sequenceBuilder);
+            _model.Serialize(jsonWriter, _options);
+            jsonWriter.Flush();
+
+            return sequenceBuilder;
+        }
+
+        private void Return(SequenceBuilder sequenceBuilder)
+        {
+            if (Interlocked.CompareExchange(ref _sequenceBuilder, sequenceBuilder, null) != null)
+            {
+                // Other instance of SequenceBuilder is cached or ModelWriter is disposed
+                // Dispose our instance of sequenceBuilder
+                sequenceBuilder.Dispose();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            var cached = Interlocked.Exchange(ref _sequenceBuilder, _disposed);
+            if (cached is SequenceBuilder sequenceBuilder)
+            {
+                sequenceBuilder.Dispose();
+            }
+        }
+
+        internal void CopyTo(Stream stream, CancellationToken cancellation)
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                builder.CopyTo(stream, cancellation);
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+
+        internal bool TryComputeLength(out long length)
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                return builder.TryComputeLength(out length);
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+
+        internal async Task CopyToAsync(Stream stream, CancellationToken cancellation)
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                await builder.CopyToAsync(stream, cancellation).ConfigureAwait(false);
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ModelWriter"/> to a <see cref="BinaryData"/>.
+        /// </summary>
+        /// <returns>A <see cref="BinaryData"/> representation of the serialized <see cref="IModelJsonSerializable{T}"/> in JSON format.</returns>
+        public BinaryData ToBinaryData()
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                bool gotLength = builder.TryComputeLength(out long length);
+                Debug.Assert(gotLength);
+                using var stream = new MemoryStream((int)length);
+                builder.CopyTo(stream, default);
+                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterInterlocked.cs
@@ -29,7 +29,7 @@ namespace Azure.Core.Serialization
         /// <param name="model">The model to serialize.</param>
         /// <param name="options">The <see cref="ModelSerializerOptions"/> to use.</param>
         /// <param name="segmentSize"></param>
-        public ModelWriterInterlocked(IModelJsonSerializable<object> model, ModelSerializerOptions options, int segmentSize)
+        public ModelWriterInterlocked(IModelJsonSerializable<object> model, ModelSerializerOptions options, int segmentSize = 16384)
         {
             _model = model;
             _options = options;
@@ -132,9 +132,10 @@ namespace Azure.Core.Serialization
             {
                 bool gotLength = builder.TryComputeLength(out long length);
                 Debug.Assert(gotLength);
-                using var stream = new MemoryStream((int)length);
-                builder.CopyTo(stream, default);
-                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+                var data = new byte[length];
+                var span = new Span<byte>(data);
+                builder.CopyToSpan(span);
+                return new BinaryData(data);
             }
             finally
             {

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.SequenceBuilder.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.SequenceBuilder.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Core.Serialization
+{
+    public sealed partial class ModelWriterLocks : IDisposable
+    {
+        private sealed class SequenceBuilder : IBufferWriter<byte>, IDisposable
+        {
+            private struct Buffer
+            {
+                public byte[] Array;
+                public int Written;
+            }
+
+            private volatile Buffer[] _buffers; // this is an array so items can be accessed by ref
+            private volatile int _count;
+            private int _segmentSize;
+
+            /// <summary>
+            /// Initializes a new instance of <see cref="SequenceBuilder"/>.
+            /// </summary>
+            /// <param name="segmentSize">The size of each buffer segment.</param>
+            public SequenceBuilder(int segmentSize = 4096)
+            {
+                _segmentSize = segmentSize;
+                _buffers = Array.Empty<Buffer>();
+            }
+
+            /// <summary>
+            /// Notifies the <see cref="SequenceBuilder"/> that bytes bytes were written to the output <see cref="Span{T}"/> or <see cref="Memory{T}"/>.
+            /// You must request a new buffer after calling <see cref="Advance(int)"/> to continue writing more data; you cannot write to a previously acquired buffer.
+            /// </summary>
+            /// <param name="bytesWritten">The number of bytes written to the <see cref="Span{T}"/> or <see cref="Memory{T}"/>.</param>
+            /// <exception cref="ArgumentOutOfRangeException"></exception>
+            public void Advance(int bytesWritten)
+            {
+                ref Buffer last = ref _buffers[_count - 1];
+                last.Written += bytesWritten;
+                if (last.Written > last.Array.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(bytesWritten));
+                }
+            }
+
+            /// <summary>
+            /// Returns a <see cref="Memory{T}"/> to write to that is at least the requested size, as specified by the <paramref name="sizeHint"/> parameter.
+            /// </summary>
+            /// <param name="sizeHint">The minimum length of the returned <see cref="Memory{T}"/>. If less than 256, a buffer of size 256 will be returned.</param>
+            /// <returns>A memory buffer of at least <paramref name="sizeHint"/> bytes. If <paramref name="sizeHint"/> is less than 256, a buffer of size 256 will be returned.</returns>
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                if (sizeHint < 256)
+                {
+                    sizeHint = 256;
+                }
+
+                int sizeToRent = sizeHint > _segmentSize ? sizeHint : _segmentSize;
+
+                if (_buffers.Length == 0)
+                {
+                    ExpandBuffers(sizeToRent);
+                }
+
+                ref Buffer last = ref _buffers[_count - 1];
+                Memory<byte> free = last.Array.AsMemory(last.Written);
+                if (free.Length >= sizeHint)
+                {
+                    return free;
+                }
+
+                // else allocate a new buffer:
+                ExpandBuffers(sizeToRent);
+
+                return _buffers[_count - 1].Array;
+            }
+
+            private readonly object _lock = new object();
+            private void ExpandBuffers(int sizeToRent)
+            {
+                lock (_lock)
+                {
+                    int bufferCount = _count == 0 ? 1 : _count * 2;
+
+                    Buffer[] resized = new Buffer[bufferCount];
+                    if (_count > 0)
+                    {
+                        _buffers.CopyTo(resized, 0);
+                    }
+                    _buffers = resized;
+                    _buffers[_count].Array = ArrayPool<byte>.Shared.Rent(sizeToRent);
+                    _count = bufferCount == 1 ? bufferCount : _count + 1;
+                }
+            }
+
+            /// <summary>
+            /// Returns a <see cref="Span{T}"/> to write to that is at least the requested size, as specified by the <paramref name="sizeHint"/> parameter.
+            /// </summary>
+            /// <param name="sizeHint">The minimum length of the returned <see cref="Span{T}"/>. If less than 256, a buffer of size 256 will be returned.</param>
+            /// <returns>A buffer of at least <paramref name="sizeHint"/> bytes. If <paramref name="sizeHint"/> is less than 256, a buffer of size 256 will be returned.</returns>
+            public Span<byte> GetSpan(int sizeHint = 0)
+            {
+                Memory<byte> memory = GetMemory(sizeHint);
+                return memory.Span;
+            }
+
+            /// <summary>
+            /// Disposes the SequenceWriter and returns the underlying buffers to the pool.
+            /// </summary>
+            public void Dispose()
+            {
+                int bufferCountToFree;
+                Buffer[] buffersToFree;
+                lock (_lock)
+                {
+                    bufferCountToFree = _count;
+                    buffersToFree = _buffers;
+                    _count = 0;
+                    _buffers = Array.Empty<Buffer>();
+                }
+
+                for (int i = 0; i < bufferCountToFree; i++)
+                {
+                    ArrayPool<byte>.Shared.Return(buffersToFree[i].Array);
+                }
+            }
+
+            /// <inheritdoc cref="RequestContent.TryComputeLength(out long)"/>
+            public bool TryComputeLength(out long length)
+            {
+                length = 0;
+                for (int i = 0; i < _count; i++)
+                {
+                    length += _buffers[i].Written;
+                }
+                return true;
+            }
+
+            /// <inheritdoc cref="RequestContent.WriteTo(Stream, CancellationToken)"/>
+            public void CopyTo(Stream stream, CancellationToken cancellation)
+            {
+                for (int i = 0; i < _count; i++)
+                {
+                    Buffer buffer = _buffers[i];
+                    stream.Write(buffer.Array, 0, buffer.Written);
+                }
+            }
+
+            /// <inheritdoc cref="RequestContent.WriteToAsync(Stream, CancellationToken)"/>
+            public async Task CopyToAsync(Stream stream, CancellationToken cancellation)
+            {
+                for (int i = 0; i < _count; i++)
+                {
+                    Buffer buffer = _buffers[i];
+                    await stream.WriteAsync(buffer.Array, 0, buffer.Written).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.SequenceBuilder.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.SequenceBuilder.cs
@@ -161,6 +161,17 @@ namespace Azure.Core.Serialization
                     await stream.WriteAsync(buffer.Array, 0, buffer.Written).ConfigureAwait(false);
                 }
             }
+
+            public void CopyToSpan(in Span<byte> bytes)
+            {
+                var span = bytes;
+                for (int i = 0; i < _count; i++)
+                {
+                    Buffer buffer = _buffers[i];
+                    buffer.Array.AsSpan(0, buffer.Written).CopyTo(span);
+                    span = span.Slice(buffer.Written);
+                }
+            }
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Core.Serialization
+{
+    /// <summary>
+    /// Provides an efficient way to serialize <see cref="IModelJsonSerializable{T}"/> into a <see cref="BinaryData"/> using multiple pooled buffers.
+    /// </summary>
+    public sealed partial class ModelWriterLocks : IDisposable
+    {
+        private readonly IModelJsonSerializable<object> _model;
+        private readonly ModelSerializerOptions _options;
+        private readonly int _segmentSize;
+        private readonly object _lock = new();
+
+        private SequenceBuilder? _sequenceBuilder;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ModelWriter"/>.
+        /// </summary>
+        /// <param name="model">The model to serialize.</param>
+        /// <param name="options">The <see cref="ModelSerializerOptions"/> to use.</param>
+        /// <param name="segmentSize"></param>
+        public ModelWriterLocks(IModelJsonSerializable<object> model, ModelSerializerOptions options, int segmentSize = 4096)
+        {
+            _model = model;
+            _options = options;
+            _segmentSize = segmentSize;
+        }
+
+        private SequenceBuilder GetSequenceBuilder()
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(ModelWriter));
+                }
+
+                if (_sequenceBuilder is {} cached)
+                {
+                    _sequenceBuilder = null;
+                    return cached;
+                }
+            }
+
+            var sequenceBuilder = new SequenceBuilder(_segmentSize);
+            using var jsonWriter = new Utf8JsonWriter(sequenceBuilder);
+            _model.Serialize(jsonWriter, _options);
+            jsonWriter.Flush();
+
+            return sequenceBuilder;
+        }
+
+        private void Return(SequenceBuilder sequenceBuilder)
+        {
+            lock (_lock)
+            {
+                if (!_disposed && _sequenceBuilder is null)
+                {
+                    _sequenceBuilder = sequenceBuilder;
+                    return;
+                }
+            }
+
+            // Other instance of SequenceBuilder is cached or ModelWriter is disposed
+            // Dispose our instance of sequenceBuilder
+            sequenceBuilder.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            SequenceBuilder? cached;
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                cached = _sequenceBuilder;
+                _sequenceBuilder = null;
+            }
+
+            cached?.Dispose();
+        }
+
+        internal void CopyTo(Stream stream, CancellationToken cancellation)
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                builder.CopyTo(stream, cancellation);
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+
+        internal bool TryComputeLength(out long length)
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                return builder.TryComputeLength(out length);
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+
+        internal async Task CopyToAsync(Stream stream, CancellationToken cancellation)
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                await builder.CopyToAsync(stream, cancellation).ConfigureAwait(false);
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ModelWriter"/> to a <see cref="BinaryData"/>.
+        /// </summary>
+        /// <returns>A <see cref="BinaryData"/> representation of the serialized <see cref="IModelJsonSerializable{T}"/> in JSON format.</returns>
+        public BinaryData ToBinaryData()
+        {
+            SequenceBuilder builder = GetSequenceBuilder();
+            try
+            {
+                bool gotLength = builder.TryComputeLength(out long length);
+                Debug.Assert(gotLength);
+                using var stream = new MemoryStream((int)length);
+                builder.CopyTo(stream, default);
+                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+            }
+            finally
+            {
+                Return(builder);
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.cs
+++ b/sdk/core/Azure.Core/src/Serialization/ModelWriterLocks.cs
@@ -146,9 +146,10 @@ namespace Azure.Core.Serialization
             {
                 bool gotLength = builder.TryComputeLength(out long length);
                 Debug.Assert(gotLength);
-                using var stream = new MemoryStream((int)length);
-                builder.CopyTo(stream, default);
-                return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+                var data = new byte[length];
+                var span = new Span<byte>(data);
+                builder.CopyToSpan(span);
+                return new BinaryData(data);
             }
             finally
             {

--- a/sdk/core/Azure.Core/tests/ModelSerialization/ModelWriterInterlockedTests.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerialization/ModelWriterInterlockedTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -371,32 +372,88 @@ namespace Azure.Core.Tests.ModelSerialization
         }
 
         [Test]
-        public async Task ReuseOfSharedArrays()
+        public async Task ArrayPoolStarvation()
         {
             var input1 = new ArrayModel(50_000_000, 1);
             var input2 = new ArrayModel(50_000_000, 2);
-            var writer1 = new ModelWriterInterlocked(input1, ModelSerializerOptions.DefaultWireOptions, 512);
-            var writer2 = new ModelWriterInterlocked(input2, ModelSerializerOptions.DefaultWireOptions, 512);
+            using var writer1 = new ModelWriterInterlocked(input1, ModelSerializerOptions.DefaultWireOptions, 512);
+            using var writer2 = new ModelWriterInterlocked(input2, ModelSerializerOptions.DefaultWireOptions, 512);
 
             var task1 = Task.Run(writer1.ToBinaryData);
             var task2 = Task.Run(writer2.ToBinaryData);
 
             await Task.WhenAll(task1, task2);
 
-            var output1 = ArrayModel.Deserialize(task1.Result);
-            var output2 = ArrayModel.Deserialize(task2.Result);
+            AssertArrayModel(ArrayModel.Deserialize(task1.Result), input1.Value, input1.Length);
+            AssertArrayModel(ArrayModel.Deserialize(task2.Result), input2.Value, input2.Length);
+        }
 
-            Assert.AreEqual(output1.Value, input1.Value);
-            Assert.AreEqual(output2.Value, input2.Value);
-            Assert.AreEqual(output1.Length, input1.Length);
-            Assert.AreEqual(output2.Length, input2.Length);
+        [Test]
+        public async Task ReuseOfSharedArrays()
+        {
+            var task1 = Task.Run(() => Enumerable.Repeat(0, 25000).Select(_ =>
+            {
+                using var writer = new ModelWriterInterlocked(new ArrayModel(5000, 1), ModelSerializerOptions.DefaultWireOptions, 512);
+                return writer.ToBinaryData();
+            }).ToArray());
+
+            var task2 = Task.Run(() => Enumerable.Repeat(0, 25000).Select(_ =>
+            {
+                using var writer = new ModelWriterInterlocked(new ArrayModel(5000, 2), ModelSerializerOptions.DefaultWireOptions, 512);
+                return writer.ToBinaryData();
+            }).ToArray());
+
+            await Task.WhenAll(task1, task2);
+
+            foreach (var data in task1.Result)
+            {
+                AssertArrayModel(ArrayModel.Deserialize(data), 1, 5000);
+            }
+
+            foreach (var data in task2.Result)
+            {
+                AssertArrayModel(ArrayModel.Deserialize(data), 2, 5000);
+            }
+        }
+
+        private void AssertArrayModel(ArrayModel model, int value, int length)
+        {
+            if (model.Value != value)
+            {
+                Assert.Fail($"Unexpected {nameof(ArrayModel)}.{nameof(ArrayModel.Value)}. Expected: {value}, actual: {model.Value}.");
+            }
+
+            if (model.Length != length)
+            {
+                Assert.Fail($"Unexpected {nameof(ArrayModel)}.{nameof(ArrayModel.Length)}. Expected: {length}, actual: {model.Length}.");
+            }
+        }
+
+        private static void AssertReadNextToken(ref Utf8JsonReader reader)
+        {
+            if (!reader.Read())
+            {
+                Assert.Fail("Unexpected end of object");
+            }
+        }
+
+        private static void AssertNextToken(ref Utf8JsonReader reader, JsonTokenType expected)
+        {
+            if (!reader.Read())
+            {
+                Assert.Fail("Unexpected end of object");
+            }
+
+            if (reader.TokenType != expected)
+            {
+                Assert.Fail($"Wrong JSON token type: expected `{expected}`, actual `{reader.TokenType}`");
+            }
         }
 
         private class ArrayModel : IModelJsonSerializable<ArrayModel>
         {
             public int Length { get; }
             public int Value { get; }
-
             public ArrayModel(int length, int value)
             {
                 Assert.Positive(value);
@@ -439,31 +496,28 @@ namespace Azure.Core.Tests.ModelSerialization
 
             private static ArrayModel Deserialize(ref Utf8JsonReader reader)
             {
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.StartObject, reader.TokenType);
+                AssertNextToken(ref reader, JsonTokenType.StartObject);
+                AssertNextToken(ref reader, JsonTokenType.PropertyName);
+                AssertNextToken(ref reader, JsonTokenType.StartArray);
+                AssertReadNextToken(ref reader);
 
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.PropertyName, reader.TokenType);
-
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.StartArray, reader.TokenType);
-
-                Assert.True(reader.Read());
                 var value = reader.GetInt32();
                 var length = 1;
 
                 while (reader.TokenType != JsonTokenType.EndArray)
                 {
-                    Assert.True(reader.Read());
+                    AssertReadNextToken(ref reader);
                     if (reader.TokenType == JsonTokenType.Number)
                     {
-                        Assert.AreEqual(value, reader.GetInt32());
+                        if (value != reader.GetInt32())
+                        {
+                            Assert.Fail($"Unexpected item in array. Expected value: {value}, actual value: {reader.GetInt32()}.");
+                        }
                         length++;
                     }
                 }
 
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.EndObject, reader.TokenType);
+                AssertNextToken(ref reader, JsonTokenType.EndObject);
                 return new ArrayModel(length, value);
             }
         }

--- a/sdk/core/Azure.Core/tests/ModelSerialization/ModelWriterTests.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerialization/ModelWriterTests.cs
@@ -116,12 +116,12 @@ namespace Azure.Core.Tests.ModelSerialization
         {
             writer.Dispose();
             object sequenceBuilder = sequenceField.GetValue(writer);
-            Assert.IsNull(sequenceBuilder);
+            Assert.AreEqual(typeof(object), sequenceBuilder?.GetType());
 
             await result;
 
             sequenceBuilder = sequenceField.GetValue(writer);
-            Assert.IsNull(sequenceBuilder);
+            Assert.AreEqual(typeof(object), sequenceBuilder?.GetType());
         }
 
         [Test]
@@ -235,7 +235,7 @@ namespace Azure.Core.Tests.ModelSerialization
 
             // sequenceBuilder should be null because the writer was disposed
             sequenceBuilder = writer.GetType().GetField("_sequenceBuilder", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(writer);
-            Assert.IsNull(sequenceBuilder);
+            Assert.AreEqual(typeof(object), sequenceBuilder?.GetType());
         }
 
         [Test]
@@ -247,7 +247,7 @@ namespace Azure.Core.Tests.ModelSerialization
 
             // sequenceBuilder should be null because the writer was disposed
             object sequenceBuilder = writer.GetType().GetField("_sequenceBuilder", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(writer);
-            Assert.IsNull(sequenceBuilder);
+            Assert.AreEqual(typeof(object), sequenceBuilder?.GetType());
         }
 
         [TestCase("J")]

--- a/sdk/core/Azure.Core/tests/ModelSerialization/ModelWriterTests.cs
+++ b/sdk/core/Azure.Core/tests/ModelSerialization/ModelWriterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -304,32 +305,88 @@ namespace Azure.Core.Tests.ModelSerialization
         }
 
         [Test]
-        public async Task ReuseOfSharedArrays()
+        public async Task ArrayPoolStarvation()
         {
             var input1 = new ArrayModel(50_000_000, 1);
             var input2 = new ArrayModel(50_000_000, 2);
-            var writer1 = new ModelWriter(input1, ModelSerializerOptions.DefaultWireOptions, 512);
-            var writer2 = new ModelWriter(input2, ModelSerializerOptions.DefaultWireOptions, 512);
+            using var writer1 = new ModelWriter(input1, ModelSerializerOptions.DefaultWireOptions, 512);
+            using var writer2 = new ModelWriter(input2, ModelSerializerOptions.DefaultWireOptions, 512);
 
             var task1 = Task.Run(writer1.ToBinaryData);
             var task2 = Task.Run(writer2.ToBinaryData);
 
             await Task.WhenAll(task1, task2);
 
-            var output1 = ArrayModel.Deserialize(task1.Result);
-            var output2 = ArrayModel.Deserialize(task2.Result);
+            AssertArrayModel(ArrayModel.Deserialize(task1.Result), input1.Value, input1.Length);
+            AssertArrayModel(ArrayModel.Deserialize(task2.Result), input2.Value, input2.Length);
+        }
 
-            Assert.AreEqual(output1.Value, input1.Value);
-            Assert.AreEqual(output2.Value, input2.Value);
-            Assert.AreEqual(output1.Length, input1.Length);
-            Assert.AreEqual(output2.Length, input2.Length);
+        [Test]
+        public async Task ReuseOfSharedArrays()
+        {
+            var task1 = Task.Run(() => Enumerable.Repeat(0, 25000).Select(_ =>
+            {
+                using var writer = new ModelWriter(new ArrayModel(5000, 1), ModelSerializerOptions.DefaultWireOptions, 512);
+                return writer.ToBinaryData();
+            }).ToArray());
+
+            var task2 = Task.Run(() => Enumerable.Repeat(0, 25000).Select(_ =>
+            {
+                using var writer = new ModelWriter(new ArrayModel(5000, 2), ModelSerializerOptions.DefaultWireOptions, 512);
+                return writer.ToBinaryData();
+            }).ToArray());
+
+            await Task.WhenAll(task1, task2);
+
+            foreach (var data in task1.Result)
+            {
+                AssertArrayModel(ArrayModel.Deserialize(data), 1, 5000);
+            }
+
+            foreach (var data in task2.Result)
+            {
+                AssertArrayModel(ArrayModel.Deserialize(data), 2, 5000);
+            }
+        }
+
+        private void AssertArrayModel(ArrayModel model, int value, int length)
+        {
+            if (model.Value != value)
+            {
+                Assert.Fail($"Unexpected {nameof(ArrayModel)}.{nameof(ArrayModel.Value)}. Expected: {value}, actual: {model.Value}.");
+            }
+
+            if (model.Length != length)
+            {
+                Assert.Fail($"Unexpected {nameof(ArrayModel)}.{nameof(ArrayModel.Length)}. Expected: {length}, actual: {model.Length}.");
+            }
+        }
+
+        private static void AssertReadNextToken(ref Utf8JsonReader reader)
+        {
+            if (!reader.Read())
+            {
+                Assert.Fail("Unexpected end of object");
+            }
+        }
+
+        private static void AssertNextToken(ref Utf8JsonReader reader, JsonTokenType expected)
+        {
+            if (!reader.Read())
+            {
+                Assert.Fail("Unexpected end of object");
+            }
+
+            if (reader.TokenType != expected)
+            {
+                Assert.Fail($"Wrong JSON token type: expected `{expected}`, actual `{reader.TokenType}`");
+            }
         }
 
         private class ArrayModel : IModelJsonSerializable<ArrayModel>
         {
             public int Length { get; }
             public int Value { get; }
-
             public ArrayModel(int length, int value)
             {
                 Assert.Positive(value);
@@ -372,31 +429,28 @@ namespace Azure.Core.Tests.ModelSerialization
 
             private static ArrayModel Deserialize(ref Utf8JsonReader reader)
             {
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.StartObject, reader.TokenType);
+                AssertNextToken(ref reader, JsonTokenType.StartObject);
+                AssertNextToken(ref reader, JsonTokenType.PropertyName);
+                AssertNextToken(ref reader, JsonTokenType.StartArray);
+                AssertReadNextToken(ref reader);
 
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.PropertyName, reader.TokenType);
-
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.StartArray, reader.TokenType);
-
-                Assert.True(reader.Read());
                 var value = reader.GetInt32();
                 var length = 1;
 
                 while (reader.TokenType != JsonTokenType.EndArray)
                 {
-                    Assert.True(reader.Read());
+                    AssertReadNextToken(ref reader);
                     if (reader.TokenType == JsonTokenType.Number)
                     {
-                        Assert.AreEqual(value, reader.GetInt32());
+                        if (value != reader.GetInt32())
+                        {
+                            Assert.Fail($"Unexpected item in array. Expected value: {value}, actual value: {reader.GetInt32()}.");
+                        }
                         length++;
                     }
                 }
 
-                Assert.True(reader.Read());
-                Assert.AreEqual(JsonTokenType.EndObject, reader.TokenType);
+                AssertNextToken(ref reader, JsonTokenType.EndObject);
                 return new ArrayModel(length, value);
             }
         }


### PR DESCRIPTION
```
AvailabilitySetDataModel:
|                            Method | SegmentSize |       Mean |     Error |    StdDev |     Median | Ratio |   Gen0 | Allocated | Alloc Ratio |
|---------------------------------- |------------ |-----------:|----------:|----------:|-----------:|------:|-------:|----------:|------------:|
|     Serialize_ModelWriter_Current |        4096 | 3,255.3 ns | 103.05 ns | 118.67 ns | 3,173.0 ns |  1.00 |      - |     728 B |        1.00 |
| Serialize_ModelWriter_Interlocked |        4096 |   741.0 ns |  17.65 ns |  20.32 ns |   728.8 ns |  0.23 | 0.0062 |     592 B |        0.81 |
|       Serialize_ModelWriter_Locks |        4096 |   786.4 ns |  15.59 ns |  17.33 ns |   778.2 ns |  0.24 | 0.0064 |     624 B |        0.86 |
|                                   |             |            |           |           |            |       |        |           |             |
|     Serialize_ModelWriter_Current |        8192 | 3,228.2 ns |  86.29 ns |  99.38 ns | 3,163.1 ns |  1.00 |      - |     728 B |        1.00 |
| Serialize_ModelWriter_Interlocked |        8192 |   756.2 ns |  15.89 ns |  18.30 ns |   750.0 ns |  0.23 | 0.0061 |     592 B |        0.81 |
|       Serialize_ModelWriter_Locks |        8192 |   799.2 ns |  17.50 ns |  20.15 ns |   786.3 ns |  0.25 | 0.0033 |     624 B |        0.86 |
|                                   |             |            |           |           |            |       |        |           |             |
|     Serialize_ModelWriter_Current |       16384 | 3,170.4 ns |  34.82 ns |  27.19 ns | 3,163.1 ns |  1.00 |      - |     728 B |        1.00 |
| Serialize_ModelWriter_Interlocked |       16384 |   736.5 ns |  10.49 ns |   8.76 ns |   734.5 ns |  0.23 | 0.0061 |     592 B |        0.81 |
|       Serialize_ModelWriter_Locks |       16384 |   784.2 ns |   2.35 ns |   1.96 ns |   784.4 ns |  0.25 | 0.0064 |     624 B |        0.86 |
|                                   |             |            |           |           |            |       |        |           |             |
|     Serialize_ModelWriter_Current |       32768 | 3,187.2 ns |  12.45 ns |  11.04 ns | 3,182.6 ns |  1.00 |      - |     728 B |        1.00 |
| Serialize_ModelWriter_Interlocked |       32768 |   746.6 ns |   5.99 ns |   5.60 ns |   745.4 ns |  0.23 | 0.0060 |     592 B |        0.81 |
|       Serialize_ModelWriter_Locks |       32768 |   774.7 ns |   3.32 ns |   2.77 ns |   774.3 ns |  0.24 | 0.0064 |     624 B |        0.86 |

ResourceProviderDataModel:
|                            Method | SegmentSize |     Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 |   Gen1 |   Gen2 | Allocated | Alloc Ratio |
|---------------------------------- |------------ |---------:|---------:|---------:|------:|--------:|-------:|-------:|-------:|----------:|------------:|
|     Serialize_ModelWriter_Current |        4096 | 619.1 us | 24.39 us | 28.09 us |  1.00 |    0.00 | 4.8077 | 4.8077 | 4.8077 | 198.89 KB |        1.00 |
| Serialize_ModelWriter_Interlocked |        4096 | 617.4 us | 26.48 us | 27.20 us |  0.99 |    0.07 | 4.8077 | 4.8077 | 4.8077 | 198.77 KB |        1.00 |
|       Serialize_ModelWriter_Locks |        4096 | 641.0 us | 16.15 us | 18.60 us |  1.04 |    0.05 | 5.2083 | 5.2083 | 5.2083 | 198.79 KB |        1.00 |
|                                   |             |          |          |          |       |         |        |        |        |           |             |
|     Serialize_ModelWriter_Current |        8192 | 626.2 us | 14.52 us | 16.14 us |  1.00 |    0.00 | 4.8077 | 4.8077 | 4.8077 | 181.22 KB |        1.00 |
| Serialize_ModelWriter_Interlocked |        8192 | 612.8 us | 15.94 us | 17.72 us |  0.98 |    0.04 | 4.6296 | 4.6296 | 4.6296 | 181.07 KB |        1.00 |
|       Serialize_ModelWriter_Locks |        8192 | 620.1 us | 21.28 us | 24.50 us |  0.99 |    0.05 | 5.0000 | 5.0000 | 5.0000 | 181.12 KB |        1.00 |
|                                   |             |          |          |          |       |         |        |        |        |           |             |
|     Serialize_ModelWriter_Current |       16384 | 624.8 us | 19.02 us | 21.91 us |  1.00 |    0.00 | 4.8077 | 4.8077 | 4.8077 | 176.45 KB |        1.00 |
| Serialize_ModelWriter_Interlocked |       16384 | 610.4 us | 23.69 us | 26.33 us |  0.98 |    0.06 | 4.8077 | 4.8077 | 4.8077 |  176.3 KB |        1.00 |
|       Serialize_ModelWriter_Locks |       16384 | 587.3 us |  7.09 us |  5.53 us |  0.94 |    0.03 | 4.4643 | 4.4643 | 4.4643 | 176.34 KB |        1.00 |
|                                   |             |          |          |          |       |         |        |        |        |           |             |
|     Serialize_ModelWriter_Current |       32768 | 625.4 us | 19.00 us | 21.88 us |  1.00 |    0.00 | 4.8077 | 4.8077 | 4.8077 | 175.24 KB |        1.00 |
| Serialize_ModelWriter_Interlocked |       32768 | 608.8 us | 20.40 us | 23.49 us |  0.97 |    0.06 | 5.0000 | 5.0000 | 5.0000 | 175.11 KB |        1.00 |
|       Serialize_ModelWriter_Locks |       32768 | 606.3 us | 19.09 us | 21.98 us |  0.97 |    0.04 | 5.0000 | 5.0000 | 5.0000 | 175.15 KB |        1.00 |

```