### PR TITLE
[Service Bus] Fix docs typo

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -302,7 +302,7 @@ namespace Azure.Messaging.ServiceBus
             }
         }
 
-        /// <summary>Gets or sets the a correlation identifier.</summary>
+        /// <summary>Gets or sets the correlation identifier.</summary>
         /// <value>Correlation identifier.</value>
         /// <remarks>
         /// Allows an application to specify a context for the message for the purposes of correlation,


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo in the doc comments for `ServiceBusMessage.CorrelationId`

# References and Related

- [Grammar issue for CorrelationId description (#38209)](https://github.com/Azure/azure-sdk-for-net/issues/38209)