### PR TITLE
Plumb EnvVars to subscription config builder to find duplicates

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -104,6 +104,7 @@ jobs:
         parameters:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
+          EnvVars: ${{ parameters.EnvVars }}
 
       - pwsh: |
           $project = "${{ parameters.Project }}"


### PR DESCRIPTION
This will help avoid hard to diagnose issues where duplicate env var values are being defined in multiple places.

Must go in after https://github.com/Azure/azure-sdk-for-net/pull/38370