### PR TITLE
[Search] Add a work around to fix CreateAzureBlobIndexer test

### DIFF
--- a/sdk/search/Azure.Search.Documents/assets.json
+++ b/sdk/search/Azure.Search.Documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/search/Azure.Search.Documents",
-  "Tag": "net/search/Azure.Search.Documents_53888408bf"
+  "Tag": "net/search/Azure.Search.Documents_547641209a"
 }

--- a/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
@@ -85,16 +85,20 @@ namespace Azure.Search.Documents.Tests
                 dataSource.Name,
                 resources.IndexName);
 
-            SearchIndexer actualIndexer = await serviceClient.CreateIndexerAsync(
-                indexer);
+            await serviceClient.CreateIndexerAsync(indexer);
+
+            // Wait till the indexer is done.
+            await WaitForIndexingAsync(serviceClient, indexer.Name);
+
+            // Remove this workaround once the service issue is fixed: https://github.com/Azure/azure-sdk-for-net/issues/39104#issuecomment-1749469582
+            // Tracking issue: https://msdata.visualstudio.com/Azure%20Search/_workitems/edit/2737454
+            SearchIndexer actualIndexer = await serviceClient.GetIndexerAsync(indexer.Name);
 
             // Update the indexer.
             actualIndexer.Description = "Updated description";
             await serviceClient.CreateOrUpdateIndexerAsync(
                 actualIndexer,
                 onlyIfUnchanged: true);
-
-            await WaitForIndexingAsync(serviceClient, actualIndexer.Name);
 
             // Run the indexer.
             await serviceClient.RunIndexerAsync(


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/39104

**Issue**: Service is changing the etag after create without any user updates. While creating an indexer, I've noticed that the ETag value in the raw response of the 'Create' method, `"@odata.etag": "\"0x8DBC5C85B77D900\""`, differs from the ETag value displayed in the portal, `"@odata.etag": "\"0x8DBC5C85E71024A\""`. Notably, the 'Get Indexer' method returns the same ETag value as the portal.

As a workaround, use the ETag value from GET right after Create or remove the `onlyIfUnchanged: true` parameter from the `CreateOrUpdateIndexerAsync` method while service is looking into this issue.

Tracking issue: https://msdata.visualstudio.com/Azure%20Search/_workitems/edit/2737454
