### PR TITLE
Fix Method Name in Sample Code

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/UniqueIdHelper.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/UniqueIdHelper.cs
@@ -23,7 +23,7 @@ namespace Azure.DigitalTwins.Core.Samples
 
         internal static async Task<string> GetUniqueJobIdAsync(string baseName, DigitalTwinsClient client)
         {
-            return await GetUniqueIdAsync(baseName, (jobId) => client.GetImportJobsByIdAsync(jobId));
+            return await GetUniqueIdAsync(baseName, (jobId) => client.GetImportJobAsync(jobId));
         }
 
         private static async Task<string> GetUniqueIdAsync(string baseName, Func<string, Task> getResource)


### PR DESCRIPTION
A helper class in the sample code was using an old method name that no longer exists. This PR updates the method to the new name.