### PR TITLE
Azure OpenAI: fix model factory issue with uninitialized StreamingChatCompletions collection

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChatCompletions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/StreamingChatCompletions.cs
@@ -177,6 +177,7 @@ namespace Azure.AI.OpenAI
             ChatCompletions baseChatCompletions = null,
             List<StreamingChatChoice> streamingChatChoices = null)
         {
+            _baseChatCompletions = new List<ChatCompletions>();
             _baseChatCompletions.Add(baseChatCompletions);
             _streamingChatChoices = streamingChatChoices;
             _streamingTaskComplete = true;


### PR DESCRIPTION
This change addresses a customer-reported oversight in the factory-enabling constructor of `StreamingChatCompletions`.

closes #38571