### PR TITLE
[Storage] Renamed PublicAudience to DefaultAudience, Get..Audience to Create..Audience

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.net6.0.cs
@@ -354,11 +354,11 @@ namespace Azure.Storage.Blobs.Models
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public BlobAudience(string value) { throw null; }
-        public static Azure.Storage.Blobs.Models.BlobAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Blobs.Models.BlobAudience DefaultAudience { get { throw null; } }
+        public static Azure.Storage.Blobs.Models.BlobAudience CreateBlobServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Blobs.Models.BlobAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
-        public static Azure.Storage.Blobs.Models.BlobAudience GetBlobServiceAccountAudience(string storageAccountName) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Azure.Storage.Blobs.Models.BlobAudience left, Azure.Storage.Blobs.Models.BlobAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -354,11 +354,11 @@ namespace Azure.Storage.Blobs.Models
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public BlobAudience(string value) { throw null; }
-        public static Azure.Storage.Blobs.Models.BlobAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Blobs.Models.BlobAudience DefaultAudience { get { throw null; } }
+        public static Azure.Storage.Blobs.Models.BlobAudience CreateBlobServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Blobs.Models.BlobAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
-        public static Azure.Storage.Blobs.Models.BlobAudience GetBlobServiceAccountAudience(string storageAccountName) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Azure.Storage.Blobs.Models.BlobAudience left, Azure.Storage.Blobs.Models.BlobAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.1.cs
@@ -354,11 +354,11 @@ namespace Azure.Storage.Blobs.Models
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public BlobAudience(string value) { throw null; }
-        public static Azure.Storage.Blobs.Models.BlobAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Blobs.Models.BlobAudience DefaultAudience { get { throw null; } }
+        public static Azure.Storage.Blobs.Models.BlobAudience CreateBlobServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Blobs.Models.BlobAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
-        public static Azure.Storage.Blobs.Models.BlobAudience GetBlobServiceAccountAudience(string storageAccountName) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Azure.Storage.Blobs.Models.BlobAudience left, Azure.Storage.Blobs.Models.BlobAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -332,7 +332,7 @@ namespace Azure.Storage.Blobs.Specialized
             : this(
                 blobUri,
                 credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? BlobAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? BlobAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                 options,
                 storageSharedKeyCredential: null,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -348,7 +348,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// Gets or sets the Audience to use for authentication with Azure Active Directory (AAD). The audience is not considered when using a shared key.
         /// </summary>
-        /// <value>If <c>null</c>, <see cref="BlobAudience.PublicAudience" /> will be assumed.</value>
+        /// <value>If <c>null</c>, <see cref="BlobAudience.DefaultAudience" /> will be assumed.</value>
         public BlobAudience? Audience { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -362,7 +362,7 @@ namespace Azure.Storage.Blobs
             Argument.AssertNotNull(blobContainerUri, nameof(blobContainerUri));
             _uri = blobContainerUri;
 
-            string audienceScope = string.IsNullOrEmpty(options?.Audience?.ToString()) ? BlobAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope();
+            string audienceScope = string.IsNullOrEmpty(options?.Audience?.ToString()) ? BlobAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope();
 
             _authenticationPolicy = credential.AsPolicy(audienceScope, options);
             options ??= new BlobClientOptions();

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -249,7 +249,7 @@ namespace Azure.Storage.Blobs
             : this(
                   serviceUri,
                   credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? BlobAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? BlobAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                   credential,
                   options ?? new BlobClientOptions())

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobAudience.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobAudience.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.Blobs.Models
             _value = value;
         }
 
-        private const string _publicAudience = "https://storage.azure.com/";
+        private const string _defaultAudience = "https://storage.azure.com/";
 
         /// <summary>
         /// Default Audience. Use to acquire a token for authorizing requests to any Azure Storage account
@@ -38,7 +38,7 @@ namespace Azure.Storage.Blobs.Models
         ///
         /// If no audience is specified, this is the default value.
         /// </summary>
-        public static BlobAudience PublicAudience { get; } = new(_publicAudience);
+        public static BlobAudience DefaultAudience { get; } = new(_defaultAudience);
 
         /// <summary>
         /// The service endpoint for a given storage account.
@@ -48,7 +48,7 @@ namespace Azure.Storage.Blobs.Models
         /// The storage account name used to populate the service endpoint.
         /// </param>
         /// <returns></returns>
-        public static BlobAudience GetBlobServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.blob.core.windows.net/");
+        public static BlobAudience CreateBlobServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.blob.core.windows.net/");
 
         /// <summary> Determines if two <see cref="BlobAudience"/> values are the same. </summary>
         public static bool operator ==(BlobAudience left, BlobAudience right) => left.Equals(right);

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -166,7 +166,7 @@ namespace Azure.Storage.Blobs.Test
             await blob.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.PublicAudience);
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.DefaultAudience);
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {
@@ -222,7 +222,7 @@ namespace Azure.Storage.Blobs.Test
             await blob.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.GetBlobServiceAccountAudience(test.Container.AccountName));
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.CreateBlobServiceAccountAudience(test.Container.AccountName));
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -256,7 +256,7 @@ namespace Azure.Storage.Blobs.Test
             }
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.PublicAudience);
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.DefaultAudience);
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {
@@ -320,7 +320,7 @@ namespace Azure.Storage.Blobs.Test
             }
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.GetBlobServiceAccountAudience(test.Container.AccountName));
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.CreateBlobServiceAccountAudience(test.Container.AccountName));
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {
@@ -352,7 +352,7 @@ namespace Azure.Storage.Blobs.Test
             }
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.PublicAudience);
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.DefaultAudience);
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -208,7 +208,7 @@ namespace Azure.Storage.Blobs.Test
             }
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.PublicAudience);
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.DefaultAudience);
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {
@@ -272,7 +272,7 @@ namespace Azure.Storage.Blobs.Test
             }
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.GetBlobServiceAccountAudience(test.Container.AccountName));
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.CreateBlobServiceAccountAudience(test.Container.AccountName));
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -336,7 +336,7 @@ namespace Azure.Storage.Blobs.Test
             await using DisposingContainer test = await GetTestContainerAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.PublicAudience);
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.DefaultAudience);
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {
@@ -384,7 +384,7 @@ namespace Azure.Storage.Blobs.Test
             await using DisposingContainer test = await GetTestContainerAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.GetBlobServiceAccountAudience(test.Container.AccountName));
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.CreateBlobServiceAccountAudience(test.Container.AccountName));
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -156,7 +156,7 @@ namespace Azure.Storage.Blobs.Test
             await blob.CreateIfNotExistsAsync(Constants.KB);
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.PublicAudience);
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.DefaultAudience);
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {
@@ -212,7 +212,7 @@ namespace Azure.Storage.Blobs.Test
             await blob.CreateIfNotExistsAsync(Constants.KB);
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.GetBlobServiceAccountAudience(test.Container.AccountName));
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.CreateBlobServiceAccountAudience(test.Container.AccountName));
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -179,7 +179,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task Ctor_DefaultAudience()
         {
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.PublicAudience);
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.DefaultAudience);
 
             BlobServiceClient aadService = InstrumentClient(new BlobServiceClient(
                 new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint),
@@ -217,7 +217,7 @@ namespace Azure.Storage.Blobs.Test
             BlobUriBuilder uriBuilder = new BlobUriBuilder(new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint));
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.GetBlobServiceAccountAudience(uriBuilder.AccountName));
+            BlobClientOptions options = GetOptionsWithAudience(BlobAudience.CreateBlobServiceAccountAudience(uriBuilder.AccountName));
 
             BlobServiceClient aadService = InstrumentClient(new BlobServiceClient(
                 new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint),

--- a/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.net6.0.cs
@@ -538,8 +538,8 @@ namespace Azure.Storage.Files.DataLake.Models
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public DataLakeAudience(string value) { throw null; }
-        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience PublicAudience { get { throw null; } }
-        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience DataLakeServiceAccountAudience(string storageAccountName) { throw null; }
+        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience DefaultAudience { get { throw null; } }
+        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience CreateDataLakeServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Files.DataLake.Models.DataLakeAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }

--- a/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
@@ -538,8 +538,8 @@ namespace Azure.Storage.Files.DataLake.Models
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public DataLakeAudience(string value) { throw null; }
-        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience PublicAudience { get { throw null; } }
-        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience DataLakeServiceAccountAudience(string storageAccountName) { throw null; }
+        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience DefaultAudience { get { throw null; } }
+        public static Azure.Storage.Files.DataLake.Models.DataLakeAudience CreateDataLakeServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Files.DataLake.Models.DataLakeAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeClientOptions.cs
@@ -362,7 +362,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// Gets or sets the Audience to use for authentication with Azure Active Directory (AAD). The audience is not considered when using a shared key.
         /// </summary>
-        /// <value>If <c>null</c>, <see cref="DataLakeAudience.PublicAudience" /> will be assumed.</value>
+        /// <value>If <c>null</c>, <see cref="DataLakeAudience.DefaultAudience" /> will be assumed.</value>
         public DataLakeAudience? Audience { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
@@ -244,7 +244,7 @@ namespace Azure.Storage.Files.DataLake
             : this(
                 directoryUri,
                 credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                 options,
                 tokenCredential: credential)

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -261,7 +261,7 @@ namespace Azure.Storage.Files.DataLake
             : this(
                 fileUri,
                 credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                 options,
                 credential)

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -390,7 +390,7 @@ namespace Azure.Storage.Files.DataLake
             : this(
                 fileSystemUri,
                 credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                 options,
                 storageSharedKeyCredential: null,

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -456,7 +456,7 @@ namespace Azure.Storage.Files.DataLake
             : this(
                 pathUri,
                 credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                 options,
                 storageSharedKeyCredential: null,

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -316,7 +316,7 @@ namespace Azure.Storage.Files.DataLake
             : this(
                 serviceUri,
                 credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? DataLakeAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                 options,
                 storageSharedKeyCredential:null,

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Models/DataLakeAudience.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Models/DataLakeAudience.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.Files.DataLake.Models
             _value = value;
         }
 
-        private const string _publicAudience = "https://storage.azure.com/";
+        private const string _defaultAudience = "https://storage.azure.com/";
 
         /// <summary>
         /// Default Audience. Use to acquire a token for authorizing requests to any Azure Storage account
@@ -38,7 +38,7 @@ namespace Azure.Storage.Files.DataLake.Models
         ///
         /// If no audience is specified, this is the default value.
         /// </summary>
-        public static DataLakeAudience PublicAudience { get; } = new(_publicAudience);
+        public static DataLakeAudience DefaultAudience { get; } = new(_defaultAudience);
 
         /// <summary>
         /// The service endpoint for a given storage account.
@@ -48,7 +48,7 @@ namespace Azure.Storage.Files.DataLake.Models
         /// The storage account name used to populate the service endpoint.
         /// </param>
         /// <returns></returns>
-        public static DataLakeAudience DataLakeServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.blob.core.windows.net/");
+        public static DataLakeAudience CreateDataLakeServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.blob.core.windows.net/");
 
         /// <summary> Determines if two <see cref="DataLakeAudience"/> values are the same. </summary>
         public static bool operator ==(DataLakeAudience left, DataLakeAudience right) => left.Equals(right);

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -232,7 +232,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await pathClient.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.PublicAudience);
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DefaultAudience);
 
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(new Uri(Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint))
             {
@@ -288,7 +288,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await pathClient.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DataLakeServiceAccountAudience(test.FileSystem.AccountName));
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.CreateDataLakeServiceAccountAudience(test.FileSystem.AccountName));
 
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(new Uri(Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -235,7 +235,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await pathClient.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.PublicAudience);
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DefaultAudience);
 
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(new Uri(Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint))
             {
@@ -291,7 +291,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await pathClient.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DataLakeServiceAccountAudience(test.FileSystem.AccountName));
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.CreateDataLakeServiceAccountAudience(test.FileSystem.AccountName));
 
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(new Uri(Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -240,7 +240,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.PublicAudience);
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DefaultAudience);
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(new Uri(Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint))
             {
                 FileSystemName = test.FileSystem.Name,
@@ -287,7 +287,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DataLakeServiceAccountAudience(test.FileSystem.AccountName));
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.CreateDataLakeServiceAccountAudience(test.FileSystem.AccountName));
 
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(new Uri(Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -198,7 +198,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.PublicAudience);
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DefaultAudience);
 
             DataLakeServiceClient aadServiceClient = InstrumentClient(new DataLakeServiceClient(
                 service.Uri,
@@ -236,7 +236,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.DataLakeServiceAccountAudience(service.AccountName));
+            DataLakeClientOptions options = GetOptionsWithAudience(DataLakeAudience.CreateDataLakeServiceAccountAudience(service.AccountName));
 
             DataLakeServiceClient aadServiceClient = InstrumentClient(new DataLakeServiceClient(
                 service.Uri,

--- a/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.net6.0.cs
@@ -519,13 +519,13 @@ namespace Azure.Storage.Files.Shares.Models
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public ShareAudience(string value) { throw null; }
-        public static Azure.Storage.Files.Shares.Models.ShareAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Files.Shares.Models.ShareAudience DefaultAudience { get { throw null; } }
+        public static Azure.Storage.Files.Shares.Models.ShareAudience CreateShareServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Files.Shares.Models.ShareAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static Azure.Storage.Files.Shares.Models.ShareAudience GetShareServiceAccountAudience(string storageAccountName) { throw null; }
         public static bool operator ==(Azure.Storage.Files.Shares.Models.ShareAudience left, Azure.Storage.Files.Shares.Models.ShareAudience right) { throw null; }
         public static implicit operator Azure.Storage.Files.Shares.Models.ShareAudience (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Files.Shares.Models.ShareAudience left, Azure.Storage.Files.Shares.Models.ShareAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
@@ -519,13 +519,13 @@ namespace Azure.Storage.Files.Shares.Models
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public ShareAudience(string value) { throw null; }
-        public static Azure.Storage.Files.Shares.Models.ShareAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Files.Shares.Models.ShareAudience DefaultAudience { get { throw null; } }
+        public static Azure.Storage.Files.Shares.Models.ShareAudience CreateShareServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Files.Shares.Models.ShareAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static Azure.Storage.Files.Shares.Models.ShareAudience GetShareServiceAccountAudience(string storageAccountName) { throw null; }
         public static bool operator ==(Azure.Storage.Files.Shares.Models.ShareAudience left, Azure.Storage.Files.Shares.Models.ShareAudience right) { throw null; }
         public static implicit operator Azure.Storage.Files.Shares.Models.ShareAudience (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Files.Shares.Models.ShareAudience left, Azure.Storage.Files.Shares.Models.ShareAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareAudience.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareAudience.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.Files.Shares.Models
             _value = value;
         }
 
-        private const string _publicAudience = "https://storage.azure.com/";
+        private const string _defaultAudience = "https://storage.azure.com/";
 
         /// <summary>
         /// Default Audience. Use to acquire a token for authorizing requests to any Azure Storage account
@@ -38,7 +38,7 @@ namespace Azure.Storage.Files.Shares.Models
         ///
         /// If no audience is specified, this is the default value.
         /// </summary>
-        public static ShareAudience PublicAudience { get; } = new(_publicAudience);
+        public static ShareAudience DefaultAudience { get; } = new(_defaultAudience);
 
         /// <summary>
         /// The service endpoint for a given storage account.
@@ -48,7 +48,7 @@ namespace Azure.Storage.Files.Shares.Models
         /// The storage account name used to populate the service endpoint.
         /// </param>
         /// <returns></returns>
-        public static ShareAudience GetShareServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.file.core.windows.net/");
+        public static ShareAudience CreateShareServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.file.core.windows.net/");
 
         /// <summary> Determines if two <see cref="ShareAudience"/> values are the same. </summary>
         public static bool operator ==(ShareAudience left, ShareAudience right) => left.Equals(right);

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -294,7 +294,7 @@ namespace Azure.Storage.Files.Shares
             : this(
                   shareUri: shareUri,
                   authentication: credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                   options: options ?? new ShareClientOptions(),
                   storageSharedKeyCredential: default,

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClientOptions.cs
@@ -274,7 +274,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Gets or sets the Audience to use for authentication with Azure Active Directory (AAD). The audience is not considered when using a shared key.
         /// </summary>
-        /// <value>If <c>null</c>, <see cref="ShareAudience.PublicAudience" /> will be assumed.</value>
+        /// <value>If <c>null</c>, <see cref="ShareAudience.DefaultAudience" /> will be assumed.</value>
         public ShareAudience? Audience { get; set; }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -326,7 +326,7 @@ namespace Azure.Storage.Files.Shares
             : this(
                   directoryUri: directoryUri,
                   authentication: credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                   options: options ?? new ShareClientOptions(),
                   storageSharedKeyCredential: null,

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -334,7 +334,7 @@ namespace Azure.Storage.Files.Shares
             : this(
                   fileUri: fileUri,
                   authentication: credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                   options: options ?? new ShareClientOptions(),
                   storageSharedKeyCredential: null,

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -274,7 +274,7 @@ namespace Azure.Storage.Files.Shares
             : this(
                   serviceUri: serviceUri,
                   authentication: credential.AsPolicy(
-                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.PublicAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
+                    string.IsNullOrEmpty(options?.Audience?.ToString()) ? ShareAudience.DefaultAudience.CreateDefaultScope() : options.Audience.Value.CreateDefaultScope(),
                     options),
                   options: options ?? new ShareClientOptions(),
                   sharedKeyCredential: null,

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -117,7 +117,7 @@ namespace Azure.Storage.Files.Shares.Tests
             await directoryClient.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.PublicAudience);
+            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.DefaultAudience);
 
             ShareUriBuilder uriBuilder = new ShareUriBuilder(new Uri(Tenants.TestConfigOAuth.FileServiceEndpoint))
             {
@@ -171,7 +171,7 @@ namespace Azure.Storage.Files.Shares.Tests
             await directoryClient.CreateIfNotExistsAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.GetShareServiceAccountAudience(directoryClient.AccountName));
+            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.CreateShareServiceAccountAudience(directoryClient.AccountName));
 
             ShareUriBuilder uriBuilder = new ShareUriBuilder(new Uri(Tenants.TestConfigOAuth.FileServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -121,7 +121,7 @@ namespace Azure.Storage.Files.Shares.Tests
             await fileClient.CreateAsync(Constants.KB);
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.PublicAudience);
+            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.DefaultAudience);
 
             ShareUriBuilder uriBuilder = new ShareUriBuilder(new Uri(Tenants.TestConfigOAuth.FileServiceEndpoint))
             {
@@ -179,7 +179,7 @@ namespace Azure.Storage.Files.Shares.Tests
             await fileClient.CreateAsync(Constants.KB);
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.GetShareServiceAccountAudience(test.Share.AccountName));
+            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.CreateShareServiceAccountAudience(test.Share.AccountName));
 
             ShareUriBuilder uriBuilder = new ShareUriBuilder(new Uri(Tenants.TestConfigOAuth.FileServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -160,7 +160,7 @@ namespace Azure.Storage.Files.Shares.Tests
             await using DisposingShare test = await GetTestShareAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.PublicAudience);
+            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.DefaultAudience);
 
             ShareUriBuilder uriBuilder = new ShareUriBuilder(new Uri(Tenants.TestConfigOAuth.FileServiceEndpoint))
             {
@@ -210,7 +210,7 @@ namespace Azure.Storage.Files.Shares.Tests
             await using DisposingShare test = await GetTestShareAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.GetShareServiceAccountAudience(test.Share.AccountName));
+            ShareClientOptions options = GetOptionsWithAudience(ShareAudience.CreateShareServiceAccountAudience(test.Share.AccountName));
 
             ShareUriBuilder uriBuilder = new ShareUriBuilder(new Uri(Tenants.TestConfigOAuth.FileServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.net6.0.cs
@@ -193,12 +193,12 @@ namespace Azure.Storage.Queues.Models
         private readonly int _dummyPrimitive;
         public QueueAudience(string value) { throw null; }
         public static Azure.Storage.Queues.Models.QueueAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Queues.Models.QueueAudience CreateQueueServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Queues.Models.QueueAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static Azure.Storage.Queues.Models.QueueAudience GetQueueServiceAccountAudience(string storageAccountName) { throw null; }
         public static bool operator ==(Azure.Storage.Queues.Models.QueueAudience left, Azure.Storage.Queues.Models.QueueAudience right) { throw null; }
         public static implicit operator Azure.Storage.Queues.Models.QueueAudience (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Queues.Models.QueueAudience left, Azure.Storage.Queues.Models.QueueAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
@@ -193,12 +193,12 @@ namespace Azure.Storage.Queues.Models
         private readonly int _dummyPrimitive;
         public QueueAudience(string value) { throw null; }
         public static Azure.Storage.Queues.Models.QueueAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Queues.Models.QueueAudience CreateQueueServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Queues.Models.QueueAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static Azure.Storage.Queues.Models.QueueAudience GetQueueServiceAccountAudience(string storageAccountName) { throw null; }
         public static bool operator ==(Azure.Storage.Queues.Models.QueueAudience left, Azure.Storage.Queues.Models.QueueAudience right) { throw null; }
         public static implicit operator Azure.Storage.Queues.Models.QueueAudience (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Queues.Models.QueueAudience left, Azure.Storage.Queues.Models.QueueAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.1.cs
@@ -193,12 +193,12 @@ namespace Azure.Storage.Queues.Models
         private readonly int _dummyPrimitive;
         public QueueAudience(string value) { throw null; }
         public static Azure.Storage.Queues.Models.QueueAudience PublicAudience { get { throw null; } }
+        public static Azure.Storage.Queues.Models.QueueAudience CreateQueueServiceAccountAudience(string storageAccountName) { throw null; }
         public bool Equals(Azure.Storage.Queues.Models.QueueAudience other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static Azure.Storage.Queues.Models.QueueAudience GetQueueServiceAccountAudience(string storageAccountName) { throw null; }
         public static bool operator ==(Azure.Storage.Queues.Models.QueueAudience left, Azure.Storage.Queues.Models.QueueAudience right) { throw null; }
         public static implicit operator Azure.Storage.Queues.Models.QueueAudience (string value) { throw null; }
         public static bool operator !=(Azure.Storage.Queues.Models.QueueAudience left, Azure.Storage.Queues.Models.QueueAudience right) { throw null; }

--- a/sdk/storage/Azure.Storage.Queues/src/Models/QueueAudience.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Models/QueueAudience.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.Queues.Models
             _value = value;
         }
 
-        private const string _publicAudience = "https://storage.azure.com/";
+        private const string _defaultAudience = "https://storage.azure.com/";
 
         /// <summary>
         /// Default Audience. Use to acquire a token for authorizing requests to any Azure Storage account
@@ -38,7 +38,7 @@ namespace Azure.Storage.Queues.Models
         ///
         /// If no audience is specified, this is the default value.
         /// </summary>
-        public static QueueAudience PublicAudience { get; } = new(_publicAudience);
+        public static QueueAudience PublicAudience { get; } = new(_defaultAudience);
 
         /// <summary>
         /// The service endpoint for a given storage account.
@@ -48,7 +48,7 @@ namespace Azure.Storage.Queues.Models
         /// The storage account name used to populate the service endpoint.
         /// </param>
         /// <returns></returns>
-        public static QueueAudience GetQueueServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.queue.core.windows.net/");
+        public static QueueAudience CreateQueueServiceAccountAudience(string storageAccountName) => new($"https://{storageAccountName}.queue.core.windows.net/");
 
         /// <summary> Determines if two <see cref="QueueAudience"/> values are the same. </summary>
         public static bool operator ==(QueueAudience left, QueueAudience right) => left.Equals(right);

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -220,7 +220,7 @@ namespace Azure.Storage.Queues.Test
             await using DisposingQueue test = await GetTestQueueAsync();
 
             // Act - Create new blob client with the OAuth Credential and Audience
-            QueueClientOptions options = GetOptionsWithAudience(QueueAudience.GetQueueServiceAccountAudience(test.Queue.AccountName));
+            QueueClientOptions options = GetOptionsWithAudience(QueueAudience.CreateQueueServiceAccountAudience(test.Queue.AccountName));
 
             QueueUriBuilder uriBuilder = new QueueUriBuilder(new Uri(Tenants.TestConfigOAuth.QueueServiceEndpoint))
             {

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -149,7 +149,7 @@ namespace Azure.Storage.Queues.Test
             QueueUriBuilder uriBuilder = new QueueUriBuilder(new Uri(Tenants.TestConfigOAuth.QueueServiceEndpoint));
 
             // Act - Create new Queue client with the OAuth Credential and Audience
-            QueueClientOptions options = GetOptionsWithAudience(QueueAudience.GetQueueServiceAccountAudience(uriBuilder.AccountName));
+            QueueClientOptions options = GetOptionsWithAudience(QueueAudience.CreateQueueServiceAccountAudience(uriBuilder.AccountName));
 
             QueueServiceClient aadService = InstrumentClient(new QueueServiceClient(
                 new Uri(Tenants.TestConfigOAuth.QueueServiceEndpoint),


### PR DESCRIPTION
As per initial arch board review comments (before more information was provided so we decided to keep the extensible enum model).

- Renamed `<Service>Audience.PublicAudience` to `<Service>Audience.DefaultAudience`
- Renamed `<Service>Audience.Get<Service>ServiceAccountAudience` to `<Service>Audience.Create<Service>ServiceAccountAudience`

I might make further changes to this PR where I add in more convenience methods for other cloud audiences.