### PR TITLE
Update messaging stress to use addons parallel job configuration

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/Chart.lock
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.20
-digest: sha256:174a2f4b768cb47718d4b3d5a506330aa781abb31803fbeaeba3b7eef87a9f38
-generated: "2022-07-26T17:51:35.3973882-04:00"
+  version: 0.3.0
+digest: sha256:3e21a7fdf5d6b37e871a6dd9f755888166fbb24802aa517f51d1d9223b47656e
+generated: "2023-09-25T17:38:32.837147193-04:00"

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/Chart.yaml
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/Chart.yaml
@@ -5,7 +5,7 @@ description: Stress tests for Event Hubs for .NET
 
 dependencies:
 - name: stress-test-addons
-  version: 0.2.0
+  version: ~0.3.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/
 
 annotations:

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/scenarios-matrix.yaml
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/scenarios-matrix.yaml
@@ -1,22 +1,26 @@
 matrix:
   scenarios:
     consumer:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "Consumer"
+      parallel: 2
+      image: Dockerfile
+      imageBuildDir: "../../../.."
     eventprod:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "EventProd"
+      parallel: 2
+      image: Dockerfile
+      imageBuildDir: "../../../.."
     buffprod:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "BuffProd"
+      parallel: 2
+      image: Dockerfile
+      imageBuildDir: "../../../.."
     burstbuffprod:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "BurstBuffProd"
-    processor:
       image: Dockerfile
       imageBuildDir: "../../../.."
+    processor:
       scenarioName: "Processor"
+      parallel: 3
+      image: Dockerfile
+      imageBuildDir: "../../../.."

--- a/sdk/eventhub/Azure.Messaging.EventHubs/stress/templates/deploy-job.yaml
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/stress/templates/deploy-job.yaml
@@ -1,47 +1,14 @@
-{{- include "stress.deploy-job-template.from-job" (list . "stress.event-hubs-net") -}}
+{{- include "stress-test-addons.deploy-job-template.from-pod" (list . "stress.event-hubs-net") -}}
 {{- define "stress.event-hubs-net" -}}
+metadata:
+  labels:
+    testName: "net-eh-stress-{{ lower .Stress.scenarioName }}"
+    testInstance: "eventhubs-{{ lower .Stress.scenarioName }}-{{ .Release.Name }}-{{ .Release.Revision }}"
 spec:
-  {{ if eq .Stress.scenarioName "EventProd" }}
-  completions: 2
-  parallelism: 2
-  {{ end }}
-  {{ if eq .Stress.scenarioName "BuffProd" }}
-  completions: 2
-  parallelism: 2
-  {{ end }}
-  {{ if eq .Stress.scenarioName "Processor" }}
-  completions: 3
-  parallelism: 3
-  {{ end }}
-  {{ if eq .Stress.scenarioName "Consumer" }}
-  completions: 2
-  parallelism: 2
-  {{ end }}
-  completionMode: Indexed
-  template:
-    metadata:
-      labels:
-        testName: "net-eh-stress-{{ lower .Stress.scenarioName }}"
-        testInstance: "eventhubs-{{ lower .Stress.scenarioName }}-{{ .Release.Name }}-{{ .Release.Revision }}"
-    spec:
-      containers:
-        - name: role
-          image: {{ .Stress.imageTag }}
-          command: ['dotnet', "Azure.Messaging.EventHubs.Stress.dll", "--test", "{{ .Stress.scenarioName }}", "--role", "$(JOB_COMPLETION_INDEX)"]
-          imagePullPolicy: Always
-          {{- include "stress-test-addons.container-env" . | nindent 10 }}
-{{- end -}}
-
-{{- define "stress.deploy-job-template.from-job" -}}
-{{- $global := index . 0 -}}
-{{- $jobOverrideDefinition := index . 1 -}}
-# Configmap template that adds the stress test ARM template for mounting
-{{- include "stress-test-addons.deploy-configmap" $global }}
-{{- range (default (list "stress") $global.Values.scenarios) }}
----
-{{ $jobCtx := fromYaml (include "stress-test-addons.util.mergeStressContext" (list $global . )) }}
-{{- $jobOverride := fromYaml (include $jobOverrideDefinition $jobCtx) -}}
-{{- $tpl := fromYaml (include "stress-test-addons.deploy-job-template.tpl" $jobCtx) -}}
-{{- toYaml (merge $jobOverride $tpl) -}}
-{{- end }}
+  containers:
+    - name: role
+      image: {{ .Stress.imageTag }}
+      command: ['dotnet', "Azure.Messaging.EventHubs.Stress.dll", "--test", "{{ .Stress.scenarioName }}", "--role", "$(JOB_COMPLETION_INDEX)"]
+      imagePullPolicy: Always
+      {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/stress/Chart.lock
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.2.0
-digest: sha256:53cbe4c0fed047f6c611523bd34181b21a310e7a3a21cb14f649bb09e4a77648
-generated: "2022-10-28T12:40:54.5657204-07:00"
+  version: 0.3.0
+digest: sha256:3e21a7fdf5d6b37e871a6dd9f755888166fbb24802aa517f51d1d9223b47656e
+generated: "2023-09-25T21:42:38.685809722-04:00"

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/stress/Chart.yaml
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/stress/Chart.yaml
@@ -5,7 +5,7 @@ description: Stress tests for Service Bus for .NET
 
 dependencies:
 - name: stress-test-addons
-  version: 0.2.0
+  version: ~0.3.0
   repository: https://stresstestcharts.blob.core.windows.net/helm/
 
 annotations:

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/stress/scenarios-matrix.yaml
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/stress/scenarios-matrix.yaml
@@ -1,22 +1,27 @@
 matrix:
   scenarios:
     sendrec:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "SendRec"
+      parallel: 2
+      image: Dockerfile
+      imageBuildDir: "../../../.."
     sendrecbatch:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "SendRecBatch"
+      parallel: 2
+      image: Dockerfile
+      imageBuildDir: "../../../.."
     sesssendrec:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "SessionSendRec"
+      parallel: 2
+      image: Dockerfile
+      imageBuildDir: "../../../.."
     sesssendproc:
-      image: Dockerfile
-      imageBuildDir: "../../../.."
       scenarioName: "SessionSendProc"
-    sendproc:
+      parallel: 2
       image: Dockerfile
       imageBuildDir: "../../../.."
+    sendproc:
       scenarioName: "SendProc"
+      parallel: 2
+      image: Dockerfile
+      imageBuildDir: "../../../.."

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/stress/templates/deploy-job.yaml
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/stress/templates/deploy-job.yaml
@@ -1,33 +1,14 @@
-{{- include "stress.deploy-job-template.from-job" (list . "stress.service-bus") -}}
+{{- include "stress-test-addons.deploy-job-template.from-pod" (list . "stress.service-bus") -}}
 {{- define "stress.service-bus" -}}
+metadata:
+  labels:
+    testName: "net-sb-stress-{{ lower .Stress.scenarioName }}"
+    testInstance: "servicebus-{{ lower .Stress.scenarioName }}-{{ .Release.Name }}-{{ .Release.Revision }}"
 spec:
-  completions: 2
-  parallelism: 2
-  completionMode: Indexed
-  template:
-    metadata:
-      labels:
-        testName: "net-sb-stress-{{ lower .Stress.scenarioName }}"
-        testInstance: "servicebus-{{ lower .Stress.scenarioName }}-{{ .Release.Name }}-{{ .Release.Revision }}"
-    spec:
-      containers:
-        - name: role
-          image: {{ .Stress.imageTag }}
-          command: ['dotnet', "Azure.Messaging.ServiceBus.Stress.dll", "--test", "{{ .Stress.scenarioName }}", "--role", "$(JOB_COMPLETION_INDEX)"]
-          imagePullPolicy: Always
-          {{- include "stress-test-addons.container-env" . | nindent 10 }}
-{{- end -}}
-
-{{- define "stress.deploy-job-template.from-job" -}}
-{{- $global := index . 0 -}}
-{{- $jobOverrideDefinition := index . 1 -}}
-# Configmap template that adds the stress test ARM template for mounting
-{{- include "stress-test-addons.deploy-configmap" $global }}
-{{- range (default (list "stress") $global.Values.scenarios) }}
----
-{{ $jobCtx := fromYaml (include "stress-test-addons.util.mergeStressContext" (list $global . )) }}
-{{- $jobOverride := fromYaml (include $jobOverrideDefinition $jobCtx) -}}
-{{- $tpl := fromYaml (include "stress-test-addons.deploy-job-template.tpl" $jobCtx) -}}
-{{- toYaml (merge $jobOverride $tpl) -}}
-{{- end }}
+  containers:
+    - name: role
+      image: {{ .Stress.imageTag }}
+      command: ['dotnet', "Azure.Messaging.ServiceBus.Stress.dll", "--test", "{{ .Stress.scenarioName }}", "--role", "$(JOB_COMPLETION_INDEX)"]
+      imagePullPolicy: Always
+      {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}


### PR DESCRIPTION
This PR simplifies the messaging stress tests now that we support parallel test configurations via the matrix config.
