### PR TITLE
[AppConfig] Allow unknown condition members

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fixed `GetConfigurationSettings(SettingSelector)` not setting `ContentType` and `LastModified` properties [(#38524)](https://github.com/Azure/azure-sdk-for-net/issues/38524).
 
+- `FeatureFlagConfigurationSetting`  will now allow custom attributes under the `conditions` element in the setting value.  Previously, only `client_filters` was recognized and other data would be discarded.
+
 ### Other Changes
 
 ## 1.2.1 (2023-09-13)


### PR DESCRIPTION
# Summary

The focus of these changes is to allow for unknown members to be present in the `conditions` property of a feature flag configuration setting.  Previously, these were ignored as the setting assumed that `conditions` should be treated as a well-known member.  This change moves the well-known member to `conditions/client_filters` and preserves unknown children of `conditions`.