### PR TITLE
Allow Users to Configure Retry Policy for Credentials through ClientFactory

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Identity;
 using Microsoft.Extensions.Azure;
@@ -421,6 +422,7 @@ namespace Azure.Core.Extensions.Tests
                 new KeyValuePair<string, string>("tenantId", "ConfigurationTenantId"),
                 new KeyValuePair<string, string>("clientId", "ConfigurationClientId"),
                 new KeyValuePair<string, string>("tokenFilePath", "ConfigurationTokenFilePath"),
+                new KeyValuePair<string, string>("additionallyAllowedTenants", "ExtraConfigurationTenantId1;ExtraConfigurationTenantId2"),
                 new KeyValuePair<string, string>("credential", "workloadidentity")
             );
 
@@ -439,6 +441,11 @@ namespace Azure.Core.Extensions.Tests
             var actualTokenFilePath = fileCacheType.GetField("_tokenFilePath", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(fileCache);
 
             Assert.AreEqual("ConfigurationTokenFilePath", actualTokenFilePath);
+
+            string[] tenants = (string[])typeof(WorkloadIdentityCredential).GetProperty("AdditionallyAllowedTenantIds", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(workloadIdentityCredential);
+            Assert.AreEqual(2, tenants.Length);
+            Assert.AreEqual("ExtraConfigurationTenantId1", tenants[0]);
+            Assert.AreEqual("ExtraConfigurationTenantId2", tenants[1]);
         }
 
         [Test]
@@ -450,6 +457,7 @@ namespace Azure.Core.Extensions.Tests
                 { "AZURE_TENANT_ID", "EnvTenantId" },
                 { "AZURE_CLIENT_ID", "EnvClientId" },
                 { "AZURE_FEDERATED_TOKEN_FILE", "EnvTokenFilePath" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "ExtraEnvTenantId1;ExtraEnvTenantId2" },
             });
 
             var credential = ClientFactory.CreateCredential(configuration);
@@ -467,6 +475,11 @@ namespace Azure.Core.Extensions.Tests
             var actualTokenFilePath = fileCacheType.GetField("_tokenFilePath", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(fileCache);
 
             Assert.AreEqual("EnvTokenFilePath", actualTokenFilePath);
+
+            string[] tenants = (string[])typeof(WorkloadIdentityCredential).GetProperty("AdditionallyAllowedTenantIds", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(workloadIdentityCredential);
+            Assert.AreEqual(2, tenants.Length);
+            Assert.AreEqual("ExtraEnvTenantId1", tenants[0]);
+            Assert.AreEqual("ExtraEnvTenantId2", tenants[1]);
         }
 
         [TestCase(null, null, null)]
@@ -552,9 +565,226 @@ namespace Azure.Core.Extensions.Tests
             Assert.AreEqual("key", client.AzureSasCredential.Signature);
         }
 
+        [Test]
+        public void CanConfigureManagedIdentityCredentialRetryDefaults()
+        {
+            RetryOptions expected = CreateRetryOptions();
+
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("credential", "managedidentity"));
+
+            var credential = ClientFactory.CreateCredential(configuration);
+            AssertRetryOptions<ManagedIdentityCredential>(expected, credential);
+        }
+
+        [Test]
+        public void CanConfigureManagedIdentityCredentialRetry()
+        {
+            CanConfigureCredentialRetry<ManagedIdentityCredential>(
+                new KeyValuePair<string, string>("credential", "managedidentity"));
+        }
+
+        [Test]
+        public void CanConfigureWorkloadIdentityCredentialRetryDefaults()
+        {
+            RetryOptions expected = CreateRetryOptions();
+
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("tenantId", "ExampleTenantId"),
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"),
+                new KeyValuePair<string, string>("tokenFilePath", "ExampleTokenFilePath"),
+                new KeyValuePair<string, string>("credential", "workloadidentity"));
+
+            var credential = ClientFactory.CreateCredential(configuration);
+            AssertRetryOptions<WorkloadIdentityCredential>(expected, credential);
+        }
+
+        [Test]
+        public void CanConfigureWorkloadIdentityCredentialRetry()
+        {
+            CanConfigureCredentialRetry<WorkloadIdentityCredential>(
+                new KeyValuePair<string, string>("tenantId", "ExampleTenantId"),
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"),
+                new KeyValuePair<string, string>("tokenFilePath", "ExampleTokenFilePath"),
+                new KeyValuePair<string, string>("credential", "workloadidentity"));
+        }
+
+        [Test]
+        public void CanConfigureClientSecretCredentialRetryDefaults()
+        {
+            RetryOptions expected = CreateRetryOptions();
+
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("tenantId", "ExampleTenantId"),
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"),
+                new KeyValuePair<string, string>("clientSecret", "ExampleClientSecret"));
+
+            var credential = ClientFactory.CreateCredential(configuration);
+            AssertRetryOptions<ClientSecretCredential>(expected, credential);
+        }
+
+        [Test]
+        public void CanConfigureClientSecretCredentialRetry()
+        {
+            CanConfigureCredentialRetry<ClientSecretCredential>(
+                new KeyValuePair<string, string>("tenantId", "ExampleTenantId"),
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"),
+                new KeyValuePair<string, string>("clientSecret", "ExampleClientSecret"));
+        }
+
+        [Test]
+        public void CanConfigureClientCertificateCredentialRetryDefaults()
+        {
+            var localCert = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            localCert.Open(OpenFlags.ReadOnly);
+            var someLocalCert = localCert.Certificates[0].Thumbprint;
+            localCert.Close();
+
+            RetryOptions expected = CreateRetryOptions();
+
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"),
+                new KeyValuePair<string, string>("clientCertificate", someLocalCert),
+                new KeyValuePair<string, string>("clientCertificateStoreLocation", "currentUser"),
+                new KeyValuePair<string, string>("clientCertificateStoreName", "my"),
+                new KeyValuePair<string, string>("tenantId", "ExampleTenantId"));
+
+            var credential = ClientFactory.CreateCredential(configuration);
+            AssertRetryOptions<ClientCertificateCredential>(expected, credential);
+        }
+
+        [Test]
+        public void CanConfigureClientCertificateCredentialRetry()
+        {
+            var localCert = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            localCert.Open(OpenFlags.ReadOnly);
+            var someLocalCert = localCert.Certificates[0].Thumbprint;
+            localCert.Close();
+
+            CanConfigureCredentialRetry<ClientCertificateCredential>(
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"),
+                new KeyValuePair<string, string>("clientCertificate", someLocalCert),
+                new KeyValuePair<string, string>("clientCertificateStoreLocation", "currentUser"),
+                new KeyValuePair<string, string>("clientCertificateStoreName", "my"),
+                new KeyValuePair<string, string>("tenantId", "ExampleTenantId"));
+        }
+
+        [Test]
+        public void CanConfigureDefaultAzureCredentialRetryDefaults()
+        {
+            RetryOptions expected = CreateRetryOptions();
+
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"));
+
+            var credential = ClientFactory.CreateCredential(configuration);
+            AssertRetryOptions<DefaultAzureCredential>(expected, credential);
+        }
+
+        [Test]
+        public void CanConfigureDefaultAzureCredentialRetry()
+        {
+            CanConfigureCredentialRetry<DefaultAzureCredential>(
+                new KeyValuePair<string, string>("clientId", "ExampleClientId"));
+        }
+
+        private static void CanConfigureCredentialRetry<T>(
+            params KeyValuePair<string, string>[] configurationItems)
+            where T : TokenCredential
+        {
+            RetryOptions expected = CreateRetryOptions(
+                delay: TimeSpan.FromSeconds(2),
+                maxDelay: TimeSpan.FromMinutes(1),
+                maxRetries: 12,
+                networkTimeout: TimeSpan.FromMinutes(5));
+
+            foreach (RetryMode mode in new RetryMode[] { RetryMode.Fixed, RetryMode.Exponential })
+            {
+                expected.Mode = mode;
+
+                IConfiguration configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configurationItems)
+                    .AddInMemoryCollection(new KeyValuePair<string, string>[]
+                    {
+                        new KeyValuePair<string, string>($"retry:{nameof(RetryOptions.Delay)}", expected.Delay.ToString()),
+                        new KeyValuePair<string, string>($"retry:{nameof(RetryOptions.MaxDelay)}", expected.MaxDelay.ToString()),
+                        new KeyValuePair<string, string>($"retry:{nameof(RetryOptions.MaxRetries)}", expected.MaxRetries.ToString()),
+                        new KeyValuePair<string, string>($"retry:{nameof(RetryOptions.Mode)}", expected.Mode.ToString()),
+                        new KeyValuePair<string, string>($"retry:{nameof(RetryOptions.NetworkTimeout)}", expected.NetworkTimeout.ToString())
+                    })
+                    .Build();
+
+                var credential = ClientFactory.CreateCredential(configuration);
+                AssertRetryOptions<T>(expected, credential);
+            }
+        }
+
         private IConfiguration GetConfiguration(params KeyValuePair<string, string>[] items)
         {
             return new ConfigurationBuilder().AddInMemoryCollection(items).Build();
+        }
+
+        private static RetryOptions CreateRetryOptions(
+            TimeSpan? delay = null,
+            TimeSpan? maxDelay = null,
+            int maxRetries = 3,
+            RetryMode mode = RetryMode.Exponential,
+            TimeSpan? networkTimeout = null)
+        {
+            var options = Activator.CreateInstance(typeof(RetryOptions), nonPublic: true) as RetryOptions;
+            options.Delay = delay ?? TimeSpan.FromSeconds(0.8);
+            options.MaxDelay = maxDelay ?? TimeSpan.FromMinutes(1);
+            options.MaxRetries = maxRetries;
+            options.Mode = mode;
+            options.NetworkTimeout = networkTimeout ?? TimeSpan.FromSeconds(100);
+
+            return options;
+        }
+
+        private static void AssertRetryOptions<T>(RetryOptions expected, object actualCredential)
+            where T : TokenCredential
+        {
+            Assembly azureCore = typeof(TokenCredential).Assembly;
+            Assembly azureIdentity = typeof(DefaultAzureCredential).Assembly;
+
+            // Unfortunately, much of this information is embedded in the internal HTTP pipeline,
+            // so it takes a bit of effort to figure out whether classes were configured in the expected way.
+            Assert.IsInstanceOf(typeof(T), actualCredential);
+            Type credentialPipelineType = azureIdentity.DefinedTypes.Single(x => x.FullName == "Azure.Identity.CredentialPipeline");
+            object credentialPipeline = typeof(T).GetField("_pipeline", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(actualCredential);
+            HttpPipeline httpPipeline = credentialPipelineType.GetProperty("HttpPipeline", BindingFlags.Public | BindingFlags.Instance).GetValue(credentialPipeline) as HttpPipeline;
+            ReadOnlyMemory<HttpPipelinePolicy> policies = (ReadOnlyMemory<HttpPipelinePolicy>)typeof(HttpPipeline).GetField("_pipeline", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(httpPipeline);
+
+            // Validate RetryPolicy
+            RetryPolicy actualRetryPolicy = policies.ToArray().Single(x => x.GetType() == typeof(RetryPolicy)) as RetryPolicy;
+            DelayStrategy delayStrategy = typeof(RetryPolicy).GetField("_delayStrategy", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(actualRetryPolicy) as DelayStrategy;
+            int maxRetries = (int)typeof(RetryPolicy).GetField("_maxRetries", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(actualRetryPolicy);
+
+            Assert.AreEqual(expected.MaxRetries, maxRetries);
+
+            Type expectedStrategyType = expected.Mode switch
+            {
+                RetryMode.Exponential => azureCore.DefinedTypes.Single(x => x.FullName == "Azure.Core.ExponentialDelayStrategy"),
+                RetryMode.Fixed => azureCore.DefinedTypes.Single(x => x.FullName == "Azure.Core.FixedDelayStrategy"),
+                _ => throw new AssertionException($"Unexpected retry mode: {expected.Mode}"),
+            };
+
+            Assert.IsInstanceOf(expectedStrategyType, delayStrategy);
+            TimeSpan delay = (TimeSpan)expectedStrategyType.GetField("_delay", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(delayStrategy);
+            Assert.AreEqual(expected.Delay, delay);
+
+            if (expected.Mode == RetryMode.Exponential)
+            {
+                TimeSpan maxDelay = (TimeSpan)typeof(DelayStrategy).GetField("_maxDelay", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(delayStrategy);
+                Assert.AreEqual(expected.MaxDelay, maxDelay);
+            }
+
+            // Validate ResponseBodyPolicy
+            Type responseBodyPolicyType = azureCore.DefinedTypes.Single(x => x.FullName == "Azure.Core.Pipeline.ResponseBodyPolicy");
+            object actualResponseBodyPolicy = policies.ToArray().Single(x => x.GetType() == responseBodyPolicyType);
+            TimeSpan networkTimeout = (TimeSpan)responseBodyPolicyType.GetField("_networkTimeout", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(actualResponseBodyPolicy);
+
+            Assert.AreEqual(expected.NetworkTimeout, networkTimeout);
         }
     }
 }


### PR DESCRIPTION
Resolves #39049

- Adds support for `retry` section, the same name used by [`ClientOptions.Retry`](https://learn.microsoft.com/en-us/dotnet/api/azure.core.clientoptions.retry?view=azure-dotnet#azure-core-clientoptions-retry), for the following credential types:
  - `ClientCertificateCredential`
  - `ClientSecretCredential`
  - `DefaultAzureCredential`
  - `ManagedIdentityCredential`
  - `WorkloadIdentityCredential`
- Update `WorkloadIdentityCredential` creation to optionally set `AdditionallyAllowedTenants` through the configuration
