### PR TITLE
Client-Side Encryption Telemetry

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -83,6 +83,7 @@
     <Compile Include="$(AzureStorageSharedSources)StorageResponseClassifier.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageRequestFailedDetailsParser.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StorageTelemetryPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageVersionExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriQueryParamsCollection.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -1515,6 +1515,12 @@ namespace Azure.Storage.Blobs.Specialized
                 {
                     scope.Start();
 
+                    using DisposableBucket disposableBucket = new();
+                    if (ClientSideEncryption != default)
+                    {
+                        disposableBucket.Add(Shared.StorageExtensions.CreateClientSideEncryptionScope(ClientSideEncryption.EncryptionVersion));
+                    }
+
                     // Start downloading the blob
                     Response<BlobDownloadStreamingResult> response = await StartDownloadAsync(
                         range,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -1801,7 +1801,7 @@ namespace Azure.Storage.Blobs
             {
                 if (_blockBlobClient == null)
                 {
-                    _blockBlobClient = new BlockBlobClient(Uri, ClientConfiguration);
+                    _blockBlobClient = new BlockBlobClient(Uri, ClientConfiguration, ClientSideEncryption);
                 }
                 return _blockBlobClient;
             }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -326,6 +326,15 @@ namespace Azure.Storage.Blobs.Specialized
             _blockBlobRestClient = BuildBlockBlobRestClient(blobUri);
         }
 
+        internal BlockBlobClient(
+            Uri blobUri,
+            BlobClientConfiguration clientConfiguration,
+            ClientSideEncryptionOptions clientSideEncryption)
+            : base(blobUri, clientConfiguration, clientSideEncryption)
+        {
+            _blockBlobRestClient = BuildBlockBlobRestClient(blobUri);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockBlobClient"/>
         /// class.
@@ -876,6 +885,12 @@ namespace Azure.Storage.Blobs.Specialized
                     content = content?.WithNoDispose().WithProgress(progressHandler);
 
                     ResponseWithHeaders<BlockBlobUploadHeaders> response;
+
+                    using DisposableBucket disposableBucket = new();
+                    if (ClientSideEncryption != default)
+                    {
+                        disposableBucket.Add(Shared.StorageExtensions.CreateClientSideEncryptionScope(ClientSideEncryption.EncryptionVersion));
+                    }
 
                     if (async)
                     {
@@ -2167,6 +2182,12 @@ namespace Azure.Storage.Blobs.Specialized
                     BlockLookupList blocks = new BlockLookupList() { Latest = base64BlockIds.ToList() };
 
                     ResponseWithHeaders<BlockBlobCommitBlockListHeaders> response;
+
+                    using DisposableBucket disposableBucket = new();
+                    if (ClientSideEncryption != default)
+                    {
+                        disposableBucket.Add(Shared.StorageExtensions.CreateClientSideEncryptionScope(ClientSideEncryption.EncryptionVersion));
+                    }
 
                     if (async)
                     {

--- a/sdk/storage/Azure.Storage.Blobs/tests/StorageTelemetryTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/StorageTelemetryTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Storage.Test.Shared;
+using Microsoft.Net.Http.Headers;
+using NUnit.Framework;
+
+namespace Azure.Storage.Blobs.Tests
+{
+    public class StorageTelemetryTests : BlobTestBase
+    {
+        private const string CseV1UserAgentString = "azstorage-clientsideencryption/1.0";
+        private const string CseV2UserAgentString = "azstorage-clientsideencryption/2.0";
+
+        private ClientBuilder<BlobServiceClient, BlobClientOptions> ClientBuilder { get; }
+
+        public StorageTelemetryTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, RecordedTestMode.Live /* RecordedTestMode.Record /* to re-record */)
+        {
+            ClientBuilder = ClientBuilderExtensions.GetNewBlobsClientBuilder(Tenants, serviceVersion);
+        }
+
+        private Action<Request> GetCheckAzFeatureUserAgent(ClientSideEncryptionVersion version)
+        {
+            bool IsCommitBlockList(Request request)
+                => request.Method == RequestMethod.Put && request.Uri.Query.Contains("comp=blocklist");
+            bool IsPutBlob(Request request)
+                => request.Method == RequestMethod.Put && !request.Uri.Query.Contains("comp");
+            bool IsDownloadRange(Request request)
+                => request.Method == RequestMethod.Get && !request.Uri.Query.Contains("comp");
+            return req =>
+            {
+                if (!req.Headers.TryGetValue(HeaderNames.UserAgent, out string userAgent))
+                {
+                    Assert.Fail("Missing User-Agent header in request.");
+                }
+                string expected = version switch
+                {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    ClientSideEncryptionVersion.V1_0 => CseV1UserAgentString,
+#pragma warning restore CS0618 // Type or member is obsolete
+                    ClientSideEncryptionVersion.V2_0 => CseV2UserAgentString,
+                    _ => throw new ArgumentException("Bad CSE version"),
+                };
+
+                if (IsCommitBlockList(req) || IsPutBlob(req) || IsDownloadRange(req))
+                {
+                    Assert.That(userAgent, Does.Contain(expected));
+                }
+                else
+                {
+                    Assert.That(userAgent, Does.Not.Contain(expected));
+                }
+            };
+        }
+
+        [Test]
+        [LiveOnly]
+        public async Task ClientSideEncryption_Upload(
+#pragma warning disable CS0618 // Type or member is obsolete
+            [Values(ClientSideEncryptionVersion.V2_0, ClientSideEncryptionVersion.V1_0)] ClientSideEncryptionVersion cseVersion,
+#pragma warning restore CS0618 // Type or member is obsolete
+            [Values(true, false)] bool split)
+        {
+            await using DisposingContainer disposingContainer = await ClientBuilder.GetTestContainerAsync();
+
+            AssertMessageContentsPolicy assertionPolicy = new(checkRequest: GetCheckAzFeatureUserAgent(cseVersion))
+            {
+                CheckRequest = true
+            };
+            Specialized.SpecializedBlobClientOptions clientOptions = new()
+            {
+                ClientSideEncryption = new(cseVersion)
+                {
+                    KeyEncryptionKey = this.GetIKeyEncryptionKey(default).Object,
+                    KeyWrapAlgorithm = ClientSideEncryptionTestExtensions.s_algorithmName
+                }
+            };
+            clientOptions.AddPolicy(assertionPolicy, HttpPipelinePosition.BeforeTransport);
+
+            BlobClient encryptedClient = InstrumentClient(new BlobClient(
+                disposingContainer.Container.GetBlobClient(GetNewBlobName()).Uri,
+                ClientBuilder.Tenants.GetNewSharedKeyCredentials(),
+                clientOptions));
+
+            const int dataSize = Constants.KB;
+            int chunkSize = split ? dataSize / 2 : dataSize * 2;
+            StorageTransferOptions transferOptions = new()
+            {
+                InitialTransferSize = chunkSize,
+                MaximumTransferSize = chunkSize,
+            };
+
+            // Assertions are in assertionPolicy
+            await encryptedClient.UploadAsync(
+                BinaryData.FromBytes(GetRandomBuffer(Constants.KB)),
+                new Models.BlobUploadOptions()
+                {
+                    TransferOptions = transferOptions
+                });
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -653,6 +653,9 @@ namespace Azure.Storage
 
         internal static class ClientSideEncryption
         {
+            public const string HttpMessagePropertyKeyV1 = "Azure.Storage.StorageTelemetryPolicy.ClientSideEncryption.V1";
+            public const string HttpMessagePropertyKeyV2 = "Azure.Storage.StorageTelemetryPolicy.ClientSideEncryption.V2";
+
             public const string AgentMetadataKey = "EncryptionLibrary";
 
             public const string AesCbcPkcs5Padding = "AES/CBC/PKCS5Padding";

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.Clients.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.Clients.cs
@@ -118,6 +118,9 @@ namespace Azure.Storage
 
         public static class ClientSideEncryption
         {
+            public static ArgumentException UnrecognizedVersion()
+                => new ArgumentException($"Unrecognized ClientSideEncryptionVersion");
+
             public static InvalidOperationException ClientSideEncryptionVersionNotSupported(string versionString = default)
                 => new InvalidOperationException("This library does not support the given version of client-side encryption." +
                     versionString == default ? "" : $" Version ID = {versionString}");

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -107,7 +107,9 @@ namespace Azure.Storage
             StorageResponseClassifier classifier = new();
             var pipelineOptions = new HttpPipelineOptions(options)
             {
-                PerCallPolicies = { StorageServerTimeoutPolicy.Shared, StorageTelemetryPolicy.Shared },
+                PerCallPolicies = { StorageServerTimeoutPolicy.Shared },
+                // needed *after* core applies the user agent; can't have that without going per-retry
+                PerRetryPolicies = { StorageTelemetryPolicy.Shared },
                 ResponseClassifier = classifier,
                 RequestFailedDetailsParser = new StorageRequestFailedDetailsParser()
             };

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -107,7 +107,7 @@ namespace Azure.Storage
             StorageResponseClassifier classifier = new();
             var pipelineOptions = new HttpPipelineOptions(options)
             {
-                PerCallPolicies = { StorageServerTimeoutPolicy.Shared },
+                PerCallPolicies = { StorageServerTimeoutPolicy.Shared, StorageTelemetryPolicy.Shared },
                 ResponseClassifier = classifier,
                 RequestFailedDetailsParser = new StorageRequestFailedDetailsParser()
             };

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageExtensions.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Pipeline;
 
 namespace Azure.Storage.Shared
 {
@@ -71,6 +73,23 @@ namespace Azure.Storage.Shared
             return new HttpAuthorization(
                 Constants.CopyHttpAuthorization.BearerScheme,
                 accessToken.Token);
+        }
+
+        /// <summary>
+        /// Temporary use of pipeline scopes for triggering use of AzFeatures flag.
+        /// Future work is to provide direct access to a RequestContext for a given message via generated code.
+        /// </summary>
+        public static IDisposable CreateClientSideEncryptionScope(ClientSideEncryptionVersion version)
+        {
+            string key = version switch
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                ClientSideEncryptionVersion.V1_0 => Constants.ClientSideEncryption.HttpMessagePropertyKeyV1,
+#pragma warning restore CS0618 // Type or member is obsolete
+                ClientSideEncryptionVersion.V2_0 => Constants.ClientSideEncryption.HttpMessagePropertyKeyV2,
+                _ => throw new ArgumentException("Unrecognized ClientSideEncryptionVersion"),
+            };
+            return HttpPipeline.CreateHttpMessagePropertiesScope(new Dictionary<string, object> { { key, true } });
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageExtensions.cs
@@ -87,7 +87,7 @@ namespace Azure.Storage.Shared
                 ClientSideEncryptionVersion.V1_0 => Constants.ClientSideEncryption.HttpMessagePropertyKeyV1,
 #pragma warning restore CS0618 // Type or member is obsolete
                 ClientSideEncryptionVersion.V2_0 => Constants.ClientSideEncryption.HttpMessagePropertyKeyV2,
-                _ => throw new ArgumentException("Unrecognized ClientSideEncryptionVersion"),
+                _ => throw Errors.ClientSideEncryption.UnrecognizedVersion(),
             };
             return HttpPipeline.CreateHttpMessagePropertiesScope(new Dictionary<string, object> { { key, true } });
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageTelemetryPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageTelemetryPolicy.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Storage
+{
+    internal class StorageTelemetryPolicy : HttpPipelineSynchronousPolicy
+    {
+        private const string CseIdentifierV2 = "azstorage-clientsideencryption/2.0";
+        private const string CseIdentifierV1 = "azstorage-clientsideencryption/1.0";
+
+        [Flags]
+        private enum AzFeatures
+        {
+            None = 0,
+            CseV1 = 1,
+            CseV2 = 2,
+        }
+
+        private StorageTelemetryPolicy()
+        {
+        }
+
+        public static StorageTelemetryPolicy Shared { get; } = new StorageTelemetryPolicy();
+
+        public override void OnSendingRequest(HttpMessage message)
+        {
+            AzFeatures azFeatures = AzFeatures.None;
+            if (message.TryGetProperty(Constants.ClientSideEncryption.HttpMessagePropertyKeyV2, out _))
+            {
+                azFeatures |= AzFeatures.CseV2;
+            }
+            else if (message.TryGetProperty(Constants.ClientSideEncryption.HttpMessagePropertyKeyV1, out _))
+            {
+                azFeatures |= AzFeatures.CseV1;
+            }
+
+            if (azFeatures != AzFeatures.None)
+            {
+                ApplyAzFeatures(message, azFeatures);
+            }
+        }
+
+        private static void ApplyAzFeatures(HttpMessage message, AzFeatures azFeatures)
+        {
+            string azFeatureString = Serialize(azFeatures);
+            if (message.Request.Headers.TryGetValue(HttpHeader.Names.UserAgent, out string userAgent))
+            {
+                message.Request.Headers.SetValue(HttpHeader.Names.UserAgent, TransformUserAgent(userAgent, azFeatureString));
+            }
+            else // no user agent string present, just set the feature string as the whole user agent
+            {
+                message.Request.Headers.SetValue(HttpHeader.Names.UserAgent, azFeatureString);
+            }
+        }
+
+        private static string Serialize(AzFeatures azFeatures)
+        {
+            // currently only support specific CSE strings. This will be generalized in the future.
+            if ((azFeatures & AzFeatures.CseV2) == AzFeatures.CseV2)
+            {
+                return CseIdentifierV2;
+            }
+            if ((azFeatures & AzFeatures.CseV1) == AzFeatures.CseV1)
+            {
+                return CseIdentifierV1;
+            }
+            return "";
+        }
+
+        private static string TransformUserAgent(string userAgent, string injection)
+        {
+            if (string.IsNullOrEmpty(injection))
+            {
+                return userAgent;
+            }
+            return string.Join(" ", injection, userAgent);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageTelemetryPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageTelemetryPolicy.cs
@@ -47,7 +47,7 @@ namespace Azure.Storage
         private static void ApplyAzFeatures(HttpMessage message, AzFeatures azFeatures)
         {
             string azFeatureString = Serialize(azFeatures);
-            if (message.Request.Headers.TryGetValue(HttpHeader.Names.UserAgent, out string userAgent))
+            if (message.Request.Headers.TryGetValue(HttpHeader.Names.UserAgent, out string userAgent) && !userAgent.Contains(azFeatureString))
             {
                 message.Request.Headers.SetValue(HttpHeader.Names.UserAgent, TransformUserAgent(userAgent, azFeatureString));
             }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
@@ -72,6 +72,7 @@
     <Compile Include="$(AzureStorageSharedSources)StorageRequestValidationPipelinePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageSharedKeyCredentialInternals.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageSharedKeyPipelinePolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StorageTelemetryPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageResponseClassifier.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageVersionExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
@@ -77,6 +77,7 @@
     <Compile Include="$(AzureStorageSharedSources)StorageSharedKeyPipelinePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageResponseClassifier.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StorageTelemetryPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageVersionExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StreamPartition.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)TransferValidationOptionsExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
+++ b/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
@@ -65,6 +65,7 @@
     <Compile Include="$(AzureStorageSharedSources)StorageSharedKeyPipelinePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageResponseClassifier.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StorageTelemetryPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageVersionExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriQueryParamsCollection.cs" LinkBase="Shared" />


### PR DESCRIPTION
Augments `User-Agent` header to indicate usage of client-side encryption.

While this pipeline policy should really be per-call, it is currently dependent on the existing policy that applies the user-agent in the first place, and cannot pick that up unless it is inserted per-retry. In the future, these sorts of indicators will be in their own header, so this seems to be an acceptable temporary solution.