### PR TITLE
Parse any json into BinaryData not just objects

### DIFF
--- a/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryElementJsonConverter.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/src/DataFactoryElementJsonConverter.cs
@@ -330,7 +330,7 @@ namespace Azure.Core.Expressions.DataFactory
                 return new DataFactoryElement<T?>((T)(object)new Uri(json.GetString()!));
             }
 
-            if (typeof(T) == typeof(BinaryData) && json.ValueKind == JsonValueKind.Object)
+            if (typeof(T) == typeof(BinaryData))
             {
                 return new DataFactoryElement<T?>((T)(object)BinaryData.FromString(json.GetRawText()!));
             }

--- a/sdk/core/Azure.Core.Expressions.DataFactory/tests/DataFactoryElementTests.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/tests/DataFactoryElementTests.cs
@@ -492,6 +492,22 @@ namespace Azure.Core.Expressions.DataFactory.Tests
         }
 
         [Test]
+        public void BinaryDataCanHandleNonObjectsValues()
+        {
+            var docString = JsonDocument.Parse(StringJson);
+            var dfeString = DataFactoryElementJsonConverter.Deserialize<BinaryData>(docString.RootElement)!;
+            Assert.AreEqual(StringJson, JsonSerializer.Serialize(dfeString));
+
+            var docBool = JsonDocument.Parse(BoolJson);
+            var dfeBool = DataFactoryElementJsonConverter.Deserialize<BinaryData>(docBool.RootElement)!;
+            Assert.AreEqual(BoolJson, JsonSerializer.Serialize(dfeBool));
+
+            var docInt = JsonDocument.Parse(IntJson);
+            var dfeInt = DataFactoryElementJsonConverter.Deserialize<BinaryData>(docInt.RootElement)!;
+            Assert.AreEqual(IntJson, JsonSerializer.Serialize(dfeInt));
+        }
+
+        [Test]
         public void SerializationOfListOfT()
         {
             var elements = new List<TestModel>


### PR DESCRIPTION
This is needed to handle SetVariable activity inside ADF, because user can set `0` which should be parsed as number, or `"someString"` or Expression...