### PR TITLE
[AppConfig] Fix disposed stream access

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Bugs Fixed
 
-- `FeatureFlagConfigurationSetting` and `SecretReferenceConfigurationSetting` will now retain custom attributes in the setting value.  Previously, only attributes that were defined in the associated JSON schema were allowed and unknown attributes were discarded.  
+- `FeatureFlagConfigurationSetting` and `SecretReferenceConfigurationSetting` will now retain custom attributes in the setting value.  Previously, only attributes that were defined in the associated JSON schema were allowed and unknown attributes were discarded.
 
 - Added the ability to create `FeatureFlagConfigurationSetting` and `SecretReferenceConfigurationSetting` instances with an ETag, matching `ConfigurationSetting`.  This allows all setting types to use the [GetConfigurationSettingAsync](https://learn.microsoft.com/dotnet/api/azure.data.appconfiguration.configurationclient.getconfigurationsettingasync?view=azure-dotnet#azure-data-appconfiguration-configurationclient-getconfigurationsettingasync(azure-data-appconfiguration-configurationsetting-system-boolean-system-threading-cancellationtoken)) overload that accepts `onlyIfUnchanged.`  Previously, this was not possible for specialized settings types.
 
 - Added the ability to create `FeatureFlagConfigurationSetting` and `SecretReferenceConfigurationSetting` instances for testing purposes using the `ConfigurationModelFactory`. It was previously not possible to populate service-owned fields when testing.
+
+- Marked a constructor overload of `ConfigurationSetting` that was intended for testing purposes as non-visible, as the `ConfigurationModelFactory` should instead be used.
+
+- Fixed a bug where a disposed content stream was used to attempt deserialization in some scenarios, such as using a custom `HttpMessageHandler` that returns `StringContent`.
 
 ## 1.3.0-beta.2 (2023-07-11)
 
@@ -77,7 +81,7 @@
 
 #### New Features
 
-- Added `SecretReferenceConfigurationSetting` type to represent a configuration setting that references a KeyVault Secret. 
+- Added `SecretReferenceConfigurationSetting` type to represent a configuration setting that references a KeyVault Secret.
 - Added `FeatureFlagConfigurationSetting` type to represent a configuration setting that controls a feature flag.
 - Added `AddSyncToken` to `ConfigurationClient` to be able to provide external synchronization tokens.
 
@@ -89,7 +93,7 @@
 
 - Update the tag list for the AzConfig package
 
-## 1.0.0 
+## 1.0.0
 
 ### Breaking changes
 
@@ -99,11 +103,11 @@
 
 - Fixed multiple issues with connection string parsing in `ConfigurationClient`.
 
-## 1.0.0-preview.6 
+## 1.0.0-preview.6
 
 - Bugfixes: [#8920](https://github.com/Azure/azure-sdk-for-net/issues/8920)
 
-## 1.0.0-preview.5 
+## 1.0.0-preview.5
 
 ### Breaking changes
 
@@ -116,7 +120,7 @@
 - Added new overload for the method `ConfigurationClient.GetRevisions` that accepts key and optional label.
 - Added new overload for the method `ConfigurationClient.GetConfigurationSetting` that accepts `ConfigurationSetting` and its datetime stamp.
 
-## 1.0.0-preview.4 
+## 1.0.0-preview.4
 
 ### Breaking changes
 
@@ -135,11 +139,11 @@
 - Made `ConfigurationSetting` serializable by `System.Text.Json` serializers.
 - Updated documentation and samples.
 
-## 1.0.0-preview.3 
+## 1.0.0-preview.3
 
 - Fixed an issue where special characters were escaped incorrectly.
 
-## 1.0.0-preview.2 
+## 1.0.0-preview.2
 
 - Enabled conditional requests.
 - Added support for setting `x-ms-client-request-id`, `x-ms-correlation-request-id`, and `correlation-context` headers.

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -21,13 +19,13 @@ namespace Azure.Data.AppConfiguration
 
         private static async Task<Response<ConfigurationSetting>> CreateResponseAsync(Response response, CancellationToken cancellation)
         {
-            ConfigurationSetting result = await ConfigurationServiceSerializer.DeserializeSettingAsync(response.ContentStream, cancellation).ConfigureAwait(false);
+            ConfigurationSetting result = await ConfigurationServiceSerializer.DeserializeSettingAsync(response.Content, cancellation).ConfigureAwait(false);
             return Response.FromValue(result, response);
         }
 
         private static Response<ConfigurationSetting> CreateResponse(Response response)
         {
-            return Response.FromValue(ConfigurationServiceSerializer.DeserializeSetting(response.ContentStream), response);
+            return Response.FromValue(ConfigurationServiceSerializer.DeserializeSetting(response.Content), response);
         }
 
         private static Response<ConfigurationSetting> CreateResourceModifiedResponse(Response response)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationServiceSerializer.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/ConfigurationServiceSerializer.cs
@@ -169,18 +169,18 @@ namespace Azure.Data.AppConfiguration
             }
         }
 
-        public static async Task<ConfigurationSetting> DeserializeSettingAsync(Stream content, CancellationToken cancellation)
+        public static async Task<ConfigurationSetting> DeserializeSettingAsync(BinaryData content, CancellationToken cancellation)
         {
-            using (JsonDocument json = await JsonDocument.ParseAsync(content, default, cancellation).ConfigureAwait(false))
+            using (JsonDocument json = await JsonDocument.ParseAsync(content.ToStream(), default, cancellation).ConfigureAwait(false))
             {
                 JsonElement root = json.RootElement;
                 return ReadSetting(root);
             }
         }
 
-        public static ConfigurationSetting DeserializeSetting(Stream content)
+        public static ConfigurationSetting DeserializeSetting(BinaryData content)
         {
-            using JsonDocument json = JsonDocument.Parse(content, default);
+            using JsonDocument json = JsonDocument.Parse(content.ToMemory(), default);
             JsonElement root = json.RootElement;
             return ReadSetting(root);
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a bug where JSON members in the value for Feature Flags and Secret References which are not defined in the JSON schema were discarded.  The schema itself allows for arbitrary JSON members, the Azure portal supports them in its advanced view, and the service documentation also refers to them.

This change preserves unknown JSON attributes while allowing the well-known properties of the setting to override their associated JSON members.

Constructor overloads that accept an ETag were also added to Feature Flags and Secret References.  This aligns with ConfigurationSetting and allows use of the GetConfigurationSettingsAsync overload that accepts `onlyIfUnchanged`, which was previously not accessible for specialized settings.

# References and Resources

- [[BUG] AppConfig: Cannot set ETag when constructing FeatureFlagConfigurationSetting (#38098)](https://github.com/Azure/azure-sdk-for-net/issues/38098)
- [[AppConfig] Fix disposed stream access (#38471)](https://github.com/Azure/azure-sdk-for-net/pull/38471) _(previous iteration)_