### PR TITLE
Added ModelFactory Substitute

### DIFF
--- a/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.net6.0.cs
+++ b/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.net6.0.cs
@@ -137,6 +137,7 @@ namespace System.Net.ClientModel.Core
     }
     public static partial class ModelReaderWriter
     {
+        public static T? Create<T>(object jsonSerializable) where T : System.Net.ClientModel.Core.IJsonModel<T> { throw null; }
         public static object? Read(System.BinaryData data, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type returnType, System.Net.ClientModel.Core.ModelReaderWriterFormat format) { throw null; }
         public static object? Read(System.BinaryData data, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type returnType, System.Net.ClientModel.Core.ModelReaderWriterOptions? options = null) { throw null; }
         public static T? Read<T>(System.BinaryData data, System.Net.ClientModel.Core.ModelReaderWriterFormat format) where T : System.Net.ClientModel.Core.IModel<T> { throw null; }
@@ -167,6 +168,7 @@ namespace System.Net.ClientModel.Core
     }
     public partial class ModelReaderWriterOptions
     {
+        public static readonly System.Net.ClientModel.Core.ModelReaderWriterOptions DefaultJsonOptions;
         public static readonly System.Net.ClientModel.Core.ModelReaderWriterOptions DefaultWireOptions;
         public ModelReaderWriterOptions() { }
         public ModelReaderWriterOptions(System.Net.ClientModel.Core.ModelReaderWriterFormat format) { }

--- a/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.netstandard2.0.cs
@@ -135,6 +135,7 @@ namespace System.Net.ClientModel.Core
     }
     public static partial class ModelReaderWriter
     {
+        public static T? Create<T>(object jsonSerializable) where T : System.Net.ClientModel.Core.IJsonModel<T> { throw null; }
         public static object? Read(System.BinaryData data, System.Type returnType, System.Net.ClientModel.Core.ModelReaderWriterFormat format) { throw null; }
         public static object? Read(System.BinaryData data, System.Type returnType, System.Net.ClientModel.Core.ModelReaderWriterOptions? options = null) { throw null; }
         public static T? Read<T>(System.BinaryData data, System.Net.ClientModel.Core.ModelReaderWriterFormat format) where T : System.Net.ClientModel.Core.IModel<T> { throw null; }
@@ -165,6 +166,7 @@ namespace System.Net.ClientModel.Core
     }
     public partial class ModelReaderWriterOptions
     {
+        public static readonly System.Net.ClientModel.Core.ModelReaderWriterOptions DefaultJsonOptions;
         public static readonly System.Net.ClientModel.Core.ModelReaderWriterOptions DefaultWireOptions;
         public ModelReaderWriterOptions() { }
         public ModelReaderWriterOptions(System.Net.ClientModel.Core.ModelReaderWriterFormat format) { }

--- a/sdk/core/System.Net.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.Net.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net.ClientModel.Core;
 using System.Net.ClientModel.Internal;
+using System.Text.Json;
 
 namespace System.Net.ClientModel.Core
 {
@@ -12,6 +13,21 @@ namespace System.Net.ClientModel.Core
     /// </summary>
     public static class ModelReaderWriter
     {
+        /// <summary>
+        /// Creates an instance of a model from an instance of an anonymous type.
+        /// </summary>
+        /// <typeparam name="T">The type of the model to create.</typeparam>
+        /// <param name="jsonSerializable">An instance of an anonymous type representing the model</param>
+        /// <returns>A <typeparamref name="T"/> instance.</returns>
+        public static T? Create<T>(object jsonSerializable) where T : IJsonModel<T>
+        {
+            BinaryData json = BinaryData.FromObjectAsJson(jsonSerializable);
+            var reader = new Utf8JsonReader(json);
+            IJsonModel<T> instance = (T)Activator.CreateInstance(typeof(T), true)!;
+            T? read = instance.Read(ref reader, ModelReaderWriterOptions.DefaultJsonOptions);
+            return read;
+        }
+
         /// <summary>
         /// Converts the value of a model into a <see cref="BinaryData"/>.
         /// </summary>

--- a/sdk/core/System.Net.ClientModel/src/ModelReaderWriter/ModelReaderWriterOptions.cs
+++ b/sdk/core/System.Net.ClientModel/src/ModelReaderWriter/ModelReaderWriterOptions.cs
@@ -21,6 +21,11 @@ namespace System.Net.ClientModel.Core
         /// </summary>
         public static readonly ModelReaderWriterOptions DefaultWireOptions = _singletonMap[ModelReaderWriterFormat.Wire];
 
+        /// <summary>
+        /// Default options for writing models into the JSON format.
+        /// </summary>
+        public static readonly ModelReaderWriterOptions DefaultJsonOptions = _singletonMap[ModelReaderWriterFormat.Json];
+
         public static ModelReaderWriterOptions GetOptions(ModelReaderWriterFormat format)
             => _singletonMap.TryGetValue(format, out ModelReaderWriterOptions? options) ? options! : new ModelReaderWriterOptions(format);
 

--- a/sdk/core/System.Net.ClientModel/tests/client/OpenAIClient/Choice.Serialization.cs
+++ b/sdk/core/System.Net.ClientModel/tests/client/OpenAIClient/Choice.Serialization.cs
@@ -18,7 +18,7 @@ public partial class Choice
         internal static Choice DeserializeChoice(JsonElement element, ModelReaderWriterOptions options)
         {
             bool wire = options.Format == ModelReaderWriterFormat.Wire;
-            if (options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
+            if (!wire && options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
 
             if (element.ValueKind == JsonValueKind.Null)
             {
@@ -85,7 +85,7 @@ public partial class Choice
         internal void Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
             bool wire = options.Format == ModelReaderWriterFormat.Wire;
-            if (options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
+            if (!wire && options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
 
             writer.WriteStartObject();
             writer.WriteString(wire?"text"u8:"Text"u8, this.Text);

--- a/sdk/core/System.Net.ClientModel/tests/client/OpenAIClient/Completions.Serialization.cs
+++ b/sdk/core/System.Net.ClientModel/tests/client/OpenAIClient/Completions.Serialization.cs
@@ -23,7 +23,7 @@ public partial class Completions : IJsonModel<Completions>
     internal static Completions DeserializeCompletions(JsonElement element, ModelReaderWriterOptions options)
     {
         bool wire = options.Format == ModelReaderWriterFormat.Wire;
-        if (options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
+        if (!wire && options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
 
         if (element.ValueKind == JsonValueKind.Null)
         {
@@ -102,7 +102,7 @@ public partial class Completions : IJsonModel<Completions>
     void IJsonModel<Completions>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         bool wire = options.Format == ModelReaderWriterFormat.Wire;
-        if (options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
+        if (!wire && options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
 
         writer.WriteStartObject();
         writer.WriteString(wire?"id"u8:"Id"u8, this.Id);

--- a/sdk/core/System.Net.ClientModel/tests/client/OpenAIClient/Completions.Serialization.cs
+++ b/sdk/core/System.Net.ClientModel/tests/client/OpenAIClient/Completions.Serialization.cs
@@ -104,8 +104,6 @@ public partial class Completions : IJsonModel<Completions>
         bool wire = options.Format == ModelReaderWriterFormat.Wire;
         if (options.Format != ModelReaderWriterFormat.Json) throw new ArgumentOutOfRangeException(nameof(options.Format));
 
-        ModelSerializerHelper.ValidateFormat<Completions>(this, options.Format);
-
         writer.WriteStartObject();
         writer.WriteString(wire?"id"u8:"Id"u8, this.Id);
         writer.WriteString(wire?"created"u8:"Created"u8, this.Created);

--- a/sdk/core/System.Net.ClientModel/tests/client/OpenAIClientTests.cs
+++ b/sdk/core/System.Net.ClientModel/tests/client/OpenAIClientTests.cs
@@ -3,6 +3,8 @@
 
 using NUnit.Framework;
 using OpenAI;
+using System.Net.ClientModel.Core;
+using System.Threading;
 
 namespace System.Net.ClientModel.Tests;
 
@@ -30,5 +32,17 @@ public class OpenAIClientTests
         Choice choice = result.Value.Choices[0];
 
         Assert.IsTrue(choice.Text.StartsWith("\n\nLife is"));
+    }
+
+    [Test]
+    public void ModelFactory()
+    {
+        Completions model = ModelReaderWriter.Create<Completions>(new
+        {
+            Choices = new object[] {
+               new { Text = "Good!" }
+            }
+        });
+        Assert.AreEqual(model.Choices[0].Text, "Good!");
     }
 }

--- a/sdk/core/System.Net.ClientModel/tests/client/System.Net.ClientModel.Tests.Client.csproj
+++ b/sdk/core/System.Net.ClientModel/tests/client/System.Net.ClientModel.Tests.Client.csproj
@@ -4,7 +4,6 @@
     <Description>Test client code for use in System.Net.ClientModel test libraries.</Description>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsTestSupportProject>true</IsTestSupportProject>
-		<LangVersion>preview</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/sdk/core/System.Net.ClientModel/tests/client/System.Net.ClientModel.Tests.Client.csproj
+++ b/sdk/core/System.Net.ClientModel/tests/client/System.Net.ClientModel.Tests.Client.csproj
@@ -4,6 +4,7 @@
     <Description>Test client code for use in System.Net.ClientModel test libraries.</Description>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IsTestSupportProject>true</IsTestSupportProject>
+		<LangVersion>preview</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Now that models will be serializable, we don't need ModelFactory anymore. This PR adds ModelReaderWriter.Create method (that will be used instead of the model factories), and a test showing how such method can be used to create instances of a model. 
