### PR TITLE
[Storage][DataMovement] Fix several issues with pause/resume

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.net6.0.cs
@@ -40,9 +40,9 @@ namespace Azure.Storage.DataMovement.Blobs
         public Azure.Storage.DataMovement.StorageResource FromContainer(string containerUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public delegate Azure.AzureSasCredential GetAzureSasCredential(string uri, bool readOnly);
-        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(string uri, bool readOnly);
-        public delegate Azure.Core.TokenCredential GetTokenCredential(string uri, bool readOnly);
+        public delegate Azure.AzureSasCredential GetAzureSasCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Core.TokenCredential GetTokenCredential(System.Uri uri, bool readOnly);
     }
     public partial class BlobStorageResourceContainerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/api/Azure.Storage.DataMovement.Blobs.netstandard2.0.cs
@@ -40,9 +40,9 @@ namespace Azure.Storage.DataMovement.Blobs
         public Azure.Storage.DataMovement.StorageResource FromContainer(string containerUri, Azure.Storage.DataMovement.Blobs.BlobStorageResourceContainerOptions options = null) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromDestinationAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected override System.Threading.Tasks.Task<Azure.Storage.DataMovement.StorageResource> FromSourceAsync(Azure.Storage.DataMovement.DataTransferProperties properties, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public delegate Azure.AzureSasCredential GetAzureSasCredential(string uri, bool readOnly);
-        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(string uri, bool readOnly);
-        public delegate Azure.Core.TokenCredential GetTokenCredential(string uri, bool readOnly);
+        public delegate Azure.AzureSasCredential GetAzureSasCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Storage.StorageSharedKeyCredential GetStorageSharedKeyCredential(System.Uri uri, bool readOnly);
+        public delegate Azure.Core.TokenCredential GetTokenCredential(System.Uri uri, bool readOnly);
     }
     public partial class BlobStorageResourceContainerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobsStorageResourceProvider.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlobsStorageResourceProvider.cs
@@ -24,7 +24,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <param name="readOnly">
         /// Whether the permission can be read-only.
         /// </param>
-        public delegate StorageSharedKeyCredential GetStorageSharedKeyCredential(string uri, bool readOnly);
+        public delegate StorageSharedKeyCredential GetStorageSharedKeyCredential(Uri uri, bool readOnly);
 
         /// <summary>
         /// Delegate for fetching a token credential for a given URI.
@@ -35,7 +35,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <param name="readOnly">
         /// Whether the permission can be read-only.
         /// </param>
-        public delegate TokenCredential GetTokenCredential(string uri, bool readOnly);
+        public delegate TokenCredential GetTokenCredential(Uri uri, bool readOnly);
 
         /// <summary>
         /// Delegate for fetching a SAS credential for a given URI.
@@ -46,7 +46,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <param name="readOnly">
         /// Whether the permission can be read-only.
         /// </param>
-        public delegate AzureSasCredential GetAzureSasCredential(string uri, bool readOnly);
+        public delegate AzureSasCredential GetAzureSasCredential(Uri uri, bool readOnly);
 
         private enum ResourceType
         {
@@ -74,7 +74,7 @@ namespace Azure.Storage.DataMovement.Blobs
         private readonly GetAzureSasCredential _getAzureSasCredential;
 
         /// <summary>
-        /// Default constrctor.
+        /// Default constructor.
         /// </summary>
         public BlobsStorageResourceProvider()
         {
@@ -235,7 +235,7 @@ namespace Azure.Storage.DataMovement.Blobs
             CancellationToken cancellationToken)
         {
             ResourceType type = GetType(getSource ? properties.SourceTypeId : properties.DestinationTypeId, properties.IsContainer);
-            string uri = getSource ? properties.SourcePath : properties.DestinationPath;
+            Uri uri = getSource ? properties.SourceUri : properties.DestinationUri;
             IBlobResourceRehydrator rehydrator = type switch
             {
                 ResourceType.BlockBlob => new BlockBlobResourceRehydrator(),
@@ -310,9 +310,9 @@ namespace Azure.Storage.DataMovement.Blobs
             BlobContainerClient client = _credentialType switch
             {
                 CredentialType.None => new BlobContainerClient(new Uri(containerUri)),
-                CredentialType.SharedKey => new BlobContainerClient(new Uri(containerUri), _getStorageSharedKeyCredential(containerUri, false)),
-                CredentialType.Token => new BlobContainerClient(new Uri(containerUri), _getTokenCredential(containerUri, false)),
-                CredentialType.Sas => new BlobContainerClient(new Uri(containerUri), _getAzureSasCredential(containerUri, false)),
+                CredentialType.SharedKey => new BlobContainerClient(new Uri(containerUri), _getStorageSharedKeyCredential(new Uri(containerUri), false)),
+                CredentialType.Token => new BlobContainerClient(new Uri(containerUri), _getTokenCredential(new Uri(containerUri), false)),
+                CredentialType.Sas => new BlobContainerClient(new Uri(containerUri), _getAzureSasCredential(new Uri(containerUri), false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };
             return new BlobStorageResourceContainer(client, options);
@@ -348,9 +348,9 @@ namespace Azure.Storage.DataMovement.Blobs
                 BlockBlobClient blockClient = _credentialType switch
                 {
                     CredentialType.None => new BlockBlobClient(new Uri(blobUri)),
-                    CredentialType.SharedKey => new BlockBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(blobUri, false)),
-                    CredentialType.Token => new BlockBlobClient(new Uri(blobUri), _getTokenCredential(blobUri, false)),
-                    CredentialType.Sas => new BlockBlobClient(new Uri(blobUri), _getAzureSasCredential(blobUri, false)),
+                    CredentialType.SharedKey => new BlockBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
+                    CredentialType.Token => new BlockBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
+                    CredentialType.Sas => new BlockBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
                     _ => throw BadCredentialTypeException(_credentialType),
                 };
                 return new BlockBlobStorageResource(blockClient, options as BlockBlobStorageResourceOptions);
@@ -360,9 +360,9 @@ namespace Azure.Storage.DataMovement.Blobs
                 PageBlobClient pageClient = _credentialType switch
                 {
                     CredentialType.None => new PageBlobClient(new Uri(blobUri)),
-                    CredentialType.SharedKey => new PageBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(blobUri, false)),
-                    CredentialType.Token => new PageBlobClient(new Uri(blobUri), _getTokenCredential(blobUri, false)),
-                    CredentialType.Sas => new PageBlobClient(new Uri(blobUri), _getAzureSasCredential(blobUri, false)),
+                    CredentialType.SharedKey => new PageBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
+                    CredentialType.Token => new PageBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
+                    CredentialType.Sas => new PageBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
                     _ => throw BadCredentialTypeException(_credentialType),
                 };
                 return new PageBlobStorageResource(pageClient, options as PageBlobStorageResourceOptions);
@@ -372,9 +372,9 @@ namespace Azure.Storage.DataMovement.Blobs
                 AppendBlobClient appendClient = _credentialType switch
                 {
                     CredentialType.None => new AppendBlobClient(new Uri(blobUri)),
-                    CredentialType.SharedKey => new AppendBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(blobUri, false)),
-                    CredentialType.Token => new AppendBlobClient(new Uri(blobUri), _getTokenCredential(blobUri, false)),
-                    CredentialType.Sas => new AppendBlobClient(new Uri(blobUri), _getAzureSasCredential(blobUri, false)),
+                    CredentialType.SharedKey => new AppendBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
+                    CredentialType.Token => new AppendBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
+                    CredentialType.Sas => new AppendBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
                     _ => throw BadCredentialTypeException(_credentialType),
                 };
                 return new AppendBlobStorageResource(appendClient, options as AppendBlobStorageResourceOptions);
@@ -382,9 +382,9 @@ namespace Azure.Storage.DataMovement.Blobs
             BlockBlobClient client = _credentialType switch
             {
                 CredentialType.None => new BlockBlobClient(new Uri(blobUri)),
-                CredentialType.SharedKey => new BlockBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(blobUri, false)),
-                CredentialType.Token => new BlockBlobClient(new Uri(blobUri), _getTokenCredential(blobUri, false)),
-                CredentialType.Sas => new BlockBlobClient(new Uri(blobUri), _getAzureSasCredential(blobUri, false)),
+                CredentialType.SharedKey => new BlockBlobClient(new Uri(blobUri), _getStorageSharedKeyCredential(new Uri(blobUri), false)),
+                CredentialType.Token => new BlockBlobClient(new Uri(blobUri), _getTokenCredential(new Uri(blobUri), false)),
+                CredentialType.Sas => new BlockBlobClient(new Uri(blobUri), _getAzureSasCredential(new Uri(blobUri), false)),
                 _ => throw BadCredentialTypeException(_credentialType),
             };
             return new BlockBlobStorageResource(client, options as BlockBlobStorageResourceOptions);
@@ -514,13 +514,14 @@ namespace Azure.Storage.DataMovement.Blobs
                     cancellationToken).ConfigureAwait(false);
             }
 
-            private string GetPath(DataTransferProperties properties, bool getSource)
-                => getSource ? properties.SourcePath : properties.DestinationPath;
+            private Uri GetUri(DataTransferProperties properties, bool getSource)
+                => getSource ? properties.SourceUri : properties.DestinationUri;
+
             private string GetPrefix(DataTransferProperties properties, bool getSource)
-                => new BlobUriBuilder(new Uri(GetPath(properties, getSource))).BlobName;
+                => new BlobUriBuilder(GetUri(properties, getSource)).BlobName;
 
             private Uri GetContainerUri(DataTransferProperties properties, bool getSource)
-                => new BlobUriBuilder(new Uri(GetPath(properties, getSource)))
+                => new BlobUriBuilder(GetUri(properties, getSource))
                 {
                     BlobName = ""
                 }.ToUri();
@@ -577,15 +578,15 @@ namespace Azure.Storage.DataMovement.Blobs
                     cancellationToken).ConfigureAwait(false);
             }
 
-            private string GetPath(DataTransferProperties properties, bool getSource)
-                => getSource ? properties.SourcePath : properties.DestinationPath;
+            private Uri GetUri(DataTransferProperties properties, bool getSource)
+                => getSource ? properties.SourceUri : properties.DestinationUri;
 
             public async Task<StorageResource> RehydrateAsync(
                 DataTransferProperties properties,
                 bool isSource,
                 CancellationToken cancellationToken)
                 => new BlockBlobStorageResource(
-                    new BlockBlobClient(new Uri(GetPath(properties, isSource))),
+                    new BlockBlobClient(GetUri(properties, isSource)),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -594,7 +595,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 StorageSharedKeyCredential credential,
                 CancellationToken cancellationToken)
                 => new BlockBlobStorageResource(
-                    new BlockBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new BlockBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -603,7 +604,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 TokenCredential credential,
                 CancellationToken cancellationToken)
                 => new BlockBlobStorageResource(
-                    new BlockBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new BlockBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -612,7 +613,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 AzureSasCredential credential,
                 CancellationToken cancellationToken)
                 => new BlockBlobStorageResource(
-                    new BlockBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new BlockBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
         }
 
@@ -632,15 +633,15 @@ namespace Azure.Storage.DataMovement.Blobs
                     cancellationToken).ConfigureAwait(false);
             }
 
-            private string GetPath(DataTransferProperties properties, bool getSource)
-                => getSource ? properties.SourcePath : properties.DestinationPath;
+            private Uri GetUri(DataTransferProperties properties, bool getSource)
+                => getSource ? properties.SourceUri : properties.DestinationUri;
 
             public async Task<StorageResource> RehydrateAsync(
                 DataTransferProperties properties,
                 bool isSource,
                 CancellationToken cancellationToken)
                 => new PageBlobStorageResource(
-                    new PageBlobClient(new Uri(GetPath(properties, isSource))),
+                    new PageBlobClient(GetUri(properties, isSource)),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -649,7 +650,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 StorageSharedKeyCredential credential,
                 CancellationToken cancellationToken)
                 => new PageBlobStorageResource(
-                    new PageBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new PageBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -658,7 +659,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 TokenCredential credential,
                 CancellationToken cancellationToken)
                 => new PageBlobStorageResource(
-                    new PageBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new PageBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -667,7 +668,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 AzureSasCredential credential,
                 CancellationToken cancellationToken)
                 => new PageBlobStorageResource(
-                    new PageBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new PageBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
         }
 
@@ -687,15 +688,15 @@ namespace Azure.Storage.DataMovement.Blobs
                     cancellationToken).ConfigureAwait(false));
             }
 
-            private string GetPath(DataTransferProperties properties, bool getSource)
-                => getSource ? properties.SourcePath : properties.DestinationPath;
+            private Uri GetUri(DataTransferProperties properties, bool getSource)
+                => getSource ? properties.SourceUri : properties.DestinationUri;
 
             public async Task<StorageResource> RehydrateAsync(
                 DataTransferProperties properties,
                 bool isSource,
                 CancellationToken cancellationToken)
                 => new AppendBlobStorageResource(
-                    new AppendBlobClient(new Uri(GetPath(properties, isSource))),
+                    new AppendBlobClient(GetUri(properties, isSource)),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -704,7 +705,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 StorageSharedKeyCredential credential,
                 CancellationToken cancellationToken)
                 => new AppendBlobStorageResource(
-                    new AppendBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new AppendBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -713,7 +714,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 TokenCredential credential,
                 CancellationToken cancellationToken)
                 => new AppendBlobStorageResource(
-                    new AppendBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new AppendBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
 
             public async Task<StorageResource> RehydrateAsync(
@@ -722,7 +723,7 @@ namespace Azure.Storage.DataMovement.Blobs
                 AzureSasCredential credential,
                 CancellationToken cancellationToken)
                 => new AppendBlobStorageResource(
-                    new AppendBlobClient(new Uri(GetPath(properties, isSource)), credential),
+                    new AppendBlobClient(GetUri(properties, isSource), credential),
                     await GetOptionsAsync(properties, isSource, cancellationToken).ConfigureAwait(false));
         }
         #endregion

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/RehydrateBlobResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/RehydrateBlobResourceTests.cs
@@ -36,7 +36,6 @@ namespace Azure.Storage.DataMovement.Tests
                 StorageResourceType.BlockBlob => "BlockBlob",
                 StorageResourceType.PageBlob => "PageBlob",
                 StorageResourceType.AppendBlob => "AppendBlob",
-                StorageResourceType.Local => "LocalFile",
                 _ => throw new NotImplementedException(),
             };
         }
@@ -48,7 +47,6 @@ namespace Azure.Storage.DataMovement.Tests
                 StorageResourceType.BlockBlob => "blob",
                 StorageResourceType.PageBlob => "blob",
                 StorageResourceType.AppendBlob => "blob",
-                StorageResourceType.Local => "local",
                 _ => throw new NotImplementedException(),
             };
         }
@@ -67,8 +65,8 @@ namespace Azure.Storage.DataMovement.Tests
             var mock = new Mock<DataTransferProperties>(MockBehavior.Strict);
             mock.Setup(p => p.TransferId).Returns(transferId);
             mock.Setup(p => p.Checkpointer).Returns(new TransferCheckpointStoreOptions(checkpointerPath));
-            mock.Setup(p => p.SourcePath).Returns(sourcePath);
-            mock.Setup(p => p.DestinationPath).Returns(destinationPath);
+            mock.Setup(p => p.SourceUri).Returns(new Uri(sourcePath));
+            mock.Setup(p => p.DestinationUri).Returns(new Uri(destinationPath));
             mock.Setup(p => p.SourceTypeId).Returns(sourceResourceId);
             mock.Setup(p => p.DestinationTypeId).Returns(destinationResourceId);
             mock.Setup(p => p.SourceProviderId).Returns(sourceProviderId);
@@ -167,8 +165,8 @@ namespace Azure.Storage.DataMovement.Tests
             string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
             string originalPath = isSource ? sourcePath : destinationPath;
 
-            StorageResourceType sourceType = !isSource ? StorageResourceType.Local : StorageResourceType.BlockBlob;
-            StorageResourceType destinationType = isSource ? StorageResourceType.Local : StorageResourceType.BlockBlob;
+            StorageResourceType sourceType = StorageResourceType.BlockBlob;
+            StorageResourceType destinationType = StorageResourceType.BlockBlob;
 
             DataTransferProperties transferProperties = GetProperties(
                 test.DirectoryPath,
@@ -206,7 +204,7 @@ namespace Azure.Storage.DataMovement.Tests
             string sourcePath = "https://storageaccount.blob.core.windows.net/container/blobsource";
             string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
 
-            StorageResourceType sourceType = StorageResourceType.Local;
+            StorageResourceType sourceType = StorageResourceType.BlockBlob;
             StorageResourceType destinationType = StorageResourceType.BlockBlob;
 
             DataTransferProperties transferProperties = GetProperties(
@@ -262,8 +260,8 @@ namespace Azure.Storage.DataMovement.Tests
             string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
             string originalPath = isSource ? sourcePath : destinationPath;
 
-            StorageResourceType sourceType = !isSource ? StorageResourceType.Local : StorageResourceType.PageBlob;
-            StorageResourceType destinationType = isSource ? StorageResourceType.Local : StorageResourceType.PageBlob;
+            StorageResourceType sourceType = StorageResourceType.PageBlob;
+            StorageResourceType destinationType = StorageResourceType.PageBlob;
 
             DataTransferProperties transferProperties = GetProperties(
                 test.DirectoryPath,
@@ -301,7 +299,7 @@ namespace Azure.Storage.DataMovement.Tests
             string sourcePath = "https://storageaccount.blob.core.windows.net/container/blobsource";
             string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
 
-            StorageResourceType sourceType = StorageResourceType.Local;
+            StorageResourceType sourceType = StorageResourceType.PageBlob;
             StorageResourceType destinationType = StorageResourceType.PageBlob;
 
             DataTransferProperties transferProperties = GetProperties(
@@ -357,8 +355,8 @@ namespace Azure.Storage.DataMovement.Tests
             string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
             string originalPath = isSource ? sourcePath : destinationPath;
 
-            StorageResourceType sourceType = !isSource ? StorageResourceType.Local : StorageResourceType.AppendBlob;
-            StorageResourceType destinationType = isSource ? StorageResourceType.Local : StorageResourceType.AppendBlob;
+            StorageResourceType sourceType = StorageResourceType.AppendBlob;
+            StorageResourceType destinationType = StorageResourceType.AppendBlob;
 
             DataTransferProperties transferProperties = GetProperties(
                 test.DirectoryPath,
@@ -396,7 +394,7 @@ namespace Azure.Storage.DataMovement.Tests
             string sourcePath = "https://storageaccount.blob.core.windows.net/container/blobsource";
             string destinationPath = "https://storageaccount.blob.core.windows.net/container/blobdest";
 
-            StorageResourceType sourceType = StorageResourceType.Local;
+            StorageResourceType sourceType = StorageResourceType.AppendBlob;
             StorageResourceType destinationType = StorageResourceType.AppendBlob;
 
             DataTransferProperties transferProperties = GetProperties(
@@ -459,8 +457,8 @@ namespace Azure.Storage.DataMovement.Tests
                 destinationPaths.Add(string.Join("/", destinationParentPath, childPath));
             }
 
-            StorageResourceType sourceType = !isSource ? StorageResourceType.Local : StorageResourceType.BlockBlob;
-            StorageResourceType destinationType = isSource ? StorageResourceType.Local : StorageResourceType.BlockBlob;
+            StorageResourceType sourceType = StorageResourceType.BlockBlob;
+            StorageResourceType destinationType = StorageResourceType.BlockBlob;
 
             string originalPath = isSource ? sourceParentPath : destinationParentPath;
 

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -63,13 +63,13 @@ namespace Azure.Storage.DataMovement
     {
         protected internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.TransferCheckpointStoreOptions Checkpointer { get { throw null; } }
-        public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationProviderId { get { throw null; } }
         public virtual string DestinationTypeId { get { throw null; } }
+        public virtual System.Uri DestinationUri { get { throw null; } }
         public virtual bool IsContainer { get { throw null; } }
-        public virtual string SourcePath { get { throw null; } }
         public virtual string SourceProviderId { get { throw null; } }
         public virtual string SourceTypeId { get { throw null; } }
+        public virtual System.Uri SourceUri { get { throw null; } }
         public virtual string TransferId { get { throw null; } }
     }
     public enum DataTransferState

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -63,13 +63,13 @@ namespace Azure.Storage.DataMovement
     {
         protected internal DataTransferProperties() { }
         public virtual Azure.Storage.DataMovement.TransferCheckpointStoreOptions Checkpointer { get { throw null; } }
-        public virtual string DestinationPath { get { throw null; } }
         public virtual string DestinationProviderId { get { throw null; } }
         public virtual string DestinationTypeId { get { throw null; } }
+        public virtual System.Uri DestinationUri { get { throw null; } }
         public virtual bool IsContainer { get { throw null; } }
-        public virtual string SourcePath { get { throw null; } }
         public virtual string SourceProviderId { get { throw null; } }
         public virtual string SourceTypeId { get { throw null; } }
+        public virtual System.Uri SourceUri { get { throw null; } }
         public virtual string TransferId { get { throw null; } }
     }
     public enum DataTransferState

--- a/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CheckpointerExtensions.cs
@@ -65,10 +65,10 @@ namespace Azure.Storage.DataMovement
             {
                 TransferId = transferId,
                 SourceTypeId = sourceResourceId,
-                SourcePath = header.ParentSourcePath,
+                SourceUri = new Uri(header.ParentSourcePath),
                 SourceProviderId = header.SourceProviderId,
                 DestinationTypeId = destResourceId,
-                DestinationPath = header.ParentDestinationPath,
+                DestinationUri = new Uri(header.ParentDestinationPath),
                 DestinationProviderId = header.DestinationProviderId,
                 IsContainer = isContainer,
             };
@@ -77,7 +77,7 @@ namespace Azure.Storage.DataMovement
         internal static async Task<bool> IsEnumerationCompleteAsync(
             this TransferCheckpointer checkpointer,
             string transferId,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             using (Stream stream = await checkpointer.ReadJobPlanFileAsync(
                 transferId,
@@ -92,7 +92,7 @@ namespace Azure.Storage.DataMovement
         internal static async Task OnEnumerationCompleteAsync(
             this TransferCheckpointer checkpointer,
             string transferId,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             byte[] enumerationComplete = { Convert.ToByte(true) };
             await checkpointer.WriteToJobPlanFileAsync(

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferProperties.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferProperties.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Azure.Storage.DataMovement
 {
     /// <summary>
@@ -24,9 +26,9 @@ namespace Azure.Storage.DataMovement
         public virtual string SourceTypeId { get; internal set; }
 
         /// <summary>
-        /// Contains the Source path of the Storage Resource.
+        /// Contains the Source uri of the Storage Resource.
         /// </summary>
-        public virtual string SourcePath { get; internal set; }
+        public virtual Uri SourceUri { get; internal set; }
 
         /// <summary>
         /// A string ID for the source resource provider that should be used for rehydration.
@@ -39,9 +41,9 @@ namespace Azure.Storage.DataMovement
         public virtual string DestinationTypeId { get; internal set; }
 
         /// <summary>
-        /// Contains the Destination path of the Storage Resource.
+        /// Contains the Destination uri of the Storage Resource.
         /// </summary>
-        public virtual string DestinationPath { get; internal set; }
+        public virtual Uri DestinationUri { get; internal set; }
 
         /// <summary>
         /// A string ID for the destination resource provider that should be used for rehydration.

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalDirectoryStorageResourceContainer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalDirectoryStorageResourceContainer.cs
@@ -38,6 +38,17 @@ namespace Azure.Storage.DataMovement
         }
 
         /// <summary>
+        /// Internal Constructor for uri
+        /// </summary>
+        /// <param name="uri"></param>
+        internal LocalDirectoryStorageResourceContainer(Uri uri)
+        {
+            Argument.AssertNotNull(uri, nameof(uri));
+            Argument.AssertNotNullOrWhiteSpace(uri.AbsoluteUri, nameof(uri));
+            _uri = uri;
+        }
+
+        /// <summary>
         /// Gets the storage Resource
         /// </summary>
         /// <param name="childPath"></param>

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
@@ -57,11 +57,12 @@ namespace Azure.Storage.DataMovement
         }
 
         /// <summary>
-        /// Intenral Constructor for uri
+        /// Internal Constructor for uri
         /// </summary>
         /// <param name="uri"></param>
         internal LocalFileStorageResource(Uri uri)
         {
+            Argument.AssertNotNull(uri, nameof(uri));
             Argument.AssertNotNullOrWhiteSpace(uri.AbsoluteUri, nameof(uri));
             _uri = uri;
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFilesStorageResourceProvider.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFilesStorageResourceProvider.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -34,10 +34,10 @@ namespace Azure.Storage.DataMovement
         private StorageResource FromTransferProperties(DataTransferProperties properties, bool getSource)
         {
             Argument.AssertNotNull(properties, nameof(properties));
-            string storedPath = getSource ? properties.SourcePath : properties.DestinationPath;
+            Uri storedUri = getSource ? properties.SourceUri : properties.DestinationUri;
             return properties.IsContainer
-                ? new LocalDirectoryStorageResourceContainer(storedPath)
-                : new LocalFileStorageResource(storedPath);
+                ? new LocalDirectoryStorageResourceContainer(storedUri)
+                : new LocalFileStorageResource(storedUri);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceTransferJob.cs
@@ -113,7 +113,7 @@ namespace Azure.Storage.DataMovement
                     }
                 }
 
-                if (await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
+                if (!await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
                 {
                     await foreach (JobPartInternal jobPartInternal in GetStorageResourcesAsync().ConfigureAwait(false))
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
@@ -205,16 +205,8 @@ namespace Azure.Storage.DataMovement
                 preserveLastModifiedTime: false, // TODO: update when supported
                 checksumVerificationOption: 0); // TODO: update when supported
 
-            // Create the source Path
-            // Remove any query or SAS that could be attach to the Uri
-            UriBuilder sourceUriBuilder = new UriBuilder(jobPart._sourceResource.Uri.AbsoluteUri);
-            sourceUriBuilder.Query = "";
-            string sourcePath = sourceUriBuilder.Uri.AbsoluteUri;
-
-            // Remove any query or SAS that could be attach to the Uri
-            UriBuilder destinationUriBuilder = new UriBuilder(jobPart._destinationResource.Uri.AbsoluteUri);
-            destinationUriBuilder.Query = "";
-            string destinationPath = destinationUriBuilder.Uri.AbsoluteUri;
+            string sourcePath = jobPart._sourceResource.Uri.ToSanitizedString();
+            string destinationPath = jobPart._destinationResource.Uri.ToSanitizedString();
 
             return new JobPartPlanHeader(
                 version: DataMovementConstants.JobPartPlanFile.SchemaVersion,

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/JobPlanExtensions.cs
@@ -285,5 +285,14 @@ namespace Azure.Storage.DataMovement
             // Write the length
             writer.Write(bytes.Length);
         }
+
+        internal static string ToSanitizedString(this Uri uri)
+        {
+            UriBuilder builder = new(uri);
+
+            // Remove any query parameters (including SAS)
+            builder.Query = string.Empty;
+            return builder.Uri.AbsoluteUri;
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/LocalTransferCheckpointer.cs
@@ -76,8 +76,8 @@ namespace Azure.Storage.DataMovement
                 destination.ProviderId,
                 false, /* enumerationComplete */
                 new DataTransferStatusInternal(),
-                source.Uri.AbsoluteUri,
-                destination.Uri.AbsoluteUri);
+                source.Uri.ToSanitizedString(),
+                destination.Uri.ToSanitizedString());
 
             using (Stream headerStream = new MemoryStream())
             {

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriTransferJob.cs
@@ -111,7 +111,7 @@ namespace Azure.Storage.DataMovement
                     }
                 }
 
-                if (await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
+                if (!await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
                 {
                     await foreach (JobPartInternal jobPartInternal in GetStorageResourcesAsync().ConfigureAwait(false))
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -405,16 +405,8 @@ namespace Azure.Storage.DataMovement
 
         internal async Task OnEnumerationComplete()
         {
-            try
-            {
-                await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                await InvokeFailedArgAsync(ex).ConfigureAwait(false);
-                return;
-            }
             _enumerationComplete = true;
+            await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id).ConfigureAwait(false);
 
             // If there were no job parts enumerated and we haven't already aborted/completed the job.
             if (_jobParts.Count == 0 &&

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
@@ -111,7 +111,7 @@ namespace Azure.Storage.DataMovement
                     }
                 }
 
-                if (await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
+                if (!await _checkpointer.IsEnumerationCompleteAsync(_dataTransfer.Id, _cancellationToken).ConfigureAwait(false))
                 {
                     await foreach (JobPartInternal jobPartInternal in GetStorageResourcesAsync().ConfigureAwait(false))
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/GetTransfersTests.cs
@@ -234,20 +234,20 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            string parentRemotePath = "https://account.blob.core.windows.net/resume-test/";
-            string parentLocalPath1 = "/resume-test/";
-            string parentLocalPath2 = @"C:\Windows\Path\";
+            Uri parentRemoteUri = new("https://account.blob.core.windows.net/resume-test/");
+            Uri parentLocalUri1 = new("file://resume-test/");
+            Uri parentLocalUri2 = new(@"file:///C:\Windows\Path\");
 
             LocalTransferCheckpointerFactory factory = new LocalTransferCheckpointerFactory(test.DirectoryPath);
 
             // Build expected results first to use to populate checkpointer
             DataTransferProperties[] expectedResults = new DataTransferProperties[]
             {
-                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "local", SourceTypeId = "LocalFile", SourcePath = parentLocalPath1 + "file1", DestinationProviderId = "blob", DestinationTypeId = "BlockBlob", DestinationPath = parentRemotePath + "file1", IsContainer = false },
-                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "blob", SourceTypeId = "BlockBlob", SourcePath = parentRemotePath + "file2/", DestinationProviderId = "local", DestinationTypeId = "LocalFile", DestinationPath = parentLocalPath1 + "file2/", IsContainer = false },
-                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "blob", SourceTypeId = "BlockBlob", SourcePath = parentRemotePath + "file3", DestinationProviderId = "blob", DestinationTypeId = "BlockBlob", DestinationPath = parentRemotePath + "file3", IsContainer = false },
-                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "blob", SourceTypeId = "BlockBlob", SourcePath = parentRemotePath, DestinationProviderId = "local", DestinationTypeId = "LocalFile", DestinationPath = parentLocalPath1, IsContainer = true },
-                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "local", SourceTypeId = "LocalFile", SourcePath = parentLocalPath2, DestinationProviderId = "blob", DestinationTypeId = "AppendBlob", DestinationPath = parentRemotePath, IsContainer = true },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "local", SourceTypeId = "LocalFile", SourceUri = new Uri(parentLocalUri1, "file1"), DestinationProviderId = "blob", DestinationTypeId = "BlockBlob", DestinationUri = new Uri(parentRemoteUri, "file1"), IsContainer = false },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "blob", SourceTypeId = "BlockBlob", SourceUri = new Uri(parentRemoteUri, "file2/"), DestinationProviderId = "local", DestinationTypeId = "LocalFile", DestinationUri = new Uri(parentLocalUri1, "file2/"), IsContainer = false },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "blob", SourceTypeId = "BlockBlob", SourceUri = new Uri(parentRemoteUri, "file3"), DestinationProviderId = "blob", DestinationTypeId = "BlockBlob", DestinationUri = new Uri(parentRemoteUri, "file3"), IsContainer = false },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "blob", SourceTypeId = "BlockBlob", SourceUri = parentRemoteUri, DestinationProviderId = "local", DestinationTypeId = "LocalFile", DestinationUri = parentLocalUri1, IsContainer = true },
+                new DataTransferProperties { TransferId = Guid.NewGuid().ToString(), SourceProviderId = "local", SourceTypeId = "LocalFile", SourceUri = parentLocalUri2, DestinationProviderId = "blob", DestinationTypeId = "AppendBlob", DestinationUri = parentRemoteUri, IsContainer = true },
             };
 
             // Add a transfer for each expected result
@@ -319,8 +319,8 @@ namespace Azure.Storage.DataMovement.Tests
             factory.CreateStubJobPlanFile(
                 checkpointerPath,
                 properties.TransferId,
-                parentSourcePath: properties.SourcePath,
-                parentDestinationPath: properties.DestinationPath,
+                parentSourcePath: properties.SourceUri.AbsoluteUri,
+                parentDestinationPath: properties.DestinationUri.AbsoluteUri,
                 sourceProviderId: properties.SourceProviderId,
                 destinationProviderId: properties.DestinationProviderId);
 
@@ -334,13 +334,13 @@ namespace Azure.Storage.DataMovement.Tests
                     // Put extra slash on end of last part for testing
                     if (i == numParts - 1)
                     {
-                        sourcePaths.Add(properties.SourcePath + $"file{i}/");
-                        destinationPaths.Add(properties.DestinationPath + $"file{i}/");
+                        sourcePaths.Add(properties.SourceUri + $"file{i}/");
+                        destinationPaths.Add(properties.DestinationUri + $"file{i}/");
                         continue;
                     }
 
-                    sourcePaths.Add(properties.SourcePath + $"file{i}");
-                    destinationPaths.Add(properties.DestinationPath + $"file{i}");
+                    sourcePaths.Add(properties.SourceUri + $"file{i}");
+                    destinationPaths.Add(properties.DestinationUri + $"file{i}");
                 }
 
                 factory.CreateStubJobPartPlanFilesAsync(
@@ -360,8 +360,8 @@ namespace Azure.Storage.DataMovement.Tests
                     properties.TransferId,
                     1, /* jobPartCount */
                     InProgressStatus,
-                    new List<string> { properties.SourcePath },
-                    new List<string> { properties.DestinationPath },
+                    new List<string> { properties.SourceUri.AbsoluteUri },
+                    new List<string> { properties.DestinationUri.AbsoluteUri },
                     sourceResourceId: properties.SourceTypeId,
                     destinationResourceId: properties.DestinationTypeId);
             }
@@ -372,10 +372,10 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(expected.TransferId, actual.TransferId);
             Assert.AreEqual(expected.SourceProviderId, actual.SourceProviderId);
             Assert.AreEqual(expected.SourceTypeId, actual.SourceTypeId);
-            Assert.AreEqual(expected.SourcePath.TrimEnd('\\', '/'), actual.SourcePath.TrimEnd('\\', '/'));
+            Assert.AreEqual(expected.SourceUri.AbsoluteUri.TrimEnd('\\', '/'), actual.SourceUri.AbsoluteUri.TrimEnd('\\', '/'));
             Assert.AreEqual(expected.DestinationProviderId, actual.DestinationProviderId);
             Assert.AreEqual(expected.DestinationTypeId, actual.DestinationTypeId);
-            Assert.AreEqual(expected.DestinationPath.TrimEnd('\\', '/'), actual.DestinationPath.TrimEnd('\\', '/'));
+            Assert.AreEqual(expected.DestinationUri.AbsoluteUri.TrimEnd('\\', '/'), actual.DestinationUri.AbsoluteUri.TrimEnd('\\', '/'));
             Assert.AreEqual(expected.IsContainer, actual.IsContainer);
         }
     }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalDirectoryStorageResourceTests.cs
@@ -32,6 +32,7 @@ namespace Azure.Storage.DataMovement.Tests
 
                 // Assert
                 Assert.AreEqual(path, storageResource.Uri.LocalPath);
+                Assert.AreEqual(Uri.UriSchemeFile, storageResource.Uri.Scheme);
             }
         }
 
@@ -45,7 +46,10 @@ namespace Azure.Storage.DataMovement.Tests
                 new LocalDirectoryStorageResourceContainer("   "));
 
             Assert.Catch<ArgumentException>(() =>
-                new LocalDirectoryStorageResourceContainer(default));
+                new LocalDirectoryStorageResourceContainer(path: default));
+
+            Assert.Catch<ArgumentException>(() =>
+                new LocalDirectoryStorageResourceContainer(uri: default));
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalFileStorageResourceTests.cs
@@ -69,6 +69,7 @@ namespace Azure.Storage.DataMovement.Tests
 
                 // Assert
                 Assert.AreEqual(path, storageResource.Uri.LocalPath);
+                Assert.AreEqual(Uri.UriSchemeFile, storageResource.Uri.Scheme);
             }
         }
 
@@ -82,7 +83,10 @@ namespace Azure.Storage.DataMovement.Tests
                 new LocalFileStorageResource("   "));
 
             Assert.Catch<ArgumentException>(() =>
-                new LocalFileStorageResource((string)default));
+                new LocalFileStorageResource(path: default));
+
+            Assert.Catch<ArgumentException>(() =>
+                new LocalFileStorageResource(uri: default));
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -63,8 +63,8 @@ namespace Azure.Storage.DataMovement.Tests
 
         private async Task AssertSourceAndDestinationAsync(
             TransferDirection transferType,
-            StorageResourceItem sourceResource,
-            StorageResourceItem destinationResource,
+            StorageResource sourceResource,
+            StorageResource destinationResource,
             BlobContainerClient sourceContainer,
             BlobContainerClient destinationContainer)
         {
@@ -97,9 +97,10 @@ namespace Azure.Storage.DataMovement.Tests
             }
         }
 
-        private async Task<LocalFileStorageResource> CreateLocalFileSourceResourceAsync(
+        private async Task<StorageResource> CreateLocalFileSourceResourceAsync(
             long size,
-            string directory)
+            string directory,
+            LocalFilesStorageResourceProvider provider)
         {
             string localSourceFile = await CreateRandomFileAsync(directory);
             // create a new file and copy contents of stream into it, and then close the FileStream
@@ -109,13 +110,14 @@ namespace Azure.Storage.DataMovement.Tests
             {
                 await originalStream.CopyToAsync(fileStream);
             }
-            return new LocalFileStorageResource(localSourceFile);
+            return provider.FromFile(localSourceFile);
         }
 
-        private async Task<BlockBlobStorageResource> CreateBlobSourceResourceAsync(
+        private async Task<StorageResource> CreateBlobSourceResourceAsync(
             long size,
             string blobName,
             BlobContainerClient container,
+            BlobsStorageResourceProvider provider,
             BlockBlobStorageResourceOptions options = default)
         {
             BlockBlobClient blobClient = container.GetBlockBlobClient(blobName);
@@ -128,52 +130,55 @@ namespace Azure.Storage.DataMovement.Tests
                 originalStream.Position = 0;
                 await blobClient.UploadAsync(originalStream);
             }
-            return new BlockBlobStorageResource(blobClient, options);
+            return provider.FromClient(blobClient, options);
         }
 
-        private BlockBlobStorageResource CreateBlobDestinationResource(
+        private StorageResource CreateBlobDestinationResource(
             BlobContainerClient container,
+            BlobsStorageResourceProvider provider,
             string blobName = default,
             BlockBlobStorageResourceOptions options = default)
         {
             blobName ??= GetNewBlobName();
             BlockBlobClient destinationClient = container.GetBlockBlobClient(blobName);
-            return new BlockBlobStorageResource(destinationClient, options);
+            return provider.FromClient(destinationClient, options);
         }
 
-        private async Task<(StorageResourceItem SourceResource, StorageResourceItem DestinationResource)> CreateStorageResourcesAsync(
+        private async Task<(StorageResource SourceResource, StorageResource DestinationResource)> CreateStorageResourcesAsync(
             TransferDirection transferType,
             long size,
             string localDirectory,
             BlobContainerClient sourceContainer,
             BlobContainerClient destinationContainer,
+            BlobsStorageResourceProvider blobProvider,
+            LocalFilesStorageResourceProvider localProvider,
             string storagePath = default)
         {
             storagePath ??= GetNewBlobName();
 
-            StorageResourceItem SourceResource = default;
-            StorageResourceItem DestinationResource = default;
+            StorageResource SourceResource = default;
+            StorageResource DestinationResource = default;
             if (transferType == TransferDirection.Download)
             {
                 Argument.AssertNotNull(sourceContainer, nameof(sourceContainer));
                 Argument.AssertNotNullOrEmpty(localDirectory, nameof(localDirectory));
-                SourceResource ??= await CreateBlobSourceResourceAsync(size, storagePath, sourceContainer);
-                DestinationResource ??= new LocalFileStorageResource(Path.Combine(localDirectory, storagePath));
+                SourceResource ??= await CreateBlobSourceResourceAsync(size, storagePath, sourceContainer, blobProvider);
+                DestinationResource ??= localProvider.FromFile(Path.Combine(localDirectory, storagePath));
             }
             else if (transferType == TransferDirection.Copy)
             {
                 Argument.AssertNotNull(sourceContainer, nameof(sourceContainer));
                 Argument.AssertNotNull(destinationContainer, nameof(destinationContainer));
-                SourceResource ??= await CreateBlobSourceResourceAsync(size, storagePath, sourceContainer);
-                DestinationResource ??= CreateBlobDestinationResource(destinationContainer, storagePath);
+                SourceResource ??= await CreateBlobSourceResourceAsync(size, storagePath, sourceContainer, blobProvider);
+                DestinationResource ??= CreateBlobDestinationResource(destinationContainer, blobProvider, storagePath);
             }
             else
             {
                 // Default to Upload
                 Argument.AssertNotNullOrEmpty(localDirectory, nameof(localDirectory));
                 Argument.AssertNotNull(destinationContainer, nameof(destinationContainer));
-                SourceResource ??= await CreateLocalFileSourceResourceAsync(size, localDirectory);
-                DestinationResource ??= CreateBlobDestinationResource(destinationContainer, storagePath);
+                SourceResource ??= await CreateLocalFileSourceResourceAsync(size, localDirectory, localProvider);
+                DestinationResource ??= CreateBlobDestinationResource(destinationContainer, blobProvider, storagePath);
             }
             return (SourceResource, DestinationResource);
         }
@@ -190,20 +195,24 @@ namespace Azure.Storage.DataMovement.Tests
             string localDirectory = default,
             BlobContainerClient sourceContainer = default,
             BlobContainerClient destinationContainer = default,
-            StorageResourceItem sourceResource = default,
-            StorageResourceItem destinationResource = default,
+            StorageResource sourceResource = default,
+            StorageResource destinationResource = default,
             DataTransferOptions transferOptions = default,
-            long size = Constants.KB * 100)
+            long size = Constants.KB * 100,
+            BlobsStorageResourceProvider blobProvider = default,
+            LocalFilesStorageResourceProvider localProvider = default)
         {
             Argument.AssertNotNull(manager, nameof(manager));
             if (sourceResource == default && destinationResource == default)
             {
-                (StorageResourceItem source, StorageResourceItem dest) = await CreateStorageResourcesAsync(
+                (StorageResource source, StorageResource dest) = await CreateStorageResourcesAsync(
                     transferType: transferType,
                     size: size,
                     localDirectory: localDirectory,
                     sourceContainer: sourceContainer,
-                    destinationContainer: destinationContainer);
+                    destinationContainer: destinationContainer,
+                    blobProvider: blobProvider,
+                    localProvider: localProvider);
                 sourceResource = source;
                 destinationResource = dest;
             }
@@ -230,10 +239,14 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync();
             await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             TransferManager transferManager = new TransferManager(options);
             DataTransferOptions transferOptions = new DataTransferOptions();
@@ -248,7 +261,9 @@ namespace Azure.Storage.DataMovement.Tests
                 sourceContainer: sourceContainer.Container,
                 destinationContainer: destinationContainer.Container,
                 size: Constants.KB * 100,
-                transferOptions: transferOptions);
+                transferOptions: transferOptions,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -278,10 +293,14 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync();
             await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
-                ErrorHandling = DataTransferErrorMode.ContinueOnFailure
+                ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             DataTransferOptions transferOptions = new DataTransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
@@ -296,7 +315,9 @@ namespace Azure.Storage.DataMovement.Tests
                 sourceContainer: sourceContainer.Container,
                 destinationContainer: destinationContainer.Container,
                 size: Constants.KB * 100,
-                transferOptions: transferOptions);
+                transferOptions: transferOptions,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -342,10 +363,14 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync();
             await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
-                ErrorHandling = DataTransferErrorMode.ContinueOnFailure
+                ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             DataTransferOptions transferOptions = new DataTransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
@@ -360,7 +385,9 @@ namespace Azure.Storage.DataMovement.Tests
                 sourceContainer: sourceContainer.Container,
                 destinationContainer: destinationContainer.Container,
                 size: Constants.KB * 100,
-                transferOptions: transferOptions);
+                transferOptions: transferOptions,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -383,7 +410,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(File.Exists(fileName.FullPath));
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferDirection.Upload)]
         [TestCase(TransferDirection.Download)]
@@ -394,34 +421,36 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
             using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
-            await using DisposingContainer destinationContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
+            await using DisposingContainer destinationContainer = await GetTestContainerAsync();
 
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
-                ResumeProviders = new() { new BlobsStorageResourceProvider(), new LocalFilesStorageResourceProvider() },
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             DataTransferOptions transferOptions = new DataTransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
             TransferManager transferManager = new TransferManager(options);
             long size = Constants.KB * 100;
 
-            (StorageResourceItem sResource, StorageResourceItem dResource) = await CreateStorageResourcesAsync(
+            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourcesAsync(
                 transferType: transferType,
                 size: size,
                 localDirectory: localDirectory.DirectoryPath,
                 sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
-            StorageResourceItem sourceResource = sResource;
-            StorageResourceItem destinationResource = dResource;
+                destinationContainer: destinationContainer.Container,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.
             DataTransfer transfer = await CreateSingleLongTransferAsync(
                 manager: transferManager,
-                sourceResource: sourceResource,
-                destinationResource: destinationResource,
+                sourceResource: sResource,
+                destinationResource: dResource,
                 transferOptions: transferOptions);
 
             // Act - Pause Job
@@ -439,7 +468,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transfer.Id,
                 transferOptions: resumeOptions);
 
-            CancellationTokenSource waitTransferCompletion = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            CancellationTokenSource waitTransferCompletion = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await resumeTransfer.WaitForCompletionAsync(waitTransferCompletion.Token);
 
             // Assert
@@ -450,8 +479,8 @@ namespace Azure.Storage.DataMovement.Tests
             // Verify transfer
             await AssertSourceAndDestinationAsync(
                 transferType: transferType,
-                sourceResource: sourceResource,
-                destinationResource: destinationResource,
+                sourceResource: sResource,
+                destinationResource: dResource,
                 sourceContainer: sourceContainer.Container,
                 destinationContainer: destinationContainer.Container);
         }
@@ -469,23 +498,27 @@ namespace Azure.Storage.DataMovement.Tests
             await using DisposingContainer sourceContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
             await using DisposingContainer destinationContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
 
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
-                ResumeProviders = new() { new BlobsStorageResourceProvider(), new LocalFilesStorageResourceProvider() },
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             DataTransferOptions transferOptions = new DataTransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
             TransferManager transferManager = new TransferManager(options);
             long size = Constants.KB * 100;
 
-            (StorageResourceItem sResource, StorageResourceItem dResource) = await CreateStorageResourcesAsync(
+            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourcesAsync(
                 transferType: transferType,
                 size: size,
                 localDirectory: localDirectory.DirectoryPath,
                 sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
+                destinationContainer: destinationContainer.Container,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.
@@ -510,7 +543,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transfer.Id,
                 resumeOptions);
 
-            CancellationTokenSource waitTransferCompletion = new CancellationTokenSource(TimeSpan.FromSeconds(600));
+            CancellationTokenSource waitTransferCompletion = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await resumeTransfer.WaitForCompletionAsync(waitTransferCompletion.Token);
 
             // Assert
@@ -527,11 +560,12 @@ namespace Azure.Storage.DataMovement.Tests
                 destinationContainer: destinationContainer.Container);
         }
 
-        private async Task<BlobStorageResourceContainer> CreateBlobDirectorySourceResourceAsync(
+        private async Task<StorageResource> CreateBlobDirectorySourceResourceAsync(
             long size,
             int blobCount,
             string directoryPath,
             BlobContainerClient container,
+            BlobsStorageResourceProvider provider,
             BlobStorageResourceContainerOptions options = default)
         {
             for (int i = 0; i < blobCount; i++)
@@ -548,32 +582,35 @@ namespace Azure.Storage.DataMovement.Tests
             }
             options ??= new();
             options.BlobDirectoryPrefix = directoryPath;
-            return new BlobStorageResourceContainer(container, options);
+            return provider.FromClient(container, options);
         }
 
-        private async Task<LocalDirectoryStorageResourceContainer> CreateLocalDirectorySourceResourceAsync(
+        private async Task<StorageResource> CreateLocalDirectorySourceResourceAsync(
             long size,
             int fileCount,
-            string directoryPath)
+            string directoryPath,
+            LocalFilesStorageResourceProvider provider)
         {
             for (int i = 0; i < fileCount; i++)
             {
                 await CreateRandomFileAsync(directoryPath, size: size);
             }
-            return new LocalDirectoryStorageResourceContainer(directoryPath);
+            return provider.FromDirectory(directoryPath);
         }
 
-        private async Task<(StorageResourceContainer SourceResource, StorageResourceContainer DestinationResource)> CreateStorageResourceContainersAsync(
+        private async Task<(StorageResource SourceResource, StorageResource DestinationResource)> CreateStorageResourceContainersAsync(
             TransferDirection transferType,
             long size,
             int transferCount,
             string sourceDirectoryPath,
             string destinationDirectoryPath,
             BlobContainerClient sourceContainer,
-            BlobContainerClient destinationContainer)
+            BlobContainerClient destinationContainer,
+            BlobsStorageResourceProvider blobProvider,
+            LocalFilesStorageResourceProvider localProvider)
         {
-            StorageResourceContainer SourceResource = default;
-            StorageResourceContainer DestinationResource = default;
+            StorageResource SourceResource = default;
+            StorageResource DestinationResource = default;
             if (transferType == TransferDirection.Download)
             {
                 Argument.AssertNotNull(sourceContainer, nameof(sourceContainer));
@@ -582,8 +619,9 @@ namespace Azure.Storage.DataMovement.Tests
                     size: size,
                     blobCount: transferCount,
                     directoryPath: GetNewBlobDirectoryName(),
-                    container: sourceContainer);
-                DestinationResource ??= new LocalDirectoryStorageResourceContainer(destinationDirectoryPath);
+                    container: sourceContainer,
+                    provider: blobProvider);
+                DestinationResource ??= localProvider.FromDirectory(destinationDirectoryPath);
             }
             else if (transferType == TransferDirection.Copy)
             {
@@ -597,8 +635,9 @@ namespace Azure.Storage.DataMovement.Tests
                     size: size,
                     blobCount: transferCount,
                     directoryPath: GetNewBlobDirectoryName(),
-                    container: sourceContainer);
-                DestinationResource ??= new BlobStorageResourceContainer(destinationContainer, options);
+                    container: sourceContainer,
+                    provider: blobProvider);
+                DestinationResource ??= blobProvider.FromClient(destinationContainer, options);
             }
             else
             {
@@ -608,13 +647,14 @@ namespace Azure.Storage.DataMovement.Tests
                 SourceResource ??= await CreateLocalDirectorySourceResourceAsync(
                     size: size,
                     fileCount: transferCount,
-                    directoryPath: sourceDirectoryPath);
+                    directoryPath: sourceDirectoryPath,
+                    provider: localProvider);
 
                 BlobStorageResourceContainerOptions options = new()
                 {
                     BlobDirectoryPrefix = GetNewBlobDirectoryName()
                 };
-                DestinationResource ??= new BlobStorageResourceContainer(destinationContainer, options);
+                DestinationResource ??= blobProvider.FromClient(destinationContainer, options);
             }
             return (SourceResource, DestinationResource);
         }
@@ -632,23 +672,27 @@ namespace Azure.Storage.DataMovement.Tests
             string destinationDirectory = default,
             BlobContainerClient sourceContainer = default,
             BlobContainerClient destinationContainer = default,
-            StorageResourceContainer sourceResource = default,
-            StorageResourceContainer destinationResource = default,
+            StorageResource sourceResource = default,
+            StorageResource destinationResource = default,
             DataTransferOptions transferOptions = default,
             int transferCount = 100,
-            long size = Constants.MB)
+            long size = Constants.MB,
+            BlobsStorageResourceProvider blobProvider = default,
+            LocalFilesStorageResourceProvider localProvider = default)
         {
             Argument.AssertNotNull(manager, nameof(manager));
             if (sourceResource == default && destinationResource == default)
             {
-                (StorageResourceContainer source, StorageResourceContainer dest) = await CreateStorageResourceContainersAsync(
+                (StorageResource source, StorageResource dest) = await CreateStorageResourceContainersAsync(
                     transferType: transferType,
                     size: size,
                     transferCount: transferCount,
                     sourceDirectoryPath: sourceDirectory,
                     destinationDirectoryPath: destinationDirectory,
                     sourceContainer: sourceContainer,
-                    destinationContainer: destinationContainer);
+                    destinationContainer: destinationContainer,
+                    blobProvider: blobProvider,
+                    localProvider: localProvider);
                 sourceResource = source;
                 destinationResource = dest;
             }
@@ -676,10 +720,14 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory destinationDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync();
             await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             TransferManager transferManager = new TransferManager(options);
             DataTransferOptions transferOptions = new DataTransferOptions();
@@ -697,7 +745,9 @@ namespace Azure.Storage.DataMovement.Tests
                 destinationContainer: destinationContainer.Container,
                 size: Constants.KB * 4,
                 transferCount: partCount,
-                transferOptions: transferOptions);
+                transferOptions: transferOptions,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -721,10 +771,14 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory destinationDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync();
             await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             TransferManager transferManager = new TransferManager(options);
             DataTransferOptions transferOptions = new DataTransferOptions();
@@ -742,7 +796,9 @@ namespace Azure.Storage.DataMovement.Tests
                 destinationContainer: destinationContainer.Container,
                 size: Constants.KB * 4,
                 transferCount: partCount,
-                transferOptions: transferOptions);
+                transferOptions: transferOptions,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -766,10 +822,14 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory destinationDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync();
             await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             TransferManager transferManager = new TransferManager(options);
             DataTransferOptions transferOptions = new DataTransferOptions();
@@ -787,7 +847,9 @@ namespace Azure.Storage.DataMovement.Tests
                 destinationContainer: destinationContainer.Container,
                 size: Constants.KB * 4,
                 transferCount: partCount,
-                transferOptions: transferOptions);
+                transferOptions: transferOptions,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Act
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -804,7 +866,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(DataTransferState.Paused, transfer.TransferStatus.State);
         }
 
-        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferDirection.Upload)]
         [TestCase(TransferDirection.Download)]
@@ -816,12 +878,15 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory sourceDirectory = DisposingLocalDirectory.GetTestDirectory();
             using DisposingLocalDirectory destinationDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
-            await using DisposingContainer destinationContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
+            await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
-                ResumeProviders = new() { new BlobsStorageResourceProvider(), new LocalFilesStorageResourceProvider() },
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             TransferManager transferManager = new TransferManager(options);
             DataTransferOptions transferOptions = new DataTransferOptions();
@@ -829,23 +894,23 @@ namespace Azure.Storage.DataMovement.Tests
             long size = Constants.KB * 4;
             int partCount = 4;
 
-            (StorageResourceContainer sResource, StorageResourceContainer dResource) = await CreateStorageResourceContainersAsync(
+            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourceContainersAsync(
                 transferType: transferType,
                 size: size,
                 transferCount: partCount,
                 sourceDirectoryPath: sourceDirectory.DirectoryPath,
                 destinationDirectoryPath: destinationDirectory.DirectoryPath,
                 sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
-            StorageResourceContainer sourceResource = sResource;
-            StorageResourceContainer destinationResource = dResource;
+                destinationContainer: destinationContainer.Container,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.
             DataTransfer transfer = await CreateDirectoryLongTransferAsync(
                 manager: transferManager,
-                sourceResource: sourceResource,
-                destinationResource: destinationResource,
+                sourceResource: sResource,
+                destinationResource: dResource,
                 transferOptions: transferOptions);
 
             // Act - Pause Job
@@ -874,8 +939,8 @@ namespace Azure.Storage.DataMovement.Tests
             // Verify transfer
             await AssertDirectorySourceAndDestinationAsync(
                 transferType: transferType,
-                sourceResource: sourceResource,
-                destinationResource: destinationResource,
+                sourceResource: sResource as StorageResourceContainer,
+                destinationResource: dResource as StorageResourceContainer,
                 sourceContainer: sourceContainer.Container,
                 destinationContainer: destinationContainer.Container);
         }
@@ -892,12 +957,15 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory sourceDirectory = DisposingLocalDirectory.GetTestDirectory();
             using DisposingLocalDirectory destinationDirectory = DisposingLocalDirectory.GetTestDirectory();
             await using DisposingContainer sourceContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
-            await using DisposingContainer destinationContainer = await GetTestContainerAsync(publicAccessType: PublicAccessType.BlobContainer);
+            await using DisposingContainer destinationContainer = await GetTestContainerAsync();
+
+            BlobsStorageResourceProvider blobProvider = new(GetSharedKeyCredential());
+            LocalFilesStorageResourceProvider localProvider = new();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointerOptions = new TransferCheckpointStoreOptions(checkpointerDirectory.DirectoryPath),
                 ErrorHandling = DataTransferErrorMode.ContinueOnFailure,
-                ResumeProviders = new() { new BlobsStorageResourceProvider(), new LocalFilesStorageResourceProvider() },
+                ResumeProviders = new() { blobProvider, localProvider },
             };
             TransferManager transferManager = new TransferManager(options);
             DataTransferOptions transferOptions = new DataTransferOptions();
@@ -905,23 +973,23 @@ namespace Azure.Storage.DataMovement.Tests
             long size = Constants.KB * 4;
             int partCount = 4;
 
-            (StorageResourceContainer sResource, StorageResourceContainer dResource) = await CreateStorageResourceContainersAsync(
+            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourceContainersAsync(
                 transferType: transferType,
                 size: size,
                 transferCount: partCount,
                 sourceDirectoryPath: sourceDirectory.DirectoryPath,
                 destinationDirectoryPath: destinationDirectory.DirectoryPath,
                 sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
-            StorageResourceContainer sourceResource = sResource;
-            StorageResourceContainer destinationResource = dResource;
+                destinationContainer: destinationContainer.Container,
+                blobProvider: blobProvider,
+                localProvider: localProvider);
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.
             DataTransfer transfer = await CreateDirectoryLongTransferAsync(
                 manager: transferManager,
-                sourceResource: sourceResource,
-                destinationResource: destinationResource,
+                sourceResource: sResource,
+                destinationResource: dResource,
                 transferOptions: transferOptions);
 
             // Act - Pause Job
@@ -950,8 +1018,8 @@ namespace Azure.Storage.DataMovement.Tests
             // Verify transfer
             await AssertDirectorySourceAndDestinationAsync(
                 transferType: transferType,
-                sourceResource: sourceResource,
-                destinationResource: destinationResource,
+                sourceResource: sResource as StorageResourceContainer,
+                destinationResource: dResource as StorageResourceContainer,
                 sourceContainer: sourceContainer.Container,
                 destinationContainer: destinationContainer.Container);
         }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -383,7 +383,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.IsTrue(File.Exists(fileName.FullPath));
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferDirection.Upload)]
         [TestCase(TransferDirection.Download)]
@@ -439,7 +439,7 @@ namespace Azure.Storage.DataMovement.Tests
                 transferId: transfer.Id,
                 transferOptions: resumeOptions);
 
-            CancellationTokenSource waitTransferCompletion = new CancellationTokenSource(TimeSpan.FromSeconds(600));
+            CancellationTokenSource waitTransferCompletion = new CancellationTokenSource(TimeSpan.FromSeconds(15));
             await resumeTransfer.WaitForCompletionAsync(waitTransferCompletion.Token);
 
             // Assert
@@ -804,7 +804,7 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.AreEqual(DataTransferState.Paused, transfer.TransferStatus.State);
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
+        //[Ignore("https://github.com/Azure/azure-sdk-for-net/issues/35439")]
         [RecordedTest]
         [TestCase(TransferDirection.Upload)]
         [TestCase(TransferDirection.Download)]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/RehydrateStorageResourceTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/RehydrateStorageResourceTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.DataMovement.JobPlan;
@@ -45,11 +44,24 @@ namespace Azure.Storage.DataMovement.Tests
             string destinationResourceId,
             bool isContainer)
         {
+            UriBuilder sourceBuilder = new UriBuilder()
+            {
+                Scheme = Uri.UriSchemeFile,
+                Host = "",
+                Path = sourcePath,
+            };
+            UriBuilder destinationBuilder = new UriBuilder()
+            {
+                Scheme = Uri.UriSchemeFile,
+                Host = "",
+                Path = destinationPath,
+            };
+
             var mock = new Mock<DataTransferProperties>(MockBehavior.Strict);
             mock.Setup(p => p.TransferId).Returns(transferId);
             mock.Setup(p => p.Checkpointer).Returns(new TransferCheckpointStoreOptions(checkpointerPath));
-            mock.Setup(p => p.SourcePath).Returns(sourcePath);
-            mock.Setup(p => p.DestinationPath).Returns(destinationPath);
+            mock.Setup(p => p.SourceUri).Returns(sourceBuilder.Uri);
+            mock.Setup(p => p.DestinationUri).Returns(destinationBuilder.Uri);
             mock.Setup(p => p.SourceTypeId).Returns(sourceResourceId);
             mock.Setup(p => p.DestinationTypeId).Returns(destinationResourceId);
             mock.Setup(p => p.IsContainer).Returns(isContainer);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/DataMovementBlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/DataMovementBlobTestBase.cs
@@ -297,6 +297,8 @@ namespace Azure.Storage.DataMovement.Tests
             return builder.ToSasQueryParameters(userDelegationKey, accountName);
         }
 
+        public StorageSharedKeyCredential GetSharedKeyCredential() => Tenants.GetNewSharedKeyCredentials();
+
         public BlobServiceClient GetServiceClient_AccountSas(
             StorageSharedKeyCredential sharedKeyCredentials = default,
             BlobSasQueryParameters sasCredentials = default)


### PR DESCRIPTION
This change addresses a few regressions with pause/resume that were discovered by running the disabled e2e pause/resume tests.

- Change paths in `DataTransferProperties` to `Uri`. There was an issue when resuming single transfers with local resources because we save the fully qualified file name (i.e., `file:///C:\path` in the checkpoint files and the providers were passing that to the string constructor of local resource types which was failing. Changing the paths in DataTransferProperties makes it more clear of the format of these paths and forces providers to use the internal `Uri` constructors (added that constructor for container)
- Invert check for `IsEnumerationComplete` when resuming a job (oops, my bad from the last PR!)
- Change around how we handle enumerationComplete to avoid hangs during pause. Do not pass cancellation token when saving value to checkpointer to allow that operation to finish even during a pause.
- Refactored tests themselves to use new provider concepts correctly.
- Sanitize SAS out of paths in job plan file.

Currently all pause/resume tests pass except container e2e tests. Those will be addressed in next PR.
