### PR TITLE
Azure OpenAI: fix Whisper snippets (remove redundant BinaryData.FromStream)

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/README.md
+++ b/sdk/openai/Azure.AI.OpenAI/README.md
@@ -403,7 +403,6 @@ Uri imageUri = imageGenerations.Value.Data[0].Url;
 
 ```C# Snippet:TranscribeAudio
 using Stream audioStreamFromFile = File.OpenRead("myAudioFile.mp3");
-BinaryData audioFileData = BinaryData.FromStream(audioStreamFromFile);
 
 var transcriptionOptions = new AudioTranscriptionOptions()
 {
@@ -425,7 +424,6 @@ Console.WriteLine(transcription.Text);
 
 ```C# Snippet:TranslateAudio
 using Stream audioStreamFromFile = File.OpenRead("mySpanishAudioFile.mp3");
-BinaryData audioFileData = BinaryData.FromStream(audioStreamFromFile);
 
 var translationOptions = new AudioTranslationOptions()
 {

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample09_TranscribeAudio.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample09_TranscribeAudio.cs
@@ -20,7 +20,6 @@ namespace Azure.AI.OpenAI.Tests.Samples
 
             #region Snippet:TranscribeAudio
             using Stream audioStreamFromFile = File.OpenRead("myAudioFile.mp3");
-            BinaryData audioFileData = BinaryData.FromStream(audioStreamFromFile);
 
             var transcriptionOptions = new AudioTranscriptionOptions()
             {

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample10_TranslateAudio.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample10_TranslateAudio.cs
@@ -20,7 +20,6 @@ namespace Azure.AI.OpenAI.Tests.Samples
 
             #region Snippet:TranslateAudio
             using Stream audioStreamFromFile = File.OpenRead("mySpanishAudioFile.mp3");
-            BinaryData audioFileData = BinaryData.FromStream(audioStreamFromFile);
 
             var translationOptions = new AudioTranslationOptions()
             {


### PR DESCRIPTION
The snippets demonstrating Azure OpenAI audio transcription and translation using the Whisper model have a bug: a bad merge at some point ended up with a redundancy between a local variable capturing the return value of `BinaryData.FromStream` and an identical use of `BinaryData.FromStream` used in-line with the options initializers.

The two uses of the method conflict with each other and cause the operation to fail with a "bad format" error.

Tests are not impacted. This was purely an issue in the "compile-only" samples snippets and the downstream ingestion points (README, ref docs).