### PR TITLE
DataMovement unify TransferAndVerify Part 3

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement",
-  "Tag": "net/storage/Azure.Storage.DataMovement_0682ba876f"
+  "Tag": "net/storage/Azure.Storage.DataMovement_d8993077de"
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TransferValidator.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TransferValidator.cs
@@ -38,6 +38,13 @@ namespace Azure.Storage.DataMovement.Tests
             options ??= new DataTransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(options);
 
+            if (cancellationToken == default)
+            {
+                CancellationTokenSource cts = new();
+                cts.CancelAfter(TimeSpan.FromSeconds(10));
+                cancellationToken = cts.Token;
+            }
+
             DataTransfer transfer = await TransferManager.StartTransferAsync(
                 sourceResource,
                 destinationResource,
@@ -74,6 +81,13 @@ namespace Azure.Storage.DataMovement.Tests
             DataTransferOptions options = default,
             CancellationToken cancellationToken = default)
         {
+            if (cancellationToken == default)
+            {
+                CancellationTokenSource cts = new();
+                cts.CancelAfter(TimeSpan.FromSeconds(10));
+                cancellationToken = cts.Token;
+            }
+
             DataTransfer transfer = await TransferManager.StartTransferAsync(
                sourceResource,
                destinationResource,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
@@ -68,7 +68,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             using (Stream fs = File.OpenWrite(filePath))
             {
-                await new MemoryStream(GetRandomBuffer(size)).CopyToAsync(fs, cancellationToken);
+                await new MemoryStream(GetRandomBuffer(size)).CopyToAsync(fs, bufferSize: Constants.KB, cancellationToken);
             }
 
             LocalFileStorageResource sourceResource = new(filePath);
@@ -479,7 +479,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             using (Stream fs = File.OpenWrite(filePath))
             {
-                await (await CreateLimitedMemoryStream(size)).CopyToAsync(fs, cancellationToken);
+                await (await CreateLimitedMemoryStream(size)).CopyToAsync(fs, bufferSize: Constants.KB, cancellationToken);
             }
 
             LocalFileStorageResource sourceResource = new(filePath);
@@ -862,7 +862,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             using (Stream fs = File.OpenWrite(filePath))
             {
-                await (await CreateLimitedMemoryStream(size)).CopyToAsync(fs, cancellationToken);
+                await (await CreateLimitedMemoryStream(size)).CopyToAsync(fs, bufferSize: Constants.KB, cancellationToken);
             }
 
             LocalFileStorageResource sourceResource = new(filePath);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
@@ -3,8 +3,6 @@
 
 extern alias DMBlobs;
 using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -15,8 +13,6 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Tests;
 using DMBlobs::Azure.Storage.DataMovement.Blobs;
-using Microsoft.CodeAnalysis;
-using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
 namespace Azure.Storage.DataMovement.Tests


### PR DESCRIPTION
blob single upload tests

Part 1 #39300
Part 2 #39364

Adds a default timeout of 10 seconds for TransferManager transfers started using the TransferValidator test utility.