### PR TITLE
Fix offline storage during network errors

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bugs Fixed
 
+* Fixed an issue during network failures which prevented the exporter to store
+the telemetry offline for retrying at a later time.
+([#38832](https://github.com/Azure/azure-sdk-for-net/pull/38832))
+
 ### Other Changes
 
 * Update OpenTelemetry dependencies

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/ApplicationInsightsRestClient.cs
@@ -42,7 +42,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             catch (Exception ex)
             {
                 AzureMonitorExporterEventSource.Log.FailedToTransmit(ex);
-                if (ex.InnerException?.Source != "System.Net.Http")
+                if (ex.InnerException?.Source != "System.Net.Http" && ex.InnerException?.Source != "System")
                 {
                     message?.Dispose();
                     throw;
@@ -70,7 +70,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             catch (Exception ex)
             {
                 AzureMonitorExporterEventSource.Log.FailedToTransmit(ex);
-                if (ex.InnerException?.Source != "System.Net.Http")
+                if (ex.InnerException?.Source != "System.Net.Http" && ex.InnerException?.Source != "System")
                 {
                     message?.Dispose();
                     throw;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs
@@ -178,7 +178,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
                     if (result == ExportResult.Failure && _fileBlobProvider != null)
                     {
-                        _transmissionStateManager.EnableBackOff(httpMessage.Response);
+                        _transmissionStateManager.EnableBackOff(httpMessage.HasResponse ? httpMessage.Response : null);
                         result = HttpPipelineHelper.HandleFailures(httpMessage, _fileBlobProvider, _connectionVars, origin, _isAadEnabled);
                     }
                     else

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmissionStateManager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmissionStateManager.cs
@@ -96,7 +96,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             CloseTransmission();
         }
 
-        internal void EnableBackOff(Response response)
+        internal void EnableBackOff(Response? response)
         {
             if (Interlocked.Exchange(ref _syncBackOffIntervalCalculation, 1) == 0)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TransmitFromStorageHandler.cs
@@ -69,7 +69,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         }
                         else
                         {
-                            _transmissionStateManager.EnableBackOff(httpMessage.Response);
+                            _transmissionStateManager.EnableBackOff(httpMessage.HasResponse ? httpMessage.Response : null);
                             HttpPipelineHelper.HandleFailures(httpMessage, blob, _blobProvider, _connectionVars, _isAadEnabled);
                             break;
                         }


### PR DESCRIPTION
Accessing `Response` on `httpMessage` when there is no Response throws an exception. We first need to check for response. This was causing an issue during network failures. (Telemetry was not stored offline due to this exception).


