### PR TITLE
Add Setter to CallInvite to allow pstn to pstn tranfer call

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -268,7 +268,7 @@ namespace Azure.Communication.CallAutomation
         public CallInvite(Azure.Communication.MicrosoftTeamsUserIdentifier targetIdentity) { }
         public CallInvite(Azure.Communication.PhoneNumberIdentifier targetPhoneNumberIdentity, Azure.Communication.PhoneNumberIdentifier callerIdNumber) { }
         public Azure.Communication.CallAutomation.CustomContext CustomContext { get { throw null; } }
-        public Azure.Communication.PhoneNumberIdentifier SourceCallerIdNumber { get { throw null; } }
+        public Azure.Communication.PhoneNumberIdentifier SourceCallerIdNumber { get { throw null; } set { } }
         public string SourceDisplayName { get { throw null; } set { } }
         public Azure.Communication.CommunicationIdentifier Target { get { throw null; } }
     }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/CallInvite.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/CallInvite.cs
@@ -52,7 +52,7 @@ namespace Azure.Communication.CallAutomation
         /// The caller ID number to appear on target PSTN callee.
         /// </summary>
         /// <value></value>
-        public PhoneNumberIdentifier SourceCallerIdNumber { get; }
+        public PhoneNumberIdentifier SourceCallerIdNumber { get; set;  }
 
         /// <summary>
         /// The display name to appear on target callee.


### PR DESCRIPTION
[GroupTransfer][PSTNtoPSTN]transfer fails from call initiated by ACS 

Add setter in CallInvite model to allow pstn to pstn call
