### PR TITLE
Replace Azure AD references with Entra

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AuthorizationCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AuthorizationCodeCredential.cs
@@ -37,11 +37,11 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientSecretCredential with the details needed to authenticate against Microsoft Entra ID with a prefetched authorization code.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
         /// <param name="authorizationCode">The authorization code obtained from a call to authorize. The code should be obtained with all required scopes.
-        /// See https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information.</param>
+        /// See https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information.</param>
         public AuthorizationCodeCredential(string tenantId, string clientId, string clientSecret, string authorizationCode)
             : this(tenantId, clientId, clientSecret, authorizationCode, null)
         {
@@ -50,12 +50,12 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientSecretCredential with the details needed to authenticate against Microsoft Entra ID with a prefetched authorization code.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
         /// <param name="authorizationCode">The authorization code obtained from a call to authorize. The code should be obtained with all required scopes.
-        /// See https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// See https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public AuthorizationCodeCredential(
             string tenantId,
             string clientId,
@@ -67,12 +67,12 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientSecretCredential with the details needed to authenticate against Microsoft Entra ID with a prefetched authorization code.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
         /// <param name="authorizationCode">The authorization code obtained from a call to authorize. The code should be obtained with all required scopes.
-        /// See https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// See https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow for more information.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AuthorizationCodeCredential(string tenantId, string clientId, string clientSecret, string authorizationCode, TokenCredentialOptions options)
             : this(tenantId, clientId, clientSecret, authorizationCode, options, null)

--- a/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
@@ -52,16 +52,16 @@ namespace Azure.Identity
         internal bool _isChainedCredential;
 
         /// <summary>
-        /// Create an instance of CliCredential class.
+        /// Create an instance of <see cref="AzureCliCredential"/> class.
         /// </summary>
         public AzureCliCredential()
             : this(CredentialPipeline.GetInstance(null), default)
         { }
 
         /// <summary>
-        /// Create an instance of CliCredential class.
+        /// Create an instance of <see cref="AzureCliCredential"/> class.
         /// </summary>
-        /// <param name="options"> The Azure Active Directory tenant (directory) Id of the service principal. </param>
+        /// <param name="options"> The Microsoft Entra tenant (directory) ID of the service principal. </param>
         public AzureCliCredential(AzureCliCredentialOptions options)
             : this(CredentialPipeline.GetInstance(null), default, options)
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/AzureDeveloperCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureDeveloperCliCredential.cs
@@ -54,7 +54,7 @@ namespace Azure.Identity
         /// <summary>
         /// Create an instance of the <see cref="AzureDeveloperCliCredential"/> class.
         /// </summary>
-        /// <param name="options"> The Azure Active Directory tenant (directory) Id of the service principal. </param>
+        /// <param name="options"> The Microsoft Entra tenant (directory) ID of the service principal. </param>
         public AzureDeveloperCliCredential(AzureDeveloperCliCredentialOptions options)
             : this(CredentialPipeline.GetInstance(null), default, options)
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientAssertionCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientAssertionCredential.cs
@@ -34,10 +34,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with an asynchronous callback that provides a signed client assertion to authenticate against Microsoft Entra ID.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="assertionCallback">An asynchronous callback returning a valid client assertion used to authenticate the service principal.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ClientAssertionCredential(string tenantId, string clientId, Func<CancellationToken, Task<string>> assertionCallback, ClientAssertionCredentialOptions options = default)
         {
             Argument.AssertNotNull(clientId, nameof(clientId));
@@ -53,10 +53,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with a synchronous callback that provides a signed client assertion to authenticate against Microsoft Entra ID.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="assertionCallback">A synchronous callback returning a valid client assertion used to authenticate the service principal.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ClientAssertionCredential(string tenantId, string clientId, Func<string> assertionCallback, ClientAssertionCredentialOptions options = default)
         {
             Argument.AssertNotNull(clientId, nameof(clientId));

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredential.cs
@@ -48,7 +48,7 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with the details needed to authenticate against Microsoft Entra ID with the specified certificate.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificatePath">The path to a file which contains both the client certificate and private key.</param>
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath)
@@ -58,10 +58,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with the details needed to authenticate against Microsoft Entra ID with the specified certificate.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificatePath">The path to a file which contains both the client certificate and private key.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, TokenCredentialOptions options)
             : this(tenantId, clientId, clientCertificatePath, null, options, null, null)
@@ -70,10 +70,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with the details needed to authenticate against Microsoft Entra ID with the specified certificate.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificatePath">The path to a file which contains both the client certificate and private key.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, ClientCertificateCredentialOptions options)
             : this(tenantId, clientId, clientCertificatePath, null, options, null, null)
         { }
@@ -81,7 +81,7 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with the details needed to authenticate against Microsoft Entra ID with the specified certificate.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificate">The authentication X509 Certificate of the service principal</param>
         public ClientCertificateCredential(string tenantId, string clientId, X509Certificate2 clientCertificate)
@@ -91,10 +91,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with the details needed to authenticate against Microsoft Entra ID with the specified certificate.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificate">The authentication X509 Certificate of the service principal</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ClientCertificateCredential(string tenantId, string clientId, X509Certificate2 clientCertificate, TokenCredentialOptions options)
             : this(tenantId, clientId, clientCertificate, options, null, null)
@@ -103,10 +103,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientCertificateCredential with the details needed to authenticate against Microsoft Entra ID with the specified certificate.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientCertificate">The authentication X509 Certificate of the service principal</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ClientCertificateCredential(string tenantId, string clientId, X509Certificate2 clientCertificate, ClientCertificateCredentialOptions options)
             : this(tenantId, clientId, clientCertificate, options, null, null)
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/ClientSecretCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ClientSecretCredential.cs
@@ -48,7 +48,7 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientSecretCredential with the details needed to authenticate against Microsoft Entra ID with a client secret.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
         public ClientSecretCredential(string tenantId, string clientId, string clientSecret)
@@ -59,10 +59,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientSecretCredential with the details needed to authenticate against Microsoft Entra ID with a client secret.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to the Microsoft Entra ID.</param>
         public ClientSecretCredential(string tenantId, string clientId, string clientSecret, ClientSecretCredentialOptions options)
             : this(tenantId, clientId, clientSecret, options, null, null)
         {
@@ -71,10 +71,10 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the ClientSecretCredential with the details needed to authenticate against Microsoft Entra ID with a client secret.
         /// </summary>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID of the service principal.</param>
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ClientSecretCredential(string tenantId, string clientId, string clientSecret, TokenCredentialOptions options)
             : this(tenantId, clientId, clientSecret, options, null, null)
         {

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredential.cs
@@ -72,9 +72,9 @@ namespace Azure.Identity
         /// <summary>
         /// Creates an instance of the <see cref="DefaultAzureCredential"/> class.
         /// </summary>
-        /// <param name="options">Options that configure the management of the requests sent to Azure Active Directory services, and determine which credentials are included in the <see cref="DefaultAzureCredential"/> authentication flow.</param>
+        /// <param name="options">Options that configure the management of the requests sent to Microsoft Entra ID, and determine which credentials are included in the <see cref="DefaultAzureCredential"/> authentication flow.</param>
         public DefaultAzureCredential(DefaultAzureCredentialOptions options)
-            // we call ValidateAuthoriyHostOption to validate that we have a valid authority host before constructing the DAC chain
+            // we call ValidateAuthorityHostOption to validate that we have a valid authority host before constructing the DAC chain
             // if we don't validate this up front it will end up throwing an exception out of a static initializer which obscures the error.
             : this(new DefaultAzureCredentialFactory(ValidateAuthorityHostOption(options)))
         {

--- a/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
@@ -67,7 +67,7 @@ namespace Azure.Identity
         /// Creates an instance of the EnvironmentCredential class and reads client secret details from environment variables.
         /// If the expected environment variables are not found at this time, the GetToken method will return the default <see cref="AccessToken"/> when invoked.
         /// </summary>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public EnvironmentCredential(TokenCredentialOptions options)
             : this(CredentialPipeline.GetInstance(options), options)
@@ -77,7 +77,7 @@ namespace Azure.Identity
         /// Creates an instance of the EnvironmentCredential class and reads client secret details from environment variables.
         /// If the expected environment variables are not found at this time, the GetToken method will return the default <see cref="AccessToken"/> when invoked.
         /// </summary>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public EnvironmentCredential(EnvironmentCredentialOptions options)
             : this(CredentialPipeline.GetInstance(options), options)
         { }

--- a/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/ManagedIdentityCredential.cs
@@ -36,10 +36,10 @@ namespace Azure.Identity
         /// Creates an instance of the ManagedIdentityCredential capable of authenticating a resource with a managed identity.
         /// </summary>
         /// <param name="clientId">
-        /// The client id to authenticate for a user assigned managed identity.  More information on user assigned managed identities can be found here:
-        /// https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm
+        /// The client ID to authenticate for a user-assigned managed identity. More information on user-assigned managed identities can be found here:
+        /// https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm
         /// </param>
-        /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ManagedIdentityCredential(string clientId = null, TokenCredentialOptions options = null)
             : this(new ManagedIdentityClient(new ManagedIdentityClientOptions { ClientId = clientId, Pipeline = CredentialPipeline.GetInstance(options), Options = options }))
         {
@@ -50,10 +50,10 @@ namespace Azure.Identity
         /// Creates an instance of the ManagedIdentityCredential capable of authenticating a resource with a managed identity.
         /// </summary>
         /// <param name="resourceId">
-        /// The resource id to authenticate for a user assigned managed identity.  More information on user assigned managed identities can be found here:
-        /// https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm
+        /// The resource ID to authenticate for a user-assigned managed identity. More information on user-assigned managed identities can be found here:
+        /// https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm
         /// </param>
-        /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options to configure the management of the requests sent to Microsoft Entra ID.</param>
         public ManagedIdentityCredential(ResourceIdentifier resourceId, TokenCredentialOptions options = null)
             : this(new ManagedIdentityClient(new ManagedIdentityClientOptions { ResourceIdentifier = resourceId, Pipeline = CredentialPipeline.GetInstance(options), Options = options }))
         {

--- a/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/UsernamePasswordCredential.cs
@@ -43,7 +43,7 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="username">The user account's username, also known as UPN.</param>
         /// <param name="password">The user account's password.</param>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID or name.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID or name.</param>
         /// <param name="clientId">The client (application) ID of an App Registration in the tenant.</param>
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId)
             : this(username, password, tenantId, clientId, (TokenCredentialOptions)null)
@@ -55,7 +55,7 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="username">The user account's user name, UPN.</param>
         /// <param name="password">The user account's password.</param>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID or name.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID or name.</param>
         /// <param name="clientId">The client (application) ID of an App Registration in the tenant.</param>
         /// <param name="options">The client options for the newly created UsernamePasswordCredential</param>
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, TokenCredentialOptions options)
@@ -68,7 +68,7 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="username">The user account's user name, UPN.</param>
         /// <param name="password">The user account's password.</param>
-        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID or name.</param>
+        /// <param name="tenantId">The Microsoft Entra tenant (directory) ID or name.</param>
         /// <param name="clientId">The client (application) ID of an App Registration in the tenant.</param>
         /// <param name="options">The client options for the newly created UsernamePasswordCredential</param>
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, UsernamePasswordCredentialOptions options)

--- a/sdk/identity/Azure.Identity/src/Credentials/WorkloadIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/WorkloadIdentityCredential.cs
@@ -34,7 +34,7 @@ namespace Azure.Identity
         /// <summary>
         /// Creates a new instance of the <see cref="WorkloadIdentityCredential"/> with the specified options.
         /// </summary>
-        /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
+        /// <param name="options">Options that allow to configure the management of the requests sent to Microsoft Entra ID.</param>
         public WorkloadIdentityCredential(WorkloadIdentityCredentialOptions options)
         {
             options = options ?? new();


### PR DESCRIPTION
Replace more Azure AD references that I missed on the initial rebranding pass
