### PR TITLE
[WebPubSubClient] Parsing message returns IList

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
@@ -152,7 +152,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public override string Name { get { throw null; } }
         public override Azure.Messaging.WebPubSub.Clients.WebPubSubProtocolMessageType WebSocketMessageType { get { throw null; } }
         public override System.ReadOnlyMemory<byte> GetMessageBytes(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message) { throw null; }
-        public override Azure.Messaging.WebPubSub.Clients.WebPubSubMessage ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
+        public override System.Collections.Generic.IList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
         public override void WriteMessage(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message, System.Buffers.IBufferWriter<byte> output) { }
     }
     public partial class WebPubSubJsonReliableProtocol : Azure.Messaging.WebPubSub.Clients.WebPubSubProtocol
@@ -162,7 +162,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public override string Name { get { throw null; } }
         public override Azure.Messaging.WebPubSub.Clients.WebPubSubProtocolMessageType WebSocketMessageType { get { throw null; } }
         public override System.ReadOnlyMemory<byte> GetMessageBytes(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message) { throw null; }
-        public override Azure.Messaging.WebPubSub.Clients.WebPubSubMessage ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
+        public override System.Collections.Generic.IList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
         public override void WriteMessage(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message, System.Buffers.IBufferWriter<byte> output) { }
     }
     public abstract partial class WebPubSubMessage
@@ -176,7 +176,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public abstract string Name { get; }
         public abstract Azure.Messaging.WebPubSub.Clients.WebPubSubProtocolMessageType WebSocketMessageType { get; }
         public abstract System.ReadOnlyMemory<byte> GetMessageBytes(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message);
-        public abstract Azure.Messaging.WebPubSub.Clients.WebPubSubMessage ParseMessage(System.Buffers.ReadOnlySequence<byte> input);
+        public abstract System.Collections.Generic.IList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input);
         public abstract void WriteMessage(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message, System.Buffers.IBufferWriter<byte> output);
     }
     public enum WebPubSubProtocolMessageType

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
@@ -152,7 +152,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public override string Name { get { throw null; } }
         public override Azure.Messaging.WebPubSub.Clients.WebPubSubProtocolMessageType WebSocketMessageType { get { throw null; } }
         public override System.ReadOnlyMemory<byte> GetMessageBytes(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message) { throw null; }
-        public override System.Collections.Generic.IList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
+        public override System.Collections.Generic.IReadOnlyList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
         public override void WriteMessage(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message, System.Buffers.IBufferWriter<byte> output) { }
     }
     public partial class WebPubSubJsonReliableProtocol : Azure.Messaging.WebPubSub.Clients.WebPubSubProtocol
@@ -162,7 +162,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public override string Name { get { throw null; } }
         public override Azure.Messaging.WebPubSub.Clients.WebPubSubProtocolMessageType WebSocketMessageType { get { throw null; } }
         public override System.ReadOnlyMemory<byte> GetMessageBytes(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message) { throw null; }
-        public override System.Collections.Generic.IList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
+        public override System.Collections.Generic.IReadOnlyList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input) { throw null; }
         public override void WriteMessage(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message, System.Buffers.IBufferWriter<byte> output) { }
     }
     public abstract partial class WebPubSubMessage
@@ -176,7 +176,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public abstract string Name { get; }
         public abstract Azure.Messaging.WebPubSub.Clients.WebPubSubProtocolMessageType WebSocketMessageType { get; }
         public abstract System.ReadOnlyMemory<byte> GetMessageBytes(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message);
-        public abstract System.Collections.Generic.IList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input);
+        public abstract System.Collections.Generic.IReadOnlyList<Azure.Messaging.WebPubSub.Clients.WebPubSubMessage> ParseMessage(System.Buffers.ReadOnlySequence<byte> input);
         public abstract void WriteMessage(Azure.Messaging.WebPubSub.Clients.WebPubSubMessage message, System.Buffers.IBufferWriter<byte> output);
     }
     public enum WebPubSubProtocolMessageType

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocol.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocol.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         /// </summary>
         /// <param name="input">The serialized representation of the message.</param>
         /// <returns>A <see cref="WebPubSubMessage"/></returns>
-        public override IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
+        public override IReadOnlyList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
         {
             return _processor.ParseMessage(input);
         }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocol.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocol.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         /// </summary>
         /// <param name="input">The serialized representation of the message.</param>
         /// <returns>A <see cref="WebPubSubMessage"/></returns>
-        public override WebPubSubMessage ParseMessage(ReadOnlySequence<byte> input)
+        public override IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
         {
             return _processor.ParseMessage(input);
         }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
@@ -67,7 +67,7 @@ namespace Azure.Messaging.WebPubSub.Clients
             return new Memory<byte>(writer.ToArray());
         }
 
-        public virtual IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
+        public virtual IReadOnlyList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
         {
             try
             {

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
@@ -67,7 +67,7 @@ namespace Azure.Messaging.WebPubSub.Clients
             return new Memory<byte>(writer.ToArray());
         }
 
-        public virtual WebPubSubMessage ParseMessage(ReadOnlySequence<byte> input)
+        public virtual IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
         {
             try
             {
@@ -264,7 +264,7 @@ namespace Azure.Messaging.WebPubSub.Clients
                     case DownstreamEventType.Ack:
                         AssertNotNull(ackId, AckIdPropertyName);
                         AssertNotNull(success, SuccessPropertyName);
-                        return new AckMessage(ackId.Value, success.Value, errorDetail);
+                        return new List<WebPubSubMessage> { new AckMessage(ackId.Value, success.Value, errorDetail) };
 
                     case DownstreamEventType.Message:
                         AssertNotNull(from, FromPropertyName);
@@ -273,10 +273,10 @@ namespace Azure.Messaging.WebPubSub.Clients
                         switch (fromType)
                         {
                             case FromType.Server:
-                                return new ServerDataMessage(dataType, data, sequenceId);
+                                return new List<WebPubSubMessage> { new ServerDataMessage(dataType, data, sequenceId) };
                             case FromType.Group:
                                 AssertNotNull(group, GroupPropertyName);
-                                return new GroupDataMessage(group, dataType, data, sequenceId, fromUserId);
+                                return new List<WebPubSubMessage> { new GroupDataMessage(group, dataType, data, sequenceId, fromUserId) };
                             // Forward compatible
                             default:
                                 return null;
@@ -288,9 +288,9 @@ namespace Azure.Messaging.WebPubSub.Clients
                         switch (systemEventType)
                         {
                             case SystemEventType.Connected:
-                                return new ConnectedMessage(userId, connectionId, reconnectionToken);
+                                return new List<WebPubSubMessage> { new ConnectedMessage(userId, connectionId, reconnectionToken) };
                             case SystemEventType.Disconnected:
-                                return new DisconnectedMessage(message);
+                                return new List<WebPubSubMessage> { new DisconnectedMessage(message) };
                             // Forward compatible
                             default:
                                 return null;

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonReliableProtocol.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonReliableProtocol.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         /// </summary>
         /// <param name="input">The serialized representation of the message.</param>
         /// <returns>A <see cref="WebPubSubMessage"/></returns>
-        public override IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
+        public override IReadOnlyList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
         {
             return _processor.ParseMessage(input);
         }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonReliableProtocol.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonReliableProtocol.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         /// </summary>
         /// <param name="input">The serialized representation of the message.</param>
         /// <returns>A <see cref="WebPubSubMessage"/></returns>
-        public override WebPubSubMessage ParseMessage(ReadOnlySequence<byte> input)
+        public override IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input)
         {
             return _processor.ParseMessage(input);
         }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubProtocol.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubProtocol.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         /// </summary>
         /// <param name="input">The serialized representation of the message.</param>
         /// <returns>A <see cref="WebPubSubMessage"/></returns>
-        public abstract WebPubSubMessage ParseMessage(ReadOnlySequence<byte> input);
+        public abstract IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input);
 
         /// <summary>
         /// Writes the specified <see cref="WebPubSubMessage"/> to a writer.

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubProtocol.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubProtocol.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         /// </summary>
         /// <param name="input">The serialized representation of the message.</param>
         /// <returns>A <see cref="WebPubSubMessage"/></returns>
-        public abstract IList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input);
+        public abstract IReadOnlyList<WebPubSubMessage> ParseMessage(ReadOnlySequence<byte> input);
 
         /// <summary>
         /// Writes the specified <see cref="WebPubSubMessage"/> to a writer.

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
@@ -518,8 +518,10 @@ namespace Azure.Messaging.WebPubSub.Clients
                     {
                         try
                         {
-                            var message = _protocol.ParseMessage(result.Payload);
-                            await HandleMessageAsync(message, token).ConfigureAwait(false);
+                            foreach (var message in _protocol.ParseMessage(result.Payload))
+                            {
+                                await HandleMessageAsync(message, token).ConfigureAwait(false);
+                            }
                         }
                         catch (Exception ex)
                         {

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Protocols/JsonProtocolTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Protocols/JsonProtocolTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -152,7 +153,7 @@ namespace Azure.Messaging.WebPubSub.Client.Tests.Protocols
         {
             var protocol = new WebPubSubJsonProtocol();
             var resolvedMessage = protocol.ParseMessage(new ReadOnlySequence<byte>(payload));
-            messageAssert(resolvedMessage);
+            messageAssert(resolvedMessage[0]);
         }
 
         [TestCaseSource(nameof(GetSerializingTestData))]


### PR DESCRIPTION
# Contributing to the Azure SDK

Interface change: Return list of messages when parsing for possible further uses.

Now the protocol abstract class only be used by the library itself.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
