### PR TITLE
[WebPubSub] Fix origin validation

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.7.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.7.0 (2023-08-28)
 
 ### Bugs Fixed
-
-### Other Changes
+- Fix multi request origins validation.
 
 ## 1.6.0 (2023-07-12)
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
@@ -5,7 +5,7 @@
     <PackageId>Microsoft.Azure.WebJobs.Extensions.WebPubSub</PackageId>
     <PackageTags>Azure, WebPubSub</PackageTags>
     <Description>Azure Functions extension for the WebPubSub service</Description>
-    <Version>1.7.0-beta.1</Version>
+    <Version>1.7.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.6.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS8632;CA1056;CA2227</NoWarn>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Services/WebPubSubRequestExtensions.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Services/WebPubSubRequestExtensions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 request.Headers.TryGetValue(Constants.Headers.WebHookRequestOrigin, out StringValues requestOrigin);
                 if (requestOrigin.Any())
                 {
-                    requestHosts = requestOrigin.ToList();
+                    requestHosts = requestOrigin.SelectMany(x => x.Split(Constants.HeaderSeparator, StringSplitOptions.RemoveEmptyEntries)).ToList();
                     return true;
                 }
             }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Utilities.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Utilities.cs
@@ -218,7 +218,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         {
             if (req.Method == HttpMethod.Options || req.Method == HttpMethod.Get)
             {
-                requestHosts = req.Headers.GetValues(Constants.Headers.WebHookRequestOrigin).ToList();
+                requestHosts = req.Headers.GetValues(Constants.Headers.WebHookRequestOrigin)
+                    .SelectMany(x => x.Split(Constants.HeaderSeparator, StringSplitOptions.RemoveEmptyEntries))
+                    .ToList();
                 return true;
             }
             requestHosts = null;

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.0 (2023-08-28)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix multi request origins validation.
 
 ## 1.1.0 (2023-07-12)
 

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Extensions/WebPubSubRequestExtensions.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Extensions/WebPubSubRequestExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebPubSub.AspNetCore
                 request.Headers.TryGetValue(Constants.Headers.WebHookRequestOrigin, out StringValues requestOrigin);
                 if (requestOrigin.Count > 0)
                 {
-                    requestOrigins = requestOrigin;
+                    requestOrigins = requestOrigin.SelectMany(x => x.Split(Constants.HeaderSeparator, StringSplitOptions.RemoveEmptyEntries)).ToList();
                     return true;
                 }
             }

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Microsoft.Azure.WebPubSub.AspNetCore.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/src/Microsoft.Azure.WebPubSub.AspNetCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Azure SDK client library for the WebPubSub service</Description>
     <AssemblyTitle>Azure SDK for WebPubSub</AssemblyTitle>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <PackageTags>Azure, WebPubSub</PackageTags>


### PR DESCRIPTION
Service multiple origins has an extra space between multiple values and not able to split by `StringValues`. This issue will break abuse protection check under custom domain and replicas scenarios. 

Before fix, need skip abuse protection to work around.


# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
