### PR TITLE
[AzureMonitorExporter] eventsource to collect telemetry

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
@@ -89,6 +89,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 content.WriteNewLine();
             }
 
+            AzureMonitorDataEventSource.Log.Telemetry(content);
+
 #if DEBUG
             TelemetryDebugWriter.WriteTelemetry(content);
 #endif
@@ -98,6 +100,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         internal HttpMessage CreateTrackRequest(ReadOnlyMemory<byte> body)
         {
+            AzureMonitorDataEventSource.Log.TelemetryFromStorage(body);
+
 #if DEBUG
             TelemetryDebugWriter.WriteTelemetryFromStorage(body);
 #endif

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorDataEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorDataEventSource.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
+{
+    /// <summary>
+    /// EventSource for the AzureMonitor Telemetry.
+    /// This can be used to collect telemetry that should be emitted by the exporter.
+    /// EventSource Guid at Runtime: cf17323b-4fb7-53b5-2824-934d0ce75082.
+    /// </summary>
+    /// <remarks>
+    /// PerfView Instructions:
+    /// <list type="bullet">
+    /// <item>To collect all events: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders=*AzureMonitor-Exporter-Data</code></item>
+    /// <item>To collect events based on LogLevel: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders:AzureMonitor-Exporter-Data::Verbose</code></item>
+    /// </list>
+    /// Dotnet-Trace Instructions:
+    /// <list type="bullet">
+    /// <item>To collect all events: <code>dotnet-trace collect --process-id PID --providers AzureMonitor-Exporter-Data</code></item>
+    /// <item>To collect events based on LogLevel: <code>dotnet-trace collect --process-id PID --providers AzureMonitor-Exporter-Data::Verbose</code></item>
+    /// </list>
+    /// Logman Instructions:
+    /// <list type="number">
+    /// <item>Create a text file containing providers: <code>echo "{cf17323b-4fb7-53b5-2824-934d0ce75082}" > providers.txt</code></item>
+    /// <item>Start collecting: <code>logman -start exporter -pf providers.txt -ets -bs 1024 -nb 100 256</code></item>
+    /// <item>Stop collecting: <code>logman -stop exporter -ets</code></item>
+    /// </list>
+    /// </remarks>
+    [EventSource(Name = EventSourceName)]
+    internal sealed class AzureMonitorDataEventSource : EventSource
+    {
+        internal const string EventSourceName = "AzureMonitor-Exporter-Data";
+
+        internal static readonly AzureMonitorDataEventSource Log = new AzureMonitorDataEventSource();
+
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsEnabled(EventLevel eventLevel) => IsEnabled(eventLevel, EventKeywords.All);
+
+        [NonEvent]
+        public void Telemetry(NDJsonWriter content)
+        {
+            if (IsEnabled(EventLevel.Verbose))
+            {
+                Telemetry(content.ToString());
+            }
+        }
+
+        [Event(1, Message = "{0}", Level = EventLevel.Verbose)]
+        public void Telemetry(string telemetry) => WriteEvent(1, telemetry);
+
+        [NonEvent]
+        public void TelemetryFromStorage(ReadOnlyMemory<byte> content)
+        {
+            if (IsEnabled(EventLevel.Verbose))
+            {
+                TelemetryFromStorage(Encoding.UTF8.GetString(content.ToArray()));
+            }
+        }
+
+        [Event(2, Message = "{0}", Level = EventLevel.Verbose)]
+        public void TelemetryFromStorage(string telemetry) => WriteEvent(2, telemetry);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorDataEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorDataEventSource.cs
@@ -12,6 +12,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
     /// EventSource for the AzureMonitor Telemetry.
     /// This can be used to collect telemetry that should be emitted by the exporter.
     /// EventSource Guid at Runtime: cf17323b-4fb7-53b5-2824-934d0ce75082.
+    /// (This guid can be found by debugging this class and inspecting the "Log" singleton and reading the "Guid" property).
     /// </summary>
     /// <remarks>
     /// PerfView Instructions:

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorExporterEventSourceTests.cs
@@ -18,5 +18,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         {
             EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(AzureMonitorExporterEventSource.Log);
         }
+
+        [Fact]
+        public void EventSourceTest_AzureMonitorDataEventSource()
+        {
+            EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(AzureMonitorDataEventSource.Log);
+        }
     }
 }


### PR DESCRIPTION
This PR provides an extra mechanism to collect telemetry from a second EventSource class.
This is something that Application Insights SDK does and has been used on support investigations.


![image](https://github.com/Azure/azure-sdk-for-net/assets/28785781/f8e75698-ad9d-4e4c-a603-fd3fe2b4ee67)

