### PR TITLE
Update parameter binding data to provide ConnectionName

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -137,6 +137,7 @@ namespace Azure.Storage
             internal const int QueueEndpointPortNumber = 10001;
             internal const int TableEndpointPortNumber = 10002;
 
+            internal const string AzureWebJobsStorage = "AzureWebJobsStorage";
             internal const string UseDevelopmentSetting = "UseDevelopmentStorage";
             internal const string DevelopmentProxyUriSetting = "DevelopmentStorageProxyUri";
             internal const string DefaultEndpointsProtocolSetting = "DefaultEndpointsProtocol";

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -137,7 +137,6 @@ namespace Azure.Storage
             internal const int QueueEndpointPortNumber = 10001;
             internal const int TableEndpointPortNumber = 10002;
 
-            internal const string AzureWebJobsStorage = "AzureWebJobsStorage";
             internal const string UseDevelopmentSetting = "UseDevelopmentStorage";
             internal const string DevelopmentProxyUriSetting = "DevelopmentStorageProxyUri";
             internal const string DefaultEndpointsProtocolSetting = "DefaultEndpointsProtocol";

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 5.2.0 (2023-08-10)
+- Update ParameterBindingData content to provide connection name instead of connection section
 
 ### Features Added
 - Added support for `BlobsOptions.MaxDequeueCount`

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 5.2.0 (2023-08-10)
-- Update ParameterBindingData content to provide connection name instead of connection section
+- Updating ParameterBindingData  "Connection" value to the full connection name instead of the connection section key
 
 ### Features Added
 - Added support for `BlobsOptions.MaxDequeueCount`

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
@@ -237,11 +237,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Config
         private ParameterBindingData CreateParameterBindingData(string connection, string blobName, string containerName)
         {
             string connectionName = !string.IsNullOrEmpty(connection) ? _nameResolver.ResolveWholeString(connection) : string.Empty;
-            var connectionSection = _blobServiceClientProvider.GetWebJobsConnectionStringSection(connectionName);
 
             var blobDetails = new BlobParameterBindingDataContent()
             {
-                Connection = connectionSection.Key,
+                Connection = connectionName,
                 BlobName = blobName,
                 ContainerName = containerName
             };

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Config
 
             if (string.IsNullOrWhiteSpace(connectionName))
             {
-                connectionName = ConnectionStrings.AzureWebJobsStorage; // default
+                connectionName = Constants.AzureWebJobsStorage; // default
             }
 
             var blobDetails = new BlobParameterBindingDataContent()

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Config
 
             if (string.IsNullOrWhiteSpace(connectionName))
             {
-                connectionName = ConnectionStringNames.Storage; // default
+                connectionName = ConnectionStrings.AzureWebJobsStorage; // default
             }
 
             var blobDetails = new BlobParameterBindingDataContent()

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
@@ -231,12 +231,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Config
 
         private ParameterBindingData ConvertBlobInputToParameterBindingData(BlobBaseClient input)
         {
-            return CreateParameterBindingData(null, input.Name, input.BlobContainerName);
+            return CreateParameterBindingData(string.Empty, input.Name, input.BlobContainerName);
         }
 
         private ParameterBindingData CreateParameterBindingData(string connection, string blobName, string containerName)
         {
-            string connectionName = !string.IsNullOrEmpty(connection) ? _nameResolver.ResolveWholeString(connection) : string.Empty;
+            string connectionName = _nameResolver.ResolveWholeString(connection);
+
+            if (string.IsNullOrWhiteSpace(connectionName))
+            {
+                connectionName = ConnectionStringNames.Storage; // default
+            }
 
             var blobDetails = new BlobParameterBindingDataContent()
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Constants.cs
@@ -8,5 +8,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
         public const string DateTimeFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffK";
         public const string WebJobsBlobExtensionName = "AzureStorageBlobs";
         public const string WebJobsQueueExtensionName = "AzureStorageQueues";
+        public const string AzureWebJobsStorage = "AzureWebJobsStorage";
     }
 }


### PR DESCRIPTION
resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/1842

There is a bug where the dotnet worker is not able to find and resolve a given connection name i.e. "MyApp:StorageConnection"; this is due to some preprocessing happening in the WebJobs extension around the connection name. This was a mistake in the initial implementation, we are supposed to be returning the full connection name and not the connection section key.