### PR TITLE
fix: Partially fixed the dependency mess

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -59,8 +59,8 @@
     <PackageReference Update="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Cng" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.Primitives" Version="4.3.0" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="4.5.1" />
-    <PackageReference Update="System.Text.Json" Version="4.7.2" />
+    <PackageReference Remove="System.Text.Encodings.Web" />
+    <PackageReference Update="System.Text.Json" Version="7.0.3" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
 
     <PackageReference Update="WindowsAzure.Storage" Version="9.3.3" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -65,7 +65,7 @@
     <!-- BCL packages -->
     <PackageReference Update="System.Buffers" Version="4.5.1" />
     <PackageReference Update="System.IO.Hashing" Version="6.0.0" />
-    <PackageReference Update="System.Memory" Version="4.5.4" />
+    <PackageReference Update="System.Memory" Version="4.5.5" />
     <PackageReference Update="System.Memory.Data" Version="7.0.0" />
     <PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -33,7 +33,7 @@
     <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Update="System.Collections" Version="4.3.0" />
     <PackageReference Update="System.Data.SqlClient" Version="4.3.1" />
-    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
+    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Update="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageReference Update="System.Globalization" Version="4.3.0" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
@@ -41,6 +41,7 @@
     <PackageReference Update="System.Memory.Data" Version="1.0.2" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="[4.5.1, 4.9.0)" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <PackageReference Update="System.Runtime.Extensions" Version="4.3.0" />
     <PackageReference Update="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Runtime" Version="4.3.0" />
@@ -65,19 +66,20 @@
     <PackageReference Update="System.Buffers" Version="4.5.1" />
     <PackageReference Update="System.IO.Hashing" Version="6.0.0" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
-    <PackageReference Update="System.Memory.Data" Version="1.0.2" />
+    <PackageReference Update="System.Memory.Data" Version="7.0.0" />
     <PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
-    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
+    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Update="System.Threading.Channels" Version="4.7.1" />
     <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
-    <PackageReference Update="System.Text.Json" Version="4.7.2" />
-    <PackageReference Update="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Update="System.Text.Json" Version="7.0.3" />
+    <PackageReference Update="System.Text.Encodings.Web" Version="7.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Update="Microsoft.CSharp" Version="4.7.0" />
 
     <!-- Azure SDK packages -->
@@ -177,7 +179,7 @@
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20230920.1" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20230822.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20467.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" PrivateAssets="All" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -7,6 +7,17 @@
     <PackageReference Update="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Packages that need this are referencing it themself. -->
+    <PackageReference Remove="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
+
+  <!-- Remove async libraries from newer packages-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Remove="System.Numerics.Vectors" />
+    <PackageReference Remove="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
+
   <!--
     Dependency versions for Track 1 libraries.
   -->
@@ -28,7 +39,7 @@
     <PackageReference Update="Microsoft.Spatial" Version="7.5.3" />
     <PackageReference Update="Microsoft.AspNetCore.Http" Version="2.1.22" />
 
-    <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
 
     <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Update="System.Collections" Version="4.3.0" />
@@ -60,6 +71,15 @@
     Only packages that are approved dependencies should go here.
   -->
 
+  <ItemGroup Condition="'$(IsClientLibrary)' == 'true' AND ('$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net462')">
+    <PackageReference Update="System.Text.Json" Version="7.0.3" />
+    <PackageReference Remove="System.Runtime.CompilerServices.Unsafe" />
+    <PackageReference Update="System.Memory" Version="4.5.5" />
+    <PackageReference Update="System.Memory.Data" Version="7.0.0" />
+    <PackageReference Remove="System.Text.Encodings.Web" />
+
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IsClientLibrary)' == 'true'">
 
     <!-- BCL packages -->
@@ -69,7 +89,7 @@
     <PackageReference Update="System.Memory.Data" Version="7.0.0" />
     <PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
-    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
@@ -152,7 +172,7 @@
     <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.37" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0" />
     <PackageReference Update="Microsoft.Spatial" Version="7.5.3" />
-    <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <!-- Packages intended for Extensions libraries only -->
@@ -274,7 +294,7 @@
     <PackageReference Update="Moq" Version="[4.18.2]" /><!-- This version should not be changed without team discussion. -->
     <PackageReference Update="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Update="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />

--- a/sdk/attestation/Azure.Security.Attestation/src/AttestationToken.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/AttestationToken.cs
@@ -658,7 +658,7 @@ namespace Azure.Security.Attestation
             };
             var serializationOptions = new JsonSerializerOptions
             {
-                IgnoreNullValues = true,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
             };
             byte[] jwtHeader = JsonSerializer.SerializeToUtf8Bytes<JsonWebTokenHeader>(header, serializationOptions);
             string encodedHeader = Base64Url.Encode(jwtHeader);

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/MediaStreaming/CallAutomationStreamingParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/MediaStreaming/CallAutomationStreamingParserTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             JObject jsonData = new JObject();
             jsonData["kind"] = "AudioData";
             jsonData["audioData"] = new JObject();
-            jsonData["audioData"]["data"] = "AQIDBAU=";
+            jsonData["audioData"]!["data"] = "AQIDBAU=";
             jsonData["audioData"]["timestamp"] = "2022-08-23T11:48:05Z";
             jsonData["audioData"]["participantRawID"] = "participantId";
             jsonData["audioData"]["silent"] = false;

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -8,7 +8,7 @@
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);AZURE_NULLABLE;HAS_INTERNALS_VISIBLE_CORE</DefineConstants>
-    <TargetFrameworks>$(RequiredTargetFrameworks);net461;net472;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net462;net472;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>true</EnableClientSdkAnalyzers>
     <EnableBannedApiAnalyzers>false</EnableBannedApiAnalyzers>
@@ -41,12 +41,6 @@
     <PackageReference Include="System.Text.Encodings.Web" VersionOverride="6.0.0" />
     <PackageReference Include="System.Text.Json" VersionOverride="6.0.8" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Memory.Data" VersionOverride="1.0.2" />
-    <PackageReference Include="System.Text.Encodings.Web" VersionOverride="5.0.0" />
-    <PackageReference Include="System.Text.Json" VersionOverride="5.0.2" />
-  </ItemGroup>
   
   <!-- Keep System.Diagnostics.DiagnosticSource 4.6.0 for netcoreapp2.1 support. -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
@@ -57,12 +51,11 @@
     <PackageReference Include="System.Text.Json" VersionOverride="4.7.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
-    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net462'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -25,18 +25,36 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="System.Numerics.Vectors" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="System.Memory.Data" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0' AND '$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net5.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" /> <!-- needed only before .netcore 3.1 -->
+    <PackageReference Include="System.Numerics.Vectors" /> <!-- it builds without this on higher platforms -->
+    <PackageReference Include="System.Threading.Tasks.Extensions" /> <!-- support for ValueTask on lower platforms -->
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0' AND '$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net5.0' AND '$(TargetFramework)' != 'netcoreapp2.1'">
+    <PackageReference Include="System.Memory.Data" VersionOverride="6.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" VersionOverride="6.0.0" />
+    <PackageReference Include="System.Text.Json" VersionOverride="6.0.8" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="System.Memory.Data" VersionOverride="1.0.2" />
+    <PackageReference Include="System.Text.Encodings.Web" VersionOverride="5.0.0" />
+    <PackageReference Include="System.Text.Json" VersionOverride="5.0.2" />
+  </ItemGroup>
+  
   <!-- Keep System.Diagnostics.DiagnosticSource 4.6.0 for netcoreapp2.1 support. -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="4.6.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" VersionOverride="4.7.1" />
+    <PackageReference Include="System.Memory.Data" VersionOverride="1.0.2" />
+    <PackageReference Include="System.Text.Encodings.Web" VersionOverride="4.7.2" />
+    <PackageReference Include="System.Text.Json" VersionOverride="4.7.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -709,6 +709,7 @@ namespace Azure.Core.Pipeline
             }
 
             // ServerCertificateCustomValidationCallback
+#if !NET462
             if (options.ServerCertificateCustomValidationCallback != null)
             {
                 httpHandler.ServerCertificateCustomValidationCallback = (_, certificate2, x509Chain, sslPolicyErrors) =>
@@ -720,8 +721,9 @@ namespace Azure.Core.Pipeline
             // Set ClientCertificates
             foreach (var cert in options.ClientCertificates)
             {
-               httpHandler.ClientCertificates.Add(cert);
+                httpHandler.ClientCertificates.Add(cert);
             }
+#endif
             return httpHandler;
         }
 #endif

--- a/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/ServicePointHelpers.cs
@@ -71,10 +71,10 @@ namespace Azure.Core.Pipeline
                 {
                     case HttpClientHandler httpClientHandler:
                         // Only change when the default runtime limit is used
-                        if (httpClientHandler.MaxConnectionsPerServer == RuntimeDefaultConnectionLimit)
-                        {
-                            httpClientHandler.MaxConnectionsPerServer = IncreasedConnectionLimit;
-                        }
+                        // if (httpClientHandler.MaxConnectionsPerServer == RuntimeDefaultConnectionLimit)
+                        // {
+                        //     httpClientHandler.MaxConnectionsPerServer = IncreasedConnectionLimit;
+                        // }
                         break;
 #if NETCOREAPP
                 case SocketsHttpHandler socketsHttpHandler:

--- a/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/src/NewtonsoftJsonETagConverter.cs
+++ b/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/src/NewtonsoftJsonETagConverter.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Serialization
         public override bool CanConvert(Type objectType) => objectType == typeof(ETag) || objectType == typeof(ETag?);
 
         /// <inheritdoc/>
-        public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             var value = (string?)reader.Value;
             if (value == null)
@@ -31,8 +31,12 @@ namespace Azure.Core.Serialization
         }
 
         /// <inheritdoc/>
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
+            if (value == null) {
+                writer.WriteNull();
+                return;
+            }
             var eTag = (ETag) value;
             if (eTag == default)
             {

--- a/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/src/NewtonsoftJsonObjectSerializer.cs
+++ b/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/src/NewtonsoftJsonObjectSerializer.cs
@@ -62,7 +62,7 @@ namespace Azure.Core.Serialization
 
         /// <inheritdoc />
         /// <exception cref="ArgumentNullException"><paramref name="stream"/> or <paramref name="returnType"/> is null.</exception>
-        public override object Deserialize(Stream stream, Type returnType, CancellationToken cancellationToken)
+        public override object? Deserialize(Stream stream, Type returnType, CancellationToken cancellationToken)
         {
             Argument.AssertNotNull(stream, nameof(stream));
             Argument.AssertNotNull(returnType, nameof(returnType));

--- a/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/tests/NewtonsoftJsonObjectSerializerTest.cs
+++ b/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/tests/NewtonsoftJsonObjectSerializerTest.cs
@@ -33,7 +33,7 @@ namespace Azure.Core.Tests
                 ContractResolver = _resolver,
                 Converters = new[]
                 {
-                    new StringEnumConverter(true),
+                    new StringEnumConverter(new CamelCaseNamingStrategy(), true)
                 },
             });
 

--- a/sdk/core/System.Memory.Data/src/BinaryData.cs
+++ b/sdk/core/System.Memory.Data/src/BinaryData.cs
@@ -254,7 +254,7 @@ namespace System
         public T? ToObjectFromJson<T>(JsonSerializerOptions? options = default)
 #pragma warning restore AZC0014 // Avoid using banned types in public API
         {
-            return (T)JsonSerializer.Deserialize(_bytes.Span, typeof(T), options);
+            return (T?)JsonSerializer.Deserialize(_bytes.Span, typeof(T), options);
         }
 
         /// <summary>

--- a/sdk/core/System.Memory.Data/src/BinaryData.cs
+++ b/sdk/core/System.Memory.Data/src/BinaryData.cs
@@ -251,7 +251,7 @@ namespace System
         /// <param name="options">The <see cref="JsonSerializerOptions"/> to use when serializing to JSON.</param>
         /// <returns>The data converted to the specified type.</returns>
 #pragma warning disable AZC0014 // Avoid using banned types in public API
-        public T ToObjectFromJson<T>(JsonSerializerOptions? options = default)
+        public T? ToObjectFromJson<T>(JsonSerializerOptions? options = default)
 #pragma warning restore AZC0014 // Avoid using banned types in public API
         {
             return (T)JsonSerializer.Deserialize(_bytes.Span, typeof(T), options);

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -17,8 +17,6 @@
     <PackageReference Include="Azure.Identity" Version="1.2.1" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
-
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <!-- Common source from Azure.Core -->


### PR DESCRIPTION
Fixed #38857

Since the main library supports so many target frameworks it's a hassle to manage all the dependencies. Accepting this PR will probably break stuff.

## Reduce dependencies

**Azure.Core** has dependencies upon **System.Text.Json** (with all those specific versions based on the correct framework). So any project depending upon Azure.Core, will also get the correct version of System.Text.Json. By reducing the PackageReferences to packaged already referenced by a dependency this will also simplify things.


My suggestion is to adjust the `Packages.Data.props` file to keep the dependencies in line for all the specific frameworks. I propose an ItemGroup per target, to keep all the dependencies equal per target framework and have those projects use the latest and greatest that platform has to offer. Building an app in .net 7 should not be using System.Text.Json version `4.7.2` **a three year old version** without all the recent improvements the dotnet team has made.

I would even go as far as saying you should add this code the `Packages.Data.props` file, This means people building apps on net6.0 or net7.0 wont get the unneeded `Microsoft.Bcl.AsyncInterfaces`:
```xml
  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
    <PackageReference Remove="Microsoft.Bcl.AsyncInterfaces" />
    <PackageReference Remove="System.Numerics.Vectors" />
    <PackageReference Remove="System.Threading.Tasks.Extensions" />
  </ItemGroup>
```


## Drop support for end-of-life targets

And maybe even start considering dropping support for all those versions that are out off support for years, according to [your own support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core): 

- `.NET Core 2.1` ended support Augustus 21th **2021** which is over 2 years ago.
- `.NET5` ended support May 10th **2022** which is also over 16 months ago
- `.NET 4.6.1` ended support on April 26th **2022** according to  [this page](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-framework#sha1-retirement) which is 17 months ago.

## Remove high severity vulnerabilities

Packages.Data.props seem to be forcing `<PackageReference Update="Newtonsoft.Json" Version="10.0.3" />` which according to [nuget](https://www.nuget.org/packages/Newtonsoft.Json/10.0.3) has at least 1 [high severity vulnerability](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
