### PR TITLE
[Event Hubs] Disable extensions test

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ScaleHostEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/ScaleHostEndToEndTests.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
         }
 
         [Test]
+        [Ignore("Consistently failing in CI; caused by #38673")]
         [TestCase(false)]
         [TestCase(true)]
         public async Task ScaleHostEndToEndTest(bool tbsEnabled)


### PR DESCRIPTION
# Summary

Ignoring a function extension test that has been failing in CI until it can be corrected.