### PR TITLE
Fix CODEOWNERS for missing paths and other fun stuff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -651,8 +651,8 @@
 # PRLabel: %OpenAI
 /sdk/openai/                                                       @jpalvarezl @trrwilson @joseharriaga @m-nash
 
-# ServiceLabel: Monitor - Operational Insights %Service Attention
-#/<NotInRepo>/                                                     @omziv @anatse @raronen @ischrei @danhadari @AzmonLogA
+# ServiceLabel: %Monitor - Operational Insights %Service Attention
+#/<NotInRepo>/                                                     zy@omziv @anatse @raronen @ischrei @danhadari @AzmonLogA
 
 # ServiceLabel: %Policy %Service Attention
 #/<NotInRepo>/                                                     @aperezcloud @kenieva

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -122,7 +122,7 @@
 
 # ServiceLabel: %Attestation %Service Attention
 /sdk/attestation/                                                  @anilba06 @gkostal
-/sdk/attestation/azure-security-attestation                        @gkostal @Azure/azure-sdk-write-attestation @anilba06
+/sdk/attestation/Azure.Security.Attestation                        @gkostal @Azure/azure-sdk-write-attestation @anilba06
 
 # ServiceLabel: %Authorization %Service Attention
 /sdk/authorization/Microsoft.Azure.Management.Authorization/       @darshanhs90 @AshishGargMicrosoft
@@ -346,7 +346,7 @@
 /sdk/cosmosdb/                                                     @pjohari-ms @MehaKaushik @shurd @anfeldma-ms @zfoster @kushagraThapar
 
 # ServiceLabel: %Cost Management %Service Attention
-/sdk/cost-management/Microsoft.Azure.Management.CostManagement/    @ms-premp @ramaganesan-rg
+/sdk/costmanagement/Microsoft.Azure.Management.CostManagement/    @ms-premp @ramaganesan-rg
 
 # ServiceLabel: %Cost Management - Billing
 #/<NotInRepo>/          @ccmbpxpcrew
@@ -569,9 +569,8 @@
 /sdk/monitor/Azure.Monitor.Ingestion/                              @nisha-bhatia @JoshLove-msft @pallavit @Azure/azure-sdk-write-monitor-data-plane
 /sdk/monitor/Azure.Monitor.Query/                                  @nisha-bhatia @JoshLove-msft @pallavit @Azure/azure-sdk-write-monitor-data-plane
 
-# PRLabel: %Monitor - ApplicationInsights
 # ServiceLabel: %Monitor - ApplicationInsights %Service Attention
-/sdk/applicationinsights/Microsoft.Azure.App*/                     @omziv @anatse @raronen @ischrei @danhadari @azmonapplicationinsights
+#/<NotInRepo>/                                                     @omziv @anatse @raronen @ischrei @danhadari @azmonapplicationinsights
 
 # PRLabel: %Monitor - Distro
 # ServiceLabel: %Monitor - Distro %Service Attention
@@ -632,9 +631,6 @@
 # ServiceLabel: %Network - Network Virtual Appliance %Service Attention
 #/<NotInRepo>/                                                     @nvasuppgithub
 
-# ServiceLabel: %Network - Traffic Manager %Service Attention
-/sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/     @tmsuppgithub
-
 # ServiceLabel: %Network - Virtual WAN %Service Attention
 #/<NotInRepo>/                                                     @vwansuppgithub
 
@@ -656,7 +652,7 @@
 /sdk/openai/                                                       @jpalvarezl @trrwilson @joseharriaga @m-nash
 
 # ServiceLabel: Monitor - Operational Insights %Service Attention
-/sdk/operationalinsights/Microsoft.Azure.Ope*/                     @omziv @anatse @raronen @ischrei @danhadari @AzmonLogA
+#/<NotInRepo>/                                                     @omziv @anatse @raronen @ischrei @danhadari @AzmonLogA
 
 # ServiceLabel: %Policy %Service Attention
 #/<NotInRepo>/                                                     @aperezcloud @kenieva
@@ -677,7 +673,7 @@
 /sdk/recoveryservices-siterecovery/Microsoft.Azure.Management.RecoveryServices.SiteRecovery/ @Sharmistha-Rai
 
 # ServiceLabel: %Redis Cache %Service Attention
-/sdk/redis/Microsoft.Azure.Management.RedisCache/                  @yegu-ms
+#/<NotInRepo>/					                   @yegu-ms
 
 # ServiceLabel: %Relay %Service Attention
 /sdk/relay/Microsoft.Azure.Management.Relay/                       @jfggdl
@@ -767,9 +763,6 @@
 # ServiceLabel: %Storsimple %Service Attention
 /sdk/storsimple/Microsoft.Azure.Management.StorSimple/             @anoobbacker @ganzee @manuaery @patelkunal
 
-# ServiceLabel: %Storsimple %Service Attention
-/sdk/storsimple8000series/Microsoft.Azure.Management.StorSimple8000Series/ @archerzz @ArcturusZhang @ArthurMa1978
-
 # ServiceLabel: %Stream Analytics %Service Attention
 /sdk/streamanalytics/Microsoft.Azure.Management.StreamAnalytics/   @atpham256
 
@@ -837,10 +830,7 @@
 # ######## DPG ########
 
 # Onboarding Documentation and Quickstarts
-/doc/Data\ Plane\ Code\ Generation                                 @chunyu3 @pshao25 @lirenhe @annelo-msft
-
-# Client generation tooling
-/eng/templates/Azure.ServiceTemplate.Template                      @chunyu3 @lirenhe
+/doc/DataPlaneCodeGeneration                                       @chunyu3 @pshao25 @lirenhe @annelo-msft
 
 # PRLabel: %Cognitive - Content Safety
 /sdk/contentsafety/												   @bowgong @mengaims


### PR DESCRIPTION

Fix the CODEOWNERS for missing or changed paths. In the cases where the deprecated library was removed and the entry had a ServiceLabel, I changed it a `#/<NotInRepo>/` entry so the Service Attention rule would still work.