### PR TITLE
 Fixes for Log Scope Processing

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -15,13 +15,24 @@
 ### Bugs Fixed
 
 * Fixed an issue during network failures which prevented the exporter to store
-the telemetry offline for retrying at a later time.
-([#38832](https://github.com/Azure/azure-sdk-for-net/pull/38832))
+  the telemetry offline for retrying at a later time.
+  ([#38832](https://github.com/Azure/azure-sdk-for-net/pull/38832))
 
 * Fixed an issue where `OriginalFormat` persisted in TraceTelemetry properties
-  with IncludeFormattedMessage enabled in OpenTelemetry LoggerProvider. This fix
-  prevents data duplication in message fields and properties.
+  with IncludeFormattedMessage set to true on [
+  OpenTelemetryLoggerOptions](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs)
+  of the OpenTelemetry LoggerProvider. This fix prevents data duplication in
+  message fields and properties.
   ([#39308](https://github.com/Azure/azure-sdk-for-net/pull/39308))
+  
+* Fixed an issue related to the processing of scopes that do not adhere to a
+  key-value pair structure. Previously, when logging a scope using a statement
+  like `logger.BeginScope("SomeScopeValue")`, the value 'SomeScopeValue' would
+  be added to the properties with a key following the pattern
+  'OriginalFormatScope_*'. With this update, such non-key-value pair scopes are
+  no longer added to the properties, as they cannot be queried, resulting in
+  cleaner and more efficient log output.
+  ([#]())
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -25,14 +25,20 @@
   message fields and properties.
   ([#39308](https://github.com/Azure/azure-sdk-for-net/pull/39308))
   
-* Fixed an issue related to the processing of scopes that do not adhere to a
-  key-value pair structure. Previously, when logging a scope using a statement
-  like `logger.BeginScope("SomeScopeValue")`, the value 'SomeScopeValue' would
-  be added to the properties with a key following the pattern
-  'OriginalFormatScope_*'. With this update, such non-key-value pair scopes are
-  no longer added to the properties, as they cannot be queried, resulting in
-  cleaner and more efficient log output.
+* Fixed an issue related to the processing of scopes that do not conform to a
+  key-value pair structure.
   ([#39453](https://github.com/Azure/azure-sdk-for-net/pull/39453))
+   * **Previous Behavior**: Logging a scope with a statement like
+     `logger.BeginScope("SomeScopeValue")` would result in adding
+     'SomeScopeValue' to the properties using a key that follows the pattern
+     'scope->*'. Additionally, 'OriginalFormatScope_*' keys were used to handle
+     formatted strings within the scope.
+   * **New Behavior**: 
+     * Non-key-value pair scopes are no longer added to the properties,
+       resulting in cleaner and more efficient log output.
+     * 'OriginalFormatScope_*' keys have been removed.
+     * In case of duplicate keys within the scopes, only the first entry is
+     retained, while all subsequent duplicate entries are discarded.
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -32,7 +32,7 @@
   'OriginalFormatScope_*'. With this update, such non-key-value pair scopes are
   no longer added to the properties, as they cannot be queried, resulting in
   cleaner and more efficient log output.
-  ([#]())
+  ([#39453](https://github.com/Azure/azure-sdk-for-net/pull/39453))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -405,7 +405,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
             }
         }
 
-        [Event(40, Message = "An exception {1} occurred while converting the scope value associated with the scope key {0}.", Level = EventLevel.Warning)]
+        [Event(40, Message = "An exception {1} occurred while adding the scope value associated with the key {0}", Level = EventLevel.Warning)]
         public void FailedToConvertScopeItem(string key, string exceptionMessage) => WriteEvent(40, key, exceptionMessage);
 
         [NonEvent]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -405,7 +405,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
             }
         }
 
-        [Event(40, Message = "An exception {1} occurred while converting the scope value associated with the scope key {0}.")]
+        [Event(40, Message = "An exception {1} occurred while converting the scope value associated with the scope key {0}.", Level = EventLevel.Warning)]
         public void FailedToConvertScopeItem(string key, string exceptionMessage) => WriteEvent(40, key, exceptionMessage);
 
         [NonEvent]
@@ -417,7 +417,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
             }
         }
 
-        [Event(41, Message = "An exception {1} occurred while adding the log attribute associated with the key {0}")]
+        [Event(41, Message = "An exception {1} occurred while adding the log attribute associated with the key {0}", Level = EventLevel.Warning)]
         public void FailedToConvertLogAttribute(string key, string exceptionMessage) => WriteEvent(41, key, exceptionMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -395,5 +395,29 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
 
         [Event(39, Message = "Received a partial success from ingestion. This status code is not handled and telemetry will be lost. Error StatusCode: {0}. Error Message: {1}", Level = EventLevel.Warning)]
         public void PartialContentResponseUnhandled(string errorStatusCode, string errorMessage) => WriteEvent(39, errorStatusCode, errorMessage);
+
+        [NonEvent]
+        public void FailedToConvertScopeItem(string key, Exception ex)
+        {
+            if (IsEnabled(EventLevel.Warning))
+            {
+                FailedToConvertScopeItem(key, ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(40, Message = "An exception {1} occurred while converting the scope value associated with the scope key {0}.")]
+        public void FailedToConvertScopeItem(string key, string exceptionMessage) => WriteEvent(40, key, exceptionMessage);
+
+        [NonEvent]
+        public void FailedToConvertLogAttribute(string key, Exception ex)
+        {
+            if (IsEnabled(EventLevel.Warning))
+            {
+                FailedToConvertLogAttribute(key, ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(41, Message = "An exception {1} occurred while adding the log attribute associated with the key {0}")]
+        public void FailedToConvertLogAttribute(string key, string exceptionMessage) => WriteEvent(41, key, exceptionMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Diagnostics/AzureMonitorExporterEventSource.cs
@@ -397,27 +397,27 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics
         public void PartialContentResponseUnhandled(string errorStatusCode, string errorMessage) => WriteEvent(39, errorStatusCode, errorMessage);
 
         [NonEvent]
-        public void FailedToConvertScopeItem(string key, Exception ex)
+        public void FailedToAddScopeItem(string key, Exception ex)
         {
             if (IsEnabled(EventLevel.Warning))
             {
-                FailedToConvertScopeItem(key, ex.FlattenException().ToInvariantString());
+                FailedToAddScopeItem(key, ex.FlattenException().ToInvariantString());
             }
         }
 
         [Event(40, Message = "An exception {1} occurred while adding the scope value associated with the key {0}", Level = EventLevel.Warning)]
-        public void FailedToConvertScopeItem(string key, string exceptionMessage) => WriteEvent(40, key, exceptionMessage);
+        public void FailedToAddScopeItem(string key, string exceptionMessage) => WriteEvent(40, key, exceptionMessage);
 
         [NonEvent]
-        public void FailedToConvertLogAttribute(string key, Exception ex)
+        public void FailedToAddLogAttribute(string key, Exception ex)
         {
             if (IsEnabled(EventLevel.Warning))
             {
-                FailedToConvertLogAttribute(key, ex.FlattenException().ToInvariantString());
+                FailedToAddLogAttribute(key, ex.FlattenException().ToInvariantString());
             }
         }
 
         [Event(41, Message = "An exception {1} occurred while adding the log attribute associated with the key {0}", Level = EventLevel.Warning)]
-        public void FailedToConvertLogAttribute(string key, string exceptionMessage) => WriteEvent(41, key, exceptionMessage);
+        public void FailedToAddLogAttribute(string key, string exceptionMessage) => WriteEvent(41, key, exceptionMessage);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -41,7 +41,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     }
                     catch (Exception ex)
                     {
-                        AzureMonitorExporterEventSource.Log.FailedToConvertScopeItem(scopeItem.Key, ex);
+                        AzureMonitorExporterEventSource.Log.FailedToAddScopeItem(scopeItem.Key, ex);
                     }
                 }
             }
@@ -117,7 +117,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     }
                     catch (Exception ex)
                     {
-                        AzureMonitorExporterEventSource.Log.FailedToConvertLogAttribute(item.Key, ex);
+                        AzureMonitorExporterEventSource.Log.FailedToAddLogAttribute(item.Key, ex);
                     }
                 }
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -327,5 +327,100 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 Assert.Empty(properties); // Assert that properties are empty
             }
         }
+
+        [Fact]
+        public void LogScope_WhenToStringOnCustomObjectThrows_ShouldStillProcessValidScopeItems()
+        {
+            // Arrange.
+            var logRecords = new List<LogRecord>(1);
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeScopes = true;
+                    options.IncludeFormattedMessage = true;
+                    options.AddInMemoryExporter(logRecords);
+                });
+            });
+
+            var logger = loggerFactory.CreateLogger("Some category");
+
+            const string expectedScopeKey = "Some scope key";
+            const string validScopeKey = "Valid key";
+            const string validScopeValue = "Valid value";
+
+            // Act.
+            using (logger.BeginScope(new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>(expectedScopeKey, new CustomObject()),
+                new KeyValuePair<string, object>(validScopeKey, validScopeValue),
+            }))
+            {
+                logger.LogInformation("Some log information message.");
+            }
+
+            // Assert.
+            var logRecord = logRecords.Single();
+            var properties = new ChangeTrackingDictionary<string, string>();
+            LogsHelper.GetMessageAndSetProperties(logRecords[0], properties);
+
+            Assert.False(properties.ContainsKey(expectedScopeKey), "Properties should not contain the key of the CustomObject that threw an exception");
+            Assert.True(properties.ContainsKey(validScopeKey), "Properties should contain the key of the valid scope item.");
+            Assert.Equal(validScopeValue, properties[validScopeKey]);
+            Assert.Equal("Some log information message.", logRecords[0].FormattedMessage);
+        }
+
+        [Fact]
+        public void DuplicateKeysInLogRecordAttributesAndLogScope()
+        {
+            // Arrange.
+            var logRecords = new List<LogRecord>(1);
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeScopes = true;
+                    options.AddInMemoryExporter(logRecords);
+                });
+            });
+
+            var logger = loggerFactory.CreateLogger("Some category");
+
+            const string expectedScopeKey = "Some scope key";
+            const string expectedScopeValue = "Some scope value";
+            const string duplicateScopeValue = "Some duplicate scope value";
+
+            const string expectedAttributeValue = "Some attribute value";
+            const string duplicateAttributeValue = "Some duplicate attribute value";
+
+            // Act.
+            using (logger.BeginScope(new List<KeyValuePair<string, object>>
+            {
+                new KeyValuePair<string, object>(expectedScopeKey, expectedScopeValue),
+                new KeyValuePair<string, object>(expectedScopeKey, duplicateScopeValue),
+            }))
+            {
+                logger.LogInformation("Some log information message. {attributeKey} {attributeKey}.", expectedAttributeValue, duplicateAttributeValue);
+            }
+
+            // Assert.
+            var logRecord = logRecords.Single();
+            var properties = new ChangeTrackingDictionary<string, string>();
+            LogsHelper.GetMessageAndSetProperties(logRecords[0], properties);
+
+            Assert.Equal(2, properties.Count);
+            Assert.True(properties.TryGetValue(expectedScopeKey, out string actualScopeValue));
+            Assert.Equal(expectedScopeValue, actualScopeValue);
+            Assert.True(properties.TryGetValue("attributeKey", out string actualAttributeValue));
+            Assert.Equal(expectedAttributeValue, actualAttributeValue);
+        }
+
+        private class CustomObject
+        {
+            public override string ToString()
+            {
+                throw new InvalidOperationException("Custom exception in ToString method");
+            }
+        }
     }
 }


### PR DESCRIPTION
* Implemented logic to drop non-key-value pair scopes
* Ensured that scope values are correctly processed and represented, eliminating any unnecessary or redundant data.
* Added unit tests to validate the new behavior and ensure consistency.

**Examples:**

**Old Behavior:**

Using a scope that does not adhere to a key-value pair structure:
```
using (_logger.BeginScope("SomeScopeValue"))
{
    _logger.LogInformation("Log message");
}

// Resulted in TraceTelemetry properties:
{
  "OriginalFormatScope_1": "SomeScopeValue"
}
```
**New Behavior:**
Using the same scope after the changes:

```
using (_logger.BeginScope("SomeScopeValue"))
{
    _logger.LogInformation("Log message");
}
```

Results in no additional TraceTelemetry properties related to the non-key-value pair scope.