### PR TITLE
[Storage][DataMovement] Update checkpointer to read/write to job file - Part 2

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/PooledMemoryStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PooledMemoryStream.cs
@@ -259,6 +259,21 @@ namespace Azure.Storage.Shared
             return read;
         }
 
+        public override int ReadByte()
+        {
+            if (Position >= Length)
+            {
+                return -1;
+            }
+
+            (byte[] currentBuffer, int _, long offsetOfBuffer) = GetBufferFromPosition();
+
+            byte result = currentBuffer[Position - offsetOfBuffer];
+            Position += 1;
+
+            return result;
+        }
+
         /// <summary>
         /// According the the current <see cref="Position"/> of the stream, gets the correct buffer containing the byte
         /// at that position, as well as the stream position represented by the start of the array.

--- a/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
@@ -108,6 +108,7 @@ namespace Azure.Storage.Tests
         [TestCase(1, 0, 1)]
         [TestCase(Constants.KB, 512, 2 * Constants.KB)]
         [TestCase(Constants.KB, 512, 512)]
+        [TestCase(107, 99, 52)]
         public async Task ReadByte(int dataSize, int initialReadSize, int bufferPartitionSize)
         {
             // Arrange
@@ -129,6 +130,29 @@ namespace Azure.Storage.Tests
             // Assert
             Assert.AreEqual(initialReadSize + 1, pooledMemoryStream.Position);
             Assert.AreEqual(originalData[initialReadSize], result);
+        }
+
+        [TestCase(Constants.KB, 2 * Constants.KB)]
+        [TestCase(Constants.KB, 512)]
+        [TestCase(107, 52)]
+        public async Task ReadByte_Full(int dataSize, int bufferPartitionSize)
+        {
+            // Arrange
+            byte[] originalData = GetRandomBuffer(dataSize);
+            PooledMemoryStream pooledMemoryStream = new PooledMemoryStream(ArrayPool<byte>.Shared, bufferPartitionSize);
+            await pooledMemoryStream.WriteAsync(originalData, 0, dataSize);
+            pooledMemoryStream.Position = 0;
+
+            // Act
+            byte[] result = new byte[originalData.Length];
+            for (int i = 0; i < originalData.Length; i++)
+            {
+                result[i] = Convert.ToByte(pooledMemoryStream.ReadByte());
+            }
+
+            // Assert
+            Assert.AreEqual(originalData.Length, pooledMemoryStream.Position);
+            AssertSequenceEqual(originalData, result);
         }
 
         private static byte[] GetRandomBuffer(long size)

--- a/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
@@ -10,7 +10,6 @@ using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Storage.Shared;
 using Azure.Storage.Tests.Shared;
-using Microsoft.Diagnostics.Runtime.DacInterface;
 using NUnit.Framework;
 
 namespace Azure.Storage.Tests

--- a/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,6 +64,36 @@ namespace Azure.Storage.DataMovement
                 DestinationPath = destPath,
                 IsContainer = isContainer,
             };
+        }
+
+        internal static async Task<bool> IsEnumerationCompleteAsync(
+            this TransferCheckpointer checkpointer,
+            string transferId,
+            CancellationToken cancellationToken)
+        {
+            using (Stream stream = await checkpointer.ReadJobPlanFileAsync(
+                transferId,
+                DataMovementConstants.JobPlanFile.EnumerationCompleteIndex,
+                DataMovementConstants.OneByte,
+                cancellationToken).ConfigureAwait(false))
+            {
+                return Convert.ToBoolean(stream.ReadByte());
+            }
+        }
+
+        internal static async Task OnEnumerationCompleteAsync(
+            this TransferCheckpointer checkpointer,
+            string transferId,
+            CancellationToken cancellationToken)
+        {
+            byte[] enumerationComplete = { Convert.ToByte(true) };
+            await checkpointer.WriteToJobPlanFileAsync(
+                transferId,
+                DataMovementConstants.JobPlanFile.EnumerationCompleteIndex,
+                enumerationComplete,
+                bufferOffset: 0,
+                length: 1,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
@@ -103,12 +103,6 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         internal long? Length;
 
-        /// <summary>
-        /// Defines whether or not this was the final part in the list call. This would determine
-        /// whether or not we needed to keep listing in the job.
-        /// </summary>
-        public bool IsFinalPart { get; internal set; }
-
         internal ClientDiagnostics ClientDiagnostics { get; }
 
         /// <summary>
@@ -160,7 +154,6 @@ namespace Azure.Storage.DataMovement
             TransferCheckpointer checkpointer,
             TransferProgressTracker progressTracker,
             ArrayPool<byte> arrayPool,
-            bool isFinalPart,
             SyncAsyncEventHandler<TransferStatusEventArgs> jobPartEventHandler,
             SyncAsyncEventHandler<TransferStatusEventArgs> statusEventHandler,
             SyncAsyncEventHandler<TransferItemFailedEventArgs> failedEventHandler,
@@ -186,7 +179,6 @@ namespace Azure.Storage.DataMovement
             _progressTracker = progressTracker;
             _cancellationToken = cancellationToken;
             _arrayPool = arrayPool;
-            IsFinalPart = isFinalPart;
             PartTransferStatusEventHandler = jobPartEventHandler;
             TransferStatusEventHandler = statusEventHandler;
             TransferFailedEventHandler = failedEventHandler;
@@ -460,13 +452,10 @@ namespace Azure.Storage.DataMovement
         /// Serializes the respective job part and adds it to the checkpointer.
         /// </summary>
         /// <param name="chunksTotal">Number of chunks in the job part.</param>
-        /// <param name="isFinalPart">Defines if this part is the last job part of the job.</param>
         /// <returns></returns>
-        public async virtual Task AddJobPartToCheckpointerAsync(int chunksTotal, bool isFinalPart)
+        public async virtual Task AddJobPartToCheckpointerAsync(int chunksTotal)
         {
-            JobPartPlanHeader header = this.ToJobPartPlanHeader(
-                jobStatus: JobPartStatus,
-                isFinalPart: isFinalPart);
+            JobPartPlanHeader header = this.ToJobPartPlanHeader(jobStatus: JobPartStatus);
             using (Stream stream = new MemoryStream())
             {
                 header.Serialize(stream);

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -23,7 +23,7 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// Creating job part based on a single transfer job
         /// </summary>
-        private ServiceToServiceJobPart(ServiceToServiceTransferJob job, int partNumber, bool isFinalPart)
+        private ServiceToServiceJobPart(ServiceToServiceTransferJob job, int partNumber)
             : base(dataTransfer: job._dataTransfer,
                   partNumber: partNumber,
                   sourceResource: job._sourceResource,
@@ -35,7 +35,6 @@ namespace Azure.Storage.DataMovement
                   checkpointer: job._checkpointer,
                   progressTracker: job._progressTracker,
                   arrayPool: job.UploadArrayPool,
-                  isFinalPart: isFinalPart,
                   jobPartEventHandler: job.GetJobPartStatus(),
                   statusEventHandler: job.TransferStatusEventHandler,
                   failedEventHandler: job.TransferFailedEventHandler,
@@ -54,7 +53,6 @@ namespace Azure.Storage.DataMovement
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            bool isFinalPart,
             DataTransferStatus jobPartStatus = default,
             long? length = default)
             : base(dataTransfer: job._dataTransfer,
@@ -68,7 +66,6 @@ namespace Azure.Storage.DataMovement
                   checkpointer: job._checkpointer,
                   progressTracker: job._progressTracker,
                   arrayPool: job.UploadArrayPool,
-                  isFinalPart: isFinalPart,
                   jobPartEventHandler: job.GetJobPartStatus(),
                   statusEventHandler: job.TransferStatusEventHandler,
                   failedEventHandler: job.TransferFailedEventHandler,
@@ -88,15 +85,11 @@ namespace Azure.Storage.DataMovement
 
         public static async Task<ServiceToServiceJobPart> CreateJobPartAsync(
             ServiceToServiceTransferJob job,
-            int partNumber,
-            bool isFinalPart)
+            int partNumber)
         {
-            // Create Job Part file as we're intializing the job part
-            ServiceToServiceJobPart part = new ServiceToServiceJobPart(
-                job: job,
-                partNumber: partNumber,
-                isFinalPart: isFinalPart);
-            await part.AddJobPartToCheckpointerAsync(1, isFinalPart).ConfigureAwait(false); // For now we only store 1 chunk
+            // Create Job Part file as we're initializing the job part
+            ServiceToServiceJobPart part = new ServiceToServiceJobPart(job, partNumber);
+            await part.AddJobPartToCheckpointerAsync(1).ConfigureAwait(false); // For now we only store 1 chunk
             return part;
         }
 
@@ -105,23 +98,21 @@ namespace Azure.Storage.DataMovement
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            bool isFinalPart,
             DataTransferStatus jobPartStatus = default,
             long? length = default,
             bool partPlanFileExists = false)
         {
-            // Create Job Part file as we're intializing the job part
+            // Create Job Part file as we're initializing the job part
             ServiceToServiceJobPart part = new ServiceToServiceJobPart(
                 job: job,
                 partNumber: partNumber,
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                isFinalPart: isFinalPart,
                 length: length);
             if (!partPlanFileExists)
             {
-                await part.AddJobPartToCheckpointerAsync(1, isFinalPart).ConfigureAwait(false); // For now we only store 1 chunk
+                await part.AddJobPartToCheckpointerAsync(1).ConfigureAwait(false); // For now we only store 1 chunk
             }
             return part;
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
@@ -36,8 +36,7 @@ namespace Azure.Storage.DataMovement
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                partPlanFileExists: true,
-                isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+                partPlanFileExists: true).ConfigureAwait(false);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -62,8 +61,7 @@ namespace Azure.Storage.DataMovement
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                partPlanFileExists: true,
-                isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+                partPlanFileExists: true).ConfigureAwait(false);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -88,8 +86,7 @@ namespace Azure.Storage.DataMovement
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                partPlanFileExists: true,
-                isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+                partPlanFileExists: true).ConfigureAwait(false);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -118,8 +115,7 @@ namespace Azure.Storage.DataMovement
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource.GetStorageResourceReference(childSourceName),
                 destinationResource: destinationResource.GetStorageResourceReference(childDestinationName),
-                partPlanFileExists: true,
-                isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+                partPlanFileExists: true).ConfigureAwait(false);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -146,8 +142,7 @@ namespace Azure.Storage.DataMovement
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource.GetStorageResourceReference(childSourcePath.Substring(sourceResource.Uri.AbsoluteUri.Length + 1)),
                 destinationResource: destinationResource.GetStorageResourceReference(childDestinationPath.Substring(destinationResource.Uri.AbsoluteUri.Length + 1)),
-                partPlanFileExists: true,
-                isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+                partPlanFileExists: true).ConfigureAwait(false);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -176,8 +171,7 @@ namespace Azure.Storage.DataMovement
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource.GetStorageResourceReference(childSourceName),
                 destinationResource: destinationResource.GetStorageResourceReference(childDestinationName),
-                partPlanFileExists: true,
-                isFinalPart: header.IsFinalPart).ConfigureAwait(false);
+                partPlanFileExists: true).ConfigureAwait(false);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -188,9 +182,7 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// Translate the initial job part header to a job plan format file
         /// </summary>
-        internal static JobPartPlanHeader ToJobPartPlanHeader(this JobPartInternal jobPart,
-            DataTransferStatus jobStatus,
-            bool isFinalPart)
+        internal static JobPartPlanHeader ToJobPartPlanHeader(this JobPartInternal jobPart, DataTransferStatus jobStatus)
         {
             JobPartPlanDestinationBlob dstBlobData = new JobPartPlanDestinationBlob(
                 blobType: JobPlanBlobType.Detect, // TODO: update when supported
@@ -235,7 +227,7 @@ namespace Azure.Storage.DataMovement
                 destinationResourceId: jobPart._destinationResource.ResourceId,
                 destinationPath: destinationPath,
                 destinationExtraQuery: "", // TODO: convert options to string
-                isFinalPart: isFinalPart,
+                isFinalPart: false,
                 forceWrite: jobPart._createMode == StorageResourceCreationPreference.OverwriteIfExists, // TODO: change to enum value
                 forceIfReadOnly: false, // TODO: revisit for Azure Files
                 autoDecompress: false, // TODO: revisit if we want to support this feature

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -23,10 +23,7 @@ namespace Azure.Storage.DataMovement
         /// <summary>
         /// Creating job part based on a single transfer job
         /// </summary>
-        private StreamToUriJobPart(
-            StreamToUriTransferJob job,
-            int partNumber,
-            bool isFinalPart)
+        private StreamToUriJobPart(StreamToUriTransferJob job, int partNumber)
             : base(dataTransfer: job._dataTransfer,
                   partNumber: partNumber,
                   sourceResource: job._sourceResource,
@@ -38,7 +35,6 @@ namespace Azure.Storage.DataMovement
                   checkpointer: job._checkpointer,
                   progressTracker: job._progressTracker,
                   arrayPool: job.UploadArrayPool,
-                  isFinalPart: isFinalPart,
                   jobPartEventHandler: job.GetJobPartStatus(),
                   statusEventHandler: job.TransferStatusEventHandler,
                   failedEventHandler: job.TransferFailedEventHandler,
@@ -57,7 +53,6 @@ namespace Azure.Storage.DataMovement
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            bool isFinalPart,
             DataTransferStatus jobPartStatus = default,
             long? length = default)
             : base(dataTransfer: job._dataTransfer,
@@ -71,7 +66,6 @@ namespace Azure.Storage.DataMovement
                   checkpointer: job._checkpointer,
                   progressTracker: job._progressTracker,
                   arrayPool: job.UploadArrayPool,
-                  isFinalPart: isFinalPart,
                   jobPartEventHandler: job.GetJobPartStatus(),
                   statusEventHandler: job.TransferStatusEventHandler,
                   failedEventHandler: job.TransferFailedEventHandler,
@@ -91,17 +85,11 @@ namespace Azure.Storage.DataMovement
 
         public static async Task<StreamToUriJobPart> CreateJobPartAsync(
             StreamToUriTransferJob job,
-            int partNumber,
-            bool isFinalPart)
+            int partNumber)
         {
-            // Create Job Part file as we're intializing the job part
-            StreamToUriJobPart part = new StreamToUriJobPart(
-                job: job,
-                partNumber: partNumber,
-                isFinalPart: isFinalPart);
-            await part.AddJobPartToCheckpointerAsync(
-                chunksTotal: 1, // For now we only store 1 chunk
-                isFinalPart: isFinalPart).ConfigureAwait(false);
+            // Create Job Part file as we're initializing the job part
+            StreamToUriJobPart part = new StreamToUriJobPart(job, partNumber);
+            await part.AddJobPartToCheckpointerAsync(1).ConfigureAwait(false); // For now we only store 1 chunk
             return part;
         }
 
@@ -110,25 +98,21 @@ namespace Azure.Storage.DataMovement
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            bool isFinalPart,
             DataTransferStatus jobPartStatus = default,
             long? length = default,
             bool partPlanFileExists = false)
         {
-            // Create Job Part file as we're intializing the job part
+            // Create Job Part file as we're initializing the job part
             StreamToUriJobPart part = new StreamToUriJobPart(
                 job: job,
                 partNumber: partNumber,
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                length: length,
-                isFinalPart: isFinalPart);
+                length: length);
             if (!partPlanFileExists)
             {
-                await part.AddJobPartToCheckpointerAsync(
-                    chunksTotal: 1,
-                    isFinalPart: isFinalPart).ConfigureAwait(false); // For now we only store 1 chunk
+                await part.AddJobPartToCheckpointerAsync(1).ConfigureAwait(false); // For now we only store 1 chunk
             }
             return part;
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriTransferJob.cs
@@ -81,8 +81,7 @@ namespace Azure.Storage.DataMovement
                         // Single resource transfer, we can skip to chunking the job.
                         part = await StreamToUriJobPart.CreateJobPartAsync(
                             job: this,
-                            partNumber: partNumber,
-                            isFinalPart: true).ConfigureAwait(false);
+                            partNumber: partNumber).ConfigureAwait(false);
                         AppendJobPart(part);
                     }
                     catch (Exception ex)
@@ -103,22 +102,16 @@ namespace Azure.Storage.DataMovement
             else
             {
                 // Resuming old job with existing job parts
-                bool isFinalPartFound = false;
                 foreach (JobPartInternal part in _jobParts)
                 {
                     if (!part.JobPartStatus.HasCompletedSuccessfully)
                     {
                         part.JobPartStatus.TrySetTransferStateChange(DataTransferState.Queued);
                         yield return part;
-
-                        if (part.IsFinalPart)
-                        {
-                            // If we found the final part then we don't have to relist the container.
-                            isFinalPartFound = true;
-                        }
                     }
                 }
-                if (!isFinalPartFound)
+
+                if (await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
                 {
                     await foreach (JobPartInternal jobPartInternal in GetStorageResourcesAsync().ConfigureAwait(false))
                     {
@@ -126,7 +119,7 @@ namespace Azure.Storage.DataMovement
                     }
                 }
             }
-            _enumerationComplete = true;
+
             await OnEnumerationComplete().ConfigureAwait(false);
         }
 
@@ -152,10 +145,9 @@ namespace Azure.Storage.DataMovement
                 yield break;
             }
 
-            // List the container keep track of the last job part in order to store it properly
-            // so we know we finished enumerating/listed.
+            // List the container in this specific way because MoveNext needs to be separately wrapped
+            // in a try/catch as we can't yield return inside a try/catch.
             bool enumerationCompleted = false;
-            StorageResource lastResource = default;
             while (!enumerationCompleted)
             {
                 try
@@ -173,68 +165,36 @@ namespace Azure.Storage.DataMovement
                 }
 
                 StorageResource current = enumerator.Current;
-                if (lastResource != default)
-                {
-                    string containerUriPath = _sourceResourceContainer.Uri.GetPath();
-                    string sourceName = string.IsNullOrEmpty(containerUriPath)
-                        ? lastResource.Uri.GetPath()
-                        : lastResource.Uri.GetPath().Substring(containerUriPath.Length + 1);
 
-                    if (!existingSources.Contains(sourceName))
+                string containerUriPath = _sourceResourceContainer.Uri.GetPath();
+                string sourceName = string.IsNullOrEmpty(containerUriPath)
+                    ? current.Uri.GetPath()
+                    : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
+
+                if (!existingSources.Contains(sourceName))
+                {
+                    // Because AsyncEnumerable doesn't let us know which storage resource is the last resource
+                    // we only yield return when we know this is not the last storage resource to be listed
+                    // from the container.
+                    StreamToUriJobPart part;
+                    try
                     {
-                        // Because AsyncEnumerable doesn't let us know which storage resource is the last resource
-                        // we only yield return when we know this is not the last storage resource to be listed
-                        // from the container.
-                        StreamToUriJobPart part;
-                        try
-                        {
-                            part = await StreamToUriJobPart.CreateJobPartAsync(
-                                job: this,
-                                partNumber: partNumber,
-                                sourceResource: (StorageResourceItem)lastResource,
-                                destinationResource: _destinationResourceContainer.GetStorageResourceReference(sourceName),
-                                isFinalPart: false).ConfigureAwait(false);
-                            AppendJobPart(part);
-                        }
-                        catch (Exception ex)
-                        {
-                            await InvokeFailedArgAsync(ex).ConfigureAwait(false);
-                            yield break;
-                        }
-                        yield return part;
-                        partNumber++;
-                    }
-                }
-                lastResource = current;
-            }
-
-            // It's possible to have no job parts in a job
-            if (lastResource != default)
-            {
-                StreamToUriJobPart lastPart;
-                try
-                {
-                    // Return last part but enable the part to be the last job part of the entire job
-                    // so we know that we've finished listing in the container
-                    string containerUriPath = _sourceResourceContainer.Uri.GetPath();
-                    string lastSourceName = string.IsNullOrEmpty(containerUriPath)
-                        ? lastResource.Uri.GetPath()
-                        : lastResource.Uri.GetPath().Substring(containerUriPath.Length + 1);
-
-                    lastPart = await StreamToUriJobPart.CreateJobPartAsync(
+                        part = await StreamToUriJobPart.CreateJobPartAsync(
                             job: this,
                             partNumber: partNumber,
-                            sourceResource: (StorageResourceItem)lastResource,
-                            destinationResource: _destinationResourceContainer.GetStorageResourceReference(lastSourceName),
-                            isFinalPart: true).ConfigureAwait(false);
-                    AppendJobPart(lastPart);
+                            sourceResource: (StorageResourceItem)current,
+                            destinationResource: _destinationResourceContainer.GetStorageResourceReference(sourceName))
+                            .ConfigureAwait(false);
+                        AppendJobPart(part);
+                    }
+                    catch (Exception ex)
+                    {
+                        await InvokeFailedArgAsync(ex).ConfigureAwait(false);
+                        yield break;
+                    }
+                    yield return part;
+                    partNumber++;
                 }
-                catch (Exception ex)
-                {
-                    await InvokeFailedArgAsync(ex).ConfigureAwait(false);
-                    yield break;
-                }
-                yield return lastPart;
             }
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -405,8 +405,16 @@ namespace Azure.Storage.DataMovement
 
         internal async Task OnEnumerationComplete()
         {
+            try
+            {
+                await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                await InvokeFailedArgAsync(ex).ConfigureAwait(false);
+                return;
+            }
             _enumerationComplete = true;
-            await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false);
 
             // If there were no job parts enumerated and we haven't already aborted/completed the job.
             if (_jobParts.Count == 0 &&

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -405,6 +405,9 @@ namespace Azure.Storage.DataMovement
 
         internal async Task OnEnumerationComplete()
         {
+            _enumerationComplete = true;
+            await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false);
+
             // If there were no job parts enumerated and we haven't already aborted/completed the job.
             if (_jobParts.Count == 0 &&
                 _dataTransfer.TransferStatus.State != DataTransferState.Paused &&

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -26,8 +26,7 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         private UriToStreamJobPart(
             UriToStreamTransferJob job,
-            int partNumber,
-            bool isFinalPart)
+            int partNumber)
             : base(dataTransfer: job._dataTransfer,
                   partNumber: partNumber,
                   sourceResource: job._sourceResource,
@@ -39,7 +38,6 @@ namespace Azure.Storage.DataMovement
                   checkpointer: job._checkpointer,
                   progressTracker: job._progressTracker,
                   arrayPool: job.UploadArrayPool,
-                  isFinalPart: isFinalPart,
                   jobPartEventHandler: job.GetJobPartStatus(),
                   statusEventHandler: job.TransferStatusEventHandler,
                   failedEventHandler: job.TransferFailedEventHandler,
@@ -57,7 +55,6 @@ namespace Azure.Storage.DataMovement
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            bool isFinalPart,
             DataTransferStatus jobPartStatus = default,
             long? length = default)
             : base(dataTransfer: job._dataTransfer,
@@ -71,7 +68,6 @@ namespace Azure.Storage.DataMovement
                   checkpointer: job._checkpointer,
                   progressTracker: job._progressTracker,
                   arrayPool: job.UploadArrayPool,
-                  isFinalPart: isFinalPart,
                   jobPartEventHandler: job.GetJobPartStatus(),
                   statusEventHandler: job.TransferStatusEventHandler,
                   failedEventHandler: job.TransferFailedEventHandler,
@@ -85,17 +81,11 @@ namespace Azure.Storage.DataMovement
 
         public static async Task<UriToStreamJobPart> CreateJobPartAsync(
             UriToStreamTransferJob job,
-            int partNumber,
-            bool isFinalPart)
+            int partNumber)
         {
-            // Create Job Part file as we're intializing the job part
-            UriToStreamJobPart part = new UriToStreamJobPart(
-                job: job,
-                partNumber: partNumber,
-                isFinalPart: isFinalPart);
-            await part.AddJobPartToCheckpointerAsync(
-                chunksTotal: 1,
-                isFinalPart: isFinalPart).ConfigureAwait(false); // For now we only store 1 chunk
+            // Create Job Part file as we're initializing the job part
+            UriToStreamJobPart part = new UriToStreamJobPart(job, partNumber);
+            await part.AddJobPartToCheckpointerAsync(1).ConfigureAwait(false); // For now we only store 1 chunk
             return part;
         }
 
@@ -104,23 +94,21 @@ namespace Azure.Storage.DataMovement
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            bool isFinalPart,
             DataTransferStatus jobPartStatus = default,
             long? length = default,
             bool partPlanFileExists = false)
         {
-            // Create Job Part file as we're intializing the job part
+            // Create Job Part file as we're initializing the job part
             UriToStreamJobPart part = new UriToStreamJobPart(
                 job: job,
                 partNumber: partNumber,
                 jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                isFinalPart: isFinalPart,
                 length: length);
             if (!partPlanFileExists)
             {
-                await part.AddJobPartToCheckpointerAsync(1, isFinalPart).ConfigureAwait(false); // For now we only store 1 chunk
+                await part.AddJobPartToCheckpointerAsync(1).ConfigureAwait(false); // For now we only store 1 chunk
             }
             return part;
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
@@ -81,8 +81,7 @@ namespace Azure.Storage.DataMovement
                         // Single resource transfer, we can skip to chunking the job.
                         part = await UriToStreamJobPart.CreateJobPartAsync(
                             job: this,
-                            partNumber: partNumber,
-                            isFinalPart: true).ConfigureAwait(false);
+                            partNumber: partNumber).ConfigureAwait(false);
                         AppendJobPart(part);
                     }
                     catch (Exception ex)
@@ -103,22 +102,16 @@ namespace Azure.Storage.DataMovement
             else
             {
                 // Resuming old job with existing job parts
-                bool isFinalPartFound = false;
                 foreach (JobPartInternal part in _jobParts)
                 {
                     if (!part.JobPartStatus.HasCompletedSuccessfully)
                     {
                         part.JobPartStatus.TrySetTransferStateChange(DataTransferState.Queued);
                         yield return part;
-
-                        if (part.IsFinalPart)
-                        {
-                            // If we found the final part then we don't have to relist the container.
-                            isFinalPartFound = true;
-                        }
                     }
                 }
-                if (!isFinalPartFound)
+
+                if (await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
                 {
                     await foreach (JobPartInternal jobPartInternal in GetStorageResourcesAsync().ConfigureAwait(false))
                     {
@@ -126,7 +119,7 @@ namespace Azure.Storage.DataMovement
                     }
                 }
             }
-            _enumerationComplete = true;
+
             await OnEnumerationComplete().ConfigureAwait(false);
         }
 
@@ -152,10 +145,9 @@ namespace Azure.Storage.DataMovement
                 yield break;
             }
 
-            // List the container keep track of the last job part in order to store it properly
-            // so we know we finished enumerating/listed.
+            // List the container in this specific way because MoveNext needs to be separately wrapped
+            // in a try/catch as we can't yield return inside a try/catch.
             bool enumerationCompleted = false;
-            StorageResource lastResource = default;
             while (!enumerationCompleted)
             {
                 try
@@ -173,68 +165,36 @@ namespace Azure.Storage.DataMovement
                 }
 
                 StorageResource current = enumerator.Current;
-                if (lastResource != default)
-                {
-                    string containerUriPath = _sourceResourceContainer.Uri.GetPath();
-                    string sourceName = string.IsNullOrEmpty(containerUriPath)
-                        ? lastResource.Uri.GetPath()
-                        : lastResource.Uri.GetPath().Substring(containerUriPath.Length + 1);
 
-                    if (!existingSources.Contains(sourceName))
+                string containerUriPath = _sourceResourceContainer.Uri.GetPath();
+                string sourceName = string.IsNullOrEmpty(containerUriPath)
+                    ? current.Uri.GetPath()
+                    : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
+
+                if (!existingSources.Contains(sourceName))
+                {
+                    // Because AsyncEnumerable doesn't let us know which storage resource is the last resource
+                    // we only yield return when we know this is not the last storage resource to be listed
+                    // from the container.
+                    UriToStreamJobPart part;
+                    try
                     {
-                        // Because AsyncEnumerable doesn't let us know which storage resource is the last resource
-                        // we only yield return when we know this is not the last storage resource to be listed
-                        // from the container.
-                        UriToStreamJobPart part;
-                        try
-                        {
-                            part = await UriToStreamJobPart.CreateJobPartAsync(
-                                job: this,
-                                partNumber: partNumber,
-                                sourceResource: (StorageResourceItem)lastResource,
-                                destinationResource: _destinationResourceContainer.GetStorageResourceReference(sourceName),
-                                isFinalPart: false).ConfigureAwait(false);
-                            AppendJobPart(part);
-                        }
-                        catch (Exception ex)
-                        {
-                            await InvokeFailedArgAsync(ex).ConfigureAwait(false);
-                            yield break;
-                        }
-                        yield return part;
-                        partNumber++;
-                    }
-                }
-                lastResource = current;
-            }
-
-            // It's possible to have no job parts in a job
-            if (lastResource != default)
-            {
-                UriToStreamJobPart lastPart;
-                try
-                {
-                    // Return last part but enable the part to be the last job part of the entire job
-                    // so we know that we've finished listing in the container
-                    string containerUriPath = _sourceResourceContainer.Uri.GetPath();
-                    string lastSourceName = string.IsNullOrEmpty(containerUriPath)
-                        ? lastResource.Uri.GetPath()
-                        : lastResource.Uri.GetPath().Substring(containerUriPath.Length + 1);
-
-                    lastPart = await UriToStreamJobPart.CreateJobPartAsync(
+                        part = await UriToStreamJobPart.CreateJobPartAsync(
                             job: this,
                             partNumber: partNumber,
-                            sourceResource: (StorageResourceItem) lastResource,
-                            destinationResource: _destinationResourceContainer.GetStorageResourceReference(lastSourceName),
-                            isFinalPart: true).ConfigureAwait(false);
-                    AppendJobPart(lastPart);
+                            sourceResource: (StorageResourceItem)current,
+                            destinationResource: _destinationResourceContainer.GetStorageResourceReference(sourceName))
+                            .ConfigureAwait(false);
+                        AppendJobPart(part);
+                    }
+                    catch (Exception ex)
+                    {
+                        await InvokeFailedArgAsync(ex).ConfigureAwait(false);
+                        yield break;
+                    }
+                    yield return part;
+                    partNumber++;
                 }
-                catch (Exception ex)
-                {
-                    await InvokeFailedArgAsync(ex).ConfigureAwait(false);
-                    yield break;
-                }
-                yield return lastPart;
             }
         }
     }


### PR DESCRIPTION
This change is the second part to transitioning the checkpoint read operations to the job plan file instead of the job part plan files. This change handles swapping from `IsFinalPart` being stored in each job part plan file to storing `enumerationComplete` in the job plan file. Specifically, this change handles updating the job plan file when enumeration is complete, checking the job plan file when resuming a job to see if we need to re-enumerate, and removing `IsFinalPart` from job parts all together as it's no longer needed.

The final part is to remove `IsFinalPart` from the job part plan schema but that will come as part of the larger schema update.