### PR TITLE
[Functions] Event Hubs: Adjust default batch size

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 5.6.0-beta.1 (Unreleased)
-
-### Features Added
+## 6.0.0 (2023-09-06)
 
 ### Breaking Changes
 
-### Bugs Fixed
+- The default batch size has changed to 100 events.  Previously, the default batch size was 10.
 
-### Other Changes
+  This setting represents the maximum number of events from Event Hubs that the function can receive when it's invoked. The decision to change the default was based on developer feedback, testing, and a desire to match the defaults used by the Azure SDK for Event Hubs.  This change will be beneficial to the average scenario by helping to improve performance as well as lower costs due to fewer function executions.
+
+  We recommend testing to ensure no breaking changes are introducing to your function app before updating existing applications to version 6.0.0 or newer of the Event Hubs extension, especially if you have code code that was written to expect 10 as the max event batch size.
 
 ## 5.5.0 (2023-08-11)
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
     {
         public EventHubOptions()
         {
-            MaxEventBatchSize = 10;
+            MaxEventBatchSize = 100;
             MinEventBatchSize = 1;
             MaxWaitTime = TimeSpan.FromSeconds(60);
             ConnectionOptions = new EventHubConnectionOptions()
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
         /// <summary>
         /// Gets or sets the maximum number of events delivered in a batch. This setting applies only to functions that
-        /// receive multiple events. Default 10.
+        /// receive multiple events. Default 100.
         /// </summary>
         public int MaxEventBatchSize
         {

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>5.6.0-beta.1</Version>
+    <Version>6.0.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.5.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTriggerAttributeBindingProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTriggerAttributeBindingProviderTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.UnitTests
 
         [Test]
         [TestCase(nameof(SingleDispatch), 1)]
-        [TestCase(nameof(MultipleDispatch), 10)]
+        [TestCase(nameof(MultipleDispatch), 100)]
         public async Task TryCreateAsync_BatchCountsDefaultedCorrectly(string function, int expectedBatchCount)
         {
             ParameterInfo parameter = GetType().GetMethod(function, BindingFlags.NonPublic | BindingFlags.Static).GetParameters()[0];

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         }
 
         [Test]
-        // Using default concurrency of 10.
+        // Using concurrency of 10.
         [TestCase(10, 10, 1)]
         [TestCase(20, 10, 2)]
         [TestCase(30, 10, 3)]
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [TestCase(150, 10, 10)]
         public void GetScaleResultInternal_ReturnsExpected(long eventCount, int partitionCount, int expectedTargetWorkerCount)
         {
-            TargetScalerResult result = _targetScaler.GetScaleResultInternal(new TargetScalerContext { }, eventCount, partitionCount);
+            TargetScalerResult result = _targetScaler.GetScaleResultInternal(new TargetScalerContext { InstanceConcurrency = 10 }, eventCount, partitionCount);
             Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [TestCase(10, 20, 30, 10)] // InstanceConcurrency defined in TargetScalerContext takes precedence
         [TestCase(null, 20, 30, 30)] // TargetUnprocessedEventThreshold takes second precendence
         [TestCase(null, 20, null, 20)] // Finally MaxEventBatchSize is only used if InstanceConcurrency and TargetUnprocessedEventThreshold are both undefined
-        [TestCase(null, null, null, 10)] // Using default value of MaxEventBatchSize
+        [TestCase(null, null, null, 100)] // Using default value of MaxEventBatchSize
         public void GetDesiredConcurrencyInternal_ReturnsExpected(int? instanceConcurrency, int? maxEventBatchSize, int? targetUnprocessedEventThreshold, int expectedConcurrency)
         {
             TargetScalerContext context = new TargetScalerContext() { InstanceConcurrency = instanceConcurrency };


### PR DESCRIPTION
# Summary

The focus of these changes is to increase the default for the maximum batch size from 10 to 100.

This setting represents the maximum number of events from Event Hubs that the function can receive when it's invoked. The decision to change the default was based on developer feedback, testing, and a desire to match the defaults used by the Azure SDK for Event Hubs.  This change will be beneficial to the average scenario by helping to improve performance as well as lower costs due to fewer function executions.

# References and Related

- [[FEATURE REQ] Increase the Azure Functions Event Hubs max batch size default to 100 (#38452)](https://github.com/Azure/azure-sdk-for-net/issues/38452)