### PR TITLE
Add Parse for MutableJsonDocument from Utf8JsonReader

### DIFF
--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.cs
@@ -348,8 +348,8 @@ namespace Azure.Core.Serialization
         {
             public override DynamicData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                JsonDocument document = JsonDocument.ParseValue(ref reader);
-                return new DynamicData(new MutableJsonDocument(document, options).RootElement, DynamicDataOptions.FromSerializerOptions(options));
+                MutableJsonDocument mdoc = MutableJsonDocument.Parse(ref reader);
+                return new DynamicData(mdoc.RootElement, DynamicDataOptions.FromSerializerOptions(options));
             }
 
             public override void Write(Utf8JsonWriter writer, DynamicData value, JsonSerializerOptions options)

--- a/sdk/core/Azure.Core/src/DynamicData/MutableJsonDocument.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/MutableJsonDocument.cs
@@ -76,12 +76,25 @@ namespace Azure.Core.Json
         {
             if (!Changes.HasChanges)
             {
-                Write(stream, _original.Span);
+                WriteOriginal(stream);
                 return;
             }
 
             using Utf8JsonWriter writer = new(stream);
             RootElement.WriteTo(writer);
+        }
+
+        private void WriteOriginal(Stream stream)
+        {
+            using Utf8JsonWriter writer = new(stream);
+            if (_original.Length == 0)
+            {
+                _originalDocument.WriteTo(writer);
+            }
+            else
+            {
+                Write(stream, _original.Span);
+            }
         }
 
         private void WritePatch(Stream stream)
@@ -143,6 +156,18 @@ namespace Azure.Core.Json
         }
 
         /// <summary>
+        /// Parses JSON into a <see cref="MutableJsonDocument"/>.
+        /// </summary>
+        /// <param name="reader">Reader holding the JSON value.</param>
+        /// <param name="serializerOptions">Serializer options used to serialize and deserialize any changes to the JSON.</param>
+        /// <returns>A <see cref="MutableJsonDocument"/> representation of the value.</returns>
+        public static MutableJsonDocument Parse(ref Utf8JsonReader reader, JsonSerializerOptions? serializerOptions = default)
+        {
+            JsonDocument doc = JsonDocument.ParseValue(ref reader);
+            return new MutableJsonDocument(doc, null, serializerOptions);
+        }
+
+        /// <summary>
         /// Parses a UTF-8 encoded string representing a single JSON value into a <see cref="MutableJsonDocument"/>.
         /// </summary>
         /// <param name="utf8Json">A UTF-8 encoded string representing a JSON value.</param>
@@ -175,26 +200,15 @@ namespace Azure.Core.Json
             _originalDocument.Dispose();
         }
 
-        internal MutableJsonDocument(JsonDocument document, JsonSerializerOptions? serializerOptions) : this(document, GetBytesFromDocument(document), serializerOptions)
+        private MutableJsonDocument(JsonDocument document, JsonSerializerOptions? serializerOptions) : this(document, null, serializerOptions)
         {
         }
 
-        internal MutableJsonDocument(JsonDocument document, ReadOnlyMemory<byte> utf8Json, JsonSerializerOptions? serializerOptions)
+        private MutableJsonDocument(JsonDocument document, ReadOnlyMemory<byte> utf8Json, JsonSerializerOptions? serializerOptions)
         {
             _original = utf8Json;
             _originalDocument = document;
             _serializerOptions = serializerOptions ?? new JsonSerializerOptions();
-        }
-
-        private static ReadOnlyMemory<byte> GetBytesFromDocument(JsonDocument document)
-        {
-            using MemoryStream stream = new();
-            using (Utf8JsonWriter writer = new(stream))
-            {
-                document.WriteTo(writer);
-            }
-
-            return new ReadOnlyMemory<byte>(stream.GetBuffer(), 0, (int)stream.Position);
         }
 
         private class MutableJsonDocumentConverter : JsonConverter<MutableJsonDocument>

--- a/sdk/core/Azure.Core/src/DynamicData/MutableJsonDocument.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/MutableJsonDocument.cs
@@ -86,15 +86,14 @@ namespace Azure.Core.Json
 
         private void WriteOriginal(Stream stream)
         {
-            using Utf8JsonWriter writer = new(stream);
             if (_original.Length == 0)
             {
+                using Utf8JsonWriter writer = new(stream);
                 _originalDocument.WriteTo(writer);
+                return;
             }
-            else
-            {
-                Write(stream, _original.Span);
-            }
+
+            Write(stream, _original.Span);
         }
 
         private void WritePatch(Stream stream)
@@ -164,7 +163,7 @@ namespace Azure.Core.Json
         public static MutableJsonDocument Parse(ref Utf8JsonReader reader, JsonSerializerOptions? serializerOptions = default)
         {
             JsonDocument doc = JsonDocument.ParseValue(ref reader);
-            return new MutableJsonDocument(doc, null, serializerOptions);
+            return new MutableJsonDocument(doc, default, serializerOptions);
         }
 
         /// <summary>
@@ -200,14 +199,10 @@ namespace Azure.Core.Json
             _originalDocument.Dispose();
         }
 
-        private MutableJsonDocument(JsonDocument document, JsonSerializerOptions? serializerOptions) : this(document, null, serializerOptions)
-        {
-        }
-
         private MutableJsonDocument(JsonDocument document, ReadOnlyMemory<byte> utf8Json, JsonSerializerOptions? serializerOptions)
         {
-            _original = utf8Json;
             _originalDocument = document;
+            _original = utf8Json;
             _serializerOptions = serializerOptions ?? new JsonSerializerOptions();
         }
 
@@ -215,8 +210,7 @@ namespace Azure.Core.Json
         {
             public override MutableJsonDocument Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                JsonDocument document = JsonDocument.ParseValue(ref reader);
-                return new MutableJsonDocument(document, options);
+                return Parse(ref reader);
             }
 
             public override void Write(Utf8JsonWriter writer, MutableJsonDocument value, JsonSerializerOptions options)

--- a/sdk/core/Azure.Core/src/DynamicData/MutableJsonElement.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/MutableJsonElement.cs
@@ -1208,8 +1208,8 @@ namespace Azure.Core.Json
         {
             public override MutableJsonElement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                JsonDocument document = JsonDocument.ParseValue(ref reader);
-                return new MutableJsonDocument(document, options).RootElement;
+                MutableJsonDocument mdoc = MutableJsonDocument.Parse(ref reader);
+                return mdoc.RootElement;
             }
 
             public override void Write(Utf8JsonWriter writer, MutableJsonElement value, JsonSerializerOptions options)

--- a/sdk/core/Azure.Core/tests/DynamicData/MutableJsonDocumentTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/MutableJsonDocumentTests.cs
@@ -1106,6 +1106,28 @@ namespace Azure.Core.Tests
             Assert.AreEqual(2, mdoc.RootElement.GetInt32());
         }
 
+        [Test]
+        public void CanParseFromUtf8JsonReader()
+        {
+            ReadOnlySpan<byte> utf8Json = """
+                {
+                    "foo": 1
+                }
+                """u8;
+            Utf8JsonReader reader = new(utf8Json);
+
+            MutableJsonDocument mdoc = MutableJsonDocument.Parse(ref reader);
+
+            Assert.AreEqual(1, mdoc.RootElement.GetProperty("foo").GetInt32());
+
+            using MemoryStream stream = new();
+            mdoc.WriteTo(stream, "J");
+            stream.Flush();
+            stream.Position = 0;
+
+            Assert.AreEqual("""{"foo":1}""", BinaryData.FromStream(stream).ToString());
+        }
+
         #region Helpers
 
         internal static void ValidateWriteTo(BinaryData json, MutableJsonDocument mdoc)


### PR DESCRIPTION
The new [IModelJsonSerializable](https://apiview.dev/Assemblies/Review/77bdbcef49a3465fa96fac3fb745bf57#Azure.Core.Serialization.IModelJsonSerializable%3CT%3E) interface takes a Utf8JsonReader as an input to its Deserialize method.  Allowing a Parse from MutableJsonDocument directly from a reader will save some allocations in Patch models.