### PR TITLE
Renamed `BlobsOptions.MaxDequeueCount` to `PoisonBlobThreshold`

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 5.2.0 (2023-08-10)
 
 ### Features Added
-- Added support for `BlobsOptions.MaxDequeueCount`
+- Added support for `BlobsOptions.PoisonBlobThreshold`
 
 ## 5.1.3 (2023-06-26)
 - Loosen parameter binding data parsing and validation to allow binding BlobContainerClient without blob name. (#37124)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Host
     {
         public BlobsOptions() { }
         public int MaxDegreeOfParallelism { get { throw null; } set { } }
-        public int MaxDequeueCount { get { throw null; } set { } }
+        public int PoisonBlobThreshold { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         string Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter.Format() { throw null; }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Azure.WebJobs.Host
     /// </summary>
     public class BlobsOptions : IOptionsFormatter
     {
-        private const int DefaultMaxDequeueCount = 5;
+        private const int DefaultPoisonBlobThreshold = 5;
 
         private int _maxDegreeOfParallelism;
-        private int _poisonBlobThreshold = DefaultMaxDequeueCount;
+        private int _poisonBlobThreshold = DefaultPoisonBlobThreshold;
 
         /// <summary>
         /// Constructs a new instance.
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Host
             {
                 if (value < 1)
                 {
-                    throw new ArgumentException("MaxDequeueCount must not be less than 1.", nameof(value));
+                    throw new ArgumentException("PoisonBlobThreshold must not be less than 1.", nameof(value));
                 }
 
                 _poisonBlobThreshold = value;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Host
         private const int DefaultMaxDequeueCount = 5;
 
         private int _maxDegreeOfParallelism;
-        private int _maxDequeueCount = DefaultMaxDequeueCount;
+        private int _poisonBlobThreshold = DefaultMaxDequeueCount;
 
         /// <summary>
         /// Constructs a new instance.
@@ -56,9 +56,9 @@ namespace Microsoft.Azure.WebJobs.Host
         /// Poison Blobs
         /// </see>.
         /// </summary>
-        public int MaxDequeueCount
+        public int PoisonBlobThreshold
         {
-            get { return _maxDequeueCount; }
+            get { return _poisonBlobThreshold; }
 
             set
             {
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Host
                     throw new ArgumentException("MaxDequeueCount must not be less than 1.", nameof(value));
                 }
 
-                _maxDequeueCount = value;
+                _poisonBlobThreshold = value;
             }
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Host
             JObject options = new JObject
             {
                 { nameof(MaxDegreeOfParallelism), MaxDegreeOfParallelism },
-                { nameof(MaxDequeueCount), MaxDequeueCount }
+                { nameof(PoisonBlobThreshold), PoisonBlobThreshold }
             };
 
             return options.ToString(Formatting.Indented);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/SharedBlobQueueListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/SharedBlobQueueListenerFactory.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             {
                 BatchSize = batchSize,
                 NewBatchThreshold = newBatchThreshold,
-                MaxDequeueCount = blobsOptions.MaxDequeueCount
+                MaxDequeueCount = blobsOptions.PoisonBlobThreshold
             };
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/SharedBlobQueueListenerFactoryTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/SharedBlobQueueListenerFactoryTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             var blobOptions = new BlobsOptions()
             {
                 MaxDegreeOfParallelism = maxDegreeOfParallelism,
-                MaxDequeueCount = maxDequeueCount,
+                PoisonBlobThreshold = maxDequeueCount,
             };
 
             // Act

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/SharedBlobQueueListenerFactoryTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/SharedBlobQueueListenerFactoryTests.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         [TestCase(3, 2, 1, 1)]
         [TestCase(2, 2, 0, 1)]
         [TestCase(1, 1, 0, 1)]
-        public void ConvertsBlobOptionsToQueueOptionsCorrectly(int maxDegreeOfParallelism, int expectedBatchSize, int expectedNewBatchThreshold, int maxDequeueCount)
+        public void ConvertsBlobOptionsToQueueOptionsCorrectly(int maxDegreeOfParallelism, int expectedBatchSize, int expectedNewBatchThreshold, int poisonBlobThreshold)
         {
             // Arrange
             var blobOptions = new BlobsOptions()
             {
                 MaxDegreeOfParallelism = maxDegreeOfParallelism,
-                PoisonBlobThreshold = maxDequeueCount,
+                PoisonBlobThreshold = poisonBlobThreshold,
             };
 
             // Act
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             // Assert
             Assert.AreEqual(expectedBatchSize, queueOptions.BatchSize);
             Assert.AreEqual(expectedNewBatchThreshold, queueOptions.NewBatchThreshold);
-            Assert.AreEqual(maxDequeueCount, queueOptions.MaxDequeueCount);
+            Assert.AreEqual(poisonBlobThreshold, queueOptions.MaxDequeueCount);
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/StorageBlobsWebJobsBuilderExtensionsTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/StorageBlobsWebJobsBuilderExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             var values = new Dictionary<string, string>
             {
                 { $"{extensionPath}:MaxDegreeOfParallelism", "2" },
-                { $"{extensionPath}:MaxDequeueCount", "3" },
+                { $"{extensionPath}:PoisonBlobThreshold", "3" },
             };
 
             BlobsOptions options = TestHelpers.GetConfiguredOptions<BlobsOptions>(b =>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/StorageBlobsWebJobsBuilderExtensionsTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/StorageBlobsWebJobsBuilderExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
             }, values);
 
             Assert.AreEqual(2, options.MaxDegreeOfParallelism);
-            Assert.AreEqual(3, options.MaxDequeueCount);
+            Assert.AreEqual(3, options.PoisonBlobThreshold);
         }
     }
 }


### PR DESCRIPTION
Renamed `BlobsOptions.MaxDequeueCount` to `BlobsOptions.PoisonBlobThreshold`.

Since we haven't released yet, the changelog was just updated and not an additional log was needed.