### PR TITLE
Remove metric telemetry for resource

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2EAzureMonitorDistroTests.cs
@@ -54,14 +54,14 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             // Telemetry is serialized as json, and then byte encoded.
             // Need to parse the request content into something assertable.
             var data = ParseJsonRequestContent<ParsedData>(transport.Requests);
-            Assert.Equal(16, data.Count); // Total telemetry items
+            Assert.Equal(15, data.Count); // Total telemetry items
 
             // Group all parsed telemetry by name and get the count per name.
             var summary = data.GroupBy(x => x.name).ToDictionary(x => x.Key!, x => x.Count());
 
             Assert.Equal(4, summary.Count); // Total unique telemetry items
             Assert.Equal(8, summary["Message"]); // Count of telemetry items
-            Assert.Equal(6, summary["Metric"]);
+            Assert.Equal(5, summary["Metric"]);
             Assert.Equal(1, summary["RemoteDependency"]);
             Assert.Equal(1, summary["Request"]);
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/EnvironmentVariableConstants.cs
@@ -55,5 +55,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// INTERNAL ONLY. Used by Statsbeat to get the App Service Website Name.
         /// </summary>
         public const string WEBSITE_SITE_NAME = "WEBSITE_SITE_NAME";
+
+        /// <summary>
+        /// When set to true, exporter will emit resources as metric telemetry.
+        /// </summary>
+        public const string EXPORT_RESOURCE_METRIC = "OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -119,7 +119,20 @@ internal static class ResourceExtensions
             }
         }
 
-        if (metricsData != null)
+        bool shouldReportMetricTelemetry = false;
+        try
+        {
+            var exportResource = Environment.GetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES");
+            if (exportResource.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                shouldReportMetricTelemetry = true;
+            }
+        }
+        catch
+        {
+        }
+
+        if (shouldReportMetricTelemetry && metricsData != null)
         {
             azureMonitorResource.MetricTelemetry = new TelemetryItem(DateTime.UtcNow, azureMonitorResource, instrumentationKey!)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -122,7 +122,7 @@ internal static class ResourceExtensions
         bool shouldReportMetricTelemetry = false;
         try
         {
-            var exportResource = Environment.GetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS");
+            var exportResource = Environment.GetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC);
             if (exportResource.Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 shouldReportMetricTelemetry = true;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -122,7 +122,7 @@ internal static class ResourceExtensions
         bool shouldReportMetricTelemetry = false;
         try
         {
-            var exportResource = Environment.GetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES");
+            var exportResource = Environment.GetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS");
             if (exportResource.Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 shouldReportMetricTelemetry = true;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -33,7 +33,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", "true");
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", "true");
             var resource = CreateTestResource();
             var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
 
@@ -43,7 +43,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
         }
     }
 
@@ -196,7 +196,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", "true");
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", "true");
 
             // SDK version is static, preserve to clean up later.
             var sdkVersion = SdkVersionUtils.s_sdkVersion;
@@ -223,7 +223,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
         }
     }
 
@@ -234,7 +234,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", "true");
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", "true");
 
             var testAttributes = new Dictionary<string, object>
             {
@@ -278,7 +278,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
         }
     }
 
@@ -346,7 +346,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", envVarValue);
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", envVarValue);
 
             var resource = ResourceBuilder.CreateDefault().Build();
             var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
@@ -362,7 +362,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
         }
     }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -37,7 +37,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", envVarValue);
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, envVarValue);
             var resource = CreateTestResource();
             var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
 
@@ -54,7 +54,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, null);
         }
     }
 
@@ -207,7 +207,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", "true");
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, "true");
 
             // SDK version is static, preserve to clean up later.
             var sdkVersion = SdkVersionUtils.s_sdkVersion;
@@ -234,7 +234,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, null);
         }
     }
 
@@ -245,7 +245,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", "true");
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, "true");
 
             var testAttributes = new Dictionary<string, object>
             {
@@ -289,7 +289,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, null);
         }
     }
 
@@ -358,7 +358,7 @@ public class ResourceExtensionsTests
     {
         try
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", envVarValue);
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, envVarValue);
 
             var resource = ResourceBuilder.CreateDefault().Build();
             var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
@@ -374,7 +374,7 @@ public class ResourceExtensionsTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", null);
+            Environment.SetEnvironmentVariable(EnvironmentVariableConstants.EXPORT_RESOURCE_METRIC, null);
         }
     }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -340,6 +340,7 @@ public class ResourceExtensionsTests
     }
 
     [Theory]
+    [InlineData(null)]
     [InlineData("true")]
     [InlineData("false")]
     public void MetricTelemetryIsAddedToResourceBasedOnEnvVar(string envVarValue)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
@@ -30,12 +31,20 @@ public class ResourceExtensionsTests
     [InlineData(InstrumentationKey)]
     public void DefaultResource(string? instrumentationKey)
     {
-        var resource = CreateTestResource();
-        var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
+        try
+        {
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", "true");
+            var resource = CreateTestResource();
+            var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
 
-        Assert.StartsWith("unknown_service", azMonResource?.RoleName);
-        Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
-        Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+            Assert.StartsWith("unknown_service", azMonResource?.RoleName);
+            Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
+            Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
+        }
     }
 
     [Fact]
@@ -185,28 +194,37 @@ public class ResourceExtensionsTests
     [Fact]
     public void SdkPrefixIsNotInResourceMetrics()
     {
-        // SDK version is static, preserve to clean up later.
-        var sdkVersion = SdkVersionUtils.s_sdkVersion;
-        var testAttributes = new Dictionary<string, object>
+        try
         {
-            {"foo", "bar" },
-            { "ai.sdk.prefix", "pre_" }
-        };
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", "true");
 
-        var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
-        var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
+            // SDK version is static, preserve to clean up later.
+            var sdkVersion = SdkVersionUtils.s_sdkVersion;
+            var testAttributes = new Dictionary<string, object>
+            {
+                {"foo", "bar" },
+                { "ai.sdk.prefix", "pre_" }
+            };
 
-        Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
+            var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
 
-        var monitorBase = azMonResource.MetricTelemetry.Data;
-        var metricsData = monitorBase.BaseData as MetricsData;
+            Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
 
-        var metricDataPoint = metricsData?.Metrics[0];
-        Assert.Equal("bar", metricsData?.Properties["foo"]);
-        Assert.False(metricsData?.Properties.ContainsKey("ai.sdk.prefix"));
+            var monitorBase = azMonResource.MetricTelemetry.Data;
+            var metricsData = monitorBase.BaseData as MetricsData;
 
-        // Clean up
-        SdkVersionUtils.s_sdkVersion = sdkVersion;
+            var metricDataPoint = metricsData?.Metrics[0];
+            Assert.Equal("bar", metricsData?.Properties["foo"]);
+            Assert.False(metricsData?.Properties.ContainsKey("ai.sdk.prefix"));
+
+            // Clean up
+            SdkVersionUtils.s_sdkVersion = sdkVersion;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
+        }
     }
 
     [Theory]
@@ -214,44 +232,53 @@ public class ResourceExtensionsTests
     [InlineData(InstrumentationKey)]
     public void MetricTelemetryHasAllResourceAttributes(string? instrumentationKey)
     {
-        var testAttributes = new Dictionary<string, object>
+        try
         {
-            {SemanticConventions.AttributeServiceName, "my-service" },
-            {SemanticConventions.AttributeServiceNamespace, "my-namespace" },
-            {SemanticConventions.AttributeServiceInstance, "my-instance" },
-            {SemanticConventions.AttributeK8sDeployment, "my-deployment" },
-            {SemanticConventions.AttributeK8sPod, "my-pod" },
-            { "foo", "bar" }
-        };
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", "true");
 
-        var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
-        var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
+            var testAttributes = new Dictionary<string, object>
+            {
+                {SemanticConventions.AttributeServiceName, "my-service" },
+                {SemanticConventions.AttributeServiceNamespace, "my-namespace" },
+                {SemanticConventions.AttributeServiceInstance, "my-instance" },
+                {SemanticConventions.AttributeK8sDeployment, "my-deployment" },
+                {SemanticConventions.AttributeK8sPod, "my-pod" },
+                { "foo", "bar" }
+            };
 
-        Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+            var resource = ResourceBuilder.CreateEmpty().AddAttributes(testAttributes).Build();
+            var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
 
-        if (instrumentationKey != null)
+            Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+
+            if (instrumentationKey != null)
+            {
+                Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
+                Assert.Equal(3, azMonResource.MetricTelemetry.Tags.Count);
+                Assert.NotNull(azMonResource.MetricTelemetry.Data);
+
+                var monitorBase = azMonResource.MetricTelemetry.Data;
+                var metricsData = monitorBase.BaseData as MetricsData;
+
+                Assert.NotNull(metricsData?.Metrics);
+
+                var metricDataPoint = metricsData?.Metrics[0];
+                Assert.Equal("_OTELRESOURCE_", metricDataPoint?.Name);
+                Assert.Equal(0, metricDataPoint?.Value);
+
+                Assert.Equal(6, metricsData?.Properties.Count);
+
+                Assert.Equal("my-service", metricsData?.Properties[SemanticConventions.AttributeServiceName]);
+                Assert.Equal("my-namespace", metricsData?.Properties[SemanticConventions.AttributeServiceNamespace]);
+                Assert.Equal("my-instance", metricsData?.Properties[SemanticConventions.AttributeServiceInstance]);
+                Assert.Equal("my-deployment", metricsData?.Properties[SemanticConventions.AttributeK8sDeployment]);
+                Assert.Equal("my-pod", metricsData?.Properties[SemanticConventions.AttributeK8sPod]);
+                Assert.Equal("bar", metricsData?.Properties["foo"]);
+            }
+        }
+        finally
         {
-            Assert.Equal("Metric", azMonResource!.MetricTelemetry!.Name);
-            Assert.Equal(3, azMonResource.MetricTelemetry.Tags.Count);
-            Assert.NotNull(azMonResource.MetricTelemetry.Data);
-
-            var monitorBase = azMonResource.MetricTelemetry.Data;
-            var metricsData = monitorBase.BaseData as MetricsData;
-
-            Assert.NotNull(metricsData?.Metrics);
-
-            var metricDataPoint = metricsData?.Metrics[0];
-            Assert.Equal("_OTELRESOURCE_", metricDataPoint?.Name);
-            Assert.Equal(0, metricDataPoint?.Value);
-
-            Assert.Equal(6, metricsData?.Properties.Count);
-
-            Assert.Equal("my-service", metricsData?.Properties[SemanticConventions.AttributeServiceName]);
-            Assert.Equal("my-namespace", metricsData?.Properties[SemanticConventions.AttributeServiceNamespace]);
-            Assert.Equal("my-instance", metricsData?.Properties[SemanticConventions.AttributeServiceInstance]);
-            Assert.Equal("my-deployment", metricsData?.Properties[SemanticConventions.AttributeK8sDeployment]);
-            Assert.Equal("my-pod", metricsData?.Properties[SemanticConventions.AttributeK8sPod]);
-            Assert.Equal("bar", metricsData?.Properties["foo"]);
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
         }
     }
 
@@ -310,6 +337,33 @@ public class ResourceExtensionsTests
         // Assert
         Assert.Null(azMonResource?.RoleName);
         Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("false")]
+    public void MetricTelemetryIsAddedToResourceBasedOnEnvVar(string envVarValue)
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", envVarValue);
+
+            var resource = ResourceBuilder.CreateDefault().Build();
+            var azMonResource = resource.CreateAzureMonitorResource(InstrumentationKey);
+
+            if (envVarValue == "true")
+            {
+                Assert.NotNull(azMonResource?.MetricTelemetry);
+            }
+            else
+            {
+                Assert.Null(azMonResource?.MetricTelemetry);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES", null);
+        }
     }
 
     /// <summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -27,19 +27,30 @@ public class ResourceExtensionsTests
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData(InstrumentationKey)]
-    public void DefaultResource(string? instrumentationKey)
+    [InlineData(null, "true")]
+    [InlineData(null, "false")]
+    [InlineData(null, null)]
+    [InlineData(InstrumentationKey, "false")]
+    [InlineData(InstrumentationKey, "true")]
+    [InlineData(InstrumentationKey, null)]
+    public void DefaultResource(string? instrumentationKey, string envVarValue)
     {
         try
         {
-            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", "true");
+            Environment.SetEnvironmentVariable("OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS", envVarValue);
             var resource = CreateTestResource();
             var azMonResource = resource.CreateAzureMonitorResource(instrumentationKey);
 
             Assert.StartsWith("unknown_service", azMonResource?.RoleName);
             Assert.Equal(Dns.GetHostName(), azMonResource?.RoleInstance);
-            Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+            if (envVarValue == "true")
+            {
+                Assert.Equal(instrumentationKey != null, azMonResource?.MetricTelemetry != null);
+            }
+            else
+            {
+                Assert.Null(azMonResource?.MetricTelemetry);
+            }
         }
         finally
         {


### PR DESCRIPTION
Resource attributes are exported as a custom metric record with each batch of activities. This behavior is not yet stable and may change in future. This PR introduces an environment variable `EXPORT_METRIC_FOR_RESOURCE_ATTRIBUTES` to control this behavior for auto-instrumentation scenario. By default, the metric telemetry will no longer be exported.