### PR TITLE
DataMovment `StorageResourceContainer` internal hooks to protected APIs

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -49,6 +49,7 @@
     <Compile Include="$(AzureStorageDataMovementSharedSources)JobPlanExtensions.cs" LinkBase="Shared\DataMovement" />
     <Compile Include="$(AzureStorageDataMovementSharedSources)ResponseExtensions.cs" LinkBase="Shared\DataMovement" />
     <Compile Include="$(AzureStorageDataMovementSharedSources)LocalTransferCheckpointer.cs" LinkBase="Shared\DataMovement" />
+    <Compile Include="$(AzureStorageDataMovementSharedSources)StorageResourceContainerInternal.cs" LinkBase="Shared\DataMovement" />
     <Compile Include="$(AzureStorageDataMovementSharedSources)TransferCheckpointer.cs" LinkBase="Shared\DataMovement" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobStorageResourceContainer.cs
@@ -15,7 +15,7 @@ namespace Azure.Storage.DataMovement.Blobs
     /// <summary>
     /// The Storage Resource class for the Blob Client. Supports blob prefix directories as well as the root container.
     /// </summary>
-    internal class BlobStorageResourceContainer : StorageResourceContainer
+    internal class BlobStorageResourceContainer : StorageResourceContainerInternal
     {
         internal BlobContainerClient BlobContainerClient { get; }
         internal string DirectoryPrefix { get; }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/Azure.Storage.DataMovement.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/Azure.Storage.DataMovement.Files.Shares.csproj
@@ -32,6 +32,9 @@
     <Compile Include="$(AzureCoreSharedSources)SyncAsyncEventHandlerExtensions.cs" LinkBase="Shared\Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(AzureStorageDataMovementSharedSources)StorageResourceContainerInternal.cs" LinkBase="Shared\DataMovement" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Azure.Core" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryStorageResourceContainer.cs
@@ -11,7 +11,7 @@ using Azure.Storage.Files.Shares;
 
 namespace Azure.Storage.DataMovement.Files.Shares
 {
-    internal class ShareDirectoryStorageResourceContainer : StorageResourceContainer
+    internal class ShareDirectoryStorageResourceContainer : StorageResourceContainerInternal
     {
         internal ShareFileStorageResourceOptions ResourceOptions { get; set; }
         internal PathScanner PathScanner { get; set; }
@@ -47,20 +47,5 @@ namespace Azure.Storage.DataMovement.Files.Shares
                 yield return new ShareFileStorageResourceItem(client, ResourceOptions);
             }
         }
-
-        #region Protected Hooks
-        // Internal func to access protected member for testing.
-        internal async IAsyncEnumerable<StorageResource> GetStorageResourcesInternal(
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            await foreach (StorageResource resource in GetStorageResourcesAsync(cancellationToken).ConfigureAwait(false))
-            {
-                yield return resource;
-            }
-        }
-
-        internal StorageResourceItem GetStorageResourceReferenceInternal(string path)
-            => GetStorageResourceReference(path);
-        #endregion
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStorageResourceContainerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStorageResourceContainerTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
             // Verify StorageResourceContainer correctly invokes path scanner and returns the given files
             List<ShareFileClient> results = new();
-            await foreach (StorageResource res in resource.GetStorageResourcesInternal())
+            await foreach (StorageResource res in resource.GetStorageResourcesInternalAsync())
             {
                 Assert.That(res, Is.TypeOf(typeof(ShareFileStorageResourceItem)));
                 results.Add((res as ShareFileStorageResourceItem).ShareFileClient);

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/StorageResourceContainerInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/StorageResourceContainerInternal.cs
@@ -6,6 +6,12 @@ using System.Threading;
 
 namespace Azure.Storage.DataMovement
 {
+    /// <summary>
+    /// Middle class between the public type and implementation class.
+    /// Gives internal hook methods to protected methods of
+    /// <see cref="StorageResourceContainer"/>, allowing for internal
+    /// package use as well as testing access.
+    /// </summary>
     internal abstract class StorageResourceContainerInternal : StorageResourceContainer
     {
         internal IAsyncEnumerable<StorageResource> GetStorageResourcesInternalAsync(

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/StorageResourceContainerInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/StorageResourceContainerInternal.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Azure.Storage.DataMovement
+{
+    internal abstract class StorageResourceContainerInternal : StorageResourceContainer
+    {
+        internal IAsyncEnumerable<StorageResource> GetStorageResourcesInternalAsync(
+            CancellationToken cancellationToken = default)
+            => GetStorageResourcesAsync(cancellationToken);
+
+        internal StorageResourceItem GetStorageResourceReferenceInternal(string path)
+            => GetStorageResourceReference(path);
+    }
+}


### PR DESCRIPTION
Standardizes getting internals testing access to otherwise protected APIs. This is for container resources only. Items are being handled as part of #38938 which needed them.