### PR TITLE
Remove OpenTelemetry ASP.NET Core and HTTP metrics.

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -122,8 +122,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                             .AddAzureMonitorTraceExporter());
 
             builder.WithMetrics(b => b
-                            .AddAspNetCoreInstrumentation()
-                            .AddHttpClientInstrumentation()
                             .AddAzureMonitorMetricExporter());
 
             builder.Services.AddLogging(logging =>


### PR DESCRIPTION
* Standard metrics provide metrics for ASP.NET Core and HTTP.
* Until the OpenTelemetry ASP.NET and HTTP Instrumentation libraries are stabilized, we will rely on standard metrics for ASP.NET Core and HTTP metrics.