### PR TITLE
Use directive to set api-version as client for Resources_GetById

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/autorest.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/autorest.md
@@ -687,6 +687,10 @@ directive:
     where: $.definitions.ProviderExtendedLocation.properties.location
     transform: >
       $["x-ms-format"] = "azure-location"
+  - from: resources.json
+    where: $.paths["/{resourceId}"].get.parameters[?(@.name === "api-version")]
+    transform: >
+      delete $["x-ms-api-version"]
 ```
 
 ### Tag: package-management


### PR DESCRIPTION
Mitigate the generation change in https://github.com/Azure/azure-sdk-for-net/pull/39015/, verified in it.
Original change as below:
![image](https://github.com/Azure/azure-sdk-for-net/assets/5196139/c836571e-2f32-4d6c-a680-8b87e5f0da64)


