### PR TITLE
Decorated the out parameter of ResourceIdentifier.TryParse() with MaybeNullWhen

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -654,7 +654,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string input, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -654,7 +654,7 @@ namespace Azure.Core
         public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
         public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+        public static bool TryParse(string input, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out Azure.Core.ResourceIdentifier? result) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct ResourceType : System.IEquatable<Azure.Core.ResourceType>

--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 
@@ -526,7 +527,7 @@ namespace Azure.Core
         /// If the method returns false, result will be null.
         /// </param>
         /// <returns> True if the parse operation was successful; otherwise, false. </returns>
-        public static bool TryParse(string input, out ResourceIdentifier? result)
+        public static bool TryParse(string input, [MaybeNullWhen(false)] out ResourceIdentifier? result)
         {
             result = null;
             if (string.IsNullOrEmpty(input))

--- a/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResourceIdentifierTests.cs
@@ -816,27 +816,33 @@ namespace Azure.Core.Tests
             Assert.IsFalse(ResourceIdentifier.TryParse(id, out var result));
         }
 
+        [TestCase(null)]
+        public void NullInput(string invalidID)
+        {
+            Assert.Throws<ArgumentNullException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
+            Assert.Throws<ArgumentNullException>(() => ResourceIdentifier.Parse(invalidID));
+            Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
+        }
+
         [TestCase("")]
+        public void EmptyInput(string invalidID)
+        {
+            Assert.Throws<ArgumentException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
+            Assert.Throws<ArgumentException>(() => ResourceIdentifier.Parse(invalidID));
+            Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
+        }
+
         [TestCase(" ")]
         [TestCase("asdfghj")]
         [TestCase("123456")]
         [TestCase("!@#$%^&*/")]
         [TestCase("/subscriptions/")]
         [TestCase("/0c2f6471-1bf0-4dda-aec3-cb9272f09575/myRg/")]
-        public void InvalidRPIds(string invalidID)
+        public void InvalidInput(string invalidID)
         {
-            if (invalidID == String.Empty)
-            {
-                Assert.Throws<ArgumentException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
-                Assert.Throws<ArgumentException>(() => ResourceIdentifier.Parse(invalidID));
-                Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
-            }
-            else
-            {
-                Assert.Throws<FormatException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
-                Assert.Throws<FormatException>(() => ResourceIdentifier.Parse(invalidID));
-                Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
-            }
+            Assert.Throws<FormatException>(() => { _ = new ResourceIdentifier(invalidID).Name; });
+            Assert.Throws<FormatException>(() => ResourceIdentifier.Parse(invalidID));
+            Assert.IsFalse(ResourceIdentifier.TryParse(invalidID, out var result));
         }
 
         [TestCase(TrackedResourceId)]


### PR DESCRIPTION
Split from #39060.

Updated:

```c#
public static bool TryParse(string input, out ResourceIdentifier? result)
```

with:

```c#
public static bool TryParse(string input, [MaybeNullWhen(false)] out ResourceIdentifier? result)
```