### PR TITLE
NonDisposingStream: delegate remaining Stream APIs to inner stream

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/NonDisposingStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/NonDisposingStream.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,6 +21,8 @@ namespace Azure.Storage
         public override bool CanSeek => _innerStream.CanSeek;
 
         public override bool CanWrite => _innerStream.CanWrite;
+
+        public override bool CanTimeout => _innerStream.CanTimeout;
 
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => _innerStream.CopyToAsync(destination, bufferSize, cancellationToken);
 
@@ -42,6 +45,36 @@ namespace Azure.Storage
         public override void Write(byte[] buffer, int offset, int count) => _innerStream.Write(buffer, offset, count);
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override int ReadByte() => _innerStream.ReadByte();
+
+        public override void WriteByte(byte value) => _innerStream.WriteByte(value);
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => _innerStream.BeginRead(buffer, offset, count, callback, state);
+
+        public override int EndRead(IAsyncResult asyncResult) => _innerStream.EndRead(asyncResult);
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => _innerStream.BeginWrite(buffer, offset, count, callback, state);
+
+        public override void EndWrite(IAsyncResult asyncResult) => _innerStream.EndWrite(asyncResult);
+
+        public override int ReadTimeout { get => _innerStream.ReadTimeout; set => _innerStream.ReadTimeout = value; }
+
+        public override int WriteTimeout { get => _innerStream.WriteTimeout; set => _innerStream.WriteTimeout = value; }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+
+        public override void CopyTo(Stream destination, int bufferSize) => _innerStream.CopyTo(destination, bufferSize);
+
+        public override int Read(Span<byte> buffer) => _innerStream.Read(buffer);
+
+        public override void Write(ReadOnlySpan<byte> buffer) => _innerStream.Write(buffer);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => _innerStream.WriteAsync(buffer, cancellationToken);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => _innerStream.ReadAsync(buffer, cancellationToken);
+
+#endif
     }
 
     internal static partial class StreamExtensions


### PR DESCRIPTION
[`NonDisposingStream`](https://github.com/Azure/azure-sdk-for-net/blob/ea7dc0d229a404ba85285ec63fe533a94650f051/sdk/storage/Azure.Storage.Common/src/Shared/NonDisposingStream.cs#L12) currently implements a minimal Stream API by delegating to the inner stream.

There are cases where efficiency can be improved by implementing more of the API surface, for example the newer APIs which accept `Memory<byte>`, `Span<byte>`, and the like. By not forwarding these APIs to the inner stream, the implementation is forced to use the less efficient base implementations which typically involve renting/returning arrays from a pool and copying bytes.

This PR implements the remainder of the API surface other than the lifecycle APIs such as `Dispose`, `DisposeAsync`, and `Close`.