### PR TITLE
nit: Azure.AI.OpenAI should use Microsoft.CognitiveServices resource provider namespace

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Properties/AssemblyInfo.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Azure.Core;
 
-[assembly: Azure.Core.AzureResourceProviderNamespace("Microsoft.Insights")]
+[assembly: Azure.Core.AzureResourceProviderNamespace("Microsoft.CognitiveServices")]


### PR DESCRIPTION
It's used by distributed tracing and allows Azure Monitor and other telemetry consumers to visualize OpenAI telemetry better.