### PR TITLE
[Schema Registry] Prototype for alternative serializer API

### DIFF
--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/api/Azure.Data.SchemaRegistry.netstandard2.0.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/api/Azure.Data.SchemaRegistry.netstandard2.0.cs
@@ -81,10 +81,10 @@ namespace Azure.Data.SchemaRegistry.Serialization
         public System.Threading.Tasks.ValueTask<object> DeserializeAsync(Azure.Messaging.MessageContent content, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask<TData> DeserializeAsync<TData>(Azure.Messaging.MessageContent content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public TData Deserialize<TData>(Azure.Messaging.MessageContent content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public Azure.Messaging.MessageContent Serialize(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<Azure.Messaging.MessageContent> SerializeAsync(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<TMessage> SerializeAsync<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.Messaging.MessageContent, new() { throw null; }
-        public TMessage Serialize<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.Messaging.MessageContent, new() { throw null; }
+        public System.Threading.Tasks.ValueTask SerializeAsync<TMessage>(TMessage messageContent, object data, System.Type dataType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.Messaging.MessageContent { throw null; }
+        public System.Threading.Tasks.ValueTask SerializeAsync<TMessage, TData>(TMessage message, TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.Messaging.MessageContent { throw null; }
+        public void Serialize<TMessage>(TMessage messageContent, object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.Messaging.MessageContent { }
+        public void Serialize<TMessage, TData>(TMessage message, TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.Messaging.MessageContent { }
     }
     public partial class SchemaRegistrySerializerOptions
     {

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/samples/Sample02_Serialization.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/samples/Sample02_Serialization.md
@@ -45,7 +45,8 @@ In order to serialize an `EventData` instance with JSON information, you can do 
 var serializer = new SchemaRegistrySerializer(client, groupName, new SampleJsonValidator());
 
 var employee = new Employee { Age = 42, Name = "Caketown" };
-EventData eventData = (EventData)await serializer.SerializeAsync(employee, messageType: typeof(EventData));
+EventData eventData = new();
+await serializer.SerializeAsync(eventData, employee);
 
 // The schema Id will be included as a parameter of the content type
 Console.WriteLine(eventData.ContentType);
@@ -90,7 +91,8 @@ You can also use generic methods to serialize and deserialize the data. This may
 var serializer = new SchemaRegistrySerializer(client, groupName, new SampleJsonValidator());
 
 var employee = new Employee { Age = 42, Name = "Caketown" };
-EventData eventData = await serializer.SerializeAsync<EventData, Employee>(employee);
+EventData eventData = new();
+await serializer.SerializeAsync(eventData, employee);
 
 // The schema Id will be included as a parameter of the content type
 Console.WriteLine(eventData.ContentType);
@@ -114,7 +116,8 @@ It is also possible to serialize and deserialize using `MessageContent`. Use thi
 ```C# Snippet:SchemaRegistryJsonSerializeDeserializeMessageContent
 // The serializer serializes into JSON by default
 var serializer = new SchemaRegistrySerializer(client, groupName, new SampleJsonValidator());
-MessageContent content = await serializer.SerializeAsync<MessageContent, Employee>(employee);
+MessageContent content = new();
+await serializer.SerializeAsync(content, employee);
 
 Employee deserializedEmployee = await serializer.DeserializeAsync<Employee>(content);
 ```

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Serialization/SchemaRegistrySerializer.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Serialization/SchemaRegistrySerializer.cs
@@ -252,6 +252,7 @@ namespace Azure.Data.SchemaRegistry.Serialization
                 : SerializeInternalAsync(data, dataType, false, cancellationToken).EnsureCompleted();
 
             message.Data = bd;
+            message.ContentType = $"{_mimeType}+{retrievedSchemaId}";
         }
 
         private async ValueTask<(string SchemaId, BinaryData Data)> SerializeInternalAsync(

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Serialization/SchemaRegistrySerializer.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Serialization/SchemaRegistrySerializer.cs
@@ -141,7 +141,7 @@ namespace Azure.Data.SchemaRegistry.Serialization
         public void Serialize<TMessage, TData>(
             TMessage message,
             TData data,
-            CancellationToken cancellationToken = default) where TMessage : MessageContent, new()
+            CancellationToken cancellationToken = default) where TMessage : MessageContent
             => SerializeInternalAsync(message, data, typeof(TData), false, cancellationToken).EnsureCompleted();
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace Azure.Data.SchemaRegistry.Serialization
         public async ValueTask SerializeAsync<TMessage, TData>(
             TMessage message,
             TData data,
-            CancellationToken cancellationToken = default) where TMessage : MessageContent, new()
+            CancellationToken cancellationToken = default) where TMessage : MessageContent
             => await SerializeInternalAsync(message, data, typeof(TData), true, cancellationToken).ConfigureAwait(false);
 
         /// <summary>

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Samples/Sample02_Serialization.cs.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Samples/Sample02_Serialization.cs.cs
@@ -53,7 +53,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Samples
             var serializer = new SchemaRegistrySerializer(client, groupName, new SampleJsonValidator());
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
-            EventData eventData = (EventData)await serializer.SerializeAsync(employee, messageType: typeof(EventData));
+            EventData eventData = new();
+            await serializer.SerializeAsync(eventData, employee);
 
 #if SNIPPET
             // The schema Id will be included as a parameter of the content type
@@ -111,7 +112,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Samples
             var serializer = new SchemaRegistrySerializer(client, groupName, new SampleJsonValidator());
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
-            EventData eventData = await serializer.SerializeAsync<EventData, Employee>(employee);
+            EventData eventData = new();
+            await serializer.SerializeAsync(eventData, employee);
 
 #if SNIPPET
             // The schema Id will be included as a parameter of the content type
@@ -147,7 +149,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Samples
             #region Snippet:SchemaRegistryJsonSerializeDeserializeMessageContent
             // The serializer serializes into JSON by default
             var serializer = new SchemaRegistrySerializer(client, groupName, new SampleJsonValidator());
-            MessageContent content = await serializer.SerializeAsync<MessageContent, Employee>(employee);
+            MessageContent content = new();
+            await serializer.SerializeAsync(content, employee);
 
             Employee deserializedEmployee = await serializer.DeserializeAsync<Employee>(content);
             #endregion

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Serialization/SchemaRegistrySerializerTests.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Serialization/SchemaRegistrySerializerTests.cs
@@ -10,6 +10,7 @@ using Azure.Core;
 using Azure.Core.Serialization;
 using Azure.Core.TestFramework;
 using Azure.Data.SchemaRegistry.Serialization;
+using Azure.Messaging;
 using Moq;
 using NUnit.Framework;
 using TestSchema;
@@ -40,7 +41,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Serialization
                             SchemaRegistryModelFactory.SchemaProperties(SchemaFormat.Json, "SchemaId"), new MockResponse(200))));
 
             var serializer = new SchemaRegistrySerializer(mockClient.Object, "groupName", new SampleJsonGenerator());
-            var content = await serializer.SerializeAsync(new Employee { Age = 42, Name = "Caketown" }).ConfigureAwait(false);
+            var content = new MessageContent();
+            await serializer.SerializeAsync(content, new Employee { Age = 42, Name = "Caketown" }).ConfigureAwait(false);
             Assert.AreEqual("SchemaId", content.ContentType.ToString().Split('+')[1]);
         }
 
@@ -64,7 +66,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Serialization
             var options = new SchemaRegistrySerializerOptions { Format = SchemaFormat.Custom, Serializer = new FakeSerializer() };
 
             var serializer = new SchemaRegistrySerializer(mockClient.Object, "groupName", new SampleCustomGenerator(), options);
-            var content = await serializer.SerializeAsync(new Employee { Age = 25, Name = "Name" }).ConfigureAwait(false);
+            var content = new MessageContent();
+            await serializer.SerializeAsync(content,new Employee { Age = 25, Name = "Name" }).ConfigureAwait(false);
             Assert.AreEqual("SchemaId", content.ContentType.ToString().Split('+')[1]);
 
             // Test that the correct mime type was used
@@ -95,7 +98,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Serialization
             var sampleGeneratorAvro = new SampleCustomGenerator();
             sampleGeneratorAvro.SchemaToUse = s_avroschema;
             var serializer = new SchemaRegistrySerializer(mockClient.Object, "groupName", sampleGeneratorAvro, options);
-            var content = await serializer.SerializeAsync(new Employee { Age = 25, Name = "Name" }).ConfigureAwait(false);
+            var content = new MessageContent();
+            await serializer.SerializeAsync(content, new Employee { Age = 25, Name = "Name" }).ConfigureAwait(false);
             Assert.AreEqual("SchemaId", content.ContentType.ToString().Split('+')[1]);
 
             // Test that the correct mime type was used

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Serialization/SerializationEventSourceLiveTests.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Serialization/SerializationEventSourceLiveTests.cs
@@ -56,7 +56,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Serialization
             await client.RegisterSchemaAsync(groupName, (typeof(Employee)).Name, _schema, SchemaFormat.Json, CancellationToken.None).ConfigureAwait(false);
             await client.RegisterSchemaAsync(groupName, (typeof(EmployeeV2)).Name, _schemaV2, SchemaFormat.Json, CancellationToken.None).ConfigureAwait(false);
 
-            EventData eventData = await serializer.SerializeAsync<EventData, Employee>(employee);
+            EventData eventData = new();
+            await serializer.SerializeAsync(eventData, employee);
 
             Assert.IsFalse(eventData.IsReadOnly);
             string[] contentType = eventData.ContentType.Split('+');
@@ -78,7 +79,8 @@ namespace Azure.Data.SchemaRegistry.Tests.Serialization
             Assert.AreEqual(42, deserialized.Age);
 
             // Use different schema so we can see the cache updated
-            eventData = await serializer.SerializeAsync<EventData, EmployeeV2>(new EmployeeV2 { Age = 42, Name = "Caketown", City = "Redmond" });
+            eventData = new EventData();
+            await serializer.SerializeAsync(eventData, new EmployeeV2 { Age = 42, Name = "Caketown", City = "Redmond" });
 
             Assert.IsFalse(eventData.IsReadOnly);
             eventData.ContentType.Split('+');


### PR DESCRIPTION
## Prototype for alternative API for the schema registry serializer
Suggested by @danielmarbach in https://github.com/Azure/azure-sdk-for-net/pull/36926#discussion_r1337310153

API difference: https://apiview.dev/Assemblies/Review/26accfd449ee4d83acf4a31d5926b0f5?diffRevisionId=77043988996443119a2a982924958151&diffOnly=False&revisionId=1c17c10d4d594f148b2a7083c11dd9f2&doc=False

### A couple of quick samples showing usage difference:
#### Example 1:
Before:
```csharp
EventData eventData = await serializer.SerializeAsync<EventData, Employee>(employee);
```
After:
```csharp
EventData eventData = new();
await serializer.SerializeAsync(eventData, employee);
````

#### Example 2:
Before:
```csharp
EventData eventData = (EventData)await serializer.SerializeAsync(employee, messageType: typeof(EventData));
```
After:
```csharp
EventData eventData = new();
await serializer.SerializeAsync(eventData, employee);
````

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
