### PR TITLE
fix(ci): prepare-pipelines.xml is broken due to renamed property

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 variables:
-  NugetSecurityAnalysisWarningLevel: warn
+  nugetMultiFeedWarnLevel: warn
 
 extends:
   template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml


### PR DESCRIPTION
`NugetSecurityAnalysisWarningLevel` is renamed to `nugetMultiFeedWarnLevel`, so we need to follow up the change.
A follow up of [#3658](https://github.com/Azure/autorest.csharp/pull/3568/files)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
