### PR TITLE
Made AddAzureStorageBlobsScaleForTrigger from public to internal temporarily

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
@@ -54,6 +54,5 @@ namespace Microsoft.Extensions.Hosting
     public static partial class StorageBlobsWebJobsBuilderExtensions
     {
         public static Microsoft.Azure.WebJobs.IWebJobsBuilder AddAzureStorageBlobs(this Microsoft.Azure.WebJobs.IWebJobsBuilder builder, System.Action<Microsoft.Azure.WebJobs.Host.BlobsOptions> configureBlobs = null) { throw null; }
-        public static Microsoft.Azure.WebJobs.IWebJobsBuilder AddAzureStorageBlobsScaleForTrigger(this Microsoft.Azure.WebJobs.IWebJobsBuilder builder, Microsoft.Azure.WebJobs.Host.Scale.TriggerMetadata triggerMetadata) { throw null; }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -6,7 +6,8 @@
     <Version>5.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.1.3</ApiCompatVersion>
-    <Description>This extension adds bindings for Storage</Description>
+		<RunApiCompat>false</RunApiCompat>
+		<Description>This extension adds bindings for Storage</Description>
     <!-- https://github.com/Azure/azure-sdk-for-net/issues/19222 -->
     <NoWarn>$(NoWarn);IDT002;IDT003</NoWarn>
   </PropertyGroup>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageBlobsWebJobsBuilderExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageBlobsWebJobsBuilderExtensions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="builder"></param>
         /// <param name="triggerMetadata">Trigger metadata.</param>
         /// <returns></returns>
-        public static IWebJobsBuilder AddAzureStorageBlobsScaleForTrigger(this IWebJobsBuilder builder, TriggerMetadata triggerMetadata)
+        internal static IWebJobsBuilder AddAzureStorageBlobsScaleForTrigger(this IWebJobsBuilder builder, TriggerMetadata triggerMetadata)
         {
             builder.Services.AddSingleton<IScaleMonitorProvider>(serviceProvider =>
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/BlobScaleHostEndToEndTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/BlobScaleHostEndToEndTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests
 
         private const string Function1Name = "Function1";
 
-        private string ContainerNameTemaplte1 = "container1%rnd%";
+        //private string ContainerNameTemaplte1 = "container1%rnd%";
 
         private const string BlobConnection1 = "BlobConnection1";
 
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests
             _blobServiceClient = _fixture.BlobServiceClient;
         }
 
+        /* TODO: https://github.com/Azure/azure-sdk-for-net/issues/38326 renable test after AddAzureStorageBlobsScaleForTrigger is added back.
         [Test]
         [TestCase(true, Ignore = "true", IgnoreReason = "The test can take long time.")]
         [TestCase(false)]
@@ -66,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests
             }";
 
             string triggers = $@"{{
-""triggers"": [
+    ""triggers"": [
     {{
         ""name"": ""myQueueItem"",
         ""type"": ""queueTrigger"",
@@ -75,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests
         ""connection"": ""{BlobConnection1}"",
         ""functionName"": ""{Function1Name}""
     }}
- ]}}";
+    ]}}";
 
             IHost host = new HostBuilder().ConfigureServices(services => services.AddAzureClientsCore()).Build();
             AzureComponentFactory defaultAzureComponentFactory = host.Services.GetService<AzureComponentFactory>();
@@ -176,6 +177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests
                 return scaleStatus.Vote == ScaleVote.None && scaleStatus.FunctionScaleStatuses[Function1Name].Vote == ScaleVote.None;
             }, timeout);
         }
+        */
 
         private void SetRecentWrite(IHost scaleHost, BlobContainerClient blobContainerClient, bool setValue)
         {


### PR DESCRIPTION
Since the feature isn't ready for GA yet made it internal for now for the coming release and will undo this PR afterwards.

Disabled a test cause it did not have access to the internal method.

https://github.com/Azure/azure-sdk-for-net/issues/38326