### PR TITLE
Set min tls version for search+storage live tests

### DIFF
--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -79,7 +79,7 @@
             "usgovarizona"
         ],
         "storageAccountName": "[concat(parameters('baseName'), 'stg')]",
-        "storageApiVersion": "2019-06-01",
+        "storageApiVersion": "2022-05-01",
         "cognitiveServicesAccountName": "[concat(parameters('baseName'), 'cog')]",
         "cognitiveServicesApiVersion": "2017-04-18",
         "keyVaultName": "[concat(parameters('baseName'), 'kv')]",
@@ -111,7 +111,8 @@
             "location": "[parameters('location')]",
             "properties": {
                 "accessTier": "Hot",
-                "supportsHttpsTrafficOnly": true
+                "supportsHttpsTrafficOnly": true,
+                "minimumTlsVersion": "TLS1_2"
             },
             "sku": {
                 "name": "Standard_LRS"

--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -21,7 +21,7 @@
     },
     "variables": {
         "computeApiVersion": "2019-12-01",
-        "mgmtApiVersion": "2019-06-01",
+        "mgmtApiVersion": "2022-05-01",
         "keyvaultApiVersion": "2016-10-01",
         "authorizationApiVersion": "2018-09-01-preview",
         "blobDataContributorRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
@@ -113,7 +113,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {
@@ -161,7 +162,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {
@@ -178,7 +180,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {
@@ -196,7 +199,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {
@@ -239,7 +243,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {
@@ -288,7 +293,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {
@@ -305,7 +311,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {
@@ -322,7 +329,8 @@
                 "networkAcls": "[variables('networkAcls')]",
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {


### PR DESCRIPTION
Updating storage and search live tests as we are also seeing tls violations for the preview test sub from these pipelines.
