### PR TITLE
DataMovement Test Infra: In-Memory StorageResources

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/tests/MemoryStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/MemoryStorageResourceTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Storage.DataMovement.Tests
+{
+    internal class MemoryStorageResourceTests
+    {
+        [Test]
+        public async Task MemoryItemCopyFromStream([Values(true, false)] bool overwrite)
+        {
+            Random r = new Random();
+            byte[] data = new byte[r.Next(1, 9999)];
+            r.NextBytes(data);
+
+            MemoryStorageResourceItem item = new();
+
+            await item.CopyFromStreamAsync(
+                new MemoryStream(data),
+                data.Length,
+                overwrite,
+                data.Length);
+
+            Assert.That(item.Buffer.ToArray(), Is.EquivalentTo(data));
+        }
+
+        [Test]
+        public async Task MemoryItemCopyFromStreamOverwrite()
+        {
+            Random r = new Random();
+            byte[] oldData = new byte[r.Next(1, 9999)];
+            byte[] newData = new byte[r.Next(1, 9999)];
+            r.NextBytes(oldData);
+            r.NextBytes(newData);
+
+            MemoryStorageResourceItem item = new()
+            {
+                Buffer = new Memory<byte>(oldData)
+            };
+
+            await item.CopyFromStreamAsync(
+                new MemoryStream(newData),
+                newData.Length,
+                overwrite: true,
+                newData.Length);
+
+            Assert.That(item.Buffer.ToArray(), Is.EquivalentTo(newData));
+        }
+
+        [Test]
+        public async Task MemoryItemDeleteIfExists([Values(true, false)] bool alreadyExists)
+        {
+            Random r = new Random();
+            byte[] data = new byte[r.Next(1, 9999)];
+            r.NextBytes(data);
+
+            MemoryStorageResourceItem item = new()
+            {
+                Buffer = alreadyExists ? new Memory<byte>(data) : Memory<byte>.Empty
+            };
+
+            bool deleted = await item.DeleteIfExistsAsync();
+
+            Assert.That(deleted, Is.EqualTo(alreadyExists));
+        }
+
+        [Test]
+        public async Task MemoryItemReadStream(
+            [Values(true, false)] bool nonZeroOffset,
+            [Values(true, false)] bool sliceLength)
+        {
+            Random r = new Random();
+            byte[] data = new byte[r.Next(1024, 4096)];
+            r.NextBytes(data);
+
+            MemoryStorageResourceItem item = new()
+            {
+                Buffer = new Memory<byte>(data)
+            };
+
+            int position = nonZeroOffset ? r.Next(r.Next(data.Length / 3, data.Length * 2 / 3)) : 0;
+            int? length = sliceLength ? r.Next(1, data.Length - position) : null;
+
+            MemoryStream dest = new MemoryStream();
+            await (await item.ReadStreamAsync(position, length)).Content.CopyToAsync(dest);
+
+            Memory<byte> expectedData = length.HasValue
+                ? new Memory<byte>(data).Slice(position, length.Value)
+                : new Memory<byte>(data).Slice(position);
+            Assert.That(dest.ToArray(), Is.EquivalentTo(expectedData.ToArray()));
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceContainer.cs
@@ -20,17 +20,17 @@ namespace Azure.Storage.DataMovement.Tests
 
         public MemoryStorageResourceContainer(Uri uri)
         {
-            Uri = uri;
+            Uri = uri ?? new Uri($"memory://localhost/mycontainer/mypath-{Guid.NewGuid()}/resource-item-{Guid.NewGuid()}");
         }
 
         protected internal override StorageResourceItem GetStorageResourceReference(string path)
         {
             UriBuilder builder = new(Uri);
-            builder.Path += string.Join("/", new List<string>()
+            builder.Path = string.Join("/", new List<string>()
             {
                 builder.Path.Trim('/'),
                 path.Trim('/'),
-            }.Select(s => !string.IsNullOrWhiteSpace(s)));
+            }.Where(s => !string.IsNullOrWhiteSpace(s)));
             Uri expected = builder.Uri;
 
             foreach (StorageResourceItem item in GetStorageResources(false))

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceContainer.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Azure.Storage.Tests;
+
+namespace Azure.Storage.DataMovement.Tests
+{
+    internal class MemoryStorageResourceContainer : StorageResourceContainer
+    {
+        internal List<StorageResource> Children { get; } = new();
+
+        internal readonly Uri _uri;
+        public override Uri Uri => _uri;
+
+        private MemoryStorageResourceContainer(Uri uri)
+        {
+            _uri = uri;
+        }
+
+        public static MemoryStorageResourceContainer MakeContainer(
+            Tree<(string Name, bool IsDirectory)> containerStructure,
+            Random random = default,
+            Uri baseUri = default,
+            string basePath = default,
+            int childItemSizes = Constants.KB)
+        {
+            if (containerStructure.Value.IsDirectory)
+            {
+                throw new ArgumentException("MemoryStorageResourceContainer must be a directory");
+            }
+
+            UriBuilder baseUriBuilder = baseUri != default
+                ? new UriBuilder(baseUri)
+                : new UriBuilder()
+                {
+                    Scheme = "memory",
+                    Host = "localhost",
+                };
+
+            baseUriBuilder.Path = string.Join("/", new List<string>()
+            {
+                baseUriBuilder.Path.Trim('/'),
+                basePath.Trim('/'),
+                containerStructure.Value.Name
+            }.Select(s => !string.IsNullOrWhiteSpace(s)));
+
+            MemoryStorageResourceContainer result = new(baseUriBuilder.Uri);
+            foreach (Tree<(string Name, bool IsDirectory)> child in containerStructure)
+            {
+                if (child.Value.IsDirectory)
+                {
+                    result.Children.Add(MakeContainer(child, random, result.Uri, basePath: default, childItemSizes));
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            return result;
+        }
+
+        protected internal override StorageResourceItem GetStorageResourceReference(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected internal override IAsyncEnumerable<StorageResource> GetStorageResourcesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.DataMovement.Tests
+{
+    internal class MemoryStorageResourceItem : StorageResourceItem
+    {
+        private Memory<byte> _buffer = Memory<byte>.Empty;
+
+        private readonly Uri _uri;
+        public override Uri Uri => _uri;
+
+        protected internal override string ResourceId => "MemoryBuffer";
+
+        protected internal override DataTransferOrder TransferType => DataTransferOrder.Unordered;
+
+        protected internal override long MaxChunkSize => long.MaxValue;
+
+        protected internal override long? Length => _buffer.Length;
+
+        protected internal override Task CompleteTransferAsync(bool overwrite, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        protected internal override Task CopyBlockFromUriAsync(StorageResourceItem sourceResource, HttpRange range, bool overwrite, long completeLength, StorageResourceCopyFromUriOptions options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected internal override async Task CopyFromStreamAsync(Stream stream, long streamLength, bool overwrite, long completeLength, StorageResourceWriteToOffsetOptions options = null, CancellationToken cancellationToken = default)
+        {
+            if (!overwrite && !_buffer.IsEmpty)
+            {
+                return;
+            }
+            MemoryStream dest = new();
+            await stream.CopyToAsync(dest);
+            _buffer = new Memory<byte>(dest.ToArray());
+        }
+
+        protected internal override Task CopyFromUriAsync(StorageResourceItem sourceResource, bool overwrite, long completeLength, StorageResourceCopyFromUriOptions options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected internal override Task<bool> DeleteIfExistsAsync(CancellationToken cancellationToken = default)
+        {
+            bool result = _buffer.IsEmpty;
+            _buffer = Memory<byte>.Empty;
+            return Task.FromResult(result);
+        }
+
+        protected internal override Task<HttpAuthorization> GetCopyAuthorizationHeaderAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected internal override StorageResourceCheckpointData GetDestinationCheckpointData()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected internal override Task<StorageResourceProperties> GetPropertiesAsync(CancellationToken token = default)
+        {
+            return Task.FromResult(new StorageResourceProperties(default, default, _buffer.Length, default));
+        }
+
+        protected internal override StorageResourceCheckpointData GetSourceCheckpointData()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected internal override Task<StorageResourceReadStreamResult> ReadStreamAsync(long position = 0, long? length = null, CancellationToken cancellationToken = default)
+        {
+            var slice = length.HasValue ? _buffer.Slice((int)position, (int)length.Value) : _buffer.Slice((int)position);
+            return Task.FromResult(new StorageResourceReadStreamResult(new MemoryStream(slice.ToArray())));
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
@@ -24,7 +24,7 @@ namespace Azure.Storage.DataMovement.Tests
 
         public MemoryStorageResourceItem(Uri uri = default)
         {
-            Uri = uri ?? new Uri($"memory://localhost/mycontainer/mypath/resource-item-{Guid.NewGuid()}");
+            Uri = uri ?? new Uri($"memory://localhost/mycontainer/mypath-{Guid.NewGuid()}/resource-item-{Guid.NewGuid()}");
         }
 
         protected internal override Task CompleteTransferAsync(bool overwrite, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Adds an implementation of `StorageResourceItem` and `StorageResourceContainer` for running in-memory. Helpful for isolating individual resource implementations in testing.