### PR TITLE
[Event Hubs] Log improvements + Amqp version bump

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -105,7 +105,7 @@
     <PackageReference Update="Azure.ResourceManager" Version="1.7.0" />
 
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.2" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.3" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.2.0" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.54.1" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.31.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -97,7 +97,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="operationId">An identifier for the processing operation, allowing its activities to be correlated.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(22, Level = EventLevel.Error, Message = "An exception occurred while processing events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Operation Id: '{4}'; Error Message: '{5}'")]
+        [Event(22, Level = EventLevel.Error, Message = "An exception occurred while processing events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Operation Id: '{5}'; Error Message: '{4}'")]
         public virtual void EventBatchProcessingError(string partitionId,
                                                       string identifier,
                                                       string eventHubName,
@@ -107,7 +107,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         {
             if (IsEnabled())
             {
-                WriteEvent(22, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty, errorMessage ?? string.Empty);
+                WriteEvent(22, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty, operationId ?? string.Empty);
             }
         }
 
@@ -309,6 +309,60 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
                 eventPayload[4].DataPointer = (IntPtr)arg5Ptr;
 
                 WriteEventCore(eventId, 5, eventPayload);
+            }
+        }
+
+        /// <summary>
+        ///   Writes an event with five string arguments into a stack allocated
+        ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
+        /// </summary>
+        ///
+        /// <param name="eventId">The identifier of the event.</param>
+        /// <param name="arg1">The first argument.</param>
+        /// <param name="arg2">The second argument.</param>
+        /// <param name="arg3">The third argument.</param>
+        /// <param name="arg4">The fourth argument.</param>
+        /// <param name="arg5">The fifth argument.</param>
+        /// <param name="arg6">The sixth argument.</param>
+        ///
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteEvent(int eventId,
+                                       string arg1,
+                                       string arg2,
+                                       string arg3,
+                                       string arg4,
+                                       string arg5,
+                                       string arg6)
+        {
+            fixed (char* arg1Ptr = arg1)
+            fixed (char* arg2Ptr = arg2)
+            fixed (char* arg3Ptr = arg3)
+            fixed (char* arg4Ptr = arg4)
+            fixed (char* arg5Ptr = arg5)
+            fixed (char* arg6Ptr = arg6)
+            {
+                var eventPayload = stackalloc EventData[6];
+
+                eventPayload[0].Size = (arg1.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)arg1Ptr;
+
+                eventPayload[1].Size = (arg2.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)arg2Ptr;
+
+                eventPayload[2].Size = (arg3.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)arg3Ptr;
+
+                eventPayload[3].Size = (arg4.Length + 1) * sizeof(char);
+                eventPayload[3].DataPointer = (IntPtr)arg4Ptr;
+
+                eventPayload[4].Size = (arg5.Length + 1) * sizeof(char);
+                eventPayload[4].DataPointer = (IntPtr)arg5Ptr;
+
+                eventPayload[5].Size = (arg5.Length + 1) * sizeof(char);
+                eventPayload[5].DataPointer = (IntPtr)arg5Ptr;
+
+                WriteEventCore(eventId, 6, eventPayload);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -48,16 +48,18 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="operationId">An identifier for the processing operation, allowing its activities to be correlated.</param>
         ///
-        [Event(20, Level = EventLevel.Verbose, Message = "Starting to process a batch of events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        [Event(20, Level = EventLevel.Verbose, Message = "Starting to process a batch of events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Operation Id: '{4}'")]
         public virtual void EventBatchProcessingStart(string partitionId,
                                                       string identifier,
                                                       string eventHubName,
-                                                      string consumerGroup)
+                                                      string consumerGroup,
+                                                      string operationId)
         {
             if (IsEnabled())
             {
-                WriteEvent(20, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+                WriteEvent(20, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty);
             }
         }
 
@@ -69,16 +71,18 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="operationId">An identifier for the processing operation, allowing its activities to be correlated.</param>
         ///
-        [Event(21, Level = EventLevel.Verbose, Message = "Completed processing a batch of events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        [Event(21, Level = EventLevel.Verbose, Message = "Completed processing a batch of events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Operation Id: '{4}'")]
         public virtual void EventBatchProcessingComplete(string partitionId,
                                                          string identifier,
                                                          string eventHubName,
-                                                         string consumerGroup)
+                                                         string consumerGroup,
+                                                         string operationId)
         {
             if (IsEnabled())
             {
-                WriteEvent(21, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+                WriteEvent(21, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty);
             }
         }
 
@@ -90,18 +94,20 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="operationId">An identifier for the processing operation, allowing its activities to be correlated.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(22, Level = EventLevel.Error, Message = "An exception occurred while processing events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Error Message: '{4}'")]
+        [Event(22, Level = EventLevel.Error, Message = "An exception occurred while processing events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Operation Id: '{4}'; Error Message: '{5}'")]
         public virtual void EventBatchProcessingError(string partitionId,
                                                       string identifier,
                                                       string eventHubName,
                                                       string consumerGroup,
+                                                      string operationId,
                                                       string errorMessage)
         {
             if (IsEnabled())
             {
-                WriteEvent(22, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+                WriteEvent(22, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty, errorMessage ?? string.Empty);
             }
         }
 
@@ -188,6 +194,31 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(26, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessorClient" /> has begin processing a batch of events for a partition.
+        /// </summary>
+        ///
+        /// <param name="sequenceNumber">The sequence number of the event being passed to the handler for processing.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is taking place.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="operationId">An identifier for the processing operation, allowing its activities to be correlated.</param>
+        ///
+        [Event(27, Level = EventLevel.Verbose, Message = "Invoking the event processing handler for sequence number '{0}'.  Partition '{1}'; Processor Identifier '{2}'; Event Hub: {3}; Consumer Group: {4}; Operation Id: '{5}'")]
+        public virtual void EventBatchProcessingHandlerCall(string sequenceNumber,
+                                                            string partitionId,
+                                                            string identifier,
+                                                            string eventHubName,
+                                                            string consumerGroup,
+                                                            string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(27, sequenceNumber ?? string.Empty, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -1019,6 +1019,7 @@ namespace Azure.Messaging.EventHubs
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
+            var operation = Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture);
             var context = default(PartitionContext);
             var eventArgs = default(ProcessEventArgs);
             var caughtExceptions = default(List<Exception>);
@@ -1026,7 +1027,7 @@ namespace Azure.Messaging.EventHubs
 
             try
             {
-                Logger.EventBatchProcessingStart(partition.PartitionId, Identifier, EventHubName, ConsumerGroup);
+                Logger.EventBatchProcessingStart(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation);
 
                 // Attempt to process each event in the batch, marking if the batch was non-empty.  Exceptions during
                 // processing should be logged and cached, as the batch must be processed completely to avoid losing events.
@@ -1047,6 +1048,8 @@ namespace Azure.Messaging.EventHubs
 
                     try
                     {
+                        Logger.EventBatchProcessingHandlerCall(eventData.SequenceNumber.ToString(), partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation);
+
                         context ??= new ProcessorPartitionContext(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partition.PartitionId, () => ReadLastEnqueuedEventProperties(partition.PartitionId));
                         eventArgs = new ProcessEventArgs(context, eventData, updateToken => UpdateCheckpointAsync(partition.PartitionId, eventData.Offset, eventData.SequenceNumber, updateToken), cancellationToken);
 
@@ -1057,7 +1060,7 @@ namespace Azure.Messaging.EventHubs
                         // This exception is not surfaced to the error handler or bubbled, as the entire batch must be
                         // processed or events will be lost.  Preserve the exceptions, should any occur.
 
-                        Logger.EventBatchProcessingError(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                        Logger.EventBatchProcessingError(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation, ex.Message);
 
                         caughtExceptions ??= new List<Exception>();
                         caughtExceptions.Add(ex);
@@ -1069,6 +1072,8 @@ namespace Azure.Messaging.EventHubs
 
                 if (emptyBatch)
                 {
+                    Logger.EventBatchProcessingHandlerCall("<< No Event >>", partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation);
+
                     eventArgs = new ProcessEventArgs(new EmptyPartitionContext(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partition.PartitionId), null, EmptyEventUpdateCheckpoint, cancellationToken);
                     await _processEventAsync(eventArgs).ConfigureAwait(false);
                 }
@@ -1078,12 +1083,12 @@ namespace Azure.Messaging.EventHubs
                 // This exception was either not related to processing events or was the result of sending an empty batch to be
                 // processed.  Since there would be no other caught exceptions, tread this like a single case.
 
-                Logger.EventBatchProcessingError(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                Logger.EventBatchProcessingError(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation, ex.Message);
                 throw;
             }
             finally
             {
-                Logger.EventBatchProcessingComplete(partition.PartitionId, Identifier, EventHubName, ConsumerGroup);
+                Logger.EventBatchProcessingComplete(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation);
             }
 
             // Deal with any exceptions that occurred while processing the batch.  If more than one was

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -1130,7 +1130,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     processorClient.Identifier,
                     processorClient.EventHubName,
-                    processorClient.ConsumerGroup),
+                    processorClient.ConsumerGroup,
+                    It.IsAny<string>()),
                 Times.Once);
 
             mockLogger
@@ -1138,7 +1139,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     processorClient.Identifier,
                     processorClient.EventHubName,
-                    processorClient.ConsumerGroup),
+                    processorClient.ConsumerGroup,
+                    It.IsAny<string>()),
                 Times.Once);
 
             cancellationSource.Cancel();
@@ -1176,6 +1178,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     processorClient.Identifier,
                     processorClient.EventHubName,
                     processorClient.ConsumerGroup,
+                    It.IsAny<string>(),
                     expectedException.Message),
                 Times.Exactly(eventBatch.Length));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/PartitionLoadBalancerEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/PartitionLoadBalancerEventSource.cs
@@ -136,14 +136,18 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///   Indicates that stealable partitions were found, so randomly picking one of them to claim.
         /// </summary>
         ///
+        /// <param name="partitionId">The identifier of the partition that was selected to be stolen.</param>
+        /// <param name="stolenFrom">The identifier of the event processor that is being stolen from.</param>
         /// <param name="identifier">A unique name used to identify the associated event processor.</param>
         ///
-        [Event(7, Level = EventLevel.Informational, Message = "No unclaimed partitions, stealing from another event processor. (Identifier: '{0}')")]
-        public virtual void StealPartition(string identifier)
+        [Event(7, Level = EventLevel.Informational, Message = "No unclaimed partitions, attempting to steal partition '{0}' from event processor '{1}'. (Identifier: '{2}')")]
+        public virtual void StealPartition(string partitionId,
+                                           string stolenFrom,
+                                           string identifier)
         {
             if (IsEnabled())
             {
-                WriteEvent(7, identifier ?? string.Empty);
+                WriteEvent(7, partitionId ?? string.Empty, stolenFrom ?? string.Empty, identifier ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
@@ -420,12 +420,23 @@ namespace Azure.Messaging.EventHubs.Primitives
                     {
                         // If any partitions that can be stolen were found, randomly pick one of them to claim.
 
-                        Logger.StealPartition(OwnerIdentifier);
-
                         var index = RandomNumberGenerator.Value.Next(partitionsOwnedByProcessorWithGreaterThanMaximumOwnedPartitionsCount.Count);
+                        var partitionToSteal = partitionsOwnedByProcessorWithGreaterThanMaximumOwnedPartitionsCount[index];
+                        var stealingFrom = default(string);
+
+                        foreach (var ownership in completeOwnershipEnumerable)
+                        {
+                            if (ownership.PartitionId == partitionToSteal)
+                            {
+                                stealingFrom = ownership.OwnerIdentifier;
+                                break;
+                            }
+                        }
+
+                        Logger.StealPartition(partitionToSteal, stealingFrom, OwnerIdentifier);
 
                         var returnTask = ClaimOwnershipAsync(
-                            partitionsOwnedByProcessorWithGreaterThanMaximumOwnedPartitionsCount[index],
+                            partitionToSteal,
                             completeOwnershipEnumerable,
                             cancellationToken);
 
@@ -437,14 +448,25 @@ namespace Azure.Messaging.EventHubs.Primitives
                         // need to steal from the processors that have exactly the maximum amount to enforce balancing.  If this instance has
                         // already reached the minimum, there's no benefit to stealing, because the distribution wouldn't change.
 
-                        Logger.StealPartition(OwnerIdentifier);
-
                         // Randomly pick a processor to steal from.
 
                         var index = RandomNumberGenerator.Value.Next(partitionsOwnedByProcessorWithExactlyMaximumOwnedPartitionsCount.Count);
+                        var partitionToSteal = partitionsOwnedByProcessorWithExactlyMaximumOwnedPartitionsCount[index];
+                        var stealingFrom = default(string);
+
+                        foreach (var ownership in completeOwnershipEnumerable)
+                        {
+                            if (ownership.PartitionId == partitionToSteal)
+                            {
+                                stealingFrom = ownership.OwnerIdentifier;
+                                break;
+                            }
+                        }
+
+                        Logger.StealPartition(partitionToSteal, stealingFrom, OwnerIdentifier);
 
                         var returnTask = ClaimOwnershipAsync(
-                            partitionsOwnedByProcessorWithExactlyMaximumOwnedPartitionsCount[index],
+                            partitionToSteal,
                             completeOwnershipEnumerable,
                             cancellationToken);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Processor/PartitionLoadBalancerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Processor/PartitionLoadBalancerTests.cs
@@ -544,6 +544,63 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies that partitions ownership load balancing not attempt to steal when the number of
+        ///   processors is greater than the number of partitions.
+        /// </summary>
+        ///
+        [Test]
+        public async Task RunLoadBalancingAsyncDoesNotStealWhenLessPartitionsThanProcessors()
+        {
+            const int NumberOfPartitions = 4;
+
+            var noOwnershipIdentifier = Guid.NewGuid().ToString();
+            var partitionIds = Enumerable.Range(1, NumberOfPartitions).Select(p => p.ToString()).ToArray();
+            var storageManager = new InMemoryCheckpointStore((s) => Console.WriteLine(s));
+            var loadbalancer = new PartitionLoadBalancer(storageManager, noOwnershipIdentifier, ConsumerGroup, FullyQualifiedNamespace, EventHubName, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(10));
+
+            var mockLog = new Mock<PartitionLoadBalancerEventSource>();
+            loadbalancer.Logger = mockLog.Object;
+
+            // Create ownerships for each partition by other load balancers.
+
+            foreach (var partition in partitionIds)
+            {
+                var ownership = CreatePartitionOwnership(new[] { partition }, Guid.NewGuid().ToString());
+                await storageManager.ClaimOwnershipAsync(ownership);
+            }
+
+            // Verify that this load balancer sees all partitions as owned by others.
+
+            var totalOwnedPartitions = await storageManager.ListOwnershipAsync(loadbalancer.FullyQualifiedNamespace, loadbalancer.EventHubName, loadbalancer.ConsumerGroup);
+            var ownedByloadbalancer = GetOwnedPartitionIds(totalOwnedPartitions, loadbalancer.OwnerIdentifier);
+
+            Assert.That(totalOwnedPartitions.Count(), Is.EqualTo(NumberOfPartitions), "All partitions should be owned.");
+            Assert.That(ownedByloadbalancer, Is.Empty, "All partitions should be owned by other load balancers.");
+
+            // The load balancing state should be final and remain stable.  Run several load balancing cycles and validate that the state has
+            // not changed.
+
+            for (var index = 0; index < NumberOfPartitions; ++index)
+            {
+                await loadbalancer.RunLoadBalancingAsync(partitionIds, CancellationToken.None);
+            }
+
+            await loadbalancer.RunLoadBalancingAsync(partitionIds, CancellationToken.None);
+
+            // Verify partition ownership has not changed.
+
+            totalOwnedPartitions = await storageManager.ListOwnershipAsync(loadbalancer.FullyQualifiedNamespace, loadbalancer.EventHubName, loadbalancer.ConsumerGroup);
+            ownedByloadbalancer = GetOwnedPartitionIds(totalOwnedPartitions, loadbalancer.OwnerIdentifier);
+
+            Assert.That(totalOwnedPartitions.Count(), Is.EqualTo(NumberOfPartitions), "All partitions should be owned.");
+            Assert.That(ownedByloadbalancer, Is.Empty, "All partitions should be owned by other load balancers.");
+
+            // Verify that no attempts to steal were logged.
+
+            mockLog.Verify(log => log.ShouldStealPartition(It.IsAny<string>()), Times.Never);
+        }
+
+        /// <summary>
         ///   Verifies that partitions ownership load balancing will not attempt to steal when an uneven distribution
         ///   is already balanced.
         /// </summary>
@@ -850,7 +907,7 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLog.Verify(m => m.ClaimOwnershipStart(It.Is<string>(p => partitionIds.Contains(p))));
             mockLog.Verify(m => m.MinimumPartitionsPerEventProcessor(MinimumpartitionCount));
             mockLog.Verify(m => m.CurrentOwnershipCount(MinimumpartitionCount, loadbalancer.OwnerIdentifier));
-            mockLog.Verify(m => m.StealPartition(loadbalancer.OwnerIdentifier));
+            mockLog.Verify(m => m.StealPartition(It.IsAny<string>(), It.IsAny<string>(), loadbalancer.OwnerIdentifier));
             mockLog.Verify(m => m.ShouldStealPartition(loadbalancer.OwnerIdentifier));
             mockLog.Verify(m => m.UnclaimedPartitions(It.Is<HashSet<string>>(set => set.Count == 0 || set.All(item => partitionIds.Contains(item)))));
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Other Changes
 
+- Several improvements to logging have been made to capture additional context and fix typos.  Most notable among them is the inclusion of starting and ending sequence numbers when events are read from Event Hubs and dispatched for processing by event processor types.
+
+- The reference for the AMQP transport library, `Microsoft.Azure.Amqp`, has been bumped to 2.6.3.  This fixes an issue with timeout duration calculations during link creation and includes several efficiency improvements.
+
 ## 5.9.2 (2023-06-06)
 
 ### Other Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -246,6 +246,7 @@ namespace Azure.Messaging.EventHubs.Amqp
             var link = default(ReceivingAmqpLink);
             var retryDelay = default(TimeSpan?);
             var receivedEvents = default(List<EventData>);
+            var firstReceivedEvent = default(EventData);
             var lastReceivedEvent = default(EventData);
 
             var stopWatch = ValueStopwatch.StartNew();
@@ -293,6 +294,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                         if (receivedEventCount > 0)
                         {
+                            firstReceivedEvent = receivedEvents[0];
                             lastReceivedEvent = receivedEvents[receivedEventCount - 1];
 
                             if (lastReceivedEvent.Offset > long.MinValue)
@@ -387,7 +389,16 @@ namespace Azure.Messaging.EventHubs.Amqp
             }
             finally
             {
-                EventHubsEventSource.Log.EventReceiveComplete(EventHubName, ConsumerGroup, PartitionId, operationId, failedAttemptCount, receivedEventCount, stopWatch.GetElapsedTime().TotalSeconds);
+                EventHubsEventSource.Log.EventReceiveComplete(
+                    EventHubName,
+                    ConsumerGroup,
+                    PartitionId,
+                    operationId,
+                    failedAttemptCount,
+                    receivedEventCount,
+                    firstReceivedEvent?.SequenceNumber.ToString(),
+                    LastReceivedEvent?.SequenceNumber.ToString(),
+                    stopWatch.GetElapsedTime().TotalSeconds);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -171,20 +171,24 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="operationId">An artificial identifier for the publishing operation.</param>
         /// <param name="retryCount">The number of retries that were used for service communication.</param>
         /// <param name="eventCount">The number of events that were received in the batch.</param>
+        /// <param name="startingSequenceNumber">The sequence number of the first event in the batch.</param>
+        /// <param name="endingSequenceNumber">The sequence number of the last event in the batch.</param>
         /// <param name="durationSeconds">The total duration that the receive operation took to complete, in seconds.</param>
         ///
-        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Duration: '{6:0.00}' seconds")]
+        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Starting sequence number: '{6}', Ending sequence number: '{7}'; Duration: '{8:0.00}' seconds")]
         public virtual void EventReceiveComplete(string eventHubName,
                                                  string consumerGroup,
                                                  string partitionId,
                                                  string operationId,
                                                  int retryCount,
                                                  int eventCount,
+                                                 string startingSequenceNumber,
+                                                 string endingSequenceNumber,
                                                  double durationSeconds)
         {
             if (IsEnabled())
             {
-                WriteEvent(7, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, retryCount, eventCount, durationSeconds);
+                EventReceiveCompleteCore(7, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, retryCount, eventCount, startingSequenceNumber ?? string.Empty, endingSequenceNumber ?? string.Empty, durationSeconds);
             }
         }
 
@@ -2075,7 +2079,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="durationSeconds">The total duration that load balancing took to complete, in seconds.</param>
         /// <param name="delaySeconds">The delay, in seconds, that will be observed before the next load balancing cycle starts.</param>
         ///
-        [Event(102, Level = EventLevel.Verbose, Message = "A load balancing cycle has started for the processor instance with identifier '{0}' for Event Hub: {1}.  Total partition count: '{2}'.  Owned partition count: '{3}'.  Duration: '{4:0.00}' seconds.  Next cycle in '{5:0.00}' seconds.")]
+        [Event(102, Level = EventLevel.Verbose, Message = "A load balancing cycle has completed for the processor instance with identifier '{0}' for Event Hub: {1}.  Total partition count: '{2}'.  Owned partition count: '{3}'.  Duration: '{4:0.00}' seconds.  Next cycle in '{5:0.00}' seconds.")]
         public virtual void EventProcessorLoadBalancingCycleComplete(string identifier,
                                                                      string eventHubName,
                                                                      int totalPartitionCount,
@@ -2543,18 +2547,22 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
         /// <param name="operationId">An artificial identifier for the handler invocation.</param>
         /// <param name="eventCount">The number of events in the batch that was passed to the processing handler.</param>
+        /// <param name="startingSequenceNumber">The starting sequence number of the batch that was passed to the processing handler.</param>
+        /// <param name="endingSequenceNumber">The ending sequence number of the batch that was passed to the processing handler.</param>
         ///
-        [Event(123, Level = EventLevel.Verbose, Message = "Started dispatching events to the processing handler for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2}, Consumer Group: {3}, and Operation Id: '{4}'.  Event Count: '{5}'")]
+        [Event(123, Level = EventLevel.Verbose, Message = "Started dispatching events to the processing handler for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2}, Consumer Group: {3}, and Operation Id: '{4}'.  Event Count: '{5}', Starting Sequence Number: '{6}', Ending Sequence Number: '{7}'")]
         public virtual void EventProcessorProcessingHandlerStart(string partitionId,
                                                                  string identifier,
                                                                  string eventHubName,
                                                                  string consumerGroup,
                                                                  string operationId,
-                                                                 int eventCount)
+                                                                 int eventCount,
+                                                                 string startingSequenceNumber,
+                                                                 string endingSequenceNumber)
         {
             if (IsEnabled())
             {
-                EventProcessorProcessingHandlerStartCore(123, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty, eventCount);
+                EventProcessorProcessingHandlerStartCore(123, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty, eventCount, startingSequenceNumber ?? string.Empty, endingSequenceNumber ?? string.Empty);
             }
         }
 
@@ -2669,6 +2677,74 @@ namespace Azure.Messaging.EventHubs.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(128, identifier ?? string.Empty, eventHubName ?? string.Empty, ownershipIntervalSeconds, loadBalancingIntervalSeconds, Resources.TroubleshootingGuideLink);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the receiving of events has completed.
+        /// </summary>
+        ///
+        /// <param name="eventId">The identifier of the event.</param>
+        /// <param name="eventHubName">The name of the Event Hub being received from.</param>
+        /// <param name="partitionId">The identifier of the partition events are being received from.</param>
+        /// <param name="consumerGroup">The consumer group associated with the receive operation.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        /// <param name="retryCount">The number of retries that were used for service communication.</param>
+        /// <param name="eventCount">The number of events that were received in the batch.</param>
+        /// <param name="startingSequenceNumber">The sequence number of the first event in the batch.</param>
+        /// <param name="endingSequenceNumber">The sequence number of the last event in the batch.</param>
+        /// <param name="durationSeconds">The total duration that the receive operation took to complete, in seconds.</param>
+        ///
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void EventReceiveCompleteCore(int eventId,
+                                                     string eventHubName,
+                                                     string consumerGroup,
+                                                     string partitionId,
+                                                     string operationId,
+                                                     int retryCount,
+                                                     int eventCount,
+                                                     string startingSequenceNumber,
+                                                     string endingSequenceNumber,
+                                                     double durationSeconds)
+        {
+            fixed (char* eventHubNamePtr = eventHubName)
+            fixed (char* consumerGroupPtr = consumerGroup)
+            fixed (char* partitionIdPtr = partitionId)
+            fixed (char* operationIdPtr = operationId)
+            fixed (char* startingSequenceNumberPtr = startingSequenceNumber)
+            fixed (char* endingSequenceNumberPtr = endingSequenceNumber)
+            {
+                var eventPayload = stackalloc EventData[9];
+
+                eventPayload[0].Size = (eventHubName.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)eventHubNamePtr;
+
+                eventPayload[1].Size = (consumerGroup.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)consumerGroupPtr;
+
+                eventPayload[2].Size = (partitionId.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)partitionIdPtr;
+
+                eventPayload[3].Size = (operationId.Length + 1) * sizeof(char);
+                eventPayload[3].DataPointer = (IntPtr)operationIdPtr;
+
+                eventPayload[4].Size = Unsafe.SizeOf<int>();
+                eventPayload[4].DataPointer = (IntPtr)Unsafe.AsPointer(ref retryCount);
+
+                eventPayload[5].Size = Unsafe.SizeOf<int>();
+                eventPayload[5].DataPointer = (IntPtr)Unsafe.AsPointer(ref eventCount);
+
+                eventPayload[6].Size = (startingSequenceNumber.Length + 1) * sizeof(char);
+                eventPayload[6].DataPointer = (IntPtr)startingSequenceNumberPtr;
+
+                eventPayload[7].Size = (endingSequenceNumber.Length + 1) * sizeof(char);
+                eventPayload[7].DataPointer = (IntPtr)endingSequenceNumberPtr;
+
+                eventPayload[8].Size = Unsafe.SizeOf<double>();
+                eventPayload[8].DataPointer = (IntPtr)Unsafe.AsPointer(ref durationSeconds);
+
+                WriteEventCore(eventId, 9, eventPayload);
             }
         }
 
@@ -3015,6 +3091,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
         /// <param name="operationId">An artificial identifier for the handler invocation.</param>
         /// <param name="eventCount">The number of events in the batch that was passed to the processing handler.</param>
+        /// <param name="startingSequenceNumber">The starting sequence number of the batch that was passed to the processing handler.</param>
+        /// <param name="endingSequenceNumber">The ending sequence number of the batch that was passed to the processing handler.</param>
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -3024,15 +3102,19 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                                                                      string eventHubName,
                                                                      string consumerGroup,
                                                                      string operationId,
-                                                                     int eventCount)
+                                                                     int eventCount,
+                                                                     string startingSequenceNumber,
+                                                                     string endingSequenceNumber)
         {
             fixed (char* partitionIdPtr = partitionId)
             fixed (char* identifierPtr = identifier)
             fixed (char* eventHubNamePtr = eventHubName)
             fixed (char* consumerGroupPtr = consumerGroup)
             fixed (char* operationIdPtr = operationId)
+            fixed (char* startingSequenceNumberIdPtr = startingSequenceNumber)
+            fixed (char* endingSequenceNumberIdPtr = endingSequenceNumber)
             {
-                var eventPayload = stackalloc EventData[6];
+                var eventPayload = stackalloc EventData[8];
 
                 eventPayload[0].Size = (partitionId.Length + 1) * sizeof(char);
                 eventPayload[0].DataPointer = (IntPtr)partitionIdPtr;
@@ -3052,7 +3134,13 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                 eventPayload[5].Size = Unsafe.SizeOf<int>();
                 eventPayload[5].DataPointer = (IntPtr)Unsafe.AsPointer(ref eventCount);
 
-                WriteEventCore(eventId, 6, eventPayload);
+                eventPayload[6].Size = (startingSequenceNumber.Length + 1) * sizeof(char);
+                eventPayload[6].DataPointer = (IntPtr)startingSequenceNumberIdPtr;
+
+                eventPayload[7].Size = (endingSequenceNumber.Length + 1) * sizeof(char);
+                eventPayload[7].DataPointer = (IntPtr)endingSequenceNumberIdPtr;
+
+                WriteEventCore(eventId, 8, eventPayload);
             }
         }
 
@@ -3375,6 +3463,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                                                                   TValue3 arg7)
             where TValue1 : struct
             where TValue2 : struct
+            where TValue3 : struct
         {
             fixed (char* arg1Ptr = arg1)
             fixed (char* arg2Ptr = arg2)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -130,7 +130,12 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            var eventBatch = new[] { new EventData(new BinaryData(Array.Empty<byte>())), new EventData(new BinaryData(Array.Empty<byte>())) };
+            var eventBatch = new[]
+            {
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), sequenceNumber: 12345),
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), sequenceNumber: 67890),
+            };
+
             var partition = new EventProcessorPartition { PartitionId = "123" };
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(67, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
@@ -145,7 +150,9 @@ namespace Azure.Messaging.EventHubs.Tests
                     mockProcessor.Object.EventHubName,
                     mockProcessor.Object.ConsumerGroup,
                     It.IsAny<string>(),
-                    eventBatch.Length),
+                    eventBatch.Length,
+                    eventBatch.First().SequenceNumber.ToString(),
+                    eventBatch.Last().SequenceNumber.ToString()),
                 Times.Once);
 
             mockLogger

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- The reference for the AMQP transport library, `Microsoft.Azure.Amqp`, has been bumped to 2.6.3. This fixes an issue with timeout duration calculations during link creation and includes several efficiency improvements.
+
 ## 7.16.1 (2023-08-15)
 
 ### Bugs Fixed


### PR DESCRIPTION
# Summary

The focus of these changes is to improve logs for the event processor types and AMQP consumer.  The most notable change is the addition of the first and last sequence number of the batch when reading from Event Hubs and dispatching events to be processed.  The version of the AMQP library has been bumped to the latest stable (2.6.3), which includes a fix for timer duration calculations during link creation and a small handful of efficiency improvements.
