### PR TITLE
Move MutableJsonDocument into internal shared source

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -69,6 +69,15 @@
     <Compile Include="Shared\HttpMessageSanitizer.cs" />
     <Compile Include="Shared\InitializationConstructorAttribute.cs" />
     <Compile Include="Shared\Multipart\MemoryResponse.cs" />
+    <Compile Include="Shared\MutableJsonChange.cs" />
+    <Compile Include="Shared\MutableJsonChangeKind.cs" />
+    <Compile Include="Shared\MutableJsonDocument.ChangeTracker.cs" />
+    <Compile Include="Shared\MutableJsonDocument.cs" />
+    <Compile Include="Shared\MutableJsonElement.ArrayEnumerator.cs" />
+    <Compile Include="Shared\MutableJsonElement.cs" />
+    <Compile Include="Shared\MutableJsonElement.ObjectEnumerator.cs" />
+    <Compile Include="Shared\MutableJsonElement.WriteTo.cs" />
+    <Compile Include="Shared\MutableJsonElement.WriteTo.MergePatch.cs" />
     <Compile Include="Shared\NullableAttributes.cs" />
     <Compile Include="Shared\OperationInternalBase.cs" />
     <Compile Include="Shared\TrimmingAttribute.cs" />

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonChange.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonChange.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Text.Json;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     internal struct MutableJsonChange

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonChangeKind.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonChangeKind.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     internal enum MutableJsonChangeKind

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonDocument.ChangeTracker.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonDocument.ChangeTracker.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     internal partial class MutableJsonDocument

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonDocument.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonDocument.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonElement.ArrayEnumerator.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonElement.ArrayEnumerator.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     internal partial struct MutableJsonElement

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonElement.ObjectEnumerator.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonElement.ObjectEnumerator.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     /// <summary>

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonElement.WriteTo.MergePatch.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonElement.WriteTo.MergePatch.cs
@@ -5,6 +5,8 @@ using System;
 using System.Diagnostics;
 using System.Text.Json;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     internal partial struct MutableJsonElement

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonElement.WriteTo.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonElement.WriteTo.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     internal partial struct MutableJsonElement

--- a/sdk/core/Azure.Core/src/Shared/MutableJsonElement.cs
+++ b/sdk/core/Azure.Core/src/Shared/MutableJsonElement.cs
@@ -9,6 +9,8 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+#nullable enable
+
 namespace Azure.Core.Json
 {
     /// <summary>


### PR DESCRIPTION
This PR moves MutableJsonDocument and related types into Azure.Core internal shared source.  Prior changes have added an analyzer to encourage people not to use them https://github.com/Azure/azure-sdk-tools/pull/6642, since we plan to make them public later, and may make breaking changes to APIs/functionality as part of that process.