### PR TITLE
add a funtion to convert BinaryData to RequestContent

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/RequestContentHelper.cs
+++ b/sdk/core/Azure.Core/src/Shared/RequestContentHelper.cs
@@ -100,7 +100,7 @@ namespace Azure.Core
 #if NET6_0_OR_GREATER
             content.JsonWriter.WriteRawValue(value);
 #else
-            JsonSerializer.Serialize(content.JsonWriter, JsonDocument.Parse(value.ToString()).RootElement);
+            JsonSerializer.Serialize(content.JsonWriter, JsonDocument.Parse(value).RootElement);
 #endif
             return content;
         }

--- a/sdk/core/Azure.Core/src/Shared/RequestContentHelper.cs
+++ b/sdk/core/Azure.Core/src/Shared/RequestContentHelper.cs
@@ -94,5 +94,15 @@ namespace Azure.Core
             content.JsonWriter.WriteObjectValue(value);
             return content;
         }
+        public static RequestContent FromObject(BinaryData value)
+        {
+            var content = new Utf8JsonRequestContent();
+#if NET6_0_OR_GREATER
+            content.JsonWriter.WriteRawValue(value);
+#else
+            JsonSerializer.Serialize(content.JsonWriter, JsonDocument.Parse(value.ToString()).RootElement);
+#endif
+            return content;
+        }
     }
 }

--- a/sdk/core/Azure.Core/tests/RequestContentHelperTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestContentHelperTests.cs
@@ -27,10 +27,15 @@ namespace Azure.Core.Tests
             yield return new TestCaseData(DateTimeOffset.Parse("2022-08-26T18:38:00Z"));
         }
 
-        public static IEnumerable<TestCaseData> GetBinaryDataData()
+        public static object[] BinaryDataCases =
         {
-            yield return new TestCaseData(BinaryData.FromString("\"test\""));
-        }
+            new object[] { BinaryData.FromString("\"test\"") },
+            new object[] { new BinaryData(1)},
+            new object[] { new BinaryData(1.1)},
+            new object[] { new BinaryData(true)},
+            new object[] { BinaryData.FromObjectAsJson(new {name="a", age=1})},
+            new object[] { new BinaryData(DateTimeOffset.Parse("2022-08-26T18:38:00Z"))}
+        };
 
         [TestCase(1, 2)]
         [TestCase("a", "b")]
@@ -192,7 +197,7 @@ namespace Azure.Core.Tests
             }
         }
 
-        [TestCaseSource("GetBinaryDataData")]
+        [TestCaseSource(nameof(BinaryDataCases))]
         public void TestFromObjectForBinaryData(BinaryData value)
         {
             var content = RequestContentHelper.FromObject(value);
@@ -200,7 +205,6 @@ namespace Azure.Core.Tests
             content.WriteTo(stream, default);
             stream.Position = 0;
             var document = JsonDocument.Parse(stream);
-            Assert.AreEqual(JsonValueKind.String, document.RootElement.ValueKind);
             Assert.AreEqual(value.ToObjectFromJson(), BinaryData.FromString(document.RootElement.GetRawText()).ToObjectFromJson());
         }
     }

--- a/sdk/core/Azure.Core/tests/RequestContentHelperTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestContentHelperTests.cs
@@ -27,6 +27,11 @@ namespace Azure.Core.Tests
             yield return new TestCaseData(DateTimeOffset.Parse("2022-08-26T18:38:00Z"));
         }
 
+        public static IEnumerable<TestCaseData> GetBinaryDataData()
+        {
+            yield return new TestCaseData(BinaryData.FromString("\"test\""));
+        }
+
         [TestCase(1, 2)]
         [TestCase("a", "b")]
         [TestCase(true, false)]
@@ -185,6 +190,18 @@ namespace Azure.Core.Tests
                     Assert.AreEqual(value, DateTimeOffset.Parse(document.RootElement.GetString()));
                     break;
             }
+        }
+
+        [TestCaseSource("GetBinaryDataData")]
+        public void TestFromObjectForBinaryData(BinaryData value)
+        {
+            var content = RequestContentHelper.FromObject(value);
+            var stream = new MemoryStream();
+            content.WriteTo(stream, default);
+            stream.Position = 0;
+            var document = JsonDocument.Parse(stream);
+            Assert.AreEqual(JsonValueKind.String, document.RootElement.ValueKind);
+            Assert.AreEqual(value.ToObjectFromJson(), BinaryData.FromString(document.RootElement.GetRawText()).ToObjectFromJson());
         }
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

- Add a function in RequestContentHelper to convert BinaryData to RequestContent

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
