### PR TITLE
Revert "Adjust test projects"

### DIFF
--- a/sdk/core/Azure.Core/Azure.Core.sln
+++ b/sdk/core/Azure.Core/Azure.Core.sln
@@ -57,8 +57,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Net.ClientModel", ".
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Net.ClientModel.Tests", "..\System.Net.ClientModel\tests\System.Net.ClientModel.Tests.csproj", "{180BE182-BB02-4505-9C8E-EA077D6917B0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Net.ClientModel.Tests.Public", "..\System.Net.ClientModel\tests\public\System.Net.ClientModel.Tests.Public.csproj", "{9586444D-7F1D-41AC-A720-0FEDD5F73573}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,10 +143,6 @@ Global
 		{180BE182-BB02-4505-9C8E-EA077D6917B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{180BE182-BB02-4505-9C8E-EA077D6917B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{180BE182-BB02-4505-9C8E-EA077D6917B0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9586444D-7F1D-41AC-A720-0FEDD5F73573}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9586444D-7F1D-41AC-A720-0FEDD5F73573}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9586444D-7F1D-41AC-A720-0FEDD5F73573}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9586444D-7F1D-41AC-A720-0FEDD5F73573}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/core/System.Net.ClientModel/src/Properties/AssemblyInfo.cs
+++ b/sdk/core/System.Net.ClientModel/src/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("System.Net.ClientModel.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]

--- a/sdk/core/System.Net.ClientModel/tests/OpenAIClient/OpenAIClient.cs
+++ b/sdk/core/System.Net.ClientModel/tests/OpenAIClient/OpenAIClient.cs
@@ -1,20 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
+using Azure.Core.Pipeline;
+using System;
 using System.Net.ClientModel;
-using System.Net.ClientModel.Core.Pipeline;
+using System.Threading;
 
 namespace OpenAI;
 
 public class OpenAIClient
 {
-    private readonly MessagePipeline _pipeline;
+    private readonly HttpPipeline _pipeline;
     private readonly KeyCredential _credential;
 
     public OpenAIClient(KeyCredential credential, OpenAIClientOptions options = default)
     {
         _credential = credential;
-        _pipeline = MessagePipeline.Create(options);
+        _pipeline = HttpPipelineBuilder.Build(new PipelineBuilderOptions());
     }
 
     //public Result<Completions> GetCompletions(string prompt, CancellationToken cancellationToken = default)
@@ -44,5 +47,5 @@ public class OpenAIClient
     //    return Result.FromValue(completions, message.Response);
     //}
 
-    private class PipelineBuilderOptions : PipelineOptions { }
+    private class PipelineBuilderOptions : ClientOptions { }
 }

--- a/sdk/core/System.Net.ClientModel/tests/OpenAIClientTests.cs
+++ b/sdk/core/System.Net.ClientModel/tests/OpenAIClientTests.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using OpenAI;
+using System.Diagnostics;
+using System.Net.ClientModel;
+using Xunit;
+
 namespace System.Tests;
 
 public class OpenAIClientTests

--- a/sdk/core/System.Net.ClientModel/tests/System - Backup.Net.ClientModel.Tests.csproj
+++ b/sdk/core/System.Net.ClientModel/tests/System - Backup.Net.ClientModel.Tests.csproj
@@ -3,17 +3,17 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
-    <IsTestSupportProject>false</IsTestSupportProject>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\..\src\System.Net.ClientModel.csproj" />
+    <ProjectReference Include="..\src\System.Net.ClientModel.csproj" />
+    <ProjectReference Include="..\..\Azure.Core\src\Azure.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/core/System.Net.ClientModel/tests/System.Net.ClientModel.Tests.csproj
+++ b/sdk/core/System.Net.ClientModel/tests/System.Net.ClientModel.Tests.csproj
@@ -6,17 +6,14 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\src\System.Net.ClientModel.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="public/**" />
+    <ProjectReference Include="..\..\Azure.Core\src\Azure.Core.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#39338

@m-nash, it looks like [this PR](https://github.com/Azure/azure-sdk-for-net/pull/39338) was merged before an answer was provided to this question: https://github.com/Azure/azure-sdk-for-net/pull/39338#discussion_r1362893767

Per our offline discussion, so that we can answer that question in the context of the code that's using it, let's please include these changes with the PR that adds the internal types that require the addition of InternalsVisibleTo to the new System library.

The reason I'm asking for this is because we made a number of mistakes in Azure.Core APIs that we have customer issues filed for because people assumed their tests were testing public APIs when the APIs were internal.  Before we make this choice as a team, I would like to make sure we have considered the options we have available to us.

If we decide to add InternalsVisibleTo once we have all the information we need to understand why it is required, we will address the cost of educating the team to prevent mistakes like the ones in Core going forward.

Thanks for your understanding on this.