### PR TITLE
Use identity subscription config and pre script for live tests

### DIFF
--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -1,0 +1,30 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArguments
+)
+
+if ($EnvironmentVariables -eq $null) {
+    throw "EnvironmentVariables must be set in calling script New-TestResources.ps1"
+}
+
+$tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
+$pfxPath = Join-Path $tmp "test.pfx"
+$pemPath = Join-Path $tmp "test.pem"
+$sniPath = Join-Path $tmp "testsni.pfx"
+
+Write-Host "Creating identity test files: $pfxPath $pemPath $sniPath"
+
+[System.Convert]::FromBase64String($EnvironmentVariables['PFX_CONTENTS']) | Set-Content -Path $pfxPath -AsByteStream
+Set-Content -Path $pemPath -Value $EnvironmentVariables['PEM_CONTENTS']
+[System.Convert]::FromBase64String($EnvironmentVariables['SNI_CONTENTS']) | Set-Content -Path $sniPath -AsByteStream
+
+# Set for pipeline
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PFX;]$pfxPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PEM;]$pemPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_SNI;]$sniPath"
+# Set for local
+$env:IDENTITY_SP_CERT_PFX = $pfxPath
+$env:IDENTITY_SP_CERT_PEM = $pemPath
+$env:IDENTITY_SP_CERT_SNI = $sniPath

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -5,8 +5,14 @@ param (
     $RemainingArguments
 )
 
-if ($EnvironmentVariables -eq $null) {
-    throw "EnvironmentVariables must be set in calling script New-TestResources.ps1"
+if (!$CI) {
+    # TODO: Remove this once auto-cloud config downloads are supported locally
+    Write-Host "Skipping cert setup in local testing mode"
+    return
+}
+
+if ($EnvironmentVariables -eq $null -or $EnvironmentVariables.Count -eq 0) {
+    throw "EnvironmentVariables must be set in the calling script New-TestResources.ps1"
 }
 
 $tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -1,20 +1,21 @@
 trigger: none
 
 extends:
-  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     TimeoutInMinutes: 120
     ServiceDirectory: identity
-    SupportedClouds: 'Public,UsGov,China,Canary'
+    CloudConfig:
+      Public:
+        SubscriptionConfigurations:
+          - $(sub-config-azure-cloud-test-resources)
+          # Contains alternate tenant, AAD app and cert info for testing
+          - $(sub-config-identity-test-resources)
     PreSteps:
       - pwsh: |
           [System.Convert]::FromBase64String($env:PFX_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/test.pfx -AsByteStream
           Set-Content -Path $(Agent.TempDirectory)/test.pem -Value $env:PEM_CONTENTS
           [System.Convert]::FromBase64String($env:SNI_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/testsni.pfx -AsByteStream
-        env:
-          PFX_CONTENTS: $(net-identity-spcert-pfx)
-          PEM_CONTENTS: $(net-identity-spcert-pem)
-          SNI_CONTENTS: $(net-identity-spcert-sni)
     EnvVars:
       IDENTITY_SP_CERT_PFX: $(Agent.TempDirectory)/test.pfx
       IDENTITY_SP_CERT_PEM: $(Agent.TempDirectory)/test.pem

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -11,12 +11,3 @@ extends:
           - $(sub-config-azure-cloud-test-resources)
           # Contains alternate tenant, AAD app and cert info for testing
           - $(sub-config-identity-test-resources)
-    PreSteps:
-      - pwsh: |
-          [System.Convert]::FromBase64String($env:PFX_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/test.pfx -AsByteStream
-          Set-Content -Path $(Agent.TempDirectory)/test.pem -Value $env:PEM_CONTENTS
-          [System.Convert]::FromBase64String($env:SNI_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/testsni.pfx -AsByteStream
-    EnvVars:
-      IDENTITY_SP_CERT_PFX: $(Agent.TempDirectory)/test.pfx
-      IDENTITY_SP_CERT_PEM: $(Agent.TempDirectory)/test.pem
-      IDENTITY_SP_CERT_SNI: $(Agent.TempDirectory)/testsni.pfx


### PR DESCRIPTION
Updating the identity live tests to remove logic and env setting from yaml in favor of a dedicated keyvault config and powershell script. This will make it possible to do better local and sovereign cloud testing, and make cross-language config updates more easily.