### PR TITLE
Fix broken chat functions example in README

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/README.md
+++ b/sdk/openai/Azure.AI.OpenAI/README.md
@@ -323,7 +323,10 @@ if (responseChoice.FinishReason == CompletionsFinishReason.FunctionCall)
             ChatRole.Function,
             JsonSerializer.Serialize(
                 functionResultData,
-                new JsonSerializerOptions() {  PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+                new JsonSerializerOptions() {  PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+        {
+            Name = responseChoice.Message.FunctionCall.Name
+        };
         conversationMessages.Add(functionResponseMessage);
         // Now make a new request using all three messages in conversationMessages
     }

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample07_ChatFunctions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample07_ChatFunctions.cs
@@ -90,7 +90,10 @@ namespace Azure.AI.OpenAI.Tests.Samples
                         ChatRole.Function,
                         JsonSerializer.Serialize(
                             functionResultData,
-                            new JsonSerializerOptions() {  PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+                            new JsonSerializerOptions() {  PropertyNamingPolicy = JsonNamingPolicy.CamelCase }))
+                    {
+                        Name = responseChoice.Message.FunctionCall.Name
+                    };
                     conversationMessages.Add(functionResponseMessage);
                     // Now make a new request using all three messages in conversationMessages
                 }


### PR DESCRIPTION
The use of the ChatRole.Function message will fail if the message doesn't have its Name set to the name of function.