### PR TITLE
[Webjobs.Extensions.EventHub] Legacy checkpoint support

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -109,7 +109,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
                 // In that case, LastEnqueuedSequenceNumber will be >= 0
 
                 if ((partitionProperties.LastEnqueuedSequenceNumber != -1 && partitionProperties.LastEnqueuedSequenceNumber != (checkpoint?.SequenceNumber ?? -1))
-                    || (checkpoint == null && partitionProperties.LastEnqueuedSequenceNumber >= 0))
+                    || (checkpoint == null && partitionProperties.LastEnqueuedSequenceNumber >= 0)
+                    || (checkpoint != null && checkpoint.Offset == null && partitionProperties.LastEnqueuedSequenceNumber >= 0))
                 {
                     long partitionUnprocessedEventCount = GetUnprocessedEventCount(partitionProperties, checkpoint);
                     totalUnprocessedEventCount += partitionUnprocessedEventCount;
@@ -155,6 +156,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
                 && partitionInfo.LastEnqueuedSequenceNumber == partitionInfo.BeginningSequenceNumber)
             {
                 return 1;
+            }
+
+            // Legacy checkpoint support
+            if (checkpoint != null && checkpoint.Offset == null && partitionInfo.LastEnqueuedSequenceNumber >= 0)
+            {
+                return partitionInfo.LastEnqueuedSequenceNumber + 1;
             }
 
             var startingSequenceNumber = checkpoint?.SequenceNumber switch


### PR DESCRIPTION
We want uses the code to get unprocessed message count in Scale Controller for both track1 and track2 EventHub triggers. Track1 uses previous version of EventHub SDK and creates a checkpoint blob event the source is empty with `Offset=null`.  we want this case also be supported by `GetUnprocessedEventCount`.

Pointers to track1:
https://github.com/Azure/azure-functions-eventhubs-extension/blob/e1757a0f9295c3bebe6ab5df6d97812bd4b61044/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubsScaleMonitor.cs#L173C28-L173C122

https://github.com/Azure/azure-functions-eventhubs-extension/blob/e1757a0f9295c3bebe6ab5df6d97812bd4b61044/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubsScaleMonitor.cs#L253

