### PR TITLE
Allow As<T> to return null for reference types

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/Variant/Variant.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Variant.cs
@@ -1296,11 +1296,12 @@ namespace Azure
         {
             // Single return has a significant performance benefit.
 
-            bool result = false;
+            bool result;
 
             if (_object is null)
             {
                 value = default!;
+                result = true;
             }
             else if (typeof(T) == typeof(char[]))
             {

--- a/sdk/core/Azure.Core.Experimental/src/Variant/Variant.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Variant/Variant.cs
@@ -77,7 +77,17 @@ namespace Azure
         }
 
         [DoesNotReturn]
-        private static void ThrowInvalidCast() => throw new InvalidCastException();
+        private static void ThrowInvalidCast(Type? source, Type target)
+        {
+            if (source is null)
+            {
+                throw new InvalidCastException($"Unable to cast null Variant to type '{target}'.");
+            }
+            else
+            {
+                throw new InvalidCastException($"Unable to cast Variant of type '{source}' to type '{target}'.");
+            }
+        }
 
         [DoesNotReturn]
         private static void ThrowArgumentNull(string paramName) => throw new ArgumentNullException(paramName);
@@ -1381,9 +1391,9 @@ namespace Azure
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly T As<T>()
         {
-            if (!TryGetValue<T>(out T value))
+            if (!TryGetValue(out T value))
             {
-                ThrowInvalidCast();
+                ThrowInvalidCast(Type, typeof(T));
             }
 
             return value;

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
@@ -91,6 +91,22 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual("3", b.As<List<string>>()[0]);
         }
 
+        [Test]
+        public void ReferenceTypesCanBeNull()
+        {
+            string s = null;
+            Variant stringVariant = new(s);
+
+            Assert.AreEqual(Variant.Null, stringVariant);
+            Assert.IsNull(stringVariant.As<string>());
+
+            List<int> list = null;
+            Variant listVariant = new(list);
+
+            Assert.AreEqual(Variant.Null, listVariant);
+            Assert.IsNull(listVariant.As<string>());
+        }
+
         #region Helpers
         public static IEnumerable<Variant[]> VariantValues()
         {

--- a/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/Variant/VariantUsage.cs
@@ -107,6 +107,26 @@ namespace Azure.Core.Experimental.Tests
             Assert.IsNull(listVariant.As<string>());
         }
 
+        [Test]
+        public void NonNullableValueTypesCannotBeNull()
+        {
+            int? i = null;
+            Variant intVariant = new(i);
+
+            Assert.AreEqual(Variant.Null, intVariant);
+            Assert.Throws<InvalidCastException>(() => intVariant.As<int>());
+        }
+
+        [Test]
+        public void NullableValueTypesCanBeNull()
+        {
+            int? i = null;
+            Variant intVariant = new(i);
+
+            Assert.AreEqual(Variant.Null, intVariant);
+            Assert.IsNull(intVariant.As<int?>());
+        }
+
         #region Helpers
         public static IEnumerable<Variant[]> VariantValues()
         {


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-net/issues/32978

This PR makes it possible to return null from `As<T>` when the reference type stored by the Variant is null.