### PR TITLE
Update Sample05_IndexingDocuments.md

### DIFF
--- a/sdk/search/Azure.Search.Documents/samples/Sample05_IndexingDocuments.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample05_IndexingDocuments.md
@@ -73,7 +73,7 @@ We'll use `FieldBuilder` to do the heavy lifting and create our search index:
 
 ```C# Snippet:Azure_Search_Documents_Tests_Samples_Sample05_IndexingDocuments_CreateIndex_Create
 // Create the search index
-string indexName = "Products";
+string indexName = "products";
 await indexClient.CreateIndexAsync(
     new SearchIndex(indexName)
     {


### PR DESCRIPTION
Index name must only contain lowercase letters, digits or dashes, cannot start or end with dashes and is limited to 128 characters.

