### PR TITLE
[AppConfiguration] Fix: GetConfigurationSettings does not set the ContentType property

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `GetConfigurationSettings(SettingSelector)` not setting `ContentType` and `LastModified` properties [(#38524)](https://github.com/Azure/azure-sdk-for-net/issues/38524).
+
 ### Other Changes
 
 ## 1.2.1 (2023-09-13)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_c13e90b6f4"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_bebb69bca2"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -652,7 +652,7 @@ namespace Azure.Data.AppConfiguration
             var label = selector.LabelFilter;
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
-            IEnumerable<string> fieldsString = selector.Fields == SettingFields.All ? null : selector.Fields.ToString().ToLowerInvariant().Replace("isreadonly", "locked").Split(',');
+            IEnumerable<string> fieldsString = selector.Fields.Split();
 
             HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(key, label, null, dateTime, fieldsString, null, null, context);
             HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, null, null, context);
@@ -672,7 +672,7 @@ namespace Azure.Data.AppConfiguration
             var dateTime = selector.AcceptDateTime?.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture);
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
-            IEnumerable<string> fieldsString = selector.Fields == SettingFields.All ? null : selector.Fields.ToString().ToLowerInvariant().Replace("isreadonly", "locked").Split(',');
+            IEnumerable<string> fieldsString = selector.Fields.Split();
 
             HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(key, label, null, dateTime, fieldsString, null, null, context);
             HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, null, null, context);
@@ -724,7 +724,7 @@ namespace Azure.Data.AppConfiguration
             Argument.AssertNotNullOrEmpty(snapshotName, nameof(snapshotName));
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
-            IEnumerable<string> fieldsString = fields == SettingFields.All ? null : fields.ToString().ToLowerInvariant().Replace("isreadonly", "locked").Split(',');
+            IEnumerable<string> fieldsString = fields.Split();
 
             HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, fieldsString, snapshotName, null, context);
             HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, fieldsString, snapshotName, null, context);
@@ -742,7 +742,7 @@ namespace Azure.Data.AppConfiguration
             Argument.AssertNotNullOrEmpty(snapshotName, nameof(snapshotName));
 
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
-            IEnumerable<string> fieldsString = fields == SettingFields.All ? null : fields.ToString().ToLowerInvariant().Replace("isreadonly", "locked").Split(',');
+            IEnumerable<string> fieldsString = fields.Split();
 
             HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetConfigurationSettingsRequest(null, null, null, null, fieldsString, snapshotName, null, context);
             HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetConfigurationSettingsNextPageRequest(nextLink, null, null, null, null, fieldsString, snapshotName, null, context);
@@ -1243,7 +1243,7 @@ namespace Azure.Data.AppConfiguration
             var label = selector.LabelFilter;
             var dateTime = selector.AcceptDateTime?.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture);
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
-            IEnumerable<string> fieldsString = selector.Fields == SettingFields.All ? null : selector.Fields.ToString().ToLowerInvariant().Replace("isreadonly", "locked").Split(',');
+            IEnumerable<string> fieldsString = selector.Fields.Split();
 
             HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, null, dateTime, fieldsString, context);
             HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, context);
@@ -1262,7 +1262,7 @@ namespace Azure.Data.AppConfiguration
             var label = selector.LabelFilter;
             var dateTime = selector.AcceptDateTime?.UtcDateTime.ToString(AcceptDateTimeFormat, CultureInfo.InvariantCulture);
             RequestContext context = CreateRequestContext(ErrorOptions.Default, cancellationToken);
-            IEnumerable<string> fieldsString = selector.Fields == SettingFields.All ? null : selector.Fields.ToString().ToLowerInvariant().Replace("isreadonly", "locked").Split(',');
+            IEnumerable<string> fieldsString = selector.Fields.Split();
 
             HttpMessage FirstPageRequest(int? pageSizeHint) => CreateGetRevisionsRequest(key, label, null, dateTime, fieldsString, context);
             HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => CreateGetRevisionsNextPageRequest(nextLink, key, label, null, dateTime, fieldsString, context);

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -52,32 +52,6 @@ namespace Azure.Data.AppConfiguration
             }
         }
 
-        internal static void BuildBatchQuery(RequestUriBuilder builder, SettingSelector selector, string pageLink)
-        {
-            if (!string.IsNullOrEmpty(selector.KeyFilter))
-            {
-                builder.AppendQuery(KeyQueryFilter, selector.KeyFilter);
-            }
-
-            if (!string.IsNullOrEmpty(selector.LabelFilter))
-            {
-                builder.AppendQuery(LabelQueryFilter, selector.LabelFilter);
-            }
-
-            IEnumerable<string> splitFields = selector.Fields.Split();
-
-            if (splitFields != null)
-            {
-                string filter = string.Join(",", splitFields);
-                builder.AppendQuery(FieldsQueryFilter, filter);
-            }
-
-            if (!string.IsNullOrEmpty(pageLink))
-            {
-                builder.AppendQuery("after", pageLink, escapeValue: false);
-            }
-        }
-
         #region nobody wants to see these
         /// <summary>
         /// Check if two ConfigurationSetting instances are equal.

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
@@ -63,9 +64,11 @@ namespace Azure.Data.AppConfiguration
                 builder.AppendQuery(LabelQueryFilter, selector.LabelFilter);
             }
 
-            if (selector.Fields != SettingFields.All)
+            IEnumerable<string> splitFields = selector.Fields.Split();
+
+            if (splitFields != null)
             {
-                var filter = selector.Fields.ToString().ToLowerInvariant().Replace("isreadonly", "locked");
+                string filter = string.Join(",", splitFields);
                 builder.AppendQuery(FieldsQueryFilter, filter);
             }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingFieldsExtensions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingFieldsExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.Data.AppConfiguration
+{
+    internal static class SettingFieldsExtensions
+    {
+        /// <summary>
+        /// Maps a SettingFields member to its corresponding service name in accordance with the REST API specification.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<SettingFields, string> s_serviceNameMap = new Dictionary<SettingFields, string>()
+        {
+            { SettingFields.Key         , "key"           },
+            { SettingFields.Label       , "label"         },
+            { SettingFields.Value       , "value"         },
+            { SettingFields.ContentType , "content_type"  },
+            { SettingFields.ETag        , "etag"          },
+            { SettingFields.LastModified, "last_modified" },
+            { SettingFields.IsReadOnly  , "locked"        },
+            { SettingFields.Tags        , "tags"          }
+        };
+
+        public static IEnumerable<string> Split(this SettingFields fields)
+        {
+            if (fields == SettingFields.All)
+            {
+                return null;
+            }
+
+            var splitFields = new List<string>();
+
+            foreach (SettingFields currentField in s_serviceNameMap.Keys)
+            {
+                if ((fields & currentField) == currentField)
+                {
+                    splitFields.Add(s_serviceNameMap[currentField]);
+                }
+            }
+
+            return splitFields;
+        }
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingFieldsExtensions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingFieldsExtensions.cs
@@ -22,6 +22,11 @@ namespace Azure.Data.AppConfiguration
             { SettingFields.Tags        , "tags"          }
         };
 
+        /// <summary>
+        /// Splits <see cref="SettingFields"/> flags into their corresponding service names.
+        /// </summary>
+        /// <param name="fields">The flags to split.</param>
+        /// <returns>An enumerable containing the names of the flags. The method returns <c>null</c> for <see cref="SettingFields.All"/>.</returns>
         public static IEnumerable<string> Split(this SettingFields fields)
         {
             if (fields == SettingFields.All)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -1046,7 +1046,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
                 Assert.IsNotNull(batch[0].Key);
                 Assert.IsNotNull(batch[0].Label);
-                Assert.IsNotNull(batch[0].ETag);
+                Assert.AreNotEqual(batch[0].ETag, default(ETag));
                 Assert.IsNull(batch[0].Value);
                 Assert.IsNull(batch[0].ContentType);
                 Assert.IsNull(batch[0].LastModified);
@@ -1118,9 +1118,49 @@ namespace Azure.Data.AppConfiguration.Tests
                 Assert.IsNotNull(batch[0].Label);
                 Assert.IsNotNull(batch[0].Value);
                 Assert.IsNotNull(batch[0].ContentType);
-                Assert.IsNotNull(batch[0].ETag);
+                Assert.AreNotEqual(batch[0].ETag, default(ETag));
                 Assert.IsNotNull(batch[0].LastModified);
                 Assert.IsNotNull(batch[0].IsReadOnly);
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label));
+            }
+        }
+
+        [RecordedTest]
+        public async Task GetBatchSettingWithAllFieldsSetIndividually()
+        {
+            ConfigurationClient service = GetClient();
+            string key = GenerateKeyId("keyFields-");
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(new ConfigurationSetting(key, "my_value", "my_label")
+            {
+                ContentType = "content-type",
+                Tags = { { "my_tag", "my_tag_value" } }
+            });
+
+            try
+            {
+                SettingSelector selector = new SettingSelector
+                {
+                    KeyFilter = key,
+                    Fields = SettingFields.Key | SettingFields.Label | SettingFields.Value | SettingFields.ContentType
+                        | SettingFields.ETag | SettingFields.LastModified | SettingFields.IsReadOnly | SettingFields.Tags
+                };
+
+                ConfigurationSetting[] batch = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
+                    .ToArray();
+
+                Assert.AreEqual(1, batch.Length);
+
+                Assert.IsNotNull(batch[0].Key);
+                Assert.IsNotNull(batch[0].Label);
+                Assert.IsNotNull(batch[0].Value);
+                Assert.IsNotNull(batch[0].ContentType);
+                Assert.AreNotEqual(batch[0].ETag, default(ETag));
+                Assert.IsNotNull(batch[0].LastModified);
+                Assert.IsNotNull(batch[0].IsReadOnly);
+                Assert.IsNotEmpty(batch[0].Tags);
             }
             finally
             {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -1129,7 +1129,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
-        public async Task GetBatchSettingWithAllFieldsSetIndividually()
+        public async Task GetBatchSettingWithAllFieldsSetExplicitly()
         {
             ConfigurationClient service = GetClient();
             string key = GenerateKeyId("keyFields-");

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Data.AppConfiguration.Tests

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
@@ -115,7 +115,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual($"http://localhost/?key=key&$select=key%2C%20value", builder.ToUri().AbsoluteUri);
+            Assert.AreEqual($"http://localhost/?key=key&$select=key%2Cvalue", builder.ToUri().AbsoluteUri);
         }
 
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Azure.Core;
 
 namespace Azure.Data.AppConfiguration.Tests
 {
@@ -27,113 +26,6 @@ namespace Azure.Data.AppConfiguration.Tests
                 { "tag2", "value2" }
             }
         };
-
-        [Test]
-        public void FilterReservedCharacter()
-        {
-            var selector = new SettingSelector
-            {
-                KeyFilter = @"my_key,key\,key",
-                LabelFilter = @"my_label,label\,label"
-            };
-
-            var builder = new RequestUriBuilder();
-            builder.Reset(new Uri("http://localhost/"));
-
-            ConfigurationClient.BuildBatchQuery(builder, selector, null);
-
-            Assert.AreEqual(@"http://localhost/?key=my_key%2Ckey%5C%2Ckey&label=my_label%2Clabel%5C%2Clabel", builder.ToUri().AbsoluteUri);
-        }
-
-        [Test]
-        public void FilterContains()
-        {
-            var selector = new SettingSelector{ KeyFilter = "*key*", LabelFilter = "*label*" };
-            var builder = new RequestUriBuilder();
-            builder.Reset(new Uri("http://localhost/"));
-
-            ConfigurationClient.BuildBatchQuery(builder, selector, null);
-
-            Assert.AreEqual("http://localhost/?key=%2Akey%2A&label=%2Alabel%2A", builder.ToUri().AbsoluteUri);
-        }
-
-        [Test]
-        public void FilterNullLabel()
-        {
-            var selector = new SettingSelector { LabelFilter = "\0" };
-
-            var builder = new RequestUriBuilder();
-            builder.Reset(new Uri("http://localhost/"));
-
-            ConfigurationClient.BuildBatchQuery(builder, selector, null);
-
-            Assert.AreEqual("http://localhost/?label=%00", builder.ToUri().AbsoluteUri);
-        }
-
-        [Test]
-        public void FilterOnlyKey()
-        {
-            var key = "my-key";
-            var selector = new SettingSelector { KeyFilter = key };
-
-            var builder = new RequestUriBuilder();
-            builder.Reset(new Uri("http://localhost/"));
-
-            ConfigurationClient.BuildBatchQuery(builder, selector, null);
-
-            Assert.AreEqual($"http://localhost/?key={key}", builder.ToUri().AbsoluteUri);
-        }
-
-        [Test]
-        public void FilterOnlyLabel()
-        {
-            var label = "my-label";
-            var selector = new SettingSelector
-            {
-                LabelFilter = label
-            };
-
-            var builder = new RequestUriBuilder();
-            builder.Reset(new Uri("http://localhost/"));
-
-            ConfigurationClient.BuildBatchQuery(builder, selector, null);
-
-            Assert.AreEqual($"http://localhost/?label={label}", builder.ToUri().AbsoluteUri);
-        }
-
-        [Test]
-        public void SettingSomeFields()
-        {
-            var selector = new SettingSelector
-            {
-                KeyFilter = "key",
-                Fields = SettingFields.Key | SettingFields.Value
-            };
-
-            var builder = new RequestUriBuilder();
-            builder.Reset(new Uri("http://localhost/"));
-
-            ConfigurationClient.BuildBatchQuery(builder, selector, null);
-
-            Assert.AreEqual($"http://localhost/?key=key&$select=key%2Cvalue", builder.ToUri().AbsoluteUri);
-        }
-
-        [Test]
-        public void SettingAllFields()
-        {
-            var selector = new SettingSelector
-            {
-                KeyFilter = "key",
-                Fields = SettingFields.All
-            };
-
-            var builder = new RequestUriBuilder();
-            builder.Reset(new Uri("http://localhost/"));
-
-            ConfigurationClient.BuildBatchQuery(builder, selector, null);
-
-            Assert.AreEqual($"http://localhost/?key=key", builder.ToUri().AbsoluteUri);
-        }
 
         [Test]
         public void ConfigurationSettingEquals()

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SettingFieldsExtensionsTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SettingFieldsExtensionsTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Azure.Data.AppConfiguration.Tests
+{
+    public class SettingFieldsExtensionsTests
+    {
+        [Test]
+        public void SplitReturnsNullForAll()
+        {
+            Assert.IsNull(SettingFields.All.Split());
+        }
+
+        [Test]
+        [TestCase(SettingFields.Key, "key")]
+        [TestCase(SettingFields.Label, "label")]
+        [TestCase(SettingFields.Value, "value")]
+        [TestCase(SettingFields.ContentType, "content_type")]
+        [TestCase(SettingFields.ETag, "etag")]
+        [TestCase(SettingFields.LastModified, "last_modified")]
+        [TestCase(SettingFields.IsReadOnly, "locked")]
+        [TestCase(SettingFields.Tags, "tags")]
+        public void SplitWithSingleField(SettingFields fields, string expectedFieldString)
+        {
+            IEnumerable<string> splitFields = fields.Split();
+            string fieldString = splitFields.Single();
+
+            Assert.AreEqual(fieldString, expectedFieldString);
+        }
+
+        [Test]
+        public void SplitWithMultipleFields()
+        {
+            SettingFields fields = SettingFields.Key | SettingFields.ContentType | SettingFields.LastModified | SettingFields.IsReadOnly;
+            IEnumerable<string> splitFields = fields.Split();
+
+            Assert.AreEqual(splitFields.Count(), 4);
+            CollectionAssert.Contains(splitFields, "key");
+            CollectionAssert.Contains(splitFields, "content_type");
+            CollectionAssert.Contains(splitFields, "last_modified");
+            CollectionAssert.Contains(splitFields, "locked");
+        }
+
+        [Test]
+        public void SplitSupportsAllPossibleSettingFields()
+        {
+            foreach (SettingFields fields in Enum.GetValues(typeof(SettingFields)))
+            {
+                if (fields == SettingFields.All)
+                {
+                    continue;
+                }
+
+                IEnumerable<string> splitFields = fields.Split();
+
+                // If this assertion fails, it's likely that a new enum value has been added to SettingFields
+                // but a corresponding entry has not been added to s_serviceNameMap in SettingFieldsExtensions.
+                Assert.AreEqual(splitFields.Count(), 1, $"{nameof(SettingFields)} enum value {fields} could not be mapped to a string.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
For more context, this is the issue associated with this PR: https://github.com/Azure/azure-sdk-for-net/issues/38524

It turns out this was caused by a bug in the SDK. We were incorrectly passing a "contenttype" string as a query parameter to the service, while "content_type" was expected. The service was silently ignoring our error and the `ContentType` output property was not being populated.

More details about the cause of the bug and the fix can be found as comments in this PR.