### PR TITLE
[Core] Adding AOT attributes for warnings reported when using .NET 8 RC2

### DIFF
--- a/sdk/core/Azure.Core/src/Diagnostics/AzureCoreEventSource.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/AzureCoreEventSource.cs
@@ -56,6 +56,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(RequestEvent, Level = EventLevel.Informational, Message = "Request [{0}] {1} {2}\r\n{3}client assembly: {4}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with primitive types.")]
         public void Request(string requestId, string method, string uri, string headers, string? clientAssembly)
         {
             WriteEvent(RequestEvent, requestId, method, uri, headers, clientAssembly);
@@ -78,6 +79,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(RequestContentEvent, Level = EventLevel.Verbose, Message = "Request [{0}] content: {1}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with an array with primitive type elements.")]
         public void RequestContent(string requestId, byte[] content)
         {
             WriteEvent(RequestContentEvent, requestId, content);
@@ -99,6 +101,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(ResponseEvent, Level = EventLevel.Informational, Message = "Response [{0}] {1} {2} ({4:00.0}s)\r\n{3}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with primitive types.")]
         public void Response(string requestId, int status, string reasonPhrase, string headers, double seconds)
         {
             WriteEvent(ResponseEvent, requestId, status, reasonPhrase, headers, seconds);
@@ -121,6 +124,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(ResponseContentEvent, Level = EventLevel.Verbose, Message = "Response [{0}] content: {1}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with an array with primitive type elements.")]
         public void ResponseContent(string requestId, byte[] content)
         {
             WriteEvent(ResponseContentEvent, requestId, content);
@@ -149,12 +153,14 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(ResponseContentBlockEvent, Level = EventLevel.Verbose, Message = "Response [{0}] content block {1}: {2}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with an array with primitive type elements.")]
         public void ResponseContentBlock(string requestId, int blockNumber, byte[] content)
         {
             WriteEvent(ResponseContentBlockEvent, requestId, blockNumber, content);
         }
 
         [Event(ResponseContentTextBlockEvent, Level = EventLevel.Verbose, Message = "Response [{0}] content block {1}: {2}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with primitive types.")]
         public void ResponseContentTextBlock(string requestId, int blockNumber, string content)
         {
             WriteEvent(ResponseContentTextBlockEvent, requestId, blockNumber, content);
@@ -170,6 +176,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(ErrorResponseEvent, Level = EventLevel.Warning, Message = "Error response [{0}] {1} {2} ({4:00.0}s)\r\n{3}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with primitive types.")]
         public void ErrorResponse(string requestId, int status, string reasonPhrase, string headers, double seconds)
         {
             WriteEvent(ErrorResponseEvent, requestId, status, reasonPhrase, headers, seconds);
@@ -192,6 +199,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(ErrorResponseContentEvent, Level = EventLevel.Informational, Message = "Error response [{0}] content: {1}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with an array with primitive type elements.")]
         public void ErrorResponseContent(string requestId, byte[] content)
         {
             WriteEvent(ErrorResponseContentEvent, requestId, content);
@@ -220,12 +228,14 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(ErrorResponseContentBlockEvent, Level = EventLevel.Informational, Message = "Error response [{0}] content block {1}: {2}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with an array with primitive type elements.")]
         public void ErrorResponseContentBlock(string requestId, int blockNumber, byte[] content)
         {
             WriteEvent(ErrorResponseContentBlockEvent, requestId, blockNumber, content);
         }
 
         [Event(ErrorResponseContentTextBlockEvent, Level = EventLevel.Informational, Message = "Error response [{0}] content block {1}: {2}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with primitive types.")]
         public void ErrorResponseContentTextBlock(string requestId, int blockNumber, string content)
         {
             WriteEvent(ErrorResponseContentTextBlockEvent, requestId, blockNumber, content);
@@ -239,6 +249,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(ResponseDelayEvent, Level = EventLevel.Warning, Message = "Response [{0}] took {1:00.0}s")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with primitive types.")]
         public void ResponseDelay(string requestId, double seconds)
         {
             WriteEvent(ResponseDelayEvent, requestId, seconds);
@@ -260,6 +271,7 @@ namespace Azure.Core.Diagnostics
         }
 
         [Event(RequestRedirectEvent, Level = EventLevel.Verbose, Message = "Request [{0}] Redirecting from {1} to {2} in response to status code {3}")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "WriteEvent is used with primitive types.")]
         public void RequestRedirect(string requestId, string from, string to, int status)
         {
             WriteEvent(RequestRedirectEvent, requestId, from, to, status);


### PR DESCRIPTION
These warnings are reported starting in .NET 8 RC2. I'm assuming there were some updates in the trimmer causing them to be reported since this file hasn't been updated in awhile and the warnings don't appear in applications targeting net8 and running with earlier dotnet 8 preview SDKs.