### PR TITLE
[CODEOWNERS] Fix Schema Registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -722,7 +722,7 @@
 /sdk/schemaregistry/                                               @jsquire @JoshLove-msft
 
 # ServiceLabel: %Schema Registry %Service Attention
-#/sdk/schemaregistry/                                              @hmlam
+#/<NotInRepo>/                                                     @hmlam
 
 # ServiceLabel: %SignalR %Service Attention
 /sdk/signalr/                                                      @sffamily @chenkennt @Y-Sindo


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the Schema Registry service entry to use the special `<NotInRepo>` token rather than a path, allowing our new automation to correctly parse it.