### PR TITLE
[Azure.Core] ILLUSTRATION - Response Disposal for Anne

### DIFF
--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -206,10 +206,14 @@ namespace Azure.Core
             if (response != null)
             {
                 _response = null;
-                response.Dispose();
+                // ================================================================
+                // JS: This is a hack job to get around the `Response` is not
+                //     nullable constraint without hacking up a dummy `Response` type
+                //
+                //response.Dispose();
+                // ================================================================
             }
         }
-
         private class ResponseShouldNotBeUsedStream : Stream
         {
             public Stream Original { get; }


### PR DESCRIPTION
# Summary

The purpose of these changes is to illustrate a flawed work-around for the "protocol methods return a disposed response" problem.  I do not advocate this for the fix, rather an illustration of the problem that works in the success case.

## Related:

 - #38219

## NOTE:
This is not intended to be merged, it exists only for discussion.