### PR TITLE
[AppConfig] Hide internal constructor from ConfigurationSetting

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bugs Fixed
 
+- Added the ability to create `FeatureFlagConfigurationSetting` and `SecretReferenceConfigurationSetting` instances for testing purposes using the `ConfigurationModelFactory`. It was previously not possible to populate service-owned fields when testing.
+
+- Marked a constructor overload of `ConfigurationSetting` that was intended for testing purposes as non-visible, as the `ConfigurationModelFactory` should instead be used.
+
 ### Other Changes
 
 ## 1.3.0-beta.2 (2023-07-11)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -94,10 +94,13 @@ namespace Azure.Data.AppConfiguration
     public static partial class ConfigurationModelFactory
     {
         public static Azure.Data.AppConfiguration.ConfigurationSetting ConfigurationSetting(string key, string value, string label = null, string contentType = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
+        public static Azure.Data.AppConfiguration.FeatureFlagConfigurationSetting FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
+        public static Azure.Data.AppConfiguration.SecretReferenceConfigurationSetting SecretReferenceConfigurationSetting(string key, System.Uri secretId, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
     }
     public partial class ConfigurationSetting
     {
         public ConfigurationSetting(string key, string value, string label = null) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ConfigurationSetting(string key, string value, string label, Azure.ETag etag) { }
         public string ContentType { get { throw null; } set { } }
         public Azure.ETag ETag { get { throw null; } }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationModelFactory.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationModelFactory.cs
@@ -6,7 +6,7 @@ using System;
 namespace Azure.Data.AppConfiguration
 {
     /// <summary>
-    /// Configuration Setting model factory that enables mocking for the App Configuration client library.
+    /// Configuration Setting model factory that enables mocking for the AppConfiguration client library.
     /// </summary>
     public static class ConfigurationModelFactory
     {
@@ -32,6 +32,56 @@ namespace Azure.Data.AppConfiguration
             return new ConfigurationSetting(key, value, label)
             {
                 ContentType = contentType,
+                ETag = eTag,
+                LastModified = lastModified,
+                IsReadOnly = isReadOnly
+            };
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="FeatureFlagConfigurationSetting"/> for mocking purposes.
+        /// </summary>
+        /// <param name="featureId">The identified of the feature flag.</param>
+        /// <param name="isEnabled">The value indicating whether the feature flag is enabled.</param>
+        /// <param name="label">A label used to group this configuration setting with others.</param>
+        /// <param name="eTag">An ETag indicating the version of a configuration setting within a configuration store.</param>
+        /// <param name="lastModified">The last time a modifying operation was performed on the given configuration setting.</param>
+        /// <param name="isReadOnly">A value indicating whether the configuration setting is read only.</param>
+        public static FeatureFlagConfigurationSetting FeatureFlagConfigurationSetting(
+            string featureId,
+            bool isEnabled,
+            string label = null,
+            ETag eTag = default,
+            DateTimeOffset? lastModified = null,
+            bool? isReadOnly = null)
+        {
+            return new FeatureFlagConfigurationSetting(featureId, isEnabled, label)
+            {
+                ETag = eTag,
+                LastModified = lastModified,
+                IsReadOnly = isReadOnly
+            };
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SecretReferenceConfigurationSetting"/> for mocking purposes.
+        /// </summary>
+        /// <param name="key">The primary identifier of the configuration setting.</param>
+        /// <param name="secretId">The secret identifier to reference.</param>
+        /// <param name="label">A label used to group this configuration setting with others.</param>
+        /// <param name="eTag">An ETag indicating the version of a configuration setting within a configuration store.</param>
+        /// <param name="lastModified">The last time a modifying operation was performed on the given configuration setting.</param>
+        /// <param name="isReadOnly">A value indicating whether the configuration setting is read only.</param>
+        public static SecretReferenceConfigurationSetting SecretReferenceConfigurationSetting(
+            string key,
+            Uri secretId,
+            string label = null,
+            ETag eTag = default,
+            DateTimeOffset? lastModified = null,
+            bool? isReadOnly = null)
+        {
+            return new SecretReferenceConfigurationSetting(key, secretId, label)
+            {
                 ETag = eTag,
                 LastModified = lastModified,
                 IsReadOnly = isReadOnly

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSetting.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSetting.cs
@@ -39,6 +39,7 @@ namespace Azure.Data.AppConfiguration
         /// <param name="value">The configuration setting's value.</param>
         /// <param name="label">A label used to group this configuration setting with others.</param>
         /// <param name="etag">The ETag value for the configuration setting.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ConfigurationSetting(string key, string value, string label, ETag etag)
         {
             Key = key;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -1729,7 +1729,7 @@ namespace Azure.Data.AppConfiguration.Tests
                         ValidateCompletedOperation(operation);
                         break;
                     }
-                    await Task.Delay(125);
+                    await Delay(125);
                 }
                 var createdSnapshot = operation.Value;
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -1729,7 +1729,7 @@ namespace Azure.Data.AppConfiguration.Tests
                         ValidateCompletedOperation(operation);
                         break;
                     }
-                    await Task.Delay(500);
+                    await Task.Delay(125);
                 }
                 var createdSnapshot = operation.Value;
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsSnapshotTest.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsSnapshotTest.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using Azure.Core;
+using NUnit.Framework;
 
 namespace Azure.Data.AppConfiguration.Tests
 {


### PR DESCRIPTION
# Summary

The focus of these changes is to hide constructor of `ConfigurationSetting` that allows the service owned ETag to be set.  This was intended to be an internal constructor and was inadvertently made public.  In addition, the ability to create `FeatureFlagConfigurationSetting` and `SecretRefrenceConfigurationSetting` instances from the model factory has been added.