### PR TITLE
[App Config] Snapshot API updates

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -122,7 +122,7 @@ namespace Azure.Data.AppConfiguration
         public ConfigurationSettingsSnapshot(System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.SnapshotSettingFilter> filters) { }
         public Azure.Data.AppConfiguration.CompositionType? CompositionType { get { throw null; } set { } }
         public System.DateTimeOffset? Created { get { throw null; } }
-        public Azure.ETag Etag { get { throw null; } }
+        public Azure.ETag ETag { get { throw null; } }
         public System.DateTimeOffset? Expires { get { throw null; } }
         public System.Collections.Generic.IList<Azure.Data.AppConfiguration.SnapshotSettingFilter> Filters { get { throw null; } }
         public long? ItemCount { get { throw null; } }
@@ -130,7 +130,6 @@ namespace Azure.Data.AppConfiguration
         public System.TimeSpan? RetentionPeriod { get { throw null; } set { } }
         public long? Size { get { throw null; } }
         public Azure.Data.AppConfiguration.SnapshotStatus? Status { get { throw null; } }
-        public int? StatusCode { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> Tags { get { throw null; } }
     }
     public partial class CreateSnapshotOperation : Azure.Operation<Azure.Data.AppConfiguration.ConfigurationSettingsSnapshot>
@@ -204,15 +203,14 @@ namespace Azure.Data.AppConfiguration
         public SnapshotFields(string value) { throw null; }
         public static Azure.Data.AppConfiguration.SnapshotFields CompositionType { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Created { get { throw null; } }
-        public static Azure.Data.AppConfiguration.SnapshotFields Etag { get { throw null; } }
+        public static Azure.Data.AppConfiguration.SnapshotFields ETag { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Expires { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Filters { get { throw null; } }
-        public static Azure.Data.AppConfiguration.SnapshotFields ItemsCount { get { throw null; } }
+        public static Azure.Data.AppConfiguration.SnapshotFields ItemCount { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Name { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields RetentionPeriod { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Size { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Status { get { throw null; } }
-        public static Azure.Data.AppConfiguration.SnapshotFields StatusCode { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Tags { get { throw null; } }
         public bool Equals(Azure.Data.AppConfiguration.SnapshotFields other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -959,7 +959,7 @@ namespace Azure.Data.AppConfiguration
 
                 var matchConditions = new MatchConditions();
 
-                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.Etag } : default;
+                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.ETag } : default;
 
                 Response response = await UpdateSnapshotStatusAsync(snapshot.Name, content, requestOptions, context).ConfigureAwait(false);
                 ConfigurationSettingsSnapshot value = ConfigurationSettingsSnapshot.FromResponse(response);
@@ -995,7 +995,7 @@ namespace Azure.Data.AppConfiguration
                 };
                 using RequestContent content = SnapshotUpdateParameters.ToRequestContent(snapshotUpdateParameters);
 
-                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.Etag } : default;
+                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.ETag } : default;
 
                 Response response = UpdateSnapshotStatus(snapshot.Name, content, requestOptions, context);
                 ConfigurationSettingsSnapshot value = ConfigurationSettingsSnapshot.FromResponse(response);
@@ -1091,7 +1091,7 @@ namespace Azure.Data.AppConfiguration
                 };
                 using RequestContent content = SnapshotUpdateParameters.ToRequestContent(snapshotUpdateParameters);
 
-                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.Etag } : default;
+                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.ETag } : default;
 
                 Response response = await UpdateSnapshotStatusAsync(snapshot.Name, content, requestOptions, context).ConfigureAwait(false);
                 ConfigurationSettingsSnapshot value = ConfigurationSettingsSnapshot.FromResponse(response);
@@ -1127,7 +1127,7 @@ namespace Azure.Data.AppConfiguration
                 };
                 using RequestContent content = SnapshotUpdateParameters.ToRequestContent(snapshotUpdateParameters);
 
-                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.Etag } : default;
+                MatchConditions requestOptions = onlyIfUnchanged ? new MatchConditions { IfMatch = snapshot.ETag } : default;
 
                 Response response = UpdateSnapshotStatus(snapshot.Name, content, requestOptions, context);
                 ConfigurationSettingsSnapshot value = ConfigurationSettingsSnapshot.FromResponse(response);

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsSnapshot.Serialization.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsSnapshot.Serialization.cs
@@ -48,7 +48,6 @@ namespace Azure.Data.AppConfiguration
         {
             Optional<string> name = default;
             Optional<SnapshotStatus> status = default;
-            Optional<int> statusCode = default;
             IList<SnapshotSettingFilter> filters = default;
             Optional<CompositionType> compositionType = default;
             Optional<DateTimeOffset> created = default;
@@ -73,16 +72,6 @@ namespace Azure.Data.AppConfiguration
                         continue;
                     }
                     status = new SnapshotStatus(property.Value.GetString());
-                    continue;
-                }
-                if (property.NameEquals("status_code"))
-                {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        property.ThrowNonNullablePropertyIsNull();
-                        continue;
-                    }
-                    statusCode = property.Value.GetInt32();
                     continue;
                 }
                 if (property.NameEquals("filters"))
@@ -176,7 +165,7 @@ namespace Azure.Data.AppConfiguration
                     continue;
                 }
             }
-            return new ConfigurationSettingsSnapshot(name.Value, Optional.ToNullable(status), Optional.ToNullable(statusCode), filters, Optional.ToNullable(compositionType), Optional.ToNullable(created), Optional.ToNullable(expires), Optional.ToNullable(retentionPeriod), Optional.ToNullable(size), Optional.ToNullable(itemsCount), Optional.ToDictionary(tags), new ETag(etag.Value));
+            return new ConfigurationSettingsSnapshot(name.Value, Optional.ToNullable(status), filters, Optional.ToNullable(compositionType), Optional.ToNullable(created), Optional.ToNullable(expires), Optional.ToNullable(retentionPeriod), Optional.ToNullable(size), Optional.ToNullable(itemsCount), Optional.ToDictionary(tags), new ETag(etag.Value));
         }
 
         // Mapping raw response to model

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsSnapshot.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationSettingsSnapshot.cs
@@ -25,7 +25,6 @@ namespace Azure.Data.AppConfiguration
         /// <summary> Initializes a new instance of Snapshot. </summary>
         /// <param name="name"> The name of the snapshot. </param>
         /// <param name="status"> The current status of the snapshot. </param>
-        /// <param name="statusCode"> Provides additional information about the status of the snapshot. The status code values are modeled after HTTP status codes. </param>
         /// <param name="filters"> A list of filters used to filter the key-values included in the snapshot. </param>
         /// <param name="compositionType"> The composition type describes how the key-values within the snapshot are composed. The 'key' composition type ensures there are no two key-values containing the same key. The 'key_label' composition type ensures there are no two key-values containing the same key and label. </param>
         /// <param name="created"> The time that the snapshot was created. </param>
@@ -34,12 +33,11 @@ namespace Azure.Data.AppConfiguration
         /// <param name="size"> The size in bytes of the snapshot. </param>
         /// <param name="itemCount"> The amount of key-values in the snapshot. </param>
         /// <param name="tags"> The tags of the snapshot. </param>
-        /// <param name="etag"> A value representing the current state of the snapshot. </param>
-        internal ConfigurationSettingsSnapshot(string name, SnapshotStatus? status, int? statusCode, IList<SnapshotSettingFilter> filters, CompositionType? compositionType, DateTimeOffset? created, DateTimeOffset? expires, long? retentionPeriod, long? size, long? itemCount, IDictionary<string, string> tags, ETag etag)
+        /// <param name="eTag"> A value representing the current state of the snapshot. </param>
+        internal ConfigurationSettingsSnapshot(string name, SnapshotStatus? status, IList<SnapshotSettingFilter> filters, CompositionType? compositionType, DateTimeOffset? created, DateTimeOffset? expires, long? retentionPeriod, long? size, long? itemCount, IDictionary<string, string> tags, ETag eTag)
         {
             Name = name;
             Status = status;
-            StatusCode = statusCode;
             Filters = filters;
             CompositionType = compositionType;
             Created = created;
@@ -48,15 +46,13 @@ namespace Azure.Data.AppConfiguration
             Size = size;
             ItemCount = itemCount;
             Tags = tags;
-            Etag = etag;
+            ETag = eTag;
         }
 
         /// <summary> The name of the snapshot. </summary>
         public string Name { get; }
         /// <summary> The current status of the snapshot. </summary>
         public SnapshotStatus? Status { get; }
-        /// <summary> Provides additional information about the status of the snapshot. The status code values are modeled after HTTP status codes. </summary>
-        public int? StatusCode { get; }
         /// <summary> A list of filters used to filter the key-values included in the snapshot. </summary>
         public IList<SnapshotSettingFilter> Filters { get; }
         /// <summary> The composition type describes how the key-values within the snapshot are composed. The 'key' composition type ensures there are no two key-values containing the same key. The 'key_label' composition type ensures there are no two key-values containing the same key and label. </summary>
@@ -95,6 +91,6 @@ namespace Azure.Data.AppConfiguration
         /// <summary> The tags of the snapshot. </summary>
         public IDictionary<string, string> Tags { get; }
         /// <summary> A value representing the current state of the snapshot. </summary>
-        public ETag Etag { get; }
+        public ETag ETag { get; }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SnapshotFields.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SnapshotFields.cs
@@ -22,7 +22,6 @@ namespace Azure.Data.AppConfiguration
 
         private const string NameValue = "name";
         private const string StatusValue = "status";
-        private const string StatusCodeValue = "status_code";
         private const string FiltersValue = "filters";
         private const string CompositionTypeValue = "composition_type";
         private const string CreatedValue = "created";

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SnapshotFields.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SnapshotFields.cs
@@ -29,16 +29,14 @@ namespace Azure.Data.AppConfiguration
         private const string ExpiresValue = "expires";
         private const string RetentionPeriodValue = "retention_period";
         private const string SizeValue = "size";
-        private const string ItemsCountValue = "items_count";
+        private const string ItemCountValue = "items_count";
         private const string TagsValue = "tags";
-        private const string EtagValue = "etag";
+        private const string ETagValue = "etag";
 
         /// <summary> name. </summary>
         public static SnapshotFields Name { get; } = new SnapshotFields(NameValue);
         /// <summary> status. </summary>
         public static SnapshotFields Status { get; } = new SnapshotFields(StatusValue);
-        /// <summary> status_code. </summary>
-        public static SnapshotFields StatusCode { get; } = new SnapshotFields(StatusCodeValue);
         /// <summary> filters. </summary>
         public static SnapshotFields Filters { get; } = new SnapshotFields(FiltersValue);
         /// <summary> composition_type. </summary>
@@ -52,11 +50,11 @@ namespace Azure.Data.AppConfiguration
         /// <summary> size. </summary>
         public static SnapshotFields Size { get; } = new SnapshotFields(SizeValue);
         /// <summary> items_count. </summary>
-        public static SnapshotFields ItemsCount { get; } = new SnapshotFields(ItemsCountValue);
+        public static SnapshotFields ItemCount { get; } = new SnapshotFields(ItemCountValue);
         /// <summary> tags. </summary>
         public static SnapshotFields Tags { get; } = new SnapshotFields(TagsValue);
         /// <summary> etag. </summary>
-        public static SnapshotFields Etag { get; } = new SnapshotFields(EtagValue);
+        public static SnapshotFields ETag { get; } = new SnapshotFields(ETagValue);
         /// <summary> Determines if two <see cref="SnapshotFields"/> values are the same. </summary>
         public static bool operator ==(SnapshotFields left, SnapshotFields right) => left.Equals(right);
         /// <summary> Determines if two <see cref="SnapshotFields"/> values are not the same. </summary>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsSnapshotTest.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingsSnapshotTest.cs
@@ -15,7 +15,6 @@ namespace Azure.Data.AppConfiguration.Tests
             var settingSnapshot = new ConfigurationSettingsSnapshot(
                 "name",
                 SnapshotStatus.Ready,
-                1,
                 new List<SnapshotSettingFilter>(),
                 new CompositionType(),
                 DateTime.UtcNow,


### PR DESCRIPTION
This PR includes the following updates:

- The `StatusCode` property has been removed from `ConfigurationSettingsSnapshot`. This property was generated and copied from the [previous swagger version](https://github.com/Azure/azure-rest-api-specs/blob/3751704f5318f1175875c94b66af769db917f2d3/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json#L1574-L1579). It has been removed as it no longer exists in the latest swagger.
- The property `Etag` has been renamed to `ETag`.