### PR TITLE
Bump min tls version to 1.2 for digital twins live test event hub

### DIFF
--- a/sdk/digitaltwins/test-resources.bicep
+++ b/sdk/digitaltwins/test-resources.bicep
@@ -34,7 +34,7 @@ resource digitaltwinRoleAssignment 'Microsoft.Authorization/roleAssignments@2020
     scope: digitaltwin
 }
 
-resource eventHubNamespace 'Microsoft.EventHub/namespaces@2018-01-01-preview' = {
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2022-01-01-preview' = {
     name: baseName
     location: location
     sku: {
@@ -47,6 +47,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2018-01-01-preview' = 
         isAutoInflateEnabled: false
         maximumThroughputUnits: 0
         kafkaEnabled: false
+        minimumTlsVersion: 'TLS1_2'
     }
 }
 

--- a/sdk/digitaltwins/test-resources.bicep
+++ b/sdk/digitaltwins/test-resources.bicep
@@ -69,7 +69,7 @@ resource eventHubNamespaceAuthRules 'Microsoft.EventHub/namespaces/Authorization
         ]
     }
 }
- 
+
 resource eventHubNamespaceEventHubAuthRules 'Microsoft.EventHub/namespaces/eventhubs/authorizationRules@2017-04-01' = {
     name: '${eventHubNamespaceEventHub.name}/owner'
     properties: {
@@ -103,6 +103,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
         name: 'Standard_LRS'
     }
     kind: 'StorageV2'
+    properties: {
+        minimumTlsVersion: 'TLS1_2'
+    }
 
     resource blobService 'blobServices' = {
         name: 'default'

--- a/sdk/digitaltwins/tests.yml
+++ b/sdk/digitaltwins/tests.yml
@@ -4,13 +4,8 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: digitaltwins
-    # Enable canary and public cloud testing in separate subscriptions, so that the tests-weekly builds
-    # don't exceed the 10 azure digital twin instance hard limit
     CloudConfig:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: westcentralus
-      Canary:
-        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        Location: eastus2euap
-    Clouds: Public,Canary
+    Clouds: Public


### PR DESCRIPTION
Either the tests or deployment script are triggering violations on minimum tls version usage. Enforcing a minimum at the event hub level.
