### PR TITLE
Add PauseOnStart Recording Option

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallRecording.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallRecording.cs
@@ -62,6 +62,7 @@ namespace Azure.Communication.CallAutomation
                     RecordingChannelType = options.RecordingChannel,
                     RecordingContentType = options.RecordingContent,
                     RecordingFormatType = options.RecordingFormat,
+                    PauseOnStart = options.PauseOnStart,
                 };
 
                 if (options.AudioChannelParticipantOrdering != null && options.AudioChannelParticipantOrdering.Any())
@@ -119,6 +120,7 @@ namespace Azure.Communication.CallAutomation
                     RecordingChannelType = options.RecordingChannel,
                     RecordingContentType = options.RecordingContent,
                     RecordingFormatType = options.RecordingFormat,
+                    PauseOnStart = options.PauseOnStart,
                 };
 
                 if (options.AudioChannelParticipantOrdering != null && options.AudioChannelParticipantOrdering.Any())

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/StartRecordingOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/StartRecordingOptions.cs
@@ -46,6 +46,11 @@ namespace Azure.Communication.CallAutomation
         public RecordingFormat RecordingFormat { get; set; }
 
         /// <summary>
+        /// The pause on start option.
+        /// </summary>
+        public bool PauseOnStart { get; set; }
+
+        /// <summary>
         /// The sequential order in which audio channels are assigned to participants in the unmixed recording.
         /// When 'recordingChannelType' is set to 'unmixed' and `audioChannelParticipantOrdering is not specified,
         /// the audio channel to participant mapping will be automatically assigned based on the order in which participant

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingTests.cs
@@ -194,7 +194,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                         RecordingChannel = RecordingChannel.Mixed,
                         RecordingFormat = RecordingFormat.Mp4,
                         AudioChannelParticipantOrdering = { new CommunicationUserIdentifier("test") },
-                        ChannelAffinity = testChannelAffinities
+                        ChannelAffinity = testChannelAffinities,
+                        PauseOnStart = false,
                     })
                 },
                 new Func<CallRecording, TestDelegate>?[]
@@ -236,6 +237,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                        RecordingChannel = RecordingChannel.Mixed,
                        RecordingFormat = RecordingFormat.Mp4,
                        ChannelAffinity = testChannelAffinities,
+                       PauseOnStart = false,
                        AudioChannelParticipantOrdering = { new CommunicationUserIdentifier("test"),}
                    }).ConfigureAwait(false),
                 },


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

This change adds the pauseOnStart option for recordings in the call automation API. It is a small change