### PR TITLE
[Event Hubs] September 2023 Release Prep (non-core)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -89,7 +89,7 @@
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0-beta.4" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.8.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.9.2" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.9.3" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.16.0" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.2.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 5.10.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 5.9.3 (2023-09-12)
 
 ### Other Changes
+
+- Several improvements to logging have been made to capture additional context and fix typos.  Most notable among them is the inclusion of starting and ending sequence numbers when events are read from Event Hubs and dispatched for processing.
+
+- The reference for the AMQP transport library, `Microsoft.Azure.Amqp`, has been bumped to 2.6.3.  This fixes an issue with timeout duration calculations during link creation and includes several efficiency improvements.
 
 ## 5.9.2 (2023-06-06)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.10.0-beta.1</Version>
+    <Version>5.9.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.9.2</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 6.0.0 (2023-09-06)
+## 6.0.0 (2023-09-12)
 
 ### Breaking Changes
 
@@ -16,7 +16,7 @@
 
 - When binding to a `CancellationToken`, the token will no longer be signaled when in Drain Mode.
   To detect if the function app is in Drain Mode, use dependency injection to inject the
-  `IDrainModeManager`, and check the `IsDrainModeEnabled` property. Additionally, checkpointing 
+  `IDrainModeManager`, and check the `IsDrainModeEnabled` property. Additionally, checkpointing
   will now occur when the function app is in Drain Mode.
 
 ## 5.4.0 (2023-06-06)


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Hubs processor and function extensions libraries for the September 2023 release.

### NOTE:
This cannot be merged until the Event Hubs core package release has been performed.  Until that time, CI will fail.