### PR TITLE
[Service Bus] Clarify what retry options govern

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -91,9 +91,9 @@ namespace Azure.Messaging.ServiceBus
         /// amount of time allowed for the individual network operations used for interactions with the Service Bus service.
         /// </summary>
         /// <remarks>
-        /// The retry options are only considered for interactions with the Service Bus service. They do not apply to failures when an
-        /// application is processing messages. Developers are responsible for error handling and retries for failures that occur during
-        /// message processing.
+        /// The retry options are only considered for interactions with the Service Bus service. They do not apply to failures in the 
+        /// <see cref="ServiceBusProcessor.ProcessMessageAsync" /> handler. Developers are responsible for error handling and retries 
+        /// as part of their event handler.
         ///</remarks>
         public ServiceBusRetryOptions RetryOptions
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -92,7 +92,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <remarks>
         /// The retry options are only considered for interactions with the Service Bus service. They do not apply to failures when an
-        /// application is processing messages.  Developers are responsible for error handling and retries for failures that occur during
+        /// application is processing messages. Developers are responsible for error handling and retries for failures that occur during
         /// message processing.
         ///</remarks>
         public ServiceBusRetryOptions RetryOptions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -92,7 +92,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <remarks>
         /// The retry options are only considered for interactions with the Service Bus service. They do not apply to failures in the
-        /// <see cref="ServiceBusProcessor.ProcessMessageAsync" /> handler. Developers are responsible for error handling and retries 
+        /// <see cref="ServiceBusProcessor.ProcessMessageAsync" /> handler. Developers are responsible for error handling and retries
         /// as part of their event handler.
         ///</remarks>
         public ServiceBusRetryOptions RetryOptions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -91,7 +91,7 @@ namespace Azure.Messaging.ServiceBus
         /// amount of time allowed for the individual network operations used for interactions with the Service Bus service.
         /// </summary>
         /// <remarks>
-        /// The retry options are only considered for interactions with the Service Bus service. They do not apply to failures in the 
+        /// The retry options are only considered for interactions with the Service Bus service. They do not apply to failures in the
         /// <see cref="ServiceBusProcessor.ProcessMessageAsync" /> handler. Developers are responsible for error handling and retries 
         /// as part of their event handler.
         ///</remarks>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -86,10 +86,15 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        /// The set of options to use for determining whether a failed operation should be retried and,
+        /// The set of options to use for determining whether a failed service operation should be retried and,
         /// if so, the amount of time to wait between retry attempts.  These options also control the
-        /// amount of time allowed for receiving messages and other interactions with the Service Bus service.
+        /// amount of time allowed for the individual network operations used for interactions with the Service Bus service.
         /// </summary>
+        /// <remarks>
+        /// The retry options are only considered for interactions with the Service Bus service. They do not apply to failures when an
+        /// application is processing messages.  Developers are responsible for error handling and retries for failures that occur during
+        /// message processing.
+        ///</remarks>
         public ServiceBusRetryOptions RetryOptions
         {
             get => _retryOptions;


### PR DESCRIPTION
# Summary

The focus of these changes is to add text to clarify what the `ServiceBusClientOptions.RetryOptions` govern and explicitly mention that developers are responsible for handling failures and performing retries for message processing done by the application.