### PR TITLE
[JobRouter] Fix internal properties

### DIFF
--- a/sdk/communication/Azure.Communication.JobRouter/api/Azure.Communication.JobRouter.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/api/Azure.Communication.JobRouter.netstandard2.0.cs
@@ -4,6 +4,8 @@ namespace Azure.Communication.JobRouter
     {
         public BestWorkerMode() { }
         public BestWorkerMode(Azure.Communication.JobRouter.RouterRule scoringRule, System.Collections.Generic.IList<Azure.Communication.JobRouter.ScoringRuleParameterSelector> scoringParameterSelectors = null, bool allowScoringBatchOfWorkers = false, int? batchSize = default(int?), bool descendingOrder = true) { }
+        public Azure.Communication.JobRouter.RouterRule ScoringRule { get { throw null; } }
+        public Azure.Communication.JobRouter.Models.ScoringRuleOptions ScoringRuleOptions { get { throw null; } }
     }
     public partial class CancelExceptionAction : Azure.Communication.JobRouter.ExceptionAction
     {
@@ -193,11 +195,15 @@ namespace Azure.Communication.JobRouter
     {
         public FunctionRouterRule(System.Uri functionAppUri) { }
         public Azure.Communication.JobRouter.FunctionRouterRuleCredential Credential { get { throw null; } set { } }
+        public System.Uri FunctionUri { get { throw null; } }
     }
     public partial class FunctionRouterRuleCredential
     {
         public FunctionRouterRuleCredential(string functionKey) { }
         public FunctionRouterRuleCredential(string appKey, string clientId) { }
+        public string AppKey { get { throw null; } }
+        public string ClientId { get { throw null; } }
+        public string FunctionKey { get { throw null; } }
     }
     public partial class GetJobsOptions
     {
@@ -431,6 +437,7 @@ namespace Azure.Communication.JobRouter
     {
         public PassThroughWorkerSelectorAttachment(string key, Azure.Communication.JobRouter.LabelOperator labelOperator) { }
         public PassThroughWorkerSelectorAttachment(string key, Azure.Communication.JobRouter.LabelOperator labelOperator, System.TimeSpan? expiresAfter = default(System.TimeSpan?)) { }
+        public System.TimeSpan? ExpiresAfter { get { throw null; } }
         public string Key { get { throw null; } set { } }
         public Azure.Communication.JobRouter.LabelOperator LabelOperator { get { throw null; } set { } }
     }

--- a/sdk/communication/Azure.Communication.JobRouter/src/Models/BestWorkerMode.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Models/BestWorkerMode.cs
@@ -65,8 +65,14 @@ namespace Azure.Communication.JobRouter
             Kind = kind ?? "best-worker";
         }
 
-        internal ScoringRuleOptions ScoringRuleOptions { get; set; }
+        /// <summary>
+        /// Encapsulates all options that can be passed as parameters for scoring rule with BestWorkerMode.
+        /// </summary>
+        public ScoringRuleOptions ScoringRuleOptions { get; internal set; }
 
-        internal RouterRule ScoringRule { get; set; }
+        /// <summary>
+        /// Defines a scoring rule to use, when calculating a score to determine the best worker.
+        /// </summary>
+        public RouterRule ScoringRule { get; internal set; }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/src/Models/FunctionRouterRule.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Models/FunctionRouterRule.cs
@@ -23,6 +23,9 @@ namespace Azure.Communication.JobRouter
             }
         }
 
-        internal Uri FunctionUri { get; set; }
+        /// <summary>
+        /// URL for custom azure function.
+        /// </summary>
+        public Uri FunctionUri { get; internal set; }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/src/Models/FunctionRouterRuleCredential.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Models/FunctionRouterRuleCredential.cs
@@ -41,18 +41,18 @@ namespace Azure.Communication.JobRouter
         }
 
         /// <summary> (Optional) Access key scoped to a particular function. </summary>
-        internal string FunctionKey { get; set; }
+        public string FunctionKey { get; internal set; }
 
         /// <summary>
         /// (Optional) Access key scoped to a Azure Function app.
         /// This key grants access to all functions under the app.
         /// </summary>
-        internal string AppKey { get; set; }
+        public string AppKey { get; internal set; }
 
         /// <summary>
         /// (Optional) Client id, when AppKey is provided
         /// In context of Azure function, this is usually the name of the key
         /// </summary>
-        internal string ClientId { get; set; }
+        public string ClientId { get; internal set; }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/src/Models/PassThroughWorkerSelectorAttachment.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/src/Models/PassThroughWorkerSelectorAttachment.cs
@@ -24,7 +24,7 @@ namespace Azure.Communication.JobRouter
         }
 
         /// <summary> Describes how long the attached label selector is valid in seconds. </summary>
-        internal TimeSpan? ExpiresAfter { get; set; }
+        public TimeSpan? ExpiresAfter { get; internal set; }
 
         [CodeGenMember("ExpiresAfterSeconds")]
         internal double? _expiresAfterSeconds {


### PR DESCRIPTION
ScoringRuleOptions, ScoringRule, FunctionUri, ExpiresAfter should be public properties

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
