### PR TITLE
Replace LocalFilesStorageResourceProvider.FromPath with FromFile and Directory

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/README.md
@@ -191,7 +191,7 @@ Upload a block blob.
 
 ```C# Snippet:SimpleBlobUpload
 DataTransfer dataTransfer = await transferManager.StartTransferAsync(
-    sourceResource: files.FromPath(sourceLocalPath),
+    sourceResource: files.FromFile(sourceLocalPath),
     destinationResource: blobs.FromClient(destinationBlob));
 await dataTransfer.WaitForCompletionAsync();
 ```
@@ -200,7 +200,7 @@ Upload a directory as a specific blob type.
 
 ```C# Snippet:SimpleDirectoryUpload
 DataTransfer dataTransfer = await transferManager.StartTransferAsync(
-    sourceResource: files.FromPath(sourcePath),
+    sourceResource: files.FromDirectory(sourcePath),
     destinationResource: blobs.FromClient(
         blobContainerClient,
         new BlobStorageResourceContainerOptions()
@@ -224,7 +224,7 @@ BlobsStorageResourceProvider blobs = new();
 LocalFilesStorageResourceProvider files = new();
 DataTransfer dataTransfer = await transferManager.StartTransferAsync(
     sourceResource: blobs.FromClient(sourceBlobClient),
-    destinationResource: files.FromPath(downloadPath));
+    destinationResource: files.FromFile(downloadPath));
 await dataTransfer.WaitForCompletionAsync();
 ```
 
@@ -238,7 +238,7 @@ DataTransfer dataTransfer = await transferManager.StartTransferAsync(
         {
             BlobDirectoryPrefix = optionalSourcePrefix
         }),
-    destinationResource: files.FromPath(downloadPath));
+    destinationResource: files.FromDirectory(downloadPath));
 await dataTransfer.WaitForCompletionAsync();
 ```
 

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/samples/Sample01b_HelloWorldAsync.cs
@@ -44,7 +44,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
                 // Get a reference to a source local file
                 LocalFilesStorageResourceProvider files = new();
-                StorageResource sourceResource = files.FromPath(sourceLocalPath);
+                StorageResource sourceResource = files.FromFile(sourceLocalPath);
 
                 // Get a reference to a destination blobs
                 BlockBlobClient blockBlobClient = blobContainerClient.GetBlockBlobClient("sample-blob-block");
@@ -133,7 +133,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 // Create simple transfer single blob upload job
                 #region Snippet:SimpleBlobUpload
                 DataTransfer dataTransfer = await transferManager.StartTransferAsync(
-                    sourceResource: files.FromPath(sourceLocalPath),
+                    sourceResource: files.FromFile(sourceLocalPath),
                     destinationResource: blobs.FromClient(destinationBlob));
                 await dataTransfer.WaitForCompletionAsync();
                 #endregion
@@ -206,19 +206,19 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 LocalFilesStorageResourceProvider files = new();
                 DataTransfer dataTransfer = await transferManager.StartTransferAsync(
                     sourceResource: blobs.FromClient(sourceBlobClient),
-                    destinationResource: files.FromPath(downloadPath));
+                    destinationResource: files.FromFile(downloadPath));
                 await dataTransfer.WaitForCompletionAsync();
                 #endregion
 
                 StorageResource sourceResource2 = blobs.FromClient(sourceBlobClient);
-                StorageResource destinationResource2 = files.FromPath(downloadPath2);
+                StorageResource destinationResource2 = files.FromFile(downloadPath2);
 
                 await transferManager.StartTransferAsync(
                     sourceResource: blobs.FromClient(sourceBlobClient, new BlockBlobStorageResourceOptions()
                     {
                         DestinationConditions = new BlobRequestConditions(){ LeaseId = "xyz" }
                     }),
-                    destinationResource: files.FromPath(downloadPath2));
+                    destinationResource: files.FromFile(downloadPath2));
             }
             finally
             {
@@ -287,7 +287,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 BlobsStorageResourceProvider blobs = new();
                 LocalFilesStorageResourceProvider files = new();
                 // Get a storage resource reference to a local directory
-                StorageResource localDirectory = files.FromPath(sourcePath);
+                StorageResource localDirectory = files.FromDirectory(sourcePath);
                 // Get a storage resource to a destination blob directory
                 StorageResource directoryDestination = blobs.FromClient(
                     blobContainerClient,
@@ -306,7 +306,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 string optionalDestinationPrefix = "sample-directory2";
                 #region Snippet:SimpleDirectoryUpload
                 DataTransfer dataTransfer = await transferManager.StartTransferAsync(
-                    sourceResource: files.FromPath(sourcePath),
+                    sourceResource: files.FromDirectory(sourcePath),
                     destinationResource: blobs.FromClient(
                         blobContainerClient,
                         new BlobStorageResourceContainerOptions()
@@ -403,7 +403,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
                 // Create simple transfer directory upload job which uploads the directory and the contents of that directory
                 DataTransfer uploadDirectoryJobId = await transferManager.StartTransferAsync(
-                    files.FromPath(sourcePath),
+                    files.FromDirectory(sourcePath),
                     blobs.FromClient(
                         container,
                         new BlobStorageResourceContainerOptions() { BlobDirectoryPrefix = "sample-blob-directory" }));
@@ -508,7 +508,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
                 // Create simple transfer directory upload job which uploads the directory and the contents of that directory
                 DataTransfer uploadDirectoryJobId = await transferManager.StartTransferAsync(
-                    files.FromPath(sourcePath),
+                    files.FromDirectory(sourcePath),
                     blobs.FromClient(
                         container,
                         new BlobStorageResourceContainerOptions() { BlobDirectoryPrefix = "sample-blob-directory" }));
@@ -569,8 +569,8 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                     new BlobStorageResourceContainerOptions() { BlobDirectoryPrefix = "sample-blob-directory" });
                 StorageResource sourceDirectory2 = blobs.FromClient(blobContainerClient,
                     new BlobStorageResourceContainerOptions() { BlobDirectoryPrefix = "sample-blob-directory2" });
-                StorageResource destinationDirectory = files.FromPath(downloadPath);
-                StorageResource destinationDirectory2 = files.FromPath(downloadPath2);
+                StorageResource destinationDirectory = files.FromDirectory(downloadPath);
+                StorageResource destinationDirectory2 = files.FromDirectory(downloadPath2);
 
                 // Upload a couple of blobs so we have something to list
                 await blobContainerClient.UploadBlobAsync("first", File.OpenRead(CreateTempFile()));
@@ -605,7 +605,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                         {
                             BlobDirectoryPrefix = optionalSourcePrefix
                         }),
-                    destinationResource: files.FromPath(downloadPath));
+                    destinationResource: files.FromDirectory(downloadPath));
                 await dataTransfer.WaitForCompletionAsync();
                 #endregion
             }
@@ -733,8 +733,8 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                     new BlobStorageResourceContainerOptions() { BlobDirectoryPrefix = sourceDirectoryName2 });
 
                 // Create destination paths
-                StorageResource destinationDirectory1 = files.FromPath(downloadPath);
-                StorageResource destinationDirectory2 = files.FromPath(downloadPath2);
+                StorageResource destinationDirectory1 = files.FromDirectory(downloadPath);
+                StorageResource destinationDirectory2 = files.FromDirectory(downloadPath2);
 
                 // Upload a couple of blobs so we have something to list
                 await container.UploadBlobAsync($"{sourceDirectoryName}/fourth", File.OpenRead(originalPath));
@@ -811,7 +811,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
                 LocalFilesStorageResourceProvider files = new();
                 // Create source and destination resource
                 StorageResource sourceResource = blobs.FromClient(sourceBlob);
-                StorageResource destinationResource = files.FromPath(downloadPath);
+                StorageResource destinationResource = files.FromFile(downloadPath);
 
                 // Create simple transfer single blob download job
                 DataTransfer dataTransfer = await transferManager.StartTransferAsync(
@@ -863,7 +863,7 @@ namespace Azure.Storage.DataMovement.Blobs.Samples
 
                 // Create source and destination resource
                 StorageResource sourceResource = blobs.FromClient(sourceBlob);
-                StorageResource destinationResource = files.FromPath(downloadPath);
+                StorageResource destinationResource = files.FromFile(downloadPath);
 
                 // Create simple transfer single blob download job
                 DataTransfer dataTransfer = await transferManager.StartTransferAsync(

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobContainerClientExtensions.cs
@@ -49,7 +49,7 @@ namespace Azure.Storage.Blobs
         /// <returns>A <see cref="DataTransfer"/> instance which can be used track progress and wait for completion with <see cref="DataTransfer.WaitForCompletionAsync"/>.</returns>
         public static async Task<DataTransfer> StartUploadDirectoryAsync(this BlobContainerClient client, string localDirectoryPath, BlobContainerClientTransferOptions options)
         {
-            StorageResource localDirectory = s_filesProvider.Value.FromPath(localDirectoryPath);
+            StorageResource localDirectory = s_filesProvider.Value.FromDirectory(localDirectoryPath);
             StorageResource blobDirectory = s_blobsProvider.Value.FromClient(client, options?.BlobContainerOptions);
 
             return await s_defaultTransferManager.Value.StartTransferAsync(localDirectory, blobDirectory, options?.TransferOptions).ConfigureAwait(false);
@@ -86,7 +86,7 @@ namespace Azure.Storage.Blobs
         /// <returns></returns>
         public static async Task<DataTransfer> StartDownloadToDirectoryAsync(this BlobContainerClient client, string localDirectoryPath, BlobContainerClientTransferOptions options)
         {
-            StorageResource localDirectory = s_filesProvider.Value.FromPath(localDirectoryPath);
+            StorageResource localDirectory = s_filesProvider.Value.FromDirectory(localDirectoryPath);
             StorageResource blobDirectory = s_blobsProvider.Value.FromClient(client, options?.BlobContainerOptions);
 
             return await s_defaultTransferManager.Value.StartTransferAsync(blobDirectory, localDirectory, options?.TransferOptions).ConfigureAwait(false);

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareDirectoryClientExtensions.cs
@@ -38,7 +38,7 @@ namespace Azure.Storage.Files.Shares
             string localDirectoryPath,
             ShareDirectoryClientTransferOptions options = default)
         {
-            StorageResource localDirectory = s_localFilesProvider.Value.FromPath(localDirectoryPath);
+            StorageResource localDirectory = s_localFilesProvider.Value.FromDirectory(localDirectoryPath);
             StorageResource shareDirectory = s_shareFilesProvider.Value.FromClient(client, options?.ShareDirectoryOptions);
 
             return await s_defaultTransferManager.Value.StartTransferAsync(
@@ -57,7 +57,7 @@ namespace Azure.Storage.Files.Shares
             string localDirectoryPath,
             ShareDirectoryClientTransferOptions options = default)
         {
-            StorageResource localDirectory = s_localFilesProvider.Value.FromPath(localDirectoryPath);
+            StorageResource localDirectory = s_localFilesProvider.Value.FromDirectory(localDirectoryPath);
             StorageResource shareDirectory = s_shareFilesProvider.Value.FromClient(client, options?.ShareDirectoryOptions);
 
             return await s_defaultTransferManager.Value.StartTransferAsync(

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -95,7 +95,8 @@ namespace Azure.Storage.DataMovement
         public LocalFilesStorageResourceProvider() { }
         protected internal override string TypeId { get { throw null; } }
         protected internal override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromPath(string path) { throw null; }
+        public Azure.Storage.DataMovement.StorageResourceContainer FromDirectory(string directoryPath) { throw null; }
+        public Azure.Storage.DataMovement.StorageResourceItem FromFile(string filePath) { throw null; }
         protected internal override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class ProgressHandlerOptions

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -95,7 +95,8 @@ namespace Azure.Storage.DataMovement
         public LocalFilesStorageResourceProvider() { }
         protected internal override string TypeId { get { throw null; } }
         protected internal override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public Azure.Storage.DataMovement.StorageResource FromPath(string path) { throw null; }
+        public Azure.Storage.DataMovement.StorageResourceContainer FromDirectory(string directoryPath) { throw null; }
+        public Azure.Storage.DataMovement.StorageResourceItem FromFile(string filePath) { throw null; }
         protected internal override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class ProgressHandlerOptions

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFilesStorageResourceProvider.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFilesStorageResourceProvider.cs
@@ -41,20 +41,31 @@ namespace Azure.Storage.DataMovement
         }
 
         /// <summary>
-        /// Creates a storage resource to the file or directory at the given path.
+        /// Creates a storage resource to the file at the given path.
         /// </summary>
-        /// <param name="path">
-        /// Path to the file or directory.
+        /// <param name="filePath">
+        /// Path to the file.
         /// </param>
         /// <returns>
-        /// Storage resource to this file or directory.
+        /// Storage resource to this file.
         /// </returns>
-        public StorageResource FromPath(string path)
+        public StorageResourceItem FromFile(string filePath)
         {
-            FileAttributes attributes = File.GetAttributes(path);
-            return attributes.HasFlag(FileAttributes.Directory)
-                ? new LocalDirectoryStorageResourceContainer(path)
-                : new LocalFileStorageResource(path);
+            return new LocalFileStorageResource(filePath);
+        }
+
+        /// <summary>
+        /// Creates a storage resource to the directory at the given path.
+        /// </summary>
+        /// <param name="directoryPath">
+        /// Path to the directory.
+        /// </param>
+        /// <returns>
+        /// Storage resource to this directory.
+        /// </returns>
+        public StorageResourceContainer FromDirectory(string directoryPath)
+        {
+            return new LocalDirectoryStorageResourceContainer(directoryPath);
         }
     }
 }


### PR DESCRIPTION
Replace `LocalFilesStorageResourceProvider.FromPath` with `FromFile` and `FromDirectory`.

This would remove the need for the local file or directory to be created before creating the object. That way transfers can occur without having the destination already created.