### PR TITLE
Update Sample07_VectorSearch.md

### DIFF
--- a/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch.md
@@ -18,7 +18,7 @@ We will create an instace of `SearchIndex` and define `Hotel` fields.
 string vectorSearchConfigName = "my-vector-config";
 int modelDimensions = 1536;
 
-string indexName = "Hotel";
+string indexName = "hotel";
 SearchIndex searchIndex = new(indexName)
 {
     Fields =


### PR DESCRIPTION
Index name must only contain lowercase letters, digits or dashes, cannot start or end with dashes and is limited to 128 characters.