### PR TITLE
Transcription Data model fix

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -1535,4 +1535,23 @@ namespace Azure.Communication.CallAutomation.Models.Transcription
     {
         Display = 0,
     }
+    public partial class TranscriptionData : Azure.Communication.CallAutomation.TranscriptionPackageBase
+    {
+        internal TranscriptionData() { }
+        public double Confidence { get { throw null; } set { } }
+        public Azure.Communication.CallAutomation.Models.Transcription.TextFormat Format { get { throw null; } set { } }
+        public ulong Offset { get { throw null; } set { } }
+        public Azure.Communication.CommunicationUserIdentifier Participant { get { throw null; } set { } }
+        public Azure.Communication.CallAutomation.Models.Transcription.ResultStatus ResultStatus { get { throw null; } set { } }
+        public string Text { get { throw null; } set { } }
+        public System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.Models.Transcription.WordData> Words { get { throw null; } set { } }
+    }
+    public partial class WordData
+    {
+        public WordData() { }
+        [System.Text.Json.Serialization.JsonPropertyNameAttribute("offset")]
+        public ulong Offset { get { throw null; } set { } }
+        [System.Text.Json.Serialization.JsonPropertyNameAttribute("text")]
+        public string Text { get { throw null; } set { } }
+    }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/TranscriptionData.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/TranscriptionData.cs
@@ -10,9 +10,9 @@ namespace Azure.Communication.CallAutomation.Models.Transcription
     /// <summary>
     /// Streaming Transcription.
     /// </summary>
-    internal class TranscriptionData : TranscriptionPackageBase
+    public class TranscriptionData : TranscriptionPackageBase
     {
-        internal TranscriptionData(string text, string format, double confidence, ulong offset, IEnumerable<Word> words, string participantRawID, string resultStatus)
+        internal TranscriptionData(string text, string format, double confidence, ulong offset, IEnumerable<WordData> words, string participantRawID, string resultStatus)
         {
             Text = text;
             Format = ConvertToTextFormatEnum(format);
@@ -50,7 +50,7 @@ namespace Azure.Communication.CallAutomation.Models.Transcription
         /// <summary>
         /// The result for each word of the phrase
         /// </summary>
-        public IEnumerable<Word> Words { get; set; }
+        public IEnumerable<WordData> Words { get; set; }
 
         /// <summary>
         /// The identified speaker based on participant raw ID

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/TranscriptionDataInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/TranscriptionDataInternal.cs
@@ -40,7 +40,7 @@ namespace Azure.Communication.CallAutomation.Models.Transcription
         /// The result for each word of the phrase
         /// </summary>
         [JsonPropertyName("words")]
-        public IEnumerable<Word> Words { get; set; }
+        public IEnumerable<WordData> Words { get; set; }
 
         /// <summary>
         /// The identified speaker based on participant raw ID

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/TranscriptionPackageParser.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/TranscriptionPackageParser.cs
@@ -43,11 +43,14 @@ namespace Azure.Communication.CallAutomation
         public static TranscriptionPackageBase Parse(string stringJson)
         {
             JsonElement package = JsonDocument.Parse(stringJson).RootElement;
-            if (package.GetProperty("kind").ToString() == "TranscriptionMetadata")
+
+            string kind = package.GetProperty("kind").ToString();
+
+            if (kind == "TranscriptionMetadata")
             {
                 return JsonSerializer.Deserialize<TranscriptionMetadata>(package.GetProperty("transcriptionMetadata").ToString());
             }
-            else if (package.GetProperty("kind").ToString() == "TranscriptionData")
+            else if (kind == "TranscriptionData")
             {
                 TranscriptionDataInternal transcriptionDataInternal = JsonSerializer.Deserialize<TranscriptionDataInternal>(
                     package.GetProperty("transcriptionData").ToString()

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/WordData.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Transcription/WordData.cs
@@ -5,7 +5,10 @@ using System.Text.Json.Serialization;
 
 namespace Azure.Communication.CallAutomation.Models.Transcription
 {
-    internal class Word
+    /// <summary>
+    /// The result for each word of the phrase
+    /// </summary>
+    public class WordData
     {
         /// <summary>
         /// Text in the phrase.

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Transcription/TranscriptionPackageParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Transcription/TranscriptionPackageParserTests.cs
@@ -159,7 +159,7 @@ namespace Azure.Communication.CallAutomation.Tests.Trascription
             Assert.AreEqual(1, transcription.Offset);
 
             // validate individual words
-            IList<Word> words = transcription.Words.ToList();
+            IList<WordData> words = transcription.Words.ToList();
             Assert.AreEqual(2, words.Count);
             Assert.AreEqual("Hello", words[0].Text);
             Assert.AreEqual(1, words[0].Offset);


### PR DESCRIPTION
Transcription package fix:
1> Made non-internal TranscriptionData & Word classes as public.
2> Renamed Word to WordData, as single word classes are not allowed.
3> Cleanup vars & references