### PR TITLE
Remove unused <IncludeGeneratorSharedCode> MSBuild properties

### DIFF
--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Azure.AI.Language.Conversations.Tests.csproj
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Azure.AI.Language.Conversations.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <UseDefaultNamespaceAndOutputFolder>false</UseDefaultNamespaceAndOutputFolder>
   </PropertyGroup>

--- a/sdk/core/Azure.Core.Experimental/tests/Azure.Core.Experimental.Tests.csproj
+++ b/sdk/core/Azure.Core.Experimental/tests/Azure.Core.Experimental.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);HAS_INTERNALS_VISIBLE_CORE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core/tests/common/Azure.Core.Tests.Common.csproj
+++ b/sdk/core/Azure.Core/tests/common/Azure.Core.Tests.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <IsTestSupportProject>true</IsTestSupportProject>
   </PropertyGroup>

--- a/sdk/core/Azure.Core/tests/public/Azure.Core.Tests.Public.csproj
+++ b/sdk/core/Azure.Core/tests/public/Azure.Core.Tests.Public.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <IsTestProject>true</IsTestProject>
     <IsTestSupportProject>false</IsTestSupportProject>

--- a/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/src/Azure.Health.Insights.CancerProfiling.csproj
+++ b/sdk/healthinsights/Azure.Health.Insights.CancerProfiling/src/Azure.Health.Insights.CancerProfiling.csproj
@@ -7,7 +7,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>true</GenerateAPIListing>
     <NoWarn>$(NoWarn);CS1591;AZC0012</NoWarn>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/src/Azure.Health.Insights.ClinicalMatching.csproj
+++ b/sdk/healthinsights/Azure.Health.Insights.ClinicalMatching/src/Azure.Health.Insights.ClinicalMatching.csproj
@@ -7,7 +7,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>true</GenerateAPIListing>
     <NoWarn>$(NoWarn);CS1591;AZC0012</NoWarn>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
@@ -7,7 +7,6 @@
     </Description>
     <PackageTags>Personalizer;Azure Personalizer;Cognitive Services Personalizer;Cognitive Personalizer;Cognitive;Azure</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Azure.AI.Personalizer.csproj
@@ -7,6 +7,7 @@
     </Description>
     <PackageTags>Personalizer;Azure Personalizer;Cognitive Services Personalizer;Cognitive Personalizer;Cognitive;Azure</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Common client library tests</AssemblyTitle>

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);net6.0</TargetFrameworks>
-    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.DataMovement.Blobs client library</AssemblyTitle>


### PR DESCRIPTION
As pre-work to address:

- https://github.com/Azure/azure-sdk-for-net/issues/38143
- https://github.com/Azure/azure-sdk-for-net/issues/28369
- https://github.com/Azure/azure-sdk-for-net/issues/27337

I'm working cleaning up unused references to shared source files to make it easier to see where the actual dependencies are.

This PR removes unused references to generator shared code.  Please let me know if there are reasons these are needed!
