### PR TITLE
Marked input as nullable on ResourceIdentifier.TryParse()

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -651,7 +651,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string? input, out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -651,7 +651,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string? input, out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -654,7 +654,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string? input, out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -654,7 +654,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string? input, out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -651,7 +651,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string? input, out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -651,7 +651,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string? input, out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -526,13 +526,13 @@ namespace Azure.Core
         /// If the method returns false, result will be null.
         /// </param>
         /// <returns> True if the parse operation was successful; otherwise, false. </returns>
-        public static bool TryParse(string input, out ResourceIdentifier? result)
+        public static bool TryParse(string? input, out ResourceIdentifier? result)
         {
             result = null;
             if (string.IsNullOrEmpty(input))
                 return false;
 
-            result = new ResourceIdentifier(input);
+            result = new ResourceIdentifier(input!);
             var error = result.Parse();
             if (error is null)
                 return true;

--- a/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
@@ -816,27 +816,33 @@ namespace Azure.Core.Tests
             Assert.IsFalse(ResourceIdentifier.TryParse(id, out var result));
         }
 
+        [TestCase(null)]
+        public void NullInput(string invalidID)
+        {
+            Assert.Throws<ArgumentNullException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
+            Assert.Throws<ArgumentNullException>(() => ResourceIdentifier.Parse(invalidID));
+            Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
+        }
+
         [TestCase("")]
+        public void EmptyInput(string invalidID)
+        {
+            Assert.Throws<ArgumentException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
+            Assert.Throws<ArgumentException>(() => ResourceIdentifier.Parse(invalidID));
+            Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
+        }
+
         [TestCase(" ")]
         [TestCase("asdfghj")]
         [TestCase("123456")]
         [TestCase("!@#$%^&*/")]
         [TestCase("/subscriptions/")]
         [TestCase("/0c2f6471-1bf0-4dda-aec3-cb9272f09575/myRg/")]
-        public void InvalidRPIds(string invalidID)
+        public void InvalidInput(string invalidID)
         {
-            if (invalidID == String.Empty)
-            {
-                Assert.Throws<ArgumentException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
-                Assert.Throws<ArgumentException>(() => ResourceIdentifier.Parse(invalidID));
-                Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
-            }
-            else
-            {
-                Assert.Throws<FormatException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
-                Assert.Throws<FormatException>(() => ResourceIdentifier.Parse(invalidID));
-                Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
-            }
+            Assert.Throws<FormatException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
+            Assert.Throws<FormatException>(() => ResourceIdentifier.Parse(invalidID));
+            Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
         }
 
         [TestCase(TrackedResourceId)]


### PR DESCRIPTION
Resolves #39059, see also #39332.

Changes:

- Marked `input` as nullable: `string?`
- Split the test method into two (for redability)
- Added `null` to test scenarios
