### PR TITLE
Resolve regressions from proxy-output fix

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -303,7 +303,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestProxyVersion>1.0.0-dev.20230821.1</TestProxyVersion>
+    <TestProxyVersion>1.0.0-dev.20230912.4</TestProxyVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Hey @JoshLove-msft I'm mostly free of any fires, so I have some time to apply to this.

First, some context. I resolved [an issue](https://github.com/Azure/azure-sdk-tools/issues/6563) with the proxy not properly outputting to stderr when using `logging.error`. However, when I resolved that issue, the next eng/common update actually broke a few additional test cases, because they were checking at the end for `stderr` output...and suddenly were getting some! [Here is your comment on that sync-common PR at the time](https://github.com/Azure/azure-sdk-for-net/pull/38290#issuecomment-1685081575).

I'm filing this PR now because I have the time to apply fixes to azure-sdk-for-net, and I don't want to maintain a separate version of the proxy that doesn't output to stderr!

First, let's see what melts here.