### PR TITLE
Adding string cast operators and null APIs to Variant

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
@@ -51,10 +51,10 @@ namespace Azure
         public Variant(ushort value) { throw null; }
         public Variant(uint value) { throw null; }
         public Variant(ulong value) { throw null; }
+        public bool IsNull { get { throw null; } }
         public System.Type? Type { get { throw null; } }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
         public static Azure.Variant Create<T>(T value) { throw null; }
-        public static bool IsNull(Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<byte> (in Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<char> (in Azure.Variant value) { throw null; }
         public static explicit operator bool (in Azure.Variant value) { throw null; }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net461.cs
@@ -19,6 +19,7 @@ namespace Azure
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public static readonly Azure.Variant Null;
         public Variant(System.ArraySegment<byte> segment) { throw null; }
         public Variant(System.ArraySegment<char> segment) { throw null; }
         public Variant(bool value) { throw null; }
@@ -53,6 +54,7 @@ namespace Azure
         public System.Type? Type { get { throw null; } }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
         public static Azure.Variant Create<T>(T value) { throw null; }
+        public static bool IsNull(Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<byte> (in Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<char> (in Azure.Variant value) { throw null; }
         public static explicit operator bool (in Azure.Variant value) { throw null; }
@@ -82,6 +84,7 @@ namespace Azure
         public static explicit operator ulong? (in Azure.Variant value) { throw null; }
         public static explicit operator sbyte (in Azure.Variant value) { throw null; }
         public static explicit operator float (in Azure.Variant value) { throw null; }
+        public static explicit operator string (in Azure.Variant value) { throw null; }
         public static explicit operator ushort (in Azure.Variant value) { throw null; }
         public static explicit operator uint (in Azure.Variant value) { throw null; }
         public static explicit operator ulong (in Azure.Variant value) { throw null; }
@@ -114,6 +117,7 @@ namespace Azure
         public static implicit operator Azure.Variant (ulong? value) { throw null; }
         public static implicit operator Azure.Variant (sbyte value) { throw null; }
         public static implicit operator Azure.Variant (float value) { throw null; }
+        public static implicit operator Azure.Variant (string value) { throw null; }
         public static implicit operator Azure.Variant (ushort value) { throw null; }
         public static implicit operator Azure.Variant (uint value) { throw null; }
         public static implicit operator Azure.Variant (ulong value) { throw null; }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
@@ -51,10 +51,10 @@ namespace Azure
         public Variant(ushort value) { throw null; }
         public Variant(uint value) { throw null; }
         public Variant(ulong value) { throw null; }
+        public bool IsNull { get { throw null; } }
         public System.Type? Type { get { throw null; } }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
         public static Azure.Variant Create<T>(T value) { throw null; }
-        public static bool IsNull(Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<byte> (in Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<char> (in Azure.Variant value) { throw null; }
         public static explicit operator bool (in Azure.Variant value) { throw null; }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net6.0.cs
@@ -19,6 +19,7 @@ namespace Azure
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public static readonly Azure.Variant Null;
         public Variant(System.ArraySegment<byte> segment) { throw null; }
         public Variant(System.ArraySegment<char> segment) { throw null; }
         public Variant(bool value) { throw null; }
@@ -53,6 +54,7 @@ namespace Azure
         public System.Type? Type { get { throw null; } }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
         public static Azure.Variant Create<T>(T value) { throw null; }
+        public static bool IsNull(Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<byte> (in Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<char> (in Azure.Variant value) { throw null; }
         public static explicit operator bool (in Azure.Variant value) { throw null; }
@@ -82,6 +84,7 @@ namespace Azure
         public static explicit operator ulong? (in Azure.Variant value) { throw null; }
         public static explicit operator sbyte (in Azure.Variant value) { throw null; }
         public static explicit operator float (in Azure.Variant value) { throw null; }
+        public static explicit operator string (in Azure.Variant value) { throw null; }
         public static explicit operator ushort (in Azure.Variant value) { throw null; }
         public static explicit operator uint (in Azure.Variant value) { throw null; }
         public static explicit operator ulong (in Azure.Variant value) { throw null; }
@@ -114,6 +117,7 @@ namespace Azure
         public static implicit operator Azure.Variant (ulong? value) { throw null; }
         public static implicit operator Azure.Variant (sbyte value) { throw null; }
         public static implicit operator Azure.Variant (float value) { throw null; }
+        public static implicit operator Azure.Variant (string value) { throw null; }
         public static implicit operator Azure.Variant (ushort value) { throw null; }
         public static implicit operator Azure.Variant (uint value) { throw null; }
         public static implicit operator Azure.Variant (ulong value) { throw null; }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -51,10 +51,10 @@ namespace Azure
         public Variant(ushort value) { throw null; }
         public Variant(uint value) { throw null; }
         public Variant(ulong value) { throw null; }
+        public bool IsNull { get { throw null; } }
         public System.Type? Type { get { throw null; } }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
         public static Azure.Variant Create<T>(T value) { throw null; }
-        public static bool IsNull(Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<byte> (in Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<char> (in Azure.Variant value) { throw null; }
         public static explicit operator bool (in Azure.Variant value) { throw null; }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -19,6 +19,7 @@ namespace Azure
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
+        public static readonly Azure.Variant Null;
         public Variant(System.ArraySegment<byte> segment) { throw null; }
         public Variant(System.ArraySegment<char> segment) { throw null; }
         public Variant(bool value) { throw null; }
@@ -53,6 +54,7 @@ namespace Azure
         public System.Type? Type { get { throw null; } }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
         public static Azure.Variant Create<T>(T value) { throw null; }
+        public static bool IsNull(Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<byte> (in Azure.Variant value) { throw null; }
         public static explicit operator System.ArraySegment<char> (in Azure.Variant value) { throw null; }
         public static explicit operator bool (in Azure.Variant value) { throw null; }
@@ -82,6 +84,7 @@ namespace Azure
         public static explicit operator ulong? (in Azure.Variant value) { throw null; }
         public static explicit operator sbyte (in Azure.Variant value) { throw null; }
         public static explicit operator float (in Azure.Variant value) { throw null; }
+        public static explicit operator string (in Azure.Variant value) { throw null; }
         public static explicit operator ushort (in Azure.Variant value) { throw null; }
         public static explicit operator uint (in Azure.Variant value) { throw null; }
         public static explicit operator ulong (in Azure.Variant value) { throw null; }
@@ -114,6 +117,7 @@ namespace Azure
         public static implicit operator Azure.Variant (ulong? value) { throw null; }
         public static implicit operator Azure.Variant (sbyte value) { throw null; }
         public static implicit operator Azure.Variant (float value) { throw null; }
+        public static implicit operator Azure.Variant (string value) { throw null; }
         public static implicit operator Azure.Variant (ushort value) { throw null; }
         public static implicit operator Azure.Variant (uint value) { throw null; }
         public static implicit operator Azure.Variant (ulong value) { throw null; }

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Variant.Null.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Variant.Null.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Runtime.InteropServices;
-
 namespace Azure
 {
     public readonly partial struct Variant
@@ -17,6 +14,6 @@ namespace Azure
         /// Indicates whether the Variant is null or has a value.
         /// </summary>
         /// <returns><code>true</code> if the Variant is <code>null</code>; <code>false</code> otherwise.</returns>
-        public static bool IsNull(Variant value) => value.Type == null;
+        public bool IsNull => Type == null;
     }
 }

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Variant.Null.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Variant.Null.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Azure
+{
+    public readonly partial struct Variant
+    {
+        /// <summary>
+        /// Null Variant.
+        /// </summary>
+        public static readonly Variant Null = new((object?)null);
+
+        /// <summary>
+        /// Indicates whether the Variant is null or has a value.
+        /// </summary>
+        /// <returns><code>true</code> if the Variant is <code>null</code>; <code>false</code> otherwise.</returns>
+        public static bool IsNull(Variant value) => value.Type == null;
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Variant.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Variant.cs
@@ -951,6 +951,20 @@ namespace Azure
         public static explicit operator decimal?(in Variant value) => value.As<decimal?>();
         #endregion
 
+        #region String
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator Variant(string value) => new(value);
+
+        /// <summary>
+        /// TBD.
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator string(in Variant value) => value.As<string>();
+        #endregion
+
         #region T
         /// <summary>
         /// TBD.

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringArrays.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringArrays.cs
@@ -4,7 +4,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringArrays
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringBoolean.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringBoolean
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringByte.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringByte
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringChar.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringChar
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTime.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTime.cs
@@ -4,7 +4,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringDateTime
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTimeOffset.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDateTimeOffset.cs
@@ -4,7 +4,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringDateTimeOffset
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDecimal.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDecimal.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringDecimal
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDouble.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringDouble.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringDouble
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringEnum.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.CompilerServices;
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringEnum
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringFloat.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringFloat.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringFloat
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringInt.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringInt
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringLong.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringLong.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringLong
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringNull.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringNull.cs
@@ -4,7 +4,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringNull
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringObject.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringObject.cs
@@ -4,7 +4,7 @@
 using System;
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringObject
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringSByte.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringSByte
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringShort.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringShort.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringShort
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUInt.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUInt.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringUInt
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUShort.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringUShort
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/StoringUlong.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
     public class StoringULong
     {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/VariantCreation.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/VariantCreation.cs
@@ -3,9 +3,9 @@
 
 using NUnit.Framework;
 
-namespace Azure
+namespace Azure.Core.Experimental.Tests
 {
-    public class Creation
+    public class VariantCreation
     {
         [Test]
         public void CreateIsAllocationFree()

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure.Core.Experimental.Tests
+{
+    public class VariantUsage
+    {
+        [Test]
+        public void CanUseVariantAsString()
+        {
+            Variant variant = "hi";
+
+            Assert.AreEqual("hi", (string)variant);
+
+            Assert.IsTrue("hi" == (string)variant);
+            Assert.IsTrue((string)variant == "hi");
+
+            Assert.AreEqual("hi", $"{(string)variant}");
+        }
+
+        [Test]
+        public void CanTestForNull()
+        {
+            Variant variant = Variant.Null;
+
+            Assert.IsTrue(Variant.IsNull(variant));
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
@@ -24,8 +24,9 @@ namespace Azure.Core.Experimental.Tests
         public void CanTestForNull()
         {
             Variant variant = Variant.Null;
+            Assert.True(variant.IsNull);
 
-            Assert.IsTrue(Variant.IsNull(variant));
+            Assert.True(new Variant((object)null).IsNull);
         }
     }
 }


### PR DESCRIPTION
This PR:
- Adds cast operators to/from string in the same pattern as other primitives
- Adds `Variant.Null` and `variant.IsNull` APIs to improve UX around nulls
- Moves tests for variant to the `Azure.Core.Experimental.Tests` namespace

Addresses https://github.com/Azure/azure-sdk-for-net/issues/32978