### PR TITLE
ShareDirectoryClient extensions

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
@@ -1,5 +1,11 @@
 namespace Azure.Storage.DataMovement.Files.Shares
 {
+    public partial class ShareDirectoryClientTransferOptions
+    {
+        public ShareDirectoryClientTransferOptions() { }
+        public Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions ShareDirectoryOptions { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.DataTransferOptions TransferOptions { get { throw null; } set { } }
+    }
     public partial class ShareFilesStorageResourceProvider : Azure.Storage.DataMovement.StorageResourceProvider
     {
         public ShareFilesStorageResourceProvider() { }
@@ -23,5 +29,13 @@ namespace Azure.Storage.DataMovement.Files.Shares
     public partial class ShareFileStorageResourceOptions
     {
         public ShareFileStorageResourceOptions() { }
+    }
+}
+namespace Azure.Storage.Files.Shares
+{
+    public static partial class ShareDirectoryClientExtensions
+    {
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartDownloadToDirectoryAsync(this Azure.Storage.Files.Shares.ShareDirectoryClient client, string localDirectoryPath, Azure.Storage.DataMovement.Files.Shares.ShareDirectoryClientTransferOptions options = null) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartUploadDirectoryAsync(this Azure.Storage.Files.Shares.ShareDirectoryClient client, string localDirectoryPath, Azure.Storage.DataMovement.Files.Shares.ShareDirectoryClientTransferOptions options = null) { throw null; }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
@@ -1,5 +1,11 @@
 namespace Azure.Storage.DataMovement.Files.Shares
 {
+    public partial class ShareDirectoryClientTransferOptions
+    {
+        public ShareDirectoryClientTransferOptions() { }
+        public Azure.Storage.DataMovement.Files.Shares.ShareFileStorageResourceOptions ShareDirectoryOptions { get { throw null; } set { } }
+        public Azure.Storage.DataMovement.DataTransferOptions TransferOptions { get { throw null; } set { } }
+    }
     public partial class ShareFilesStorageResourceProvider : Azure.Storage.DataMovement.StorageResourceProvider
     {
         public ShareFilesStorageResourceProvider() { }
@@ -23,5 +29,13 @@ namespace Azure.Storage.DataMovement.Files.Shares
     public partial class ShareFileStorageResourceOptions
     {
         public ShareFileStorageResourceOptions() { }
+    }
+}
+namespace Azure.Storage.Files.Shares
+{
+    public static partial class ShareDirectoryClientExtensions
+    {
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartDownloadToDirectoryAsync(this Azure.Storage.Files.Shares.ShareDirectoryClient client, string localDirectoryPath, Azure.Storage.DataMovement.Files.Shares.ShareDirectoryClientTransferOptions options = null) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Storage.DataMovement.DataTransfer> StartUploadDirectoryAsync(this Azure.Storage.Files.Shares.ShareDirectoryClient client, string localDirectoryPath, Azure.Storage.DataMovement.Files.Shares.ShareDirectoryClientTransferOptions options = null) { throw null; }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientExtensions.cs
@@ -18,7 +18,7 @@ namespace Azure.Storage.Files.Shares
         private static Lazy<ShareFilesStorageResourceProvider> s_shareFilesProvider = new();
 
         /// <summary>
-        /// Uploads the entire contents of local directory to the blob container.
+        /// Uploads the entire contents of local directory to the share directory.
         /// </summary>
         /// <param name="client">
         /// The <see cref="ShareDirectoryClient"/> used for service operations.
@@ -46,7 +46,7 @@ namespace Azure.Storage.Files.Shares
         }
 
         /// <summary>
-        /// Downloads the contents of a blob container.
+        /// Downloads the contents of a share directory.
         /// </summary>
         /// <param name="client">The <see cref="ShareDirectoryClient"/> used for service operations.</param>
         /// <param name="localDirectoryPath">The full path to the local directory where files will be dowloaded.</param>

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientExtensions.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Storage.DataMovement;
+using Azure.Storage.DataMovement.Files.Shares;
+
+namespace Azure.Storage.Files.Shares
+{
+    /// <summary>
+    /// Data movement extension methods for the <see cref="ShareDirectoryClient"/>.
+    /// </summary>
+    public static class ShareDirectoryClientExtensions
+    {
+        private static Lazy<TransferManager> s_defaultTransferManager = new(() => new TransferManager(default));
+        private static Lazy<LocalFilesStorageResourceProvider> s_localFilesProvider = new();
+        private static Lazy<ShareFilesStorageResourceProvider> s_shareFilesProvider = new();
+
+        /// <summary>
+        /// Uploads the entire contents of local directory to the blob container.
+        /// </summary>
+        /// <param name="client">
+        /// The <see cref="ShareDirectoryClient"/> used for service operations.
+        /// </param>
+        /// <param name="localDirectoryPath">
+        /// The full path to the local directory to be uploaded.
+        /// </param>
+        /// <param name="options">
+        /// Options which control the directory upload.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DataTransfer"/> instance which can be used track progress and wait for
+        /// completion with <see cref="DataTransfer.WaitForCompletionAsync"/>.
+        /// </returns>
+        public static async Task<DataTransfer> StartUploadDirectoryAsync(
+            this ShareDirectoryClient client,
+            string localDirectoryPath,
+            ShareDirectoryClientTransferOptions options = default)
+        {
+            StorageResource localDirectory = s_localFilesProvider.Value.FromPath(localDirectoryPath);
+            StorageResource shareDirectory = s_shareFilesProvider.Value.FromClient(client, options?.ShareDirectoryOptions);
+
+            return await s_defaultTransferManager.Value.StartTransferAsync(
+                localDirectory, shareDirectory, options?.TransferOptions).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Downloads the contents of a blob container.
+        /// </summary>
+        /// <param name="client">The <see cref="ShareDirectoryClient"/> used for service operations.</param>
+        /// <param name="localDirectoryPath">The full path to the local directory where files will be dowloaded.</param>
+        /// <param name="options">Options which control the container download.</param>
+        /// <returns></returns>
+        public static async Task<DataTransfer> StartDownloadToDirectoryAsync(
+            this ShareDirectoryClient client,
+            string localDirectoryPath,
+            ShareDirectoryClientTransferOptions options = default)
+        {
+            StorageResource localDirectory = s_localFilesProvider.Value.FromPath(localDirectoryPath);
+            StorageResource shareDirectory = s_shareFilesProvider.Value.FromClient(client, options?.ShareDirectoryOptions);
+
+            return await s_defaultTransferManager.Value.StartTransferAsync(
+                shareDirectory, localDirectory, options?.TransferOptions).ConfigureAwait(false);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientTransferOptions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Storage.Files.Shares;
+
+namespace Azure.Storage.DataMovement.Files.Shares
+{
+    /// <summary>
+    /// Options applying to data transfer uploads and downloads using the <see cref="ShareDirectoryClient"/> extension methods
+    /// <see cref="ShareDirectoryClientExtensions.StartDownloadToDirectoryAsync(ShareDirectoryClient, string, ShareDirectoryClientTransferOptions)"/> and
+    /// <see cref="ShareDirectoryClientExtensions.StartUploadDirectoryAsync(ShareDirectoryClient, string, ShareDirectoryClientTransferOptions)"/>.
+    /// </summary>
+    public class ShareDirectoryClientTransferOptions
+    {
+        /// <summary>
+        /// Options pertaining to the share file directory used in the data transfer.
+        /// </summary>
+        public ShareFileStorageResourceOptions ShareDirectoryOptions { get; set; }
+
+        /// <summary>
+        /// Options pertaining to the data tranfer.
+        /// </summary>
+        public DataTransferOptions TransferOptions { get; set; }
+    }
+}

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryClientExtensionsTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryClientExtensionsTests.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Files.Shares;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Storage.DataMovement.Files.Shares.Tests
+{
+    [NonParallelizable]
+    public class ShareDirectoryClientExtensionsTests
+    {
+        private Mock<TransferManager> ExtensionMockTransferManager { get; set; }
+
+        // temporarily stores the static value that was in the extensions class
+        private Lazy<TransferManager> _backupTransferManagerValue;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            ExtensionMockTransferManager = new();
+            ExtensionMockTransferManager.Setup(tm => tm.StartTransferAsync(
+                It.IsAny<StorageResource>(),
+                It.IsAny<StorageResource>(),
+                It.IsAny<DataTransferOptions>(),
+                It.IsAny<CancellationToken>()));
+
+            _backupTransferManagerValue = (Lazy<TransferManager>)typeof(ShareDirectoryClientExtensions)
+                .GetField("s_defaultTransferManager", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+            typeof(ShareDirectoryClientExtensions)
+                .GetField("s_defaultTransferManager", BindingFlags.NonPublic | BindingFlags.Static)
+                .SetValue(null, new Lazy<TransferManager>(() => ExtensionMockTransferManager.Object));
+        }
+
+        [OneTimeTearDown]
+        public void Teardown()
+        {
+            typeof(ShareDirectoryClientExtensions)
+                .GetField("s_defaultTransferManager", BindingFlags.NonPublic | BindingFlags.Static)
+                .SetValue(null, _backupTransferManagerValue);
+        }
+
+        public async Task StartUploadDirectory([Values(true, false)] bool useOptions)
+        {
+            ShareFileStorageResourceOptions storageResourceOptions = new();
+            DataTransferOptions dataTransferOptions = new();
+            ShareDirectoryClientTransferOptions transferOptions = new()
+            {
+                ShareDirectoryOptions = storageResourceOptions,
+                TransferOptions = dataTransferOptions,
+            };
+            string localPath = "foo";
+            Mock<ShareDirectoryClient> clientMock = new();
+
+            await clientMock.Object.StartUploadDirectoryAsync(localPath, useOptions ? transferOptions : null);
+
+            ExtensionMockTransferManager.Verify(tm => tm.StartTransferAsync(
+                It.IsAny<StorageResource>(),
+                It.Is<StorageResource>(res => res is ShareDirectoryStorageResourceContainer &&
+                    (res as ShareDirectoryStorageResourceContainer).ShareDirectoryClient == clientMock.Object &&
+                    (res as ShareDirectoryStorageResourceContainer).ResourceOptions == storageResourceOptions),
+                useOptions ? dataTransferOptions : null,
+                default), Times.Once);
+            ExtensionMockTransferManager.VerifyNoOtherCalls();
+        }
+
+        public async Task StartDownloadDirectory([Values(true, false)] bool useOptions)
+        {
+            ShareFileStorageResourceOptions storageResourceOptions = new();
+            DataTransferOptions dataTransferOptions = new();
+            ShareDirectoryClientTransferOptions transferOptions = new()
+            {
+                ShareDirectoryOptions = storageResourceOptions,
+                TransferOptions = dataTransferOptions,
+            };
+            string localPath = "foo";
+            Mock<ShareDirectoryClient> clientMock = new();
+
+            await clientMock.Object.StartDownloadToDirectoryAsync(localPath, useOptions ? transferOptions : null);
+
+            ExtensionMockTransferManager.Verify(tm => tm.StartTransferAsync(
+                It.Is<StorageResource>(res => res is ShareDirectoryStorageResourceContainer &&
+                    (res as ShareDirectoryStorageResourceContainer).ShareDirectoryClient == clientMock.Object &&
+                    (res as ShareDirectoryStorageResourceContainer).ResourceOptions == storageResourceOptions),
+                It.IsAny<StorageResource>(),
+                useOptions ? dataTransferOptions : null,
+                default), Times.Once);
+            ExtensionMockTransferManager.VerifyNoOtherCalls();
+        }
+    }
+}


### PR DESCRIPTION
Extension methods bridging ShareDirectoryClient with transfer manager, similar to extensions on BlobContainerClient.