### PR TITLE
Azure OpenAI: prepare-release and changelog snap for beta.8 update

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.8 (Unreleased)
+## 1.0.0-beta.8 (2023-09-21)
 
 ### Features Added
 


### PR DESCRIPTION
This change is the standalone output from the `prepare-release.ps1` script to finalize repository state in advance of the beta.8 release. Details had already been filled out in prior PRs, so this is a *very* sparse change that just inserts the release date.