### PR TITLE
[Storage][DataMovement] Update checkpointer to read/write to job file - Part 1

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/Azure.Storage.DataMovement.Blobs.csproj
@@ -39,6 +39,7 @@
     <Compile Include="$(AzureStorageSharedSources)Errors.Clients.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)StorageExtensions.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared\Storage" />
+    <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)StreamExtensions.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobDestinationCheckpointData.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobDestinationCheckpointData.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using Azure.Core;
 using Azure.Storage.Blobs.Models;
+using static Azure.Storage.DataMovement.JobPlanExtensions;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
 using Tags = System.Collections.Generic.IDictionary<string, string>;
 
@@ -276,23 +277,6 @@ namespace Azure.Storage.DataMovement.Blobs
             length += _tagsBytes.Length;
             length += _cpkScopeBytes.Length;
             return length;
-        }
-
-        private void WriteVariableLengthFieldInfo(BinaryWriter writer, byte[] bytes, ref int currentVariableLengthIndex)
-        {
-            // Write the offset, -1 if size is 0
-            if (bytes.Length > 0)
-            {
-                writer.Write(currentVariableLengthIndex);
-                currentVariableLengthIndex += bytes.Length;
-            }
-            else
-            {
-                writer.Write(-1);
-            }
-
-            // Write the length
-            writer.Write(bytes.Length);
         }
 
         private static void CheckSchemaVersion(int version)

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -89,6 +89,10 @@ namespace Azure.Storage.DataMovement
         public bool HasSkippedItems { get { throw null; } }
         public Azure.Storage.DataMovement.DataTransferState State { get { throw null; } }
         public bool Equals(Azure.Storage.DataMovement.DataTransferStatus other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Storage.DataMovement.DataTransferStatus left, Azure.Storage.DataMovement.DataTransferStatus right) { throw null; }
+        public static bool operator !=(Azure.Storage.DataMovement.DataTransferStatus left, Azure.Storage.DataMovement.DataTransferStatus right) { throw null; }
     }
     public partial class LocalFilesStorageResourceProvider : Azure.Storage.DataMovement.StorageResourceProvider
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -89,6 +89,10 @@ namespace Azure.Storage.DataMovement
         public bool HasSkippedItems { get { throw null; } }
         public Azure.Storage.DataMovement.DataTransferState State { get { throw null; } }
         public bool Equals(Azure.Storage.DataMovement.DataTransferStatus other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Storage.DataMovement.DataTransferStatus left, Azure.Storage.DataMovement.DataTransferStatus right) { throw null; }
+        public static bool operator !=(Azure.Storage.DataMovement.DataTransferStatus left, Azure.Storage.DataMovement.DataTransferStatus right) { throw null; }
     }
     public partial class LocalFilesStorageResourceProvider : Azure.Storage.DataMovement.StorageResourceProvider
     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
@@ -38,5 +38,6 @@
     <Compile Include="$(AzureStorageSharedSources)PartitionedStream.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)ProgressIncrementingStream.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared\Storage" />
+    <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" LinkBase="Shared\Storage" />
   </ItemGroup>
 </Project>

--- a/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
@@ -2,37 +2,41 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.DataMovement.JobPlan;
 
 namespace Azure.Storage.DataMovement
 {
     internal partial class CheckpointerExtensions
     {
+        internal static async Task<DataTransferStatus> GetJobStatus(
+            this TransferCheckpointer checkpointer,
+            string transferId,
+            CancellationToken cancellationToken = default)
+        {
+            using (Stream stream = await checkpointer.ReadJobPlanFileAsync(
+                transferId,
+                DataMovementConstants.JobPlanFile.JobStatusIndex,
+                DataMovementConstants.IntSizeInBytes,
+                cancellationToken).ConfigureAwait(false))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+                JobPlanStatus jobPlanStatus = (JobPlanStatus)reader.ReadInt32();
+                return jobPlanStatus.ToDataTransferStatus();
+            }
+        }
+
         internal static async Task<bool> IsResumableAsync(
             this TransferCheckpointer checkpointer,
             string transferId,
             CancellationToken cancellationToken)
         {
-            DataTransferState transferState = (DataTransferState) await checkpointer.GetByteValue(
-                transferId,
-                DataMovementConstants.JobPartPlanFile.AtomicJobStatusStateIndex,
-                cancellationToken).ConfigureAwait(false);
-
-            byte hasFailedItemsByte = await checkpointer.GetByteValue(
-                transferId,
-                DataMovementConstants.JobPartPlanFile.AtomicJobStatusHasFailedIndex,
-                cancellationToken).ConfigureAwait(false);
-            bool hasFailedItems = Convert.ToBoolean(hasFailedItemsByte);
-
-            byte hasSkippedItemsByte = await checkpointer.GetByteValue(
-                transferId,
-                DataMovementConstants.JobPartPlanFile.AtomicJobStatusHasSkippedIndex,
-                cancellationToken).ConfigureAwait(false);
-            bool hasSkippedItems = Convert.ToBoolean(hasSkippedItemsByte);
+            DataTransferStatus jobStatus = await checkpointer.GetJobStatus(transferId, cancellationToken).ConfigureAwait(false);
 
             // Transfers marked as fully completed are not resumable
-            return transferState != DataTransferState.Completed || hasFailedItems || hasSkippedItems;
+            return jobStatus.State != DataTransferState.Completed || jobStatus.HasFailedItems || jobStatus.HasSkippedItems;
         }
 
         internal static async Task<DataTransferProperties> GetDataTransferPropertiesAsync(

--- a/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
@@ -11,7 +11,7 @@ namespace Azure.Storage.DataMovement
 {
     internal partial class CheckpointerExtensions
     {
-        internal static async Task<DataTransferStatus> GetJobStatus(
+        internal static async Task<DataTransferStatus> GetJobStatusAsync(
             this TransferCheckpointer checkpointer,
             string transferId,
             CancellationToken cancellationToken = default)
@@ -33,7 +33,7 @@ namespace Azure.Storage.DataMovement
             string transferId,
             CancellationToken cancellationToken)
         {
-            DataTransferStatus jobStatus = await checkpointer.GetJobStatus(transferId, cancellationToken).ConfigureAwait(false);
+            DataTransferStatus jobStatus = await checkpointer.GetJobStatusAsync(transferId, cancellationToken).ConfigureAwait(false);
 
             // Transfers marked as fully completed are not resumable
             return jobStatus.State != DataTransferState.Completed || jobStatus.HasFailedItems || jobStatus.HasSkippedItems;

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferStatus.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferStatus.cs
@@ -104,15 +104,48 @@ namespace Azure.Storage.DataMovement
             return Interlocked.Exchange(ref _stateValue, (int)state) != (int)state;
         }
 
-        /// <summary>
-        /// Indicates whether the current object is equal to another object of the same type.
-        /// </summary>
-        /// <param name="other">An object to compare with this object.</param>
-        /// <returns>Returns true if the current object is equal to the other parameter; otherwise, false.</returns>
+        /// <inheritdoc/>
         public bool Equals(DataTransferStatus other)
-            => State.Equals(other.State) &&
-            HasFailedItems.Equals(other.HasFailedItems) &&
-            HasSkippedItems.Equals(other.HasSkippedItems);
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return State.Equals(other.State) &&
+                HasFailedItems.Equals(other.HasFailedItems) &&
+                HasSkippedItems.Equals(other.HasSkippedItems);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator ==(DataTransferStatus left, DataTransferStatus right)
+        {
+            if (left is null)
+            {
+                if (right is null)
+                {
+                    return true;
+                }
+                return false;
+            }
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator !=(DataTransferStatus left, DataTransferStatus right) => !(left == right);
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => Equals(obj as DataTransferStatus);
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = 1225395075;
+            hashCode = hashCode * -1521134295 + State.GetHashCode();
+            hashCode = hashCode * -1521134295 + HasFailedItems.GetHashCode();
+            hashCode = hashCode * -1521134295 + HasSkippedItems.GetHashCode();
+            return hashCode;
+        }
 
         /// <summary>
         /// Performs a Deep Copy of the <see cref="DataTransferStatus"/>.

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferStatus.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferStatus.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Azure.Storage.DataMovement

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferStatus.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferStatus.cs
@@ -117,21 +117,27 @@ namespace Azure.Storage.DataMovement
                 HasSkippedItems.Equals(other.HasSkippedItems);
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Equality operator.
+        /// </summary>
+        /// <param name="left">The left hand side.</param>
+        /// <param name="right">The right hand side.</param>
+        /// <returns>True, if the two values are equal; otherwise false.</returns>
         public static bool operator ==(DataTransferStatus left, DataTransferStatus right)
         {
-            if (left is null)
+            if (left is null != right is null)
             {
-                if (right is null)
-                {
-                    return true;
-                }
                 return false;
             }
-            return left.Equals(right);
+            return left?.Equals(right) ?? true;
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Inequality operator.
+        /// </summary>
+        /// <param name="left">The left hand side.</param>
+        /// <param name="right">The right hand side.</param>
+        /// <returns>True, if the two values are not equal; otherwise false.</returns>
         public static bool operator !=(DataTransferStatus left, DataTransferStatus right) => !(left == right);
 
         /// <inheritdoc/>

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -16,6 +16,7 @@ namespace Azure.Storage.DataMovement
         internal const int MaxJobPartReaders = 64;
         internal const int MaxJobChunkTasks = 3000;
         internal const int StatusCheckInSec = 10;
+        internal const int DefaultArrayPoolArraySize = 4 * 1024;
 
         internal static class ConcurrencyTuner
         {

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransferStatusInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataTransferStatusInternal.cs
@@ -5,6 +5,9 @@ namespace Azure.Storage.DataMovement
 {
     internal class DataTransferStatusInternal : DataTransferStatus
     {
+        public DataTransferStatusInternal() : base()
+        { }
+
         public DataTransferStatusInternal(
             DataTransferState state,
             bool hasFailedItems,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
@@ -101,7 +101,7 @@ namespace Azure.Storage.DataMovement
 
             string sourceResourceId;
             string destinationResourceId;
-            using (Stream stream = await checkpointer.ReadableStreamAsync(
+            using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
@@ -172,7 +172,7 @@ namespace Azure.Storage.DataMovement
             CancellationToken cancellationToken)
         {
             string value;
-            using (Stream stream = await checkpointer.ReadableStreamAsync(
+            using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
@@ -201,7 +201,7 @@ namespace Azure.Storage.DataMovement
             CancellationToken cancellationToken)
         {
             string value;
-            using (Stream stream = await checkpointer.ReadableStreamAsync(
+            using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
@@ -228,7 +228,7 @@ namespace Azure.Storage.DataMovement
             CancellationToken cancellationToken)
         {
             byte value;
-            using (Stream stream = await checkpointer.ReadableStreamAsync(
+            using (Stream stream = await checkpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
@@ -301,6 +301,16 @@ namespace Azure.Storage.DataMovement
             return new DataTransferStatusInternal(state, hasFailed, hasSkipped);
         }
 
+        /// <summary>
+        /// Writes the length and offset field for the given byte array
+        /// and increments currentVariableLengthIndex accordingly.
+        /// </summary>
+        /// <param name="writer">The writer to write to.</param>
+        /// <param name="bytes">The data to write info about.</param>
+        /// <param name="currentVariableLengthIndex">
+        /// A reference to the current index of the variable length fields
+        /// that will be used to set the offset and then incremented.
+        /// </param>
         internal static void WriteVariableLengthFieldInfo(
             BinaryWriter writer,
             byte[] bytes,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
@@ -105,7 +105,7 @@ namespace Azure.Storage.DataMovement
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
-                readSize: readLength,
+                length: readLength,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 BinaryReader reader = new BinaryReader(stream);
@@ -176,7 +176,7 @@ namespace Azure.Storage.DataMovement
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
-                readSize: streamReadLength,
+                length: streamReadLength,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 BinaryReader reader = new BinaryReader(stream);
@@ -205,7 +205,7 @@ namespace Azure.Storage.DataMovement
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
-                readSize: streamReadLength,
+                length: streamReadLength,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 BinaryReader reader = new BinaryReader(stream);
@@ -232,7 +232,7 @@ namespace Azure.Storage.DataMovement
                 transferId: transferId,
                 partNumber: 0,
                 offset: startIndex,
-                readSize: DataMovementConstants.OneByte,
+                length: DataMovementConstants.OneByte,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 BinaryReader reader = new BinaryReader(stream);

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
@@ -51,86 +51,44 @@ namespace Azure.Storage.DataMovement
             string transferId,
             CancellationToken cancellationToken)
         {
-            int startIndex = DataMovementConstants.JobPartPlanFile.SourcePathLengthIndex;
-            int readLength = DataMovementConstants.JobPartPlanFile.DestinationExtraQueryLengthIndex - startIndex;
+            int startIndex = DataMovementConstants.JobPlanFile.ParentSourcePathOffsetIndex;
 
-            int partCount = await checkpointer.CurrentJobPartCountAsync(transferId).ConfigureAwait(false);
-            string storedSourcePath = default;
-            string storedDestPath = default;
-            for (int i = 0; i < partCount; i++)
+            string parentSourcePath = default;
+            string parentDestinationPath = default;
+            using (Stream stream = await checkpointer.ReadJobPlanFileAsync(
+                transferId: transferId,
+                offset: startIndex,
+                length: 0, // Read to the end
+                cancellationToken: cancellationToken).ConfigureAwait(false))
             {
-                using (Stream stream = await checkpointer.ReadableStreamAsync(
-                    transferId: transferId,
-                    partNumber: i,
-                    offset: startIndex,
-                    readSize: readLength,
-                    cancellationToken: cancellationToken).ConfigureAwait(false))
+                BinaryReader reader = new BinaryReader(stream);
+
+                // ParentSourcePath offset/length
+                int parentSourcePathOffset = reader.ReadInt32() - startIndex;
+                int parentSourcePathLength = reader.ReadInt32();
+
+                // ParentDestinationPath offset/length
+                int parentDestinationPathOffset = reader.ReadInt32() - startIndex;
+                int parentDestinationPathLength = reader.ReadInt32();
+
+                // ParentSourcePath
+                if (parentSourcePathOffset > 0)
                 {
-                    BinaryReader reader = new BinaryReader(stream);
+                    reader.BaseStream.Position = parentSourcePathOffset;
+                    byte[] parentSourcePathBytes = reader.ReadBytes(parentSourcePathLength);
+                    parentSourcePath = parentSourcePathBytes.ToString(parentSourcePathLength);
+                }
 
-                    // Read Source Path Length
-                    byte[] pathLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
-                    ushort pathLength = pathLengthBuffer.ToUShort();
-
-                    // Read Source Path
-                    byte[] pathBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
-                    string sourcePath = pathBuffer.ToString(pathLength);
-
-                    // Set the stream position to the start of the destination path
-                    reader.BaseStream.Position = DataMovementConstants.JobPartPlanFile.DestinationPathLengthIndex - startIndex;
-
-                    // Read Destination Path Length
-                    pathLengthBuffer = reader.ReadBytes(DataMovementConstants.UShortSizeInBytes);
-                    pathLength = pathLengthBuffer.ToUShort();
-
-                    // Read Destination Path
-                    pathBuffer = reader.ReadBytes(DataMovementConstants.JobPartPlanFile.PathStrNumBytes);
-                    string destPath = pathBuffer.ToString(pathLength);
-
-                    if (string.IsNullOrEmpty(storedSourcePath))
-                    {
-                        // If we currently don't have a path
-                        storedSourcePath = sourcePath;
-                        storedDestPath = destPath;
-                    }
-                    else
-                    {
-                        // If there's already an existing path, let's compare the two paths
-                        // and find the common parent path.
-                        storedSourcePath = GetLongestCommonString(storedSourcePath, sourcePath);
-                        storedDestPath = GetLongestCommonString(storedDestPath, destPath);
-                    }
+                // ParentDestinationPath
+                if (parentDestinationPathOffset > 0)
+                {
+                    reader.BaseStream.Position = parentDestinationPathOffset;
+                    byte[] parentDestinationPathBytes = reader.ReadBytes(parentDestinationPathLength);
+                    parentDestinationPath = parentDestinationPathBytes.ToString(parentDestinationPathLength);
                 }
             }
 
-            if (partCount == 1)
-            {
-                return (storedSourcePath, storedDestPath);
-            }
-            else
-            {
-                // The resulting stored paths are just longest common string, trim to last / to get a path
-                return (TrimStringToPath(storedSourcePath), TrimStringToPath(storedDestPath));
-            }
-        }
-
-        private static string GetLongestCommonString(string path1, string path2)
-        {
-            int length = Math.Min(path1.Length, path2.Length);
-            int index = 0;
-
-            while (index < length && path1[index] == path2[index])
-            {
-                index++;
-            }
-
-            return path1.Substring(0, index);
-        }
-
-        private static string TrimStringToPath(string path)
-        {
-            int lastSlash = path.Replace('\\', '/').LastIndexOf('/');
-            return path.Substring(0, lastSlash);
+            return (parentSourcePath, parentDestinationPath);
         }
 
         internal static async Task<(string Source, string Destination)> GetResourceIdsAsync(
@@ -307,9 +265,38 @@ namespace Azure.Storage.DataMovement
 
         internal static DataTransferStatus ToDataTransferStatus(this JobPlanStatus jobPlanStatus)
         {
+            DataTransferState state;
+            if (jobPlanStatus.HasFlag(JobPlanStatus.Queued))
+            {
+                state = DataTransferState.Queued;
+            }
+            else if (jobPlanStatus.HasFlag(JobPlanStatus.InProgress))
+            {
+                state = DataTransferState.InProgress;
+            }
+            else if (jobPlanStatus.HasFlag(JobPlanStatus.Pausing))
+            {
+                state = DataTransferState.Pausing;
+            }
+            else if (jobPlanStatus.HasFlag(JobPlanStatus.Stopping))
+            {
+                state = DataTransferState.Stopping;
+            }
+            else if (jobPlanStatus.HasFlag(JobPlanStatus.Paused))
+            {
+                state = DataTransferState.Paused;
+            }
+            else if (jobPlanStatus.HasFlag(JobPlanStatus.Completed))
+            {
+                state = DataTransferState.Completed;
+            }
+            else
+            {
+                state = DataTransferState.None;
+            }
+
             bool hasFailed = jobPlanStatus.HasFlag(JobPlanStatus.HasFailed);
             bool hasSkipped = jobPlanStatus.HasFlag(JobPlanStatus.HasSkipped);
-            DataTransferState state = (DataTransferState)Enum.Parse(typeof(DataTransferState), jobPlanStatus.ToString());
 
             return new DataTransferStatusInternal(state, hasFailed, hasSkipped);
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalTransferCheckpointer.cs
@@ -160,7 +160,7 @@ namespace Azure.Storage.DataMovement
         }
 
         /// <inheritdoc/>
-        public override async Task<Stream> ReadableStreamAsync(
+        public override async Task<Stream> ReadJobPartPlanFileAsync(
             string transferId,
             int partNumber,
             long offset,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
@@ -93,12 +93,12 @@ namespace Azure.Storage.DataMovement
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a stream to the stored memory stored checkpointing information.
+        /// Reads the specified part of the job part plan file and returns it in a Stream.
         /// </summary>
         /// <param name="transferId">The transfer ID.</param>
         /// <param name="partNumber">The job part number.</param>
-        /// <param name="offset">The offset of the current transfer.</param>
-        /// <param name="readSize">
+        /// <param name="offset">The offset to start reading the job part plan file at.</param>
+        /// <param name="length">
         /// The size of how many bytes to read.
         /// Specify 0 (zero) to create a stream that ends approximately at the end of the file.
         /// </param>
@@ -110,8 +110,8 @@ namespace Azure.Storage.DataMovement
         public abstract Task<Stream> ReadJobPartPlanFileAsync(
             string transferId,
             int partNumber,
-            long offset,
-            long readSize,
+            int offset,
+            int length,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -132,27 +132,6 @@ namespace Azure.Storage.DataMovement
             byte[] buffer,
             int bufferOffset,
             int length,
-            CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Writes to the memory mapped file to store the checkpointing information.
-        ///
-        /// Creates the file for the respective ID if it does not currently exist.
-        /// </summary>
-        /// <param name="transferId">The transfer ID.</param>
-        /// <param name="partNumber">The job part number.</param>
-        /// <param name="offset">The offset of the current transfer.</param>
-        /// <param name="buffer">The buffer to write data from to the checkpoint.</param>
-        /// <param name="cancellationToken">
-        /// Optional <see cref="CancellationToken"/> to propagate
-        /// notifications that the operation should be canceled.
-        /// </param>
-        /// <returns></returns>
-        public abstract Task WriteToCheckpointAsync(
-            string transferId,
-            int partNumber,
-            long offset,
-            byte[] buffer,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
@@ -115,6 +115,26 @@ namespace Azure.Storage.DataMovement
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Writes to the job plan file at the given offset.
+        /// </summary>
+        /// <param name="transferId">The transfer ID.</param>
+        /// <param name="fileOffset">The offset into the job plan file to start writing at.</param>
+        /// <param name="buffer">The data to write.</param>
+        /// <param name="bufferOffset">The offset into the given buffer to start reading from.</param>
+        /// <param name="length">The length of data to read from the buffer and write to the job plan file.</param>
+        /// <param name="cancellationToken">
+        /// Optional <see cref="CancellationToken"/> to propagate
+        /// notifications that the operation should be canceled.
+        /// </param>
+        public abstract Task WriteToJobPlanFileAsync(
+            string transferId,
+            int fileOffset,
+            byte[] buffer,
+            int bufferOffset,
+            int length,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Writes to the memory mapped file to store the checkpointing information.
         ///
         /// Creates the file for the respective ID if it does not currently exist.

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
@@ -107,7 +107,7 @@ namespace Azure.Storage.DataMovement
         /// notifications that the operation should be canceled.
         /// </param>
         /// <returns>The Stream to the checkpoint of the respective job ID and part number.</returns>
-        public abstract Task<Stream> ReadableStreamAsync(
+        public abstract Task<Stream> ReadJobPartPlanFileAsync(
             string transferId,
             int partNumber,
             long offset,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferCheckpointer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -69,6 +70,26 @@ namespace Azure.Storage.DataMovement
         /// <returns>The number of chunks in the job part.</returns>
         public abstract Task<int> CurrentJobPartCountAsync(
             string transferId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Reads the specified part of the job plan file and returns it in a Stream.
+        /// </summary>
+        /// <param name="transferId">The transfer ID.</param>
+        /// <param name="offset">The offset to start reading the job plan file at.</param>
+        /// <param name="length">
+        /// The maximum number of bytes to read.
+        /// Specify 0 (zero) to create a stream over teh whole file.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Optional <see cref="CancellationToken"/> to propagate
+        /// notifications that the operation should be canceled.
+        /// </param>
+        /// <returns>A Stream of the requested part of the Job Plan File.</returns>
+        public abstract Task<Stream> ReadJobPlanFileAsync(
+            string transferId,
+            int offset,
+            int length,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
@@ -550,7 +550,7 @@ namespace Azure.Storage.DataMovement
 
                     if (resumeJob)
                     {
-                        using (Stream stream = await _checkpointer.ReadableStreamAsync(
+                        using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
                             transferId: dataTransfer.Id,
                             partNumber: 0,
                             offset: 0,
@@ -590,7 +590,7 @@ namespace Azure.Storage.DataMovement
 
                     if (resumeJob)
                     {
-                        using (Stream stream = await _checkpointer.ReadableStreamAsync(
+                        using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
                             transferId: dataTransfer.Id,
                             partNumber: 0,
                             offset: 0,
@@ -623,7 +623,7 @@ namespace Azure.Storage.DataMovement
 
                     if (resumeJob)
                     {
-                        using (Stream stream = await _checkpointer.ReadableStreamAsync(
+                        using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
                             transferId: dataTransfer.Id,
                             partNumber: 0,
                             offset: 0,
@@ -675,7 +675,7 @@ namespace Azure.Storage.DataMovement
                             cancellationToken: _cancellationToken).ConfigureAwait(false);
                         for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
                         {
-                            using (Stream stream = await _checkpointer.ReadableStreamAsync(
+                            using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
                                 transferId: dataTransfer.Id,
                                 partNumber: currentJobPart,
                                 offset: 0,
@@ -722,7 +722,7 @@ namespace Azure.Storage.DataMovement
                             cancellationToken: _cancellationToken).ConfigureAwait(false);
                         for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
                         {
-                            using (Stream stream = await _checkpointer.ReadableStreamAsync(
+                            using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
                                 transferId: dataTransfer.Id,
                                 partNumber: currentJobPart,
                                 offset: 0,
@@ -762,7 +762,7 @@ namespace Azure.Storage.DataMovement
                             cancellationToken: _cancellationToken).ConfigureAwait(false);
                         for (var currentJobPart = 0; currentJobPart < jobPartCount; currentJobPart++)
                         {
-                            using (Stream stream = await _checkpointer.ReadableStreamAsync(
+                            using (Stream stream = await _checkpointer.ReadJobPartPlanFileAsync(
                                 transferId: dataTransfer.Id,
                                 partNumber: currentJobPart,
                                 offset: 0,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/TransferManager.cs
@@ -554,7 +554,7 @@ namespace Azure.Storage.DataMovement
                             transferId: dataTransfer.Id,
                             partNumber: 0,
                             offset: 0,
-                            readSize: 0,
+                            length: 0,
                             cancellationToken: _cancellationToken).ConfigureAwait(false))
                         {
                             streamToUriJob.AppendJobPart(
@@ -594,7 +594,7 @@ namespace Azure.Storage.DataMovement
                             transferId: dataTransfer.Id,
                             partNumber: 0,
                             offset: 0,
-                            readSize: 0,
+                            length: 0,
                             cancellationToken: _cancellationToken).ConfigureAwait(false))
                         {
                             serviceToServiceJob.AppendJobPart(
@@ -627,7 +627,7 @@ namespace Azure.Storage.DataMovement
                             transferId: dataTransfer.Id,
                             partNumber: 0,
                             offset: 0,
-                            readSize: 0,
+                            length: 0,
                             cancellationToken: _cancellationToken).ConfigureAwait(false))
                         {
                             uriToStreamJob.AppendJobPart(
@@ -679,7 +679,7 @@ namespace Azure.Storage.DataMovement
                                 transferId: dataTransfer.Id,
                                 partNumber: currentJobPart,
                                 offset: 0,
-                                readSize: 0,
+                                length: 0,
                                 cancellationToken: _cancellationToken).ConfigureAwait(false))
                             {
                                 streamToUriJob.AppendJobPart(
@@ -726,7 +726,7 @@ namespace Azure.Storage.DataMovement
                                 transferId: dataTransfer.Id,
                                 partNumber: currentJobPart,
                                 offset: 0,
-                                readSize: 0,
+                                length: 0,
                                 cancellationToken: _cancellationToken).ConfigureAwait(false))
                             {
                                 serviceToServiceJob.AppendJobPart(
@@ -766,7 +766,7 @@ namespace Azure.Storage.DataMovement
                                 transferId: dataTransfer.Id,
                                 partNumber: currentJobPart,
                                 offset: 0,
-                                readSize: 0,
+                                length: 0,
                                 cancellationToken: _cancellationToken).ConfigureAwait(false))
                             {
                                 uriToStreamJob.AppendJobPart(

--- a/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
@@ -127,7 +127,6 @@ namespace Azure.Storage.DataMovement.Tests
             // Act
             DataTransferStatus status = new DataTransferStatus(state, hasFailedItems, hasSkippedItems);
             IList<DataTransfer> result = await manager.GetTransfersAsync(status).ToListAsync();
-            var a = storedTransfers.Where(d => d.TransferStatus == status).ToList();
 
             // Assert
             AssertListTransfersEquals(storedTransfers.Where(d => d.TransferStatus == status).ToList(), result);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Storage.DataMovement.JobPlan;
 using NUnit.Framework;
 
 namespace Azure.Storage.DataMovement.Tests
@@ -126,9 +127,10 @@ namespace Azure.Storage.DataMovement.Tests
             // Act
             DataTransferStatus status = new DataTransferStatus(state, hasFailedItems, hasSkippedItems);
             IList<DataTransfer> result = await manager.GetTransfersAsync(status).ToListAsync();
+            var a = storedTransfers.Where(d => d.TransferStatus == status).ToList();
 
             // Assert
-            AssertListTransfersEquals(storedTransfers.Where( d => d.TransferStatus == status).ToList(), result);
+            AssertListTransfersEquals(storedTransfers.Where(d => d.TransferStatus == status).ToList(), result);
         }
 
         [Test]
@@ -281,20 +283,18 @@ namespace Azure.Storage.DataMovement.Tests
             LocalTransferCheckpointerFactory factory = new LocalTransferCheckpointerFactory(test.DirectoryPath);
 
             string transferId1 = Guid.NewGuid().ToString();
-            factory.CreateStubJobPlanFile(test.DirectoryPath, transferId1);
+            factory.CreateStubJobPlanFile(test.DirectoryPath, transferId1, status: SuccessfulCompletedStatus);
             factory.CreateStubJobPartPlanFilesAsync(
                 test.DirectoryPath,
                 transferId1,
-                3 /* jobPartCount */,
-                SuccessfulCompletedStatus);
+                3 /* jobPartCount */);
 
             string transferId2 = Guid.NewGuid().ToString();
-            factory.CreateStubJobPlanFile(test.DirectoryPath, transferId2);
+            factory.CreateStubJobPlanFile(test.DirectoryPath, transferId2, status: QueuedStatus);
             factory.CreateStubJobPartPlanFilesAsync(
                 test.DirectoryPath,
                 transferId2,
-                3 /* jobPartCount */,
-                QueuedStatus);
+                3 /* jobPartCount */);
 
             // Build TransferManager with the stored transfers
             TransferManagerOptions options = new TransferManagerOptions()
@@ -317,7 +317,11 @@ namespace Azure.Storage.DataMovement.Tests
             DataTransferProperties properties)
         {
             // First add the job plan file for the transfer
-            factory.CreateStubJobPlanFile(checkpointerPath, properties.TransferId);
+            factory.CreateStubJobPlanFile(
+                checkpointerPath,
+                properties.TransferId,
+                parentSourcePath: properties.SourcePath,
+                parentDestinationPath: properties.DestinationPath);
 
             if (properties.IsContainer)
             {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/JobPlanHeaderTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/JobPlanHeaderTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(DefaultCreateTime, header.CreateTime);
             Assert.AreEqual(DefaultJobPlanOperation, header.OperationType);
             Assert.AreEqual(false, header.EnumerationComplete);
-            Assert.AreEqual(DefaultJobPlanStatus, header.JobStatus);
+            Assert.AreEqual(DefaultJobStatus, header.JobStatus);
             Assert.AreEqual(DefaultSourcePath, header.ParentSourcePath);
             Assert.AreEqual(DefaultDestinationPath, header.ParentDestinationPath);
         }
@@ -78,7 +78,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(DefaultCreateTime, deserialized.CreateTime);
             Assert.AreEqual(DefaultJobPlanOperation, deserialized.OperationType);
             Assert.AreEqual(false, deserialized.EnumerationComplete);
-            Assert.AreEqual(DefaultJobPlanStatus, deserialized.JobStatus);
+            Assert.AreEqual(DefaultJobStatus, deserialized.JobStatus);
             Assert.AreEqual(DefaultSourcePath, deserialized.ParentSourcePath);
             Assert.AreEqual(DefaultDestinationPath, deserialized.ParentDestinationPath);
         }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
@@ -151,7 +151,7 @@ namespace Azure.Storage.DataMovement.Tests
                 DateTimeOffset.UtcNow,
                 JobPlanOperation.ServiceToService,
                 false, /* enumerationComplete */
-                JobPlanStatus.Queued,
+                new DataTransferStatus(),
                 _testSourcePath,
                 _testDestinationPath);
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerFactory.cs
@@ -74,12 +74,12 @@ namespace Azure.Storage.DataMovement.Tests
         {
             foreach (DataTransfer dataTransfer in dataTransfers)
             {
-                CreateStubJobPlanFile(_checkpointerPath, dataTransfer.Id);
+                CreateStubJobPlanFile(_checkpointerPath, dataTransfer.Id, status: dataTransfer.TransferStatus);
                 CreateStubJobPartPlanFilesAsync(
                     checkpointerPath: _checkpointerPath,
                     transferId: dataTransfer.Id,
                     jobPartCount: _partCountDefault,
-                    status: dataTransfer.TransferStatus);
+                    status: new DataTransferStatus(DataTransferState.Paused, false, false));
             }
             return new LocalTransferCheckpointer(_checkpointerPath);
         }
@@ -143,17 +143,23 @@ namespace Azure.Storage.DataMovement.Tests
             }
         }
 
-        internal void CreateStubJobPlanFile(string checkpointPath, string transferId)
+        internal void CreateStubJobPlanFile(
+            string checkpointPath,
+            string transferId,
+            string parentSourcePath = _testSourcePath,
+            string parentDestinationPath = _testDestinationPath,
+            DataTransferStatus status = default)
         {
+            status ??= new DataTransferStatus();
             JobPlanHeader header = new JobPlanHeader(
                 DataMovementConstants.JobPlanFile.SchemaVersion,
                 transferId,
                 DateTimeOffset.UtcNow,
                 JobPlanOperation.ServiceToService,
                 false, /* enumerationComplete */
-                new DataTransferStatus(),
-                _testSourcePath,
-                _testDestinationPath);
+                status,
+                parentSourcePath,
+                parentDestinationPath);
 
             string filePath = Path.Combine(checkpointPath, $"{transferId}.{DataMovementConstants.JobPlanFile.FileExtension}");
             using (FileStream stream = File.Create(filePath))

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -230,7 +230,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
@@ -356,7 +356,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 0,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header1, stream);
@@ -366,7 +366,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header2, stream);
@@ -376,7 +376,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 2,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header3, stream);
@@ -386,7 +386,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 3,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header4, stream);
@@ -438,7 +438,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
@@ -817,7 +817,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 // Assert
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
@@ -841,7 +841,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes));
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes));
         }
 
         [Test]
@@ -947,7 +947,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
             }
@@ -1029,7 +1029,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 0,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header1, stream);
             }
@@ -1038,7 +1038,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header2, stream);
             }
@@ -1047,7 +1047,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 2,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header3, stream);
             }
@@ -1056,7 +1056,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: 3,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header4, stream);
             }
@@ -1120,7 +1120,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
-                readSize: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
+                length: DataMovementConstants.JobPartPlanFile.JobPartHeaderSizeInBytes))
             {
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header, stream);
             }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -778,7 +778,7 @@ namespace Azure.Storage.DataMovement.Tests
                 actualTransferId = new Guid(transferIdBytes).ToString();
             }
 
-            DataTransferStatus actualJobStatus = await transferCheckpointer.GetJobStatus(transferId);
+            DataTransferStatus actualJobStatus = await transferCheckpointer.GetJobStatusAsync(transferId);
 
             // Assert
             Assert.AreEqual(transferId, actualTransferId);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -226,7 +226,7 @@ namespace Azure.Storage.DataMovement.Tests
             int partCount = await transferCheckpointer.CurrentJobPartCountAsync(transferId);
             Assert.AreEqual(1, partCount);
 
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
@@ -352,7 +352,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(1, transferIds.Count);
             Assert.IsTrue(transferIds.Contains(transferId));
 
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 0,
                 offset: 0,
@@ -362,7 +362,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header1, stream);
             }
 
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
@@ -372,7 +372,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header2, stream);
             }
 
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 2,
                 offset: 0,
@@ -382,7 +382,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header3, stream);
             }
 
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 3,
                 offset: 0,
@@ -434,7 +434,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(1, transferIds.Count);
             Assert.IsTrue(transferIds.Contains(transferId));
 
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
@@ -786,7 +786,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        public async Task ReadableStreamAsync()
+        public async Task ReadJobPartPlanFileAsync()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
@@ -813,7 +813,7 @@ namespace Azure.Storage.DataMovement.Tests
             }
 
             // Act
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
@@ -825,7 +825,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
-        public void ReadableStreamAsync_Error()
+        public void ReadJobPartPlanFileAsync_Error()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
@@ -837,7 +837,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Act
             Assert.CatchAsync<ArgumentException>(
-                async () => await transferCheckpointer.ReadableStreamAsync(
+                async () => await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
@@ -877,7 +877,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             header.AtomicJobStatus = newStatus;
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,
@@ -959,7 +959,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             header1.AtomicJobStatus = newStatus;
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 0,
                 offset: 0,
@@ -968,7 +968,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header1, stream);
             }
             header2.AtomicJobStatus = newStatus;
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 1,
                 offset: 0,
@@ -977,7 +977,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header2, stream);
             }
             header3.AtomicJobStatus = newStatus;
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 2,
                 offset: 0,
@@ -986,7 +986,7 @@ namespace Azure.Storage.DataMovement.Tests
                 await CheckpointerTesting.AssertJobPlanHeaderAsync(header3, stream);
             }
             header4.AtomicJobStatus = newStatus;
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: 3,
                 offset: 0,
@@ -1050,7 +1050,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Assert
             header.AtomicPartStatus = newStatus;
-            using (Stream stream = await transferCheckpointer.ReadableStreamAsync(
+            using (Stream stream = await transferCheckpointer.ReadJobPartPlanFileAsync(
                 transferId: transferId,
                 partNumber: partNumber,
                 offset: 0,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/CheckpointerTesting.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/CheckpointerTesting.cs
@@ -57,7 +57,6 @@ namespace Azure.Storage.DataMovement.Tests
         internal static readonly DataTransferStatus DefaultJobStatus = new DataTransferStatusInternal(DataTransferState.Queued, false, false);
         internal static readonly DataTransferStatus DefaultPartStatus = new DataTransferStatusInternal(DataTransferState.Queued, false, false);
         internal static readonly DateTimeOffset DefaultCreateTime = new DateTimeOffset(2023, 08, 28, 17, 26, 0, default);
-        internal const JobPlanStatus DefaultJobPlanStatus = JobPlanStatus.Queued;
 
         internal static JobPartPlanHeader CreateDefaultJobPartHeader(
             string version = DataMovementConstants.JobPartPlanFile.SchemaVersion,
@@ -183,7 +182,7 @@ namespace Azure.Storage.DataMovement.Tests
             DateTimeOffset createTime = default,
             JobPlanOperation operationType = DefaultJobPlanOperation,
             bool enumerationComplete = false,
-            JobPlanStatus jobStatus = DefaultJobPlanStatus,
+            DataTransferStatus jobStatus = default,
             string parentSourcePath = DefaultSourcePath,
             string parentDestinationPath = DefaultDestinationPath)
         {
@@ -191,6 +190,7 @@ namespace Azure.Storage.DataMovement.Tests
             {
                 createTime = DefaultCreateTime;
             }
+            jobStatus ??= DefaultJobStatus;
 
             return new JobPlanHeader(
                 version,


### PR DESCRIPTION
This change includes updates to have the checkpointer start to switch some stuff over from the job part plan files to the individual job plan file. This update includes:

- Switch JobPlanFile to work with new `DataTransferStatus` class.
- Read/Write Job (Transfer) status to job file rather than each individual part file.
- Build `DataTransferProperties` on resume from job file.
- Other small refactors.