### PR TITLE
[Storage][DataMovement] Fixes to pause/resume around enumeration

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceTransferJob.cs
@@ -85,6 +85,7 @@ namespace Azure.Storage.DataMovement
                             job: this,
                             partNumber: partNumber).ConfigureAwait(false);
                         AppendJobPart(part);
+                        await OnAllResourcesEnumerated().ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -122,6 +123,7 @@ namespace Azure.Storage.DataMovement
                 }
             }
 
+            // Call regardless of the outcome of enumeration so job can pause/finish
             await OnEnumerationComplete().ConfigureAwait(false);
         }
 
@@ -130,7 +132,7 @@ namespace Azure.Storage.DataMovement
             // Start the partNumber based on the last part number. If this is a new job,
             // the count will automatically be at 0 (the beginning).
             int partNumber = _jobParts.Count;
-            List<string> existingSources = GetJobPartSourceResourcePaths();
+            HashSet<Uri> existingSources = GetJobPartSourceResourcePaths();
             // Call listing operation on the source container
             IAsyncEnumerator<StorageResource> enumerator;
 
@@ -154,8 +156,10 @@ namespace Azure.Storage.DataMovement
             {
                 try
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
                     {
+                        await OnAllResourcesEnumerated().ConfigureAwait(false);
                         enumerationCompleted = true;
                         continue;
                     }
@@ -167,17 +171,13 @@ namespace Azure.Storage.DataMovement
                 }
 
                 StorageResource current = enumerator.Current;
-
-                string containerUriPath = _sourceResourceContainer.Uri.GetPath();
-                string sourceName = string.IsNullOrEmpty(containerUriPath)
-                    ? current.Uri.GetPath()
-                    : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
-
-                if (!existingSources.Contains(sourceName))
+                if (!existingSources.Contains(current.Uri))
                 {
-                    // Because AsyncEnumerable doesn't let us know which storage resource is the last resource
-                    // we only yield return when we know this is not the last storage resource to be listed
-                    // from the container.
+                    string containerUriPath = _sourceResourceContainer.Uri.GetPath();
+                    string sourceName = string.IsNullOrEmpty(containerUriPath)
+                        ? current.Uri.GetPath()
+                        : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
+
                     ServiceToServiceJobPart part;
                     try
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriTransferJob.cs
@@ -83,6 +83,7 @@ namespace Azure.Storage.DataMovement
                             job: this,
                             partNumber: partNumber).ConfigureAwait(false);
                         AppendJobPart(part);
+                        await OnAllResourcesEnumerated().ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -120,6 +121,7 @@ namespace Azure.Storage.DataMovement
                 }
             }
 
+            // Call regardless of the outcome of enumeration so job can pause/finish
             await OnEnumerationComplete().ConfigureAwait(false);
         }
 
@@ -128,7 +130,7 @@ namespace Azure.Storage.DataMovement
             // Start the partNumber based on the last part number. If this is a new job,
             // the count will automatically be at 0 (the beginning).
             int partNumber = _jobParts.Count;
-            List<string> existingSources = GetJobPartSourceResourcePaths();
+            HashSet<Uri> existingSources = GetJobPartSourceResourcePaths();
             // Call listing operation on the source container
             IAsyncEnumerator<StorageResource> enumerator;
 
@@ -152,8 +154,10 @@ namespace Azure.Storage.DataMovement
             {
                 try
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
                     {
+                        await OnAllResourcesEnumerated().ConfigureAwait(false);
                         enumerationCompleted = true;
                         continue;
                     }
@@ -165,17 +169,13 @@ namespace Azure.Storage.DataMovement
                 }
 
                 StorageResource current = enumerator.Current;
-
-                string containerUriPath = _sourceResourceContainer.Uri.GetPath();
-                string sourceName = string.IsNullOrEmpty(containerUriPath)
-                    ? current.Uri.GetPath()
-                    : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
-
-                if (!existingSources.Contains(sourceName))
+                if (!existingSources.Contains(current.Uri))
                 {
-                    // Because AsyncEnumerable doesn't let us know which storage resource is the last resource
-                    // we only yield return when we know this is not the last storage resource to be listed
-                    // from the container.
+                    string containerUriPath = _sourceResourceContainer.Uri.GetPath();
+                    string sourceName = string.IsNullOrEmpty(containerUriPath)
+                        ? current.Uri.GetPath()
+                        : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
+
                     StreamToUriJobPart part;
                     try
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -403,10 +403,13 @@ namespace Azure.Storage.DataMovement
                 status: _dataTransfer.TransferStatus).ConfigureAwait(false);
         }
 
-        internal async Task OnEnumerationComplete()
+        /// <summary>
+        /// Called when enumeration is complete whether it finished successfully, failed, or was paused.
+        /// All resources may or may not have been enumerated.
+        /// </summary>
+        protected async Task OnEnumerationComplete()
         {
             _enumerationComplete = true;
-            await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id).ConfigureAwait(false);
 
             // If there were no job parts enumerated and we haven't already aborted/completed the job.
             if (_jobParts.Count == 0 &&
@@ -424,6 +427,14 @@ namespace Azure.Storage.DataMovement
                 }
             }
             await CheckAndUpdateStatusAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Called when all resources have been enumerated successfully.
+        /// </summary>
+        protected async Task OnAllResourcesEnumerated()
+        {
+            await _checkpointer.OnEnumerationCompleteAsync(_dataTransfer.Id).ConfigureAwait(false);
         }
 
         internal async Task CheckAndUpdateStatusAsync()
@@ -469,9 +480,9 @@ namespace Azure.Storage.DataMovement
             }
         }
 
-        internal List<string> GetJobPartSourceResourcePaths()
+        internal HashSet<Uri> GetJobPartSourceResourcePaths()
         {
-            return _jobParts.Select( x => x._sourceResource.Uri.GetPath() ).ToList();
+            return new HashSet<Uri>(_jobParts.Select(x => x._sourceResource.Uri));
         }
 
         internal void QueueJobPart()

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
@@ -83,6 +83,7 @@ namespace Azure.Storage.DataMovement
                             job: this,
                             partNumber: partNumber).ConfigureAwait(false);
                         AppendJobPart(part);
+                        await OnAllResourcesEnumerated().ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -120,6 +121,7 @@ namespace Azure.Storage.DataMovement
                 }
             }
 
+            // Call regardless of the outcome of enumeration so job can pause/finish
             await OnEnumerationComplete().ConfigureAwait(false);
         }
 
@@ -128,7 +130,7 @@ namespace Azure.Storage.DataMovement
             // Start the partNumber based on the last part number. If this is a new job,
             // the count will automatically be at 0 (the beginning).
             int partNumber = _jobParts.Count;
-            List<string> existingSources = GetJobPartSourceResourcePaths();
+            HashSet<Uri> existingSources = GetJobPartSourceResourcePaths();
             // Call listing operation on the source container
             IAsyncEnumerator<StorageResource> enumerator;
 
@@ -152,8 +154,10 @@ namespace Azure.Storage.DataMovement
             {
                 try
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
                     {
+                        await OnAllResourcesEnumerated().ConfigureAwait(false);
                         enumerationCompleted = true;
                         continue;
                     }
@@ -165,17 +169,13 @@ namespace Azure.Storage.DataMovement
                 }
 
                 StorageResource current = enumerator.Current;
-
-                string containerUriPath = _sourceResourceContainer.Uri.GetPath();
-                string sourceName = string.IsNullOrEmpty(containerUriPath)
-                    ? current.Uri.GetPath()
-                    : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
-
-                if (!existingSources.Contains(sourceName))
+                if (!existingSources.Contains(current.Uri))
                 {
-                    // Because AsyncEnumerable doesn't let us know which storage resource is the last resource
-                    // we only yield return when we know this is not the last storage resource to be listed
-                    // from the container.
+                    string containerUriPath = _sourceResourceContainer.Uri.GetPath();
+                    string sourceName = string.IsNullOrEmpty(containerUriPath)
+                        ? current.Uri.GetPath()
+                        : current.Uri.GetPath().Substring(containerUriPath.Length + 1);
+
                     UriToStreamJobPart part;
                     try
                     {


### PR DESCRIPTION
This change contains a couple of bug fixes for pause/resume around resource enumeration.

- Only update checkpointer with enumeration complete when enumeration is fully complete. Needed to split `OnEnumerationComplete` into two methods since job status logic is always needed.
- Add a cancellation token check on each iteration for enumeration to allow for faster pausing.
- Use `HashSet` when looking for existing resources for better perf with large transfers.