### PR TITLE
Remove duplicate identity test variables

### DIFF
--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -16,12 +16,6 @@ extends:
           PEM_CONTENTS: $(net-identity-spcert-pem)
           SNI_CONTENTS: $(net-identity-spcert-sni)
     EnvVars:
-      AZURE_IDENTITY_TEST_TENANTID: $(net-identity-tenantid)
-      AZURE_IDENTITY_TEST_USERNAME: $(net-identity-username)
-      AZURE_IDENTITY_TEST_PASSWORD: $(net-identity-password)
-      IDENTITY_SP_CLIENT_ID: $(net-identity-sp-clientid)
-      IDENTITY_SP_TENANT_ID: $(net-identity-sp-tenantid)
-      IDENTITY_SP_CLIENT_SECRET: $(net-identity-sp-clientsecret)
       IDENTITY_SP_CERT_PFX: $(Agent.TempDirectory)/test.pfx
       IDENTITY_SP_CERT_PEM: $(Agent.TempDirectory)/test.pem
       IDENTITY_SP_CERT_SNI: $(Agent.TempDirectory)/testsni.pfx


### PR DESCRIPTION
These values already exist in the base subscription config, so remove them here to avoid issues.
