### PR TITLE
DynamicData: Allow arrays of objects where elements are allowed types

### DIFF
--- a/sdk/core/Azure.Core/src/DynamicData/DynamicData.AllowList.cs
+++ b/sdk/core/Azure.Core/src/DynamicData/DynamicData.AllowList.cs
@@ -158,8 +158,9 @@ namespace Azure.Core.Serialization
                         continue;
                     }
 
-                    // Don't allow heterogenous collections
-                    if (item.GetType() != elementType)
+                    // Don't allow heterogenous collections,
+                    // unless the types it's holding are allowed types.
+                    if (item.GetType() != elementType && !IsAllowedType(item.GetType()))
                     {
                         return false;
                     }

--- a/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonAllowListTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonAllowListTests.cs
@@ -95,7 +95,7 @@ namespace Azure.Core.Tests
             Assert.DoesNotThrow(() => json.Bar = jsonWithArray.MyArray);
 
             // Create list to add an item to
-            List<string> list = new((IEnumerable<string>)json.Foo);
+            List<string> list = new((string[])json.Foo);
             list.Add("d");
 
             json.Foo = list;

--- a/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonAllowListTests.cs
+++ b/sdk/core/Azure.Core/tests/DynamicData/DynamicJsonAllowListTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.Serialization;
-using System.Text.Json;
 using Azure.Core.Serialization;
 using NUnit.Framework;
 
@@ -64,6 +63,46 @@ namespace Azure.Core.Tests
 
             // New property
             Assert.DoesNotThrow(() => json.Bar = new object[] { 2, false, "b" });
+        }
+
+        [Test]
+        public void CanAssignObjectArrayOfAllowedTypes()
+        {
+            dynamic json = BinaryData.FromString("""{"foo":1}""").ToDynamicFromJson(JsonPropertyNames.CamelCase);
+
+            // Existing property
+            Assert.DoesNotThrow(() => json.Foo = new object[] { 1, null, "a" });
+
+            // New property
+            Assert.DoesNotThrow(() => json.Bar = new object[] { 2, false, "b" });
+        }
+
+        [Test]
+        public void CanAssignArrayOfDynamic()
+        {
+            dynamic jsonWithArray = BinaryData.FromString("""
+                {
+                    "MyArray": ["a", "b", "c"]
+                }
+                """).ToDynamicFromJson(JsonPropertyNames.CamelCase);
+
+            dynamic json = BinaryData.FromString("""{"foo": 1}""").ToDynamicFromJson(JsonPropertyNames.CamelCase);
+
+            // Existing property
+            Assert.DoesNotThrow(() => json.Foo = jsonWithArray.MyArray);
+
+            // New property
+            Assert.DoesNotThrow(() => json.Bar = jsonWithArray.MyArray);
+
+            // Create list to add an item to
+            List<string> list = new((IEnumerable<string>)json.Foo);
+            list.Add("d");
+
+            json.Foo = list;
+            Assert.IsTrue("a" == json.Foo[0]);
+            Assert.IsTrue("b" == json.Foo[1]);
+            Assert.IsTrue("c" == json.Foo[2]);
+            Assert.IsTrue("d" == json.Foo[3]);
         }
 
         [Test]


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-net/issues/37074

- [ ] Extend the set of allowed values as described here: https://github.com/Azure/AzureFX/pull/112#discussion_r1283775227

@KrzysztofCwalina, I believe this should allow you to replace [your helper methods here](https://github.com/KrzysztofCwalina/AzureFX/blob/main/dotnet/Azure.FX.Administration/CloudMachineAdministrationClient_appservice.cs#L101).

