### PR TITLE
Mapping "maxMessageBatchSize" to "batchOptions:maxMessageCount"

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -81,6 +81,10 @@ namespace Microsoft.Extensions.Hosting
                         "SessionHandlerOptions:MaxConcurrentSessions",
                         options.MaxConcurrentSessions);
 
+                    options.MaxMessageBatchSize = section.GetValue(
+                        "batchOptions:maxMessageCount",
+                        options.MaxConcurrentSessions);
+
                     var proxy = section.GetValue<string>("WebProxy");
                     if (!string.IsNullOrEmpty(proxy))
                     {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.Hosting
 
                     options.MaxMessageBatchSize = section.GetValue(
                         "BatchOptions:MaxMessageCount",
-                        options.MaxConcurrentSessions);
+                        options.MaxMessageBatchSize);
 
                     var proxy = section.GetValue<string>("WebProxy");
                     if (!string.IsNullOrEmpty(proxy))

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Hosting
                         options.MaxConcurrentSessions);
 
                     options.MaxMessageBatchSize = section.GetValue(
-                        "batchOptions:maxMessageCount",
+                        "BatchOptions:MaxMessageCount",
                         options.MaxConcurrentSessions);
 
                     var proxy = section.GetValue<string>("WebProxy");

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
 
             Assert.AreEqual(123, options.PrefetchCount);
             Assert.AreEqual(123, options.MaxConcurrentCalls);
-            Assert.AreEqual(123, options.MaxMessageBatchSize);
             Assert.AreEqual(20, options.MaxConcurrentSessions);
             Assert.AreEqual(5, options.MaxConcurrentCallsPerSession);
             Assert.AreEqual(20, options.MaxMessageBatchSize);

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
 
             Assert.AreEqual(123, options.PrefetchCount);
             Assert.AreEqual(123, options.MaxConcurrentCalls);
+            Assert.AreEqual(123, options.MaxMessageBatchSize);
             Assert.False(options.AutoCompleteMessages);
             Assert.AreEqual(TimeSpan.FromSeconds(15), options.MaxAutoLockRenewalDuration);
         }
@@ -65,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
 
             Assert.AreEqual(123, options.PrefetchCount);
             Assert.AreEqual(123, options.MaxConcurrentCalls);
+            Assert.AreEqual(123, options.MaxMessageBatchSize);
             Assert.AreEqual(20, options.MaxConcurrentSessions);
             Assert.AreEqual(5, options.MaxConcurrentCallsPerSession);
             Assert.AreEqual(20, options.MaxMessageBatchSize);


### PR DESCRIPTION
Need to add the mapping form old host.json fomat to new host.json format for `maxMessageCount`. We already have the mappings for other concurrency settings here: 

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs#L76

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Config/ServiceBusHostBuilderExtensions.cs#L80