### PR TITLE
[Storage][DataMovement] Rename checkpoint constants to prepare for job plan files

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -421,7 +421,7 @@ namespace Azure.Storage.DataMovement.Blobs
             // Get AccessTier
             if (!isSource)
             {
-                int startIndex = DataMovementConstants.PlanFile.DstBlobBlockBlobTierIndex;
+                int startIndex = DataMovementConstants.JobPartPlanFile.DstBlobBlockBlobTierIndex;
                 JobPartPlanBlockBlobTier accessTier = (JobPartPlanBlockBlobTier)await checkpointer.GetByteValue(
                     transferId,
                     startIndex,
@@ -446,7 +446,7 @@ namespace Azure.Storage.DataMovement.Blobs
             if (!isSource)
             {
                 // Get AccessTier
-                int startIndex = DataMovementConstants.PlanFile.DstBlobPageBlobTierIndex;
+                int startIndex = DataMovementConstants.JobPartPlanFile.DstBlobPageBlobTierIndex;
                 JobPartPlanPageBlobTier accessTier = (JobPartPlanPageBlobTier)await checkpointer.GetByteValue(
                     transferId,
                     startIndex,
@@ -469,24 +469,24 @@ namespace Azure.Storage.DataMovement.Blobs
             if (!isSource)
             {
                 // Get Metadata
-                int metadataIndex = DataMovementConstants.PlanFile.DstBlobMetadataLengthIndex;
-                int metadataReadLength = DataMovementConstants.PlanFile.DstBlobTagsLengthIndex - metadataIndex;
+                int metadataIndex = DataMovementConstants.JobPartPlanFile.DstBlobMetadataLengthIndex;
+                int metadataReadLength = DataMovementConstants.JobPartPlanFile.DstBlobTagsLengthIndex - metadataIndex;
                 string metadata = await checkpointer.GetHeaderUShortValue(
                     transferId,
                     metadataIndex,
                     metadataReadLength,
-                    DataMovementConstants.PlanFile.MetadataStrNumBytes,
+                    DataMovementConstants.JobPartPlanFile.MetadataStrNumBytes,
                     cancellationToken).ConfigureAwait(false);
                 options.Metadata = metadata.ToDictionary(nameof(metadata));
 
                 // Get blob tags
-                int tagsIndex = DataMovementConstants.PlanFile.DstBlobTagsLengthIndex;
-                int tagsReadLength = DataMovementConstants.PlanFile.DstBlobIsSourceEncrypted - tagsIndex;
+                int tagsIndex = DataMovementConstants.JobPartPlanFile.DstBlobTagsLengthIndex;
+                int tagsReadLength = DataMovementConstants.JobPartPlanFile.DstBlobIsSourceEncrypted - tagsIndex;
                 string tags = await checkpointer.GetHeaderLongValue(
                     transferId,
                     tagsIndex,
                     tagsReadLength,
-                    DataMovementConstants.PlanFile.BlobTagsStrNumBytes,
+                    DataMovementConstants.JobPartPlanFile.BlobTagsStrNumBytes,
                     cancellationToken).ConfigureAwait(false);
                 options.Tags = tags.ToDictionary(nameof(tags));
             }

--- a/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
@@ -15,7 +15,7 @@ namespace Azure.Storage.DataMovement
         {
             DataTransferStatus jobStatus = (DataTransferStatus)await checkpointer.GetByteValue(
                 transferId,
-                DataMovementConstants.PlanFile.AtomicJobStatusIndex,
+                DataMovementConstants.JobPartPlanFile.AtomicJobStatusIndex,
                 cancellationToken).ConfigureAwait(false);
 
             // Transfers marked as fully completed are not resumable

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -53,10 +53,25 @@ namespace Azure.Storage.DataMovement
             internal const string Closing = "Closing log ";
         }
 
+        internal const int OneByte = 1;
+        internal const int LongSizeInBytes = 8;
+        internal const int UShortSizeInBytes = 2;
+
         /// <summary>
-        /// Constants used for plan job transfer files
+        /// Constants used for job plan files.
         /// </summary>
-        internal static class PlanFile
+        internal static class JobPlanFile
+        {
+            internal const string SchemaVersion_b1 = "b1";
+            internal const string SchemaVersion = SchemaVersion_b1;
+
+            internal const string FileExtension = ".ndm";
+        }
+
+        /// <summary>
+        /// Constants used for job part plan files.
+        /// </summary>
+        internal static class JobPartPlanFile
         {
             internal const string SchemaVersion_b1 = "b1";
             internal const string SchemaVersion_b2 = "b2";
@@ -68,11 +83,6 @@ namespace Azure.Storage.DataMovement
             internal const int JobPartLength = 5;
             internal const int IdSize = 36; // Size of a guid with hyphens
             internal const int CustomHeaderMaxBytes = 256;
-            internal const int Padding = 8;
-
-            internal const int OneByte = 1;
-            internal const int LongSizeInBytes = 8;
-            internal const int UShortSizeInBytes = 2;
 
             // UTF-8 encoding, so 2 bytes per char
             internal const int VersionStrLength = 2;

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
@@ -225,7 +225,7 @@ namespace Azure.Storage.DataMovement
             string destinationPath = destinationUriBuilder.Uri.AbsoluteUri;
 
             return new JobPartPlanHeader(
-                version: DataMovementConstants.PlanFile.SchemaVersion,
+                version: DataMovementConstants.JobPartPlanFile.SchemaVersion,
                 startTime: DateTimeOffset.UtcNow, // TODO: update to job start time
                 transferId: jobPart._dataTransfer.Id,
                 partNumber: (uint)jobPart.PartNumber,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/Errors.DataMovement.cs
@@ -65,7 +65,7 @@ namespace Azure.Storage
             => new ArgumentException($"Invalid Job Part Plan File: The following Job Part Plan file contains an invalid Job Part Number, could not convert to a integer: {fileName}");
 
         public static ArgumentException InvalidSchemaVersionFileName(string schemaVersion)
-            => new ArgumentException($"Invalid Job Part Plan File: Job Part Schema version: {schemaVersion} does not match the Schema Version supported by the package: {DataMovementConstants.PlanFile.SchemaVersion}. Please consider altering the package version that supports the respective version.");
+            => new ArgumentException($"Invalid Job Part Plan File: Job Part Schema version: {schemaVersion} does not match the Schema Version supported by the package: {DataMovementConstants.JobPartPlanFile.SchemaVersion}. Please consider altering the package version that supports the respective version.");
 
         public static ArgumentException InvalidPlanFileElement(string elementName, int expectedSize, int actualSize)
             => throw new ArgumentException($"Invalid Job Part Plan File: Attempt to set element, \"{elementName}\" failed.\n Expected size: {expectedSize}\n Actual Size: {actualSize}");

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlan/JobPartPlanDestinationBlob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlan/JobPartPlanDestinationBlob.cs
@@ -176,7 +176,7 @@ namespace Azure.Storage.DataMovement.JobPlan
         {
             BlobType = blobType;
             NoGuessMimeType = noGuessMimeType;
-            if (contentType.Length <= DataMovementConstants.PlanFile.HeaderValueMaxLength)
+            if (contentType.Length <= DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength)
             {
                 ContentType = contentType;
                 ContentTypeLength = (ushort) contentType.Length;
@@ -185,10 +185,10 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(ContentType),
-                    expectedSize: DataMovementConstants.PlanFile.HeaderValueMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength,
                     actualSize: contentType.Length);
             }
-            if (contentEncoding.Length <= DataMovementConstants.PlanFile.HeaderValueMaxLength)
+            if (contentEncoding.Length <= DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength)
             {
                 ContentEncoding = contentEncoding;
                 ContentEncodingLength = (ushort) contentEncoding.Length;
@@ -197,10 +197,10 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(ContentEncoding),
-                    expectedSize: DataMovementConstants.PlanFile.HeaderValueMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength,
                     actualSize: contentEncoding.Length);
             }
-            if (contentLanguage.Length <= DataMovementConstants.PlanFile.HeaderValueMaxLength)
+            if (contentLanguage.Length <= DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength)
             {
                 ContentLanguage = contentLanguage;
                 ContentLanguageLength = (ushort) contentLanguage.Length;
@@ -209,10 +209,10 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(ContentLanguage),
-                    expectedSize: DataMovementConstants.PlanFile.HeaderValueMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength,
                     actualSize: contentLanguage.Length);
             }
-            if (contentDisposition.Length <= DataMovementConstants.PlanFile.HeaderValueMaxLength)
+            if (contentDisposition.Length <= DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength)
             {
                 ContentDisposition = contentDisposition;
                 ContentDispositionLength = (ushort) contentDisposition.Length;
@@ -221,10 +221,10 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(ContentDisposition),
-                    expectedSize: DataMovementConstants.PlanFile.HeaderValueMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength,
                     actualSize: contentDisposition.Length);
             }
-            if (cacheControl.Length <= DataMovementConstants.PlanFile.HeaderValueMaxLength)
+            if (cacheControl.Length <= DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength)
             {
                 CacheControl = cacheControl;
                 CacheControlLength = (ushort) cacheControl.Length;
@@ -233,14 +233,14 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(CacheControl),
-                    expectedSize: DataMovementConstants.PlanFile.HeaderValueMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength,
                     actualSize: cacheControl.Length);
             }
             BlockBlobTier = blockBlobTier;
             PageBlobTier = pageBlobTier;
             PutMd5 = putMd5;
             string metadataConvert = metadata.DictionaryToString();
-            if (metadataConvert.Length <= DataMovementConstants.PlanFile.MetadataStrMaxLength)
+            if (metadataConvert.Length <= DataMovementConstants.JobPartPlanFile.MetadataStrMaxLength)
             {
                 Metadata = metadataConvert;
                 MetadataLength = (ushort) metadataConvert.Length;
@@ -249,11 +249,11 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(Metadata),
-                    expectedSize: DataMovementConstants.PlanFile.MetadataStrMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.MetadataStrMaxLength,
                     actualSize: metadataConvert.Length);
             }
             string blobTagsConvert = blobTags.DictionaryToString();
-            if (blobTagsConvert.Length <= DataMovementConstants.PlanFile.BlobTagsStrMaxLength)
+            if (blobTagsConvert.Length <= DataMovementConstants.JobPartPlanFile.BlobTagsStrMaxLength)
             {
                 BlobTags = blobTagsConvert;
                 BlobTagsLength = blobTagsConvert.Length;
@@ -262,11 +262,11 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(blobTags),
-                    expectedSize: DataMovementConstants.PlanFile.BlobTagsStrMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.BlobTagsStrMaxLength,
                     actualSize: blobTagsConvert.Length);
             }
             IsSourceEncrypted = isSourceEncrypted;
-            if (cpkScopeInfo.Length <= DataMovementConstants.PlanFile.HeaderValueMaxLength)
+            if (cpkScopeInfo.Length <= DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength)
             {
                 CpkScopeInfo = cpkScopeInfo;
                 CpkScopeInfoLength = (ushort) cpkScopeInfo.Length;
@@ -275,7 +275,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(CpkScopeInfo),
-                    expectedSize: DataMovementConstants.PlanFile.HeaderValueMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.HeaderValueMaxLength,
                     actualSize: cpkScopeInfo.Length);
             }
             BlockSize = blockSize;

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlan/JobPartPlanFileName.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlan/JobPartPlanFileName.cs
@@ -66,7 +66,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             string checkpointerPath,
             string id,
             int jobPartNumber,
-            string schemaVersion = DataMovementConstants.PlanFile.SchemaVersion)
+            string schemaVersion = DataMovementConstants.JobPartPlanFile.SchemaVersion)
         {
             Argument.AssertNotNullOrEmpty(checkpointerPath, nameof(checkpointerPath));
             Argument.AssertNotNullOrEmpty(id, nameof(id));
@@ -76,7 +76,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             JobPartNumber = jobPartNumber;
             SchemaVersion = schemaVersion;
 
-            string fileName = $"{Id}--{JobPartNumber.ToString("D5", NumberFormatInfo.CurrentInfo)}{DataMovementConstants.PlanFile.FileExtension}{SchemaVersion}";
+            string fileName = $"{Id}--{JobPartNumber.ToString("D5", NumberFormatInfo.CurrentInfo)}{DataMovementConstants.JobPartPlanFile.FileExtension}{SchemaVersion}";
             FullPath = Path.Combine(PrefixPath, fileName);
         }
 
@@ -97,23 +97,23 @@ namespace Azure.Storage.DataMovement.JobPlan
             // {transferid}--{jobpartNumber}.steV{schemaVersion}
 
             // Check for valid Transfer Id
-            int endTransferIdIndex = fileName.IndexOf(DataMovementConstants.PlanFile.JobPlanFileNameDelimiter, StringComparison.InvariantCultureIgnoreCase);
-            if (endTransferIdIndex != DataMovementConstants.PlanFile.IdSize)
+            int endTransferIdIndex = fileName.IndexOf(DataMovementConstants.JobPartPlanFile.JobPlanFileNameDelimiter, StringComparison.InvariantCultureIgnoreCase);
+            if (endTransferIdIndex != DataMovementConstants.JobPartPlanFile.IdSize)
             {
                 throw Errors.InvalidTransferIdFileName(fullPath);
             }
             Id = fileName.Substring(0, endTransferIdIndex);
 
             // Check for valid transfer part number
-            int partStartIndex = endTransferIdIndex + DataMovementConstants.PlanFile.JobPlanFileNameDelimiter.Length;
+            int partStartIndex = endTransferIdIndex + DataMovementConstants.JobPartPlanFile.JobPlanFileNameDelimiter.Length;
             int endPartIndex = fileName.Length;
 
-            if (endPartIndex - partStartIndex != DataMovementConstants.PlanFile.JobPartLength)
+            if (endPartIndex - partStartIndex != DataMovementConstants.JobPartPlanFile.JobPartLength)
             {
                 throw Errors.InvalidJobPartFileName(fullPath);
             }
             if (!int.TryParse(
-                    fileName.Substring(partStartIndex, DataMovementConstants.PlanFile.JobPartLength),
+                    fileName.Substring(partStartIndex, DataMovementConstants.JobPartPlanFile.JobPartLength),
                     NumberStyles.Number,
                     CultureInfo.InvariantCulture,
                     out int jobPartNumber))
@@ -122,12 +122,12 @@ namespace Azure.Storage.DataMovement.JobPlan
             }
             JobPartNumber = jobPartNumber;
 
-            string fullExtension = string.Concat(DataMovementConstants.PlanFile.FileExtension, DataMovementConstants.PlanFile.SchemaVersion);
+            string fullExtension = string.Concat(DataMovementConstants.JobPartPlanFile.FileExtension, DataMovementConstants.JobPartPlanFile.SchemaVersion);
             if (!fullExtension.Equals(extension))
             {
                 throw Errors.InvalidSchemaVersionFileName(extension);
             }
-            SchemaVersion = DataMovementConstants.PlanFile.SchemaVersion;
+            SchemaVersion = DataMovementConstants.JobPartPlanFile.SchemaVersion;
 
             FullPath = fullPath;
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlan/JobPartPlanHeader.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlan/JobPartPlanHeader.cs
@@ -257,7 +257,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             Argument.AssertNotNull(dstBlobData, nameof(dstBlobData));
             Argument.AssertNotNull(dstLocalData, nameof(dstLocalData));
             // Version
-            if (version.Length == DataMovementConstants.PlanFile.VersionStrLength)
+            if (version.Length == DataMovementConstants.JobPartPlanFile.VersionStrLength)
             {
                 Version = version;
             }
@@ -265,12 +265,12 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(Version),
-                    expectedSize: DataMovementConstants.PlanFile.VersionStrLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.VersionStrLength,
                     actualSize: version.Length);
             }
             StartTime = startTime;
             // TransferId
-            if (transferId.Length == DataMovementConstants.PlanFile.TransferIdStrLength)
+            if (transferId.Length == DataMovementConstants.JobPartPlanFile.TransferIdStrLength)
             {
                 TransferId = transferId;
             }
@@ -278,12 +278,12 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(TransferId),
-                    expectedSize: DataMovementConstants.PlanFile.TransferIdStrLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.TransferIdStrLength,
                     actualSize: transferId.Length);
             }
             PartNumber = partNumber;
             // Source resource type
-            if (sourceResourceId.Length <= DataMovementConstants.PlanFile.ResourceIdMaxStrLength)
+            if (sourceResourceId.Length <= DataMovementConstants.JobPartPlanFile.ResourceIdMaxStrLength)
             {
                 SourceResourceId = sourceResourceId;
                 SourceResourceIdLength = (ushort) sourceResourceId.Length;
@@ -292,11 +292,11 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(sourceResourceId),
-                    expectedSize: DataMovementConstants.PlanFile.ResourceIdMaxStrLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.ResourceIdMaxStrLength,
                     actualSize: sourceResourceId.Length);
             }
             // SourcePath
-            if (sourcePath.Length <= DataMovementConstants.PlanFile.PathStrMaxLength)
+            if (sourcePath.Length <= DataMovementConstants.JobPartPlanFile.PathStrMaxLength)
             {
                 SourcePath = sourcePath;
                 SourcePathLength = (ushort) sourcePath.Length;
@@ -305,11 +305,11 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(SourcePath),
-                    expectedSize: DataMovementConstants.PlanFile.PathStrMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.PathStrMaxLength,
                     actualSize: sourcePath.Length);
             }
             // SourceQuery
-            if (sourceExtraQuery.Length <= DataMovementConstants.PlanFile.ExtraQueryMaxLength)
+            if (sourceExtraQuery.Length <= DataMovementConstants.JobPartPlanFile.ExtraQueryMaxLength)
             {
                 SourceExtraQuery = sourceExtraQuery;
                 SourceExtraQueryLength = (ushort) sourceExtraQuery.Length;
@@ -318,11 +318,11 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(SourceExtraQuery),
-                    expectedSize: DataMovementConstants.PlanFile.ExtraQueryMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.ExtraQueryMaxLength,
                     actualSize: sourceExtraQuery.Length);
             }
             // Destination resource type
-            if (destinationResourceId.Length <= DataMovementConstants.PlanFile.ResourceIdMaxStrLength)
+            if (destinationResourceId.Length <= DataMovementConstants.JobPartPlanFile.ResourceIdMaxStrLength)
             {
                 DestinationResourceId = destinationResourceId;
                 DestinationResourceIdLength = (ushort)destinationResourceId.Length;
@@ -331,11 +331,11 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(destinationResourceId),
-                    expectedSize: DataMovementConstants.PlanFile.ResourceIdMaxStrLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.ResourceIdMaxStrLength,
                     actualSize: destinationResourceId.Length);
             }
             // DestinationPath
-            if (destinationPath.Length <= DataMovementConstants.PlanFile.PathStrMaxLength)
+            if (destinationPath.Length <= DataMovementConstants.JobPartPlanFile.PathStrMaxLength)
             {
                 DestinationPath = destinationPath;
                 DestinationPathLength = (ushort) destinationPath.Length;
@@ -344,11 +344,11 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(DestinationPath),
-                    expectedSize: DataMovementConstants.PlanFile.PathStrMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.PathStrMaxLength,
                     actualSize: destinationPath.Length);
             }
             // DestinationQuery
-            if (destinationExtraQuery.Length <= DataMovementConstants.PlanFile.ExtraQueryMaxLength)
+            if (destinationExtraQuery.Length <= DataMovementConstants.JobPartPlanFile.ExtraQueryMaxLength)
             {
                 DestinationExtraQuery = destinationExtraQuery;
                 DestinationExtraQueryLength = (ushort) destinationExtraQuery.Length;
@@ -357,7 +357,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             {
                 throw Errors.InvalidPlanFileElement(
                     elementName: nameof(DestinationExtraQuery),
-                    expectedSize: DataMovementConstants.PlanFile.ExtraQueryMaxLength,
+                    expectedSize: DataMovementConstants.JobPartPlanFile.ExtraQueryMaxLength,
                     actualSize: destinationExtraQuery.Length);
             }
             IsFinalPart = isFinalPart;
@@ -398,13 +398,13 @@ namespace Azure.Storage.DataMovement.JobPlan
             BinaryWriter writer = new BinaryWriter(stream);
 
             // Version
-            WriteString(writer, Version, DataMovementConstants.PlanFile.VersionStrNumBytes);
+            WriteString(writer, Version, DataMovementConstants.JobPartPlanFile.VersionStrNumBytes);
 
             // StartTime
             writer.Write(StartTime.Ticks);
 
             // TransferId
-            WriteString(writer, TransferId, DataMovementConstants.PlanFile.TransferIdStrNumBytes);
+            WriteString(writer, TransferId, DataMovementConstants.JobPartPlanFile.TransferIdStrNumBytes);
 
             // PartNumber
             writer.Write(PartNumber);
@@ -413,37 +413,37 @@ namespace Azure.Storage.DataMovement.JobPlan
             writer.Write(SourceResourceIdLength);
 
             // SourceResourceId
-            WriteString(writer, SourceResourceId, DataMovementConstants.PlanFile.ResourceIdNumBytes);
+            WriteString(writer, SourceResourceId, DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes);
 
             // SourcePathLength
             writer.Write(SourcePathLength);
 
             // SourcePath
-            WriteString(writer, SourcePath, DataMovementConstants.PlanFile.PathStrNumBytes);
+            WriteString(writer, SourcePath, DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
 
             // SourceExtraQueryLength
             writer.Write(SourceExtraQueryLength);
 
             // SourceExtraQuery
-            WriteString(writer, SourceExtraQuery, DataMovementConstants.PlanFile.ExtraQueryNumBytes);
+            WriteString(writer, SourceExtraQuery, DataMovementConstants.JobPartPlanFile.ExtraQueryNumBytes);
 
             // DestinationResourceIdLength
             writer.Write(DestinationResourceIdLength);
 
             // DestinationResourceId
-            WriteString(writer, DestinationResourceId, DataMovementConstants.PlanFile.ResourceIdNumBytes);
+            WriteString(writer, DestinationResourceId, DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes);
 
             // DestinationPathLength
             writer.Write(DestinationPathLength);
 
             // DestinationPath
-            WriteString(writer, DestinationPath, DataMovementConstants.PlanFile.PathStrNumBytes);
+            WriteString(writer, DestinationPath, DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
 
             // DestinationExtraQueryLength
             writer.Write(DestinationExtraQueryLength);
 
             // DestinationExtraQuery
-            WriteString(writer, DestinationExtraQuery, DataMovementConstants.PlanFile.ExtraQueryNumBytes);
+            WriteString(writer, DestinationExtraQuery, DataMovementConstants.JobPartPlanFile.ExtraQueryNumBytes);
 
             // IsFinalPart
             writer.Write(Convert.ToByte(IsFinalPart));
@@ -482,31 +482,31 @@ namespace Azure.Storage.DataMovement.JobPlan
             writer.Write(DstBlobData.ContentTypeLength);
 
             // DstBlobData.ContentType
-            WriteString(writer, DstBlobData.ContentType, DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            WriteString(writer, DstBlobData.ContentType, DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
 
             // DstBlobData.ContentEncodingLength
             writer.Write(DstBlobData.ContentEncodingLength);
 
             // DstBlobData.ContentEncoding
-            WriteString(writer, DstBlobData.ContentEncoding, DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            WriteString(writer, DstBlobData.ContentEncoding, DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
 
             // DstBlobData.ContentLanguageLength
             writer.Write(DstBlobData.ContentLanguageLength);
 
             // DstBlobData.ContentLanguage
-            WriteString(writer, DstBlobData.ContentLanguage, DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            WriteString(writer, DstBlobData.ContentLanguage, DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
 
             // DstBlobData.ContentDispositionLength
             writer.Write(DstBlobData.ContentDispositionLength);
 
             // DstBlobData.ContentDisposition
-            WriteString(writer, DstBlobData.ContentDisposition, DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            WriteString(writer, DstBlobData.ContentDisposition, DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
 
             // DstBlobData.CacheControlLength
             writer.Write(DstBlobData.CacheControlLength);
 
             // DstBlobData.CacheControl
-            WriteString(writer, DstBlobData.CacheControl, DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            WriteString(writer, DstBlobData.CacheControl, DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
 
             // DstBlobData.BlockBlobTier
             writer.Write((byte)DstBlobData.BlockBlobTier);
@@ -521,13 +521,13 @@ namespace Azure.Storage.DataMovement.JobPlan
             writer.Write(DstBlobData.MetadataLength);
 
             // DstBlobData.Metadata
-            WriteString(writer, DstBlobData.Metadata, DataMovementConstants.PlanFile.MetadataStrNumBytes);
+            WriteString(writer, DstBlobData.Metadata, DataMovementConstants.JobPartPlanFile.MetadataStrNumBytes);
 
             // DstBlobData.BlobTagsLength
             writer.Write(DstBlobData.BlobTagsLength);
 
             // DstBlobData.BlobTags
-            WriteString(writer, DstBlobData.BlobTags, DataMovementConstants.PlanFile.BlobTagsStrNumBytes);
+            WriteString(writer, DstBlobData.BlobTags, DataMovementConstants.JobPartPlanFile.BlobTagsStrNumBytes);
 
             // DstBlobData.IsSourceEncrypted
             writer.Write(DstBlobData.IsSourceEncrypted);
@@ -536,7 +536,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             writer.Write(DstBlobData.CpkScopeInfoLength);
 
             // DstBlobData.CpkScopeInfo
-            WriteString(writer, DstBlobData.CpkScopeInfo, DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            WriteString(writer, DstBlobData.CpkScopeInfo, DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
 
             // DstBlobData.BlockSize
             writer.Write(DstBlobData.BlockSize);
@@ -592,70 +592,70 @@ namespace Azure.Storage.DataMovement.JobPlan
             reader.BaseStream.Position = 0;
 
             // Version
-            byte[] versionBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.VersionStrNumBytes);
-            string version = versionBuffer.ToString(DataMovementConstants.PlanFile.VersionStrLength);
+            byte[] versionBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.VersionStrNumBytes);
+            string version = versionBuffer.ToString(DataMovementConstants.JobPartPlanFile.VersionStrLength);
 
             // Assert the schema version before continuing
             CheckSchemaVersion(version);
 
             // Start Time
-            byte[] startTimeBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+            byte[] startTimeBuffer = reader.ReadBytes(DataMovementConstants.LongSizeInBytes);
             DateTimeOffset startTime = new DateTimeOffset(startTimeBuffer.ToLong(), new TimeSpan(0, 0, 0));
 
             // Transfer Id
-            byte[] transferIdBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.TransferIdStrNumBytes);
-            string transferId = transferIdBuffer.ToString(DataMovementConstants.PlanFile.TransferIdStrLength);
+            byte[] transferIdBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.TransferIdStrNumBytes);
+            string transferId = transferIdBuffer.ToString(DataMovementConstants.JobPartPlanFile.TransferIdStrLength);
 
             // Job Part Number
-            byte[] partNumberBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+            byte[] partNumberBuffer = reader.ReadBytes(DataMovementConstants.LongSizeInBytes);
             long partNumber = partNumberBuffer.ToLong();
 
             // SourceResourceIdLength
-            byte[] sourceResourceIdLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] sourceResourceIdLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort sourceResourceIdLength = sourceResourceIdLengthBuffer.ToUShort();
 
             // SourceResourceId
-            byte[] sourceResourceIdBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.ResourceIdNumBytes);
+            byte[] sourceResourceIdBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes);
             string sourceResourceId = sourceResourceIdBuffer.ToString(sourceResourceIdLength);
 
             // SourcePathLength
-            byte[] sourcePathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] sourcePathLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort sourcePathLength = sourcePathLengthBuffer.ToUShort();
 
             // SourcePath
-            byte[] sourcePathBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.PathStrNumBytes);
+            byte[] sourcePathBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
             string sourcePath = sourcePathBuffer.ToString(sourcePathLength);
 
             // SourceExtraQueryLength
-            byte[] sourceExtraQueryLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] sourceExtraQueryLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort sourceExtraQueryLength = sourceExtraQueryLengthBuffer.ToUShort();
 
             // SourceExtraQuery
-            byte[] sourceExtraQueryBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.ExtraQueryNumBytes);
+            byte[] sourceExtraQueryBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.ExtraQueryNumBytes);
             string sourceExtraQuery = sourceExtraQueryBuffer.ToString(sourceExtraQueryLength);
 
             // DestinationResourceIdLength
-            byte[] destinationResourceIdLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] destinationResourceIdLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort destinationResourceIdLength = destinationResourceIdLengthBuffer.ToUShort();
 
             // DestinationResourceId
-            byte[] destinationResourceIdBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.ResourceIdNumBytes);
+            byte[] destinationResourceIdBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes);
             string destinationResourceId = destinationResourceIdBuffer.ToString(destinationResourceIdLength);
 
             // DestinationPathLength
-            byte[] destinationPathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] destinationPathLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort destinationPathLength = destinationPathLengthBuffer.ToUShort();
 
             // DestinationPath
-            byte[] destinationPathBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.PathStrNumBytes);
+            byte[] destinationPathBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
             string destinationPath = destinationPathBuffer.ToString(destinationPathLength);
 
             // DestinationExtraQueryLength
-            byte[] destinationExtraQueryLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] destinationExtraQueryLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort destinationExtraQueryLength = destinationExtraQueryLengthBuffer.ToUShort();
 
             // DestinationExtraQuery
-            byte[] destinationExtraQueryBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.ExtraQueryNumBytes);
+            byte[] destinationExtraQueryBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.ExtraQueryNumBytes);
             string destinationExtraQuery = destinationExtraQueryBuffer.ToString(destinationExtraQueryLength);
 
             // IsFinalPart
@@ -678,7 +678,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             byte priority = reader.ReadByte();
 
             // TTLAfterCompletion
-            byte[] ttlAfterCompletionBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+            byte[] ttlAfterCompletionBuffer = reader.ReadBytes(DataMovementConstants.LongSizeInBytes);
             DateTimeOffset ttlAfterCompletion = new DateTimeOffset(ttlAfterCompletionBuffer.ToLong(), new TimeSpan(0, 0, 0));
 
             // JobPlanOperation
@@ -690,7 +690,7 @@ namespace Azure.Storage.DataMovement.JobPlan
             FolderPropertiesMode folderPropertyMode = (FolderPropertiesMode)folderPropertyOptionByte;
 
             // NumberChunks
-            byte[] numberChunksBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+            byte[] numberChunksBuffer = reader.ReadBytes(DataMovementConstants.LongSizeInBytes);
             long numberChunks = numberChunksBuffer.ToLong();
 
             // DstBlobData.BlobType
@@ -702,43 +702,43 @@ namespace Azure.Storage.DataMovement.JobPlan
             bool noGuessMimeType = Convert.ToBoolean(noGuessMimeTypeByte);
 
             // DstBlobData.ContentTypeLength
-            byte[] contentTypeLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] contentTypeLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort contentTypeLength = contentTypeLengthBuffer.ToUShort();
 
             // DstBlobData.ContentType
-            byte[] contentTypeBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            byte[] contentTypeBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
             string contentType = contentTypeBuffer.ToString(contentTypeLength);
 
             // DstBlobData.ContentEncodingLength
-            byte[] contentEncodingLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] contentEncodingLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort contentEncodingLength = contentEncodingLengthBuffer.ToUShort();
 
             // DstBlobData.ContentEncoding
-            byte[] contentEncodingBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            byte[] contentEncodingBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
             string contentEncoding = contentEncodingBuffer.ToString(contentEncodingLength);
 
             // DstBlobData.ContentLanguageLength
-            byte[] contentLanguageLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] contentLanguageLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort contentLanguageLength = contentLanguageLengthBuffer.ToUShort();
 
             // DstBlobData.ContentLanguage
-            byte[] contentLanguageBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            byte[] contentLanguageBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
             string contentLanguage = contentLanguageBuffer.ToString(contentLanguageLength);
 
             // DstBlobData.ContentDispositionLength
-            byte[] contentDispositionLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] contentDispositionLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort contentDispositionLength = contentDispositionLengthBuffer.ToUShort();
 
             // DstBlobData.ContentDisposition
-            byte[] contentDispositionBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            byte[] contentDispositionBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
             string contentDisposition = contentDispositionBuffer.ToString(contentDispositionLength);
 
             // DstBlobData.CacheControlLength
-            byte[] cacheControlLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] cacheControlLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort cacheControlLength = cacheControlLengthBuffer.ToUShort();
 
             // DstBlobData.CacheControl
-            byte[] cacheControlBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            byte[] cacheControlBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
             string cacheControl = cacheControlBuffer.ToString(cacheControlLength);
 
             // DstBlobData.BlockBlobTier
@@ -754,34 +754,34 @@ namespace Azure.Storage.DataMovement.JobPlan
             bool putMd5 = Convert.ToBoolean(putMd5Byte);
 
             // DstBlobData.MetadataLength
-            byte[] metadataLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] metadataLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort metadataLength = metadataLengthBuffer.ToUShort();
 
             // DstBlobData.Metadata
-            byte[] metadataBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.MetadataStrNumBytes);
+            byte[] metadataBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.MetadataStrNumBytes);
             string metadata = metadataBuffer.ToString(metadataLength);
 
             // DstBlobData.BlobTagsLength
-            byte[] blobTagsLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+            byte[] blobTagsLengthBuffer = reader.ReadBytes(DataMovementConstants.LongSizeInBytes);
             long blobTagsLength = blobTagsLengthBuffer.ToLong();
 
             // DstBlobData.BlobTags
-            byte[] blobTagsBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.BlobTagsStrNumBytes);
+            byte[] blobTagsBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.BlobTagsStrNumBytes);
             string blobTags = blobTagsBuffer.ToString(blobTagsLength);
 
             // DstBlobData.IsSourceEncrypted
             bool isSourceEncrypted = Convert.ToBoolean(reader.ReadByte());
 
             // DstBlobData.CpkScopeInfoLength
-            byte[] cpkScopeInfoLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+            byte[] cpkScopeInfoLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
             ushort cpkScopeInfoLength = cpkScopeInfoLengthBuffer.ToUShort();
 
             // DstBlobData.CpkScopeInfo
-            byte[] cpkScopeInfoBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.HeaderValueNumBytes);
+            byte[] cpkScopeInfoBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes);
             string cpkScopeInfo = cpkScopeInfoBuffer.ToString(cpkScopeInfoLength);
 
             // DstBlobData.BlockSize
-            byte[] blockSizeLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+            byte[] blockSizeLengthBuffer = reader.ReadBytes(DataMovementConstants.LongSizeInBytes);
             long blockSize = blockSizeLengthBuffer.ToLong();
 
             // DstLocalData.PreserveLastModifiedTime
@@ -898,7 +898,7 @@ namespace Azure.Storage.DataMovement.JobPlan
 
         private static void CheckSchemaVersion(string version)
         {
-            if (version != DataMovementConstants.PlanFile.SchemaVersion)
+            if (version != DataMovementConstants.JobPartPlanFile.SchemaVersion)
             {
                 throw Errors.UnsupportedSchemaVersionHeader(version);
             }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
@@ -32,7 +32,7 @@ namespace Azure.Storage.DataMovement
         internal static JobPartPlanHeader GetJobPartPlanHeader(this JobPartPlanFileName fileName)
         {
             JobPartPlanHeader result;
-            int bufferSize = DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes;
+            int bufferSize = DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes;
 
             using MemoryMappedFile memoryMappedFile = MemoryMappedFile.CreateFromFile(fileName.ToString());
             using (MemoryMappedViewStream stream = memoryMappedFile.CreateViewStream(0, bufferSize, MemoryMappedFileAccess.Read))
@@ -51,8 +51,8 @@ namespace Azure.Storage.DataMovement
             string transferId,
             CancellationToken cancellationToken)
         {
-            int startIndex = DataMovementConstants.PlanFile.SourcePathLengthIndex;
-            int readLength = DataMovementConstants.PlanFile.DestinationExtraQueryLengthIndex - startIndex;
+            int startIndex = DataMovementConstants.JobPartPlanFile.SourcePathLengthIndex;
+            int readLength = DataMovementConstants.JobPartPlanFile.DestinationExtraQueryLengthIndex - startIndex;
 
             int partCount = await checkpointer.CurrentJobPartCountAsync(transferId).ConfigureAwait(false);
             string storedSourcePath = default;
@@ -69,22 +69,22 @@ namespace Azure.Storage.DataMovement
                     BinaryReader reader = new BinaryReader(stream);
 
                     // Read Source Path Length
-                    byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+                    byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
                     ushort pathLength = pathLengthBuffer.ToUShort();
 
                     // Read Source Path
-                    byte[] pathBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.PathStrNumBytes);
+                    byte[] pathBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
                     string sourcePath = pathBuffer.ToString(pathLength);
 
                     // Set the stream position to the start of the destination path
-                    reader.BaseStream.Position = DataMovementConstants.PlanFile.DestinationPathLengthIndex - startIndex;
+                    reader.BaseStream.Position = DataMovementConstants.JobPartPlanFile.DestinationPathLengthIndex - startIndex;
 
                     // Read Destination Path Length
-                    pathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+                    pathLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
                     pathLength = pathLengthBuffer.ToUShort();
 
                     // Read Destination Path
-                    pathBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.PathStrNumBytes);
+                    pathBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
                     string destPath = pathBuffer.ToString(pathLength);
 
                     if (string.IsNullOrEmpty(storedSourcePath))
@@ -138,8 +138,8 @@ namespace Azure.Storage.DataMovement
             string transferId,
             CancellationToken cancellationToken)
         {
-            int startIndex = DataMovementConstants.PlanFile.SourceResourceIdLengthIndex;
-            int readLength = DataMovementConstants.PlanFile.DestinationPathLengthIndex - startIndex;
+            int startIndex = DataMovementConstants.JobPartPlanFile.SourceResourceIdLengthIndex;
+            int readLength = DataMovementConstants.JobPartPlanFile.DestinationPathLengthIndex - startIndex;
 
             string sourceResourceId;
             string destinationResourceId;
@@ -153,22 +153,22 @@ namespace Azure.Storage.DataMovement
                 BinaryReader reader = new BinaryReader(stream);
 
                 // Read Source Length
-                byte[] sourceLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+                byte[] sourceLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
                 ushort sourceLength = sourceLengthBuffer.ToUShort();
 
                 // Read Source
-                byte[] sourceBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.ResourceIdNumBytes);
+                byte[] sourceBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes);
                 sourceResourceId = sourceBuffer.ToString(sourceLength);
 
                 // Set the stream position to the start of the destination resource id
-                reader.BaseStream.Position = DataMovementConstants.PlanFile.DestinationResourceIdLengthIndex - startIndex;
+                reader.BaseStream.Position = DataMovementConstants.JobPartPlanFile.DestinationResourceIdLengthIndex - startIndex;
 
                 // Read Destination Length
-                byte[] destLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+                byte[] destLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
                 ushort destLength = destLengthBuffer.ToUShort();
 
                 // Read Destination
-                byte[] destBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.ResourceIdNumBytes);
+                byte[] destBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes);
                 destinationResourceId = destBuffer.ToString(destLength);
             }
 
@@ -224,7 +224,7 @@ namespace Azure.Storage.DataMovement
                 BinaryReader reader = new BinaryReader(stream);
 
                 // Read Path Length
-                byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.UShortSizeInBytes);
+                byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
                 ushort pathLength = pathLengthBuffer.ToUShort();
 
                 // Read Path
@@ -253,7 +253,7 @@ namespace Azure.Storage.DataMovement
                 BinaryReader reader = new BinaryReader(stream);
 
                 // Read Path Length
-                byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.PlanFile.LongSizeInBytes);
+                byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.LongSizeInBytes);
                 long pathLength = pathLengthBuffer.ToLong();
 
                 // Read Path
@@ -274,7 +274,7 @@ namespace Azure.Storage.DataMovement
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
-                readSize: DataMovementConstants.PlanFile.OneByte,
+                readSize: DataMovementConstants.OneByte,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 BinaryReader reader = new BinaryReader(stream);

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalTransferCheckpointer.cs
@@ -125,8 +125,8 @@ namespace Azure.Storage.DataMovement
                 // Enumerate all the job parts with the transfer id
                 foreach (string path in Directory.EnumerateFiles(_pathToCheckpointer, searchPattern, SearchOption.TopDirectoryOnly)
                     .Where(f => Path.HasExtension(string.Concat(
-                        DataMovementConstants.PlanFile.FileExtension,
-                        DataMovementConstants.PlanFile.SchemaVersion))))
+                        DataMovementConstants.JobPartPlanFile.FileExtension,
+                        DataMovementConstants.JobPartPlanFile.SchemaVersion))))
                 {
                     // Ensure each file has the matching header
                     if (JobPartPlanFileName.TryParseJobPartPlanFileName(path, out JobPartPlanFileName partPlanFileName))
@@ -181,7 +181,7 @@ namespace Azure.Storage.DataMovement
         {
             if (_transferStates.TryGetValue(transferId, out Dictionary<int, JobPartPlanFile> jobPartFiles))
             {
-                Stream copiedStream = new MemoryStream(DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes);
+                Stream copiedStream = new MemoryStream(DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes);
                 // MMF lock
                 await jobPartFiles[partNumber].WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
@@ -190,7 +190,7 @@ namespace Azure.Storage.DataMovement
                     path: jobPartFiles[partNumber].FilePath,
                     mode: FileMode.Open,
                     mapName: null,
-                    capacity: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                    capacity: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
                 {
                     using (MemoryMappedViewStream mmfStream = mmf.CreateViewStream(offset, readSize, MemoryMappedFileAccess.Read))
                     {
@@ -240,7 +240,7 @@ namespace Azure.Storage.DataMovement
                         path: jobPartFiles[partNumber].FilePath,
                         mode: FileMode.Open,
                         mapName: null,
-                        capacity: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                        capacity: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
                     {
                         using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(chunkIndex, buffer.Length, MemoryMappedFileAccess.Write))
                         {
@@ -305,8 +305,8 @@ namespace Azure.Storage.DataMovement
             DataTransferStatus status,
             CancellationToken cancellationToken = default)
         {
-            long length = DataMovementConstants.PlanFile.OneByte;
-            int offset = DataMovementConstants.PlanFile.AtomicJobStatusIndex;
+            long length = DataMovementConstants.OneByte;
+            int offset = DataMovementConstants.JobPartPlanFile.AtomicJobStatusIndex;
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
             if (_transferStates.TryGetValue(transferId, out Dictionary<int, JobPartPlanFile> jobPartFiles))
@@ -320,7 +320,7 @@ namespace Azure.Storage.DataMovement
                             path: jobPartPair.Value.FilePath,
                             mode: FileMode.Open,
                             mapName: null,
-                            capacity: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                            capacity: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
                     {
                         using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
                         {
@@ -348,8 +348,8 @@ namespace Azure.Storage.DataMovement
             DataTransferStatus status,
             CancellationToken cancellationToken = default)
         {
-            long length = DataMovementConstants.PlanFile.OneByte;
-            int offset = DataMovementConstants.PlanFile.AtomicPartStatusIndex;
+            long length = DataMovementConstants.OneByte;
+            int offset = DataMovementConstants.JobPartPlanFile.AtomicPartStatusIndex;
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
             if (_transferStates.TryGetValue(transferId, out Dictionary<int, JobPartPlanFile> jobPartFiles))
@@ -363,7 +363,7 @@ namespace Azure.Storage.DataMovement
                                 path: file.FilePath,
                                 mode: FileMode.Open,
                                 mapName: null,
-                                capacity: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                                capacity: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
                     {
                         using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
                         {
@@ -397,8 +397,8 @@ namespace Azure.Storage.DataMovement
             // Retrieve all valid checkpointer files stored in the checkpointer path.
             foreach (string path in Directory.EnumerateFiles(_pathToCheckpointer, "*", SearchOption.TopDirectoryOnly)
                 .Where(f => Path.HasExtension(string.Concat(
-                    DataMovementConstants.PlanFile.FileExtension,
-                    DataMovementConstants.PlanFile.SchemaVersion))))
+                    DataMovementConstants.JobPartPlanFile.FileExtension,
+                    DataMovementConstants.JobPartPlanFile.SchemaVersion))))
             {
                 // Ensure each file has the correct format
                 if (JobPartPlanFileName.TryParseJobPartPlanFileName(path, out JobPartPlanFileName partPlanFileName))

--- a/sdk/storage/Azure.Storage.DataMovement/tests/JobPartPlanFileNameTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/JobPartPlanFileNameTests.cs
@@ -11,7 +11,7 @@ namespace Azure.Storage.DataMovement.Tests
 {
     public class JobPartPlanFileNameTests
     {
-        private string schemaVersion = DataMovementConstants.PlanFile.SchemaVersion;
+        private string schemaVersion = DataMovementConstants.JobPartPlanFile.SchemaVersion;
 
         public JobPartPlanFileNameTests()
         {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/JobPartPlanHeaderTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/JobPartPlanHeaderTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Storage.DataMovement.Tests
                 metadata: metadata,
                 blobTags: blobTags);
 
-            Assert.AreEqual(header.Version, DataMovementConstants.PlanFile.SchemaVersion);
+            Assert.AreEqual(header.Version, DataMovementConstants.JobPartPlanFile.SchemaVersion);
             Assert.AreEqual(header.StartTime, DefaultStartTime);
             Assert.AreEqual(header.TransferId, DefaultTransferId);
             Assert.AreEqual(header.PartNumber, DefaultPartNumber);
@@ -113,7 +113,7 @@ namespace Azure.Storage.DataMovement.Tests
                 metadata: metadata,
                 blobTags: blobTags);
 
-            using (Stream stream = new MemoryStream(DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+            using (Stream stream = new MemoryStream(DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Act
                 header.Serialize(stream);
@@ -121,87 +121,87 @@ namespace Azure.Storage.DataMovement.Tests
                 // Assert
                 stream.Position = 0;
 
-                int versionSize = DataMovementConstants.PlanFile.VersionStrNumBytes;
+                int versionSize = DataMovementConstants.JobPartPlanFile.VersionStrNumBytes;
                 byte[] versionBuffer = new byte[versionSize];
                 await stream.ReadAsync(versionBuffer, 0, versionSize);
-                Assert.AreEqual(DataMovementConstants.PlanFile.SchemaVersion.ToByteArray(versionSize), versionBuffer);
+                Assert.AreEqual(DataMovementConstants.JobPartPlanFile.SchemaVersion.ToByteArray(versionSize), versionBuffer);
 
-                int startTimeSize = DataMovementConstants.PlanFile.LongSizeInBytes;
+                int startTimeSize = DataMovementConstants.LongSizeInBytes;
                 byte[] startTimeBuffer = new byte[startTimeSize];
                 await stream.ReadAsync(startTimeBuffer, 0, startTimeSize);
                 Assert.AreEqual(DefaultStartTime.Ticks.ToByteArray(startTimeSize), startTimeBuffer);
 
-                int transferIdSize = DataMovementConstants.PlanFile.TransferIdStrNumBytes;
+                int transferIdSize = DataMovementConstants.JobPartPlanFile.TransferIdStrNumBytes;
                 byte[] transferIdBuffer = new byte[transferIdSize];
                 await stream.ReadAsync(transferIdBuffer, 0, transferIdSize);
                 Assert.AreEqual(DefaultTransferId.ToByteArray(transferIdSize), transferIdBuffer);
 
-                int partNumberSize = DataMovementConstants.PlanFile.LongSizeInBytes;
+                int partNumberSize = DataMovementConstants.LongSizeInBytes;
                 byte[] partNumberBuffer = new byte[partNumberSize];
                 await stream.ReadAsync(partNumberBuffer, 0, partNumberSize);
                 Assert.AreEqual(DefaultPartNumber.ToByteArray(partNumberSize), partNumberBuffer);
 
-                int sourceResourceIdLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int sourceResourceIdLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] sourceResourceIdLengthBuffer = new byte[sourceResourceIdLengthSize];
                 await stream.ReadAsync(sourceResourceIdLengthBuffer, 0, sourceResourceIdLengthSize);
                 Assert.AreEqual(((ushort)DefaultSourceResourceId.Length).ToByteArray(sourceResourceIdLengthSize), sourceResourceIdLengthBuffer);
 
-                int sourceResourceIdSize = DataMovementConstants.PlanFile.ResourceIdNumBytes;
+                int sourceResourceIdSize = DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes;
                 byte[] sourceResourceIdBuffer = new byte[sourceResourceIdSize];
                 await stream.ReadAsync(sourceResourceIdBuffer, 0, sourceResourceIdSize);
                 Assert.AreEqual(DefaultSourceResourceId.ToByteArray(sourceResourceIdSize), sourceResourceIdBuffer);
 
-                int sourcePathLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int sourcePathLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] sourcePathLengthBuffer = new byte[sourcePathLengthSize];
                 await stream.ReadAsync(sourcePathLengthBuffer, 0, sourcePathLengthSize);
                 Assert.AreEqual(((ushort)DefaultSourcePath.Length).ToByteArray(sourcePathLengthSize), sourcePathLengthBuffer);
 
-                int sourcePathSize = DataMovementConstants.PlanFile.PathStrNumBytes;
+                int sourcePathSize = DataMovementConstants.JobPartPlanFile.PathStrNumBytes;
                 byte[] sourcePathBuffer = new byte[sourcePathSize];
                 await stream.ReadAsync(sourcePathBuffer, 0, sourcePathSize);
                 Assert.AreEqual(DefaultSourcePath.ToByteArray(sourcePathSize), sourcePathBuffer);
 
-                int sourceExtraQueryLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int sourceExtraQueryLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] sourceExtraQueryLengthBuffer = new byte[sourceExtraQueryLengthSize];
                 await stream.ReadAsync(sourceExtraQueryLengthBuffer, 0, sourceExtraQueryLengthSize);
                 Assert.AreEqual(((ushort)DefaultSourceQuery.Length).ToByteArray(sourceExtraQueryLengthSize), sourceExtraQueryLengthBuffer);
 
-                int sourceExtraQuerySize = DataMovementConstants.PlanFile.ExtraQueryNumBytes;
+                int sourceExtraQuerySize = DataMovementConstants.JobPartPlanFile.ExtraQueryNumBytes;
                 byte[] sourceExtraQueryBuffer = new byte[sourceExtraQuerySize];
                 await stream.ReadAsync(sourceExtraQueryBuffer, 0, sourceExtraQuerySize);
                 Assert.AreEqual(DefaultSourceQuery.ToByteArray(sourceExtraQuerySize), sourceExtraQueryBuffer);
 
-                int destinationResourceIdLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int destinationResourceIdLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] destinationResourceIdLengthBuffer = new byte[destinationResourceIdLengthSize];
                 await stream.ReadAsync(destinationResourceIdLengthBuffer, 0, destinationResourceIdLengthSize);
                 Assert.AreEqual(((ushort)DefaultDestinationResourceId.Length).ToByteArray(destinationResourceIdLengthSize), destinationResourceIdLengthBuffer);
 
-                int destinationResourceIdSize = DataMovementConstants.PlanFile.ResourceIdNumBytes;
+                int destinationResourceIdSize = DataMovementConstants.JobPartPlanFile.ResourceIdNumBytes;
                 byte[] destinationResourceIdBuffer = new byte[destinationResourceIdSize];
                 await stream.ReadAsync(destinationResourceIdBuffer, 0, destinationResourceIdSize);
                 Assert.AreEqual(DefaultDestinationResourceId.ToByteArray(destinationResourceIdSize), destinationResourceIdBuffer);
 
-                int destinationPathLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int destinationPathLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] destinationPathLengthBuffer = new byte[destinationPathLengthSize];
                 await stream.ReadAsync(destinationPathLengthBuffer, 0, destinationPathLengthSize);
                 Assert.AreEqual(((ushort)DefaultDestinationPath.Length).ToByteArray(destinationPathLengthSize), destinationPathLengthBuffer);
 
-                int destinationPathSize = DataMovementConstants.PlanFile.PathStrNumBytes;
+                int destinationPathSize = DataMovementConstants.JobPartPlanFile.PathStrNumBytes;
                 byte[] destinationPathBuffer = new byte[destinationPathSize];
                 await stream.ReadAsync(destinationPathBuffer, 0, destinationPathSize);
                 Assert.AreEqual(DefaultDestinationPath.ToByteArray(destinationPathSize), destinationPathBuffer);
 
-                int destinationExtraQueryLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int destinationExtraQueryLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] destinationExtraQueryLengthBuffer = new byte[destinationExtraQueryLengthSize];
                 await stream.ReadAsync(destinationExtraQueryLengthBuffer, 0, destinationExtraQueryLengthSize);
                 Assert.AreEqual(((ushort)DefaultDestinationQuery.Length).ToByteArray(destinationExtraQueryLengthSize), destinationExtraQueryLengthBuffer);
 
-                int destinationExtraQuerySize = DataMovementConstants.PlanFile.ExtraQueryNumBytes;
+                int destinationExtraQuerySize = DataMovementConstants.JobPartPlanFile.ExtraQueryNumBytes;
                 byte[] destinationExtraQueryBuffer = new byte[destinationExtraQuerySize];
                 await stream.ReadAsync(destinationExtraQueryBuffer, 0, destinationExtraQuerySize);
                 Assert.AreEqual(DefaultDestinationQuery.ToByteArray(destinationExtraQuerySize), destinationExtraQueryBuffer);
 
-                int oneByte = DataMovementConstants.PlanFile.OneByte;
+                int oneByte = DataMovementConstants.OneByte;
                 byte[] isFinalPartBuffer = new byte[oneByte];
                 await stream.ReadAsync(isFinalPartBuffer, 0, oneByte);
                 Assert.AreEqual(0, isFinalPartBuffer[0]);
@@ -222,7 +222,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await stream.ReadAsync(priorityBuffer, 0, oneByte);
                 Assert.AreEqual(0, priorityBuffer[0]);
 
-                int ttlAfterCompletionSize = DataMovementConstants.PlanFile.LongSizeInBytes;
+                int ttlAfterCompletionSize = DataMovementConstants.LongSizeInBytes;
                 byte[] ttlAfterCompletionBuffer = new byte[ttlAfterCompletionSize];
                 await stream.ReadAsync(ttlAfterCompletionBuffer, 0, ttlAfterCompletionSize);
                 Assert.AreEqual(DefaultTtlAfterCompletion.Ticks.ToByteArray(ttlAfterCompletionSize), ttlAfterCompletionBuffer);
@@ -235,7 +235,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await stream.ReadAsync(folderPropertyModeBuffer, 0, oneByte);
                 Assert.AreEqual((byte)DefaultFolderPropertiesMode, folderPropertyModeBuffer[0]);
 
-                int numberChunksSize = DataMovementConstants.PlanFile.LongSizeInBytes;
+                int numberChunksSize = DataMovementConstants.LongSizeInBytes;
                 byte[] numberChunksBuffer = new byte[numberChunksSize];
                 await stream.ReadAsync(numberChunksBuffer, 0, numberChunksSize);
                 Assert.AreEqual(DefaultNumberChunks.ToByteArray(numberChunksSize), numberChunksBuffer);
@@ -248,52 +248,52 @@ namespace Azure.Storage.DataMovement.Tests
                 await stream.ReadAsync(noGuessMimeTypeBuffer, 0, oneByte);
                 Assert.AreEqual(0, noGuessMimeTypeBuffer[0]);
 
-                int contentTypeLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int contentTypeLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] contentTypeLengthBuffer = new byte[contentTypeLengthSize];
                 await stream.ReadAsync(contentTypeLengthBuffer, 0, contentTypeLengthSize);
                 Assert.AreEqual(((ushort)DefaultContentType.Length).ToByteArray(contentTypeLengthSize), contentTypeLengthBuffer);
 
-                int contentTypeSize = DataMovementConstants.PlanFile.HeaderValueNumBytes;
+                int contentTypeSize = DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes;
                 byte[] contentTypeBuffer = new byte[contentTypeSize];
                 await stream.ReadAsync(contentTypeBuffer, 0, contentTypeSize);
                 Assert.AreEqual(DefaultContentType.ToByteArray(contentTypeSize), contentTypeBuffer);
 
-                int contentEncodingLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int contentEncodingLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] contentEncodingLengthBuffer = new byte[contentEncodingLengthSize];
                 await stream.ReadAsync(contentEncodingLengthBuffer, 0, contentEncodingLengthSize);
                 Assert.AreEqual(((ushort)DefaultContentEncoding.Length).ToByteArray(contentEncodingLengthSize), contentEncodingLengthBuffer);
 
-                int contentEncodingSize = DataMovementConstants.PlanFile.HeaderValueNumBytes;
+                int contentEncodingSize = DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes;
                 byte[] contentEncodingBuffer = new byte[contentEncodingSize];
                 await stream.ReadAsync(contentEncodingBuffer, 0, contentEncodingSize);
                 Assert.AreEqual(DefaultContentEncoding.ToByteArray(contentEncodingSize), contentEncodingBuffer);
 
-                int contentLanguageLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int contentLanguageLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] contentLanguageLengthBuffer = new byte[contentLanguageLengthSize];
                 await stream.ReadAsync(contentLanguageLengthBuffer, 0, contentLanguageLengthSize);
                 Assert.AreEqual(((ushort)DefaultContentLanguage.Length).ToByteArray(contentLanguageLengthSize), contentLanguageLengthBuffer);
 
-                int contentLanguageSize = DataMovementConstants.PlanFile.HeaderValueNumBytes;
+                int contentLanguageSize = DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes;
                 byte[] contentLanguageBuffer = new byte[contentLanguageSize];
                 await stream.ReadAsync(contentLanguageBuffer, 0, contentLanguageSize);
                 Assert.AreEqual(DefaultContentLanguage.ToByteArray(contentLanguageSize), contentLanguageBuffer);
 
-                int contentDispositionLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int contentDispositionLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] contentDispositionLengthBuffer = new byte[contentDispositionLengthSize];
                 await stream.ReadAsync(contentDispositionLengthBuffer, 0, contentDispositionLengthSize);
                 Assert.AreEqual(((ushort)DefaultContentDisposition.Length).ToByteArray(contentDispositionLengthSize), contentDispositionLengthBuffer);
 
-                int contentDispositionSize = DataMovementConstants.PlanFile.HeaderValueNumBytes;
+                int contentDispositionSize = DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes;
                 byte[] contentDispositionBuffer = new byte[contentDispositionSize];
                 await stream.ReadAsync(contentDispositionBuffer, 0, contentDispositionSize);
                 Assert.AreEqual(DefaultContentDisposition.ToByteArray(contentDispositionSize), contentDispositionBuffer);
 
-                int cacheControlLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int cacheControlLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] cacheControlLengthBuffer = new byte[cacheControlLengthSize];
                 await stream.ReadAsync(cacheControlLengthBuffer, 0, cacheControlLengthSize);
                 Assert.AreEqual(((ushort)DefaultCacheControl.Length).ToByteArray(cacheControlLengthSize), cacheControlLengthBuffer);
 
-                int cacheControlSize = DataMovementConstants.PlanFile.HeaderValueNumBytes;
+                int cacheControlSize = DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes;
                 byte[] cacheControlBuffer = new byte[cacheControlSize];
                 await stream.ReadAsync(cacheControlBuffer, 0, cacheControlSize);
                 Assert.AreEqual(DefaultCacheControl.ToByteArray(cacheControlSize), cacheControlBuffer);
@@ -311,23 +311,23 @@ namespace Azure.Storage.DataMovement.Tests
                 Assert.AreEqual(0, putMd5Buffer[0]);
 
                 string metadataStr = DictionaryToString(metadata);
-                int metadataLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int metadataLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] metadataLengthBuffer = new byte[metadataLengthSize];
                 await stream.ReadAsync(metadataLengthBuffer, 0, metadataLengthSize);
                 Assert.AreEqual(((ushort)metadataStr.Length).ToByteArray(metadataLengthSize), metadataLengthBuffer);
 
-                int metadataSize = DataMovementConstants.PlanFile.MetadataStrNumBytes;
+                int metadataSize = DataMovementConstants.JobPartPlanFile.MetadataStrNumBytes;
                 byte[] metadataBuffer = new byte[metadataSize];
                 await stream.ReadAsync(metadataBuffer, 0, metadataSize);
                 Assert.AreEqual(metadataStr.ToByteArray(metadataSize), metadataBuffer);
 
                 string blobTagsStr = DictionaryToString(blobTags);
-                int blobTagsLengthSize = DataMovementConstants.PlanFile.LongSizeInBytes;
+                int blobTagsLengthSize = DataMovementConstants.LongSizeInBytes;
                 byte[] blobTagsLengthBuffer = new byte[blobTagsLengthSize];
                 await stream.ReadAsync(blobTagsLengthBuffer, 0, blobTagsLengthSize);
                 Assert.AreEqual(((long)blobTagsStr.Length).ToByteArray(blobTagsLengthSize), blobTagsLengthBuffer);
 
-                int blobTagsSize = DataMovementConstants.PlanFile.BlobTagsStrNumBytes;
+                int blobTagsSize = DataMovementConstants.JobPartPlanFile.BlobTagsStrNumBytes;
                 byte[] blobTagsBuffer = new byte[blobTagsSize];
                 await stream.ReadAsync(blobTagsBuffer, 0, blobTagsSize);
                 Assert.AreEqual(blobTagsStr.ToByteArray(blobTagsSize), blobTagsBuffer);
@@ -336,17 +336,17 @@ namespace Azure.Storage.DataMovement.Tests
                 await stream.ReadAsync(isSourceEncryptedBuffer, 0, oneByte);
                 Assert.AreEqual(0, isSourceEncryptedBuffer[0]);
 
-                int cpkScopeInfoLengthSize = DataMovementConstants.PlanFile.UShortSizeInBytes;
+                int cpkScopeInfoLengthSize = DataMovementConstants.UShortSizeInBytes;
                 byte[] cpkScopeInfoLengthBuffer = new byte[cpkScopeInfoLengthSize];
                 await stream.ReadAsync(cpkScopeInfoLengthBuffer, 0, cpkScopeInfoLengthSize);
                 Assert.AreEqual(((ushort)DefaultCpkScopeInfo.Length).ToByteArray(cpkScopeInfoLengthSize), cpkScopeInfoLengthBuffer);
 
-                int cpkScopeInfoSize = DataMovementConstants.PlanFile.HeaderValueNumBytes;
+                int cpkScopeInfoSize = DataMovementConstants.JobPartPlanFile.HeaderValueNumBytes;
                 byte[] cpkScopeInfoBuffer = new byte[cpkScopeInfoSize];
                 await stream.ReadAsync(cpkScopeInfoBuffer, 0, cpkScopeInfoSize);
                 Assert.AreEqual(DefaultCpkScopeInfo.ToByteArray(cpkScopeInfoSize), cpkScopeInfoBuffer);
 
-                int blockSizeLengthSize = DataMovementConstants.PlanFile.LongSizeInBytes;
+                int blockSizeLengthSize = DataMovementConstants.LongSizeInBytes;
                 byte[] blockSizeLengthBuffer = new byte[blockSizeLengthSize];
                 await stream.ReadAsync(blockSizeLengthBuffer, 0, blockSizeLengthSize);
                 Assert.AreEqual(DefaultBlockSize.ToByteArray(blockSizeLengthSize), blockSizeLengthBuffer);
@@ -428,12 +428,12 @@ namespace Azure.Storage.DataMovement.Tests
                 metadata: metadata,
                 blobTags: blobTags);
 
-            using (Stream stream = new MemoryStream(DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+            using (Stream stream = new MemoryStream(DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 header.Serialize(stream);
 
                 // Act / Assert
-                DeserializeAndVerify(stream, DataMovementConstants.PlanFile.SchemaVersion, metadata, blobTags);
+                DeserializeAndVerify(stream, DataMovementConstants.JobPartPlanFile.SchemaVersion, metadata, blobTags);
             }
         }
 
@@ -447,7 +447,7 @@ namespace Azure.Storage.DataMovement.Tests
                 // Act / Assert
                 Assert.Catch<ArgumentException>(
                     () => JobPartPlanHeader.Deserialize(stream),
-                    $"The checkpoint file schema version {DataMovementConstants.PlanFile.SchemaVersion_b1} is not supported by this version of the SDK.");
+                    $"The checkpoint file schema version {DataMovementConstants.JobPartPlanFile.SchemaVersion_b1} is not supported by this version of the SDK.");
             }
         }
 
@@ -459,7 +459,7 @@ namespace Azure.Storage.DataMovement.Tests
             using (FileStream stream = File.OpenRead(samplePath))
             {
                 // Act / Assert
-                DeserializeAndVerify(stream, DataMovementConstants.PlanFile.SchemaVersion_b2, DataProvider.BuildMetadata(), DataProvider.BuildTags());
+                DeserializeAndVerify(stream, DataMovementConstants.JobPartPlanFile.SchemaVersion_b2, DataProvider.BuildMetadata(), DataProvider.BuildTags());
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
@@ -132,7 +132,7 @@ namespace Azure.Storage.DataMovement.Tests
 
                 JobPartPlanFileName fileName = new JobPartPlanFileName(checkpointerPath, transferId, partNumber);
 
-                using (FileStream stream = File.Create(fileName.FullPath, DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                using (FileStream stream = File.Create(fileName.FullPath, DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
                 {
                     header.Serialize(stream);
                 }
@@ -140,7 +140,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         internal JobPartPlanHeader CreateDefaultJobPartHeader(
-            string version = DataMovementConstants.PlanFile.SchemaVersion,
+            string version = DataMovementConstants.JobPartPlanFile.SchemaVersion,
             DateTimeOffset startTime = default,
             string transferId = _testTransferId,
             long partNumber = _testPartNumber,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -64,7 +64,7 @@ namespace Azure.Storage.DataMovement.Tests
 
                 JobPartPlanFileName fileName = new JobPartPlanFileName(checkpointerPath, transferId, i);
 
-                using (FileStream stream = File.Create(fileName.FullPath, DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                using (FileStream stream = File.Create(fileName.FullPath, DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
                 {
                     header.Serialize(stream);
                 }
@@ -215,7 +215,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
@@ -341,7 +341,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 0,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header1, stream);
@@ -351,7 +351,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header2, stream);
@@ -361,7 +361,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 2,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header3, stream);
@@ -371,7 +371,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 3,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header4, stream);
@@ -423,7 +423,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
@@ -870,7 +870,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
@@ -894,7 +894,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes));
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes));
         }
 
         [Test]
@@ -934,7 +934,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
             }
@@ -1016,7 +1016,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 0,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header1, stream);
             }
@@ -1025,7 +1025,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header2, stream);
             }
@@ -1034,7 +1034,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 2,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header3, stream);
             }
@@ -1043,7 +1043,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 3,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header4, stream);
             }
@@ -1107,7 +1107,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes))
+                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
             }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/CheckpointerTesting.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/CheckpointerTesting.cs
@@ -50,7 +50,7 @@ namespace Azure.Storage.DataMovement.Tests
         internal const DataTransferStatus DefaultPartStatus = DataTransferStatus.Queued;
 
         internal static JobPartPlanHeader CreateDefaultJobPartHeader(
-            string version = DataMovementConstants.PlanFile.SchemaVersion,
+            string version = DataMovementConstants.JobPartPlanFile.SchemaVersion,
             DateTimeOffset startTime = default,
             string transferId = DefaultTransferId,
             long partNumber = DefaultPartNumber,
@@ -167,7 +167,7 @@ namespace Azure.Storage.DataMovement.Tests
 
         internal static async Task AssertJobPlanHeaderAsync(JobPartPlanHeader header, Stream stream)
         {
-            int headerSize = DataMovementConstants.PlanFile.JobPartHeaderSizeInBytes;
+            int headerSize = DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes;
             using var originalHeaderStream = new MemoryStream(headerSize);
             header.Serialize(originalHeaderStream);
             originalHeaderStream.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
As title states, renaming some constants in preparation for the introduction of separate job-level plan files.