### PR TITLE
Fix typo in key nameused in Extensions CHANGELOG

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features Added
 
-- Added support for creating `WorkloadIdentityCredential` objects from the configuration using the `"credential": "workloadidentity"`. Users must provide values for the `tenentId`, `clientId`, and newly added `tokenFilePath` keys in the configuration, or they must set the environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`.
+- Added support for creating `WorkloadIdentityCredential` objects from the configuration using the `"credential": "workloadidentity"`. Users must provide values for the `tenantId`, `clientId`, and newly added `tokenFilePath` keys in the configuration, or they must set the environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`.
 
 ### Other Changes
 


### PR DESCRIPTION
Fix typo in key name. See correct name at: https://github.com/Azure/azure-sdk-for-net/blob/ea7dc0d229a404ba85285ec63fe533a94650f051/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs#L91