### PR TITLE
[Samples] Update Azure Identity references

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -24,7 +24,7 @@
       The static set is included here to allow for local testing of the smoke tests project
       without the need to run CI scripts to rewrite package references.
     -->
-    <PackageReference Include="Azure.Identity" Version="1.5.0-beta.3" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.2" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.3.0-beta.1" />

--- a/samples/AppSecretsConfig/AppSecretsConfig.csproj
+++ b/samples/AppSecretsConfig/AppSecretsConfig.csproj
@@ -6,7 +6,7 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.4.0" />
   </ItemGroup>
 

--- a/samples/CloudClipboard/CloudClipboard/CloudClipboard.csproj
+++ b/samples/CloudClipboard/CloudClipboard/CloudClipboard.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />

--- a/samples/CloudClipboard/GarbageCollector/GarbageCollector.csproj
+++ b/samples/CloudClipboard/GarbageCollector/GarbageCollector.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
   </ItemGroup>
 

--- a/sdk/databoxedge/Microsoft.Azure.Management.DataBoxEdge/tests/Microsoft.Azure.Management.DataBoxEdge.Tests.csproj
+++ b/sdk/databoxedge/Microsoft.Azure.Management.DataBoxEdge/tests/Microsoft.Azure.Management.DataBoxEdge.Tests.csproj
@@ -16,7 +16,7 @@
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.4.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <!--using the preview version of Azure.Identity to have access to KnownAuthorityHosts static class.-->
-    <PackageReference Include="Azure.Identity" Version="1.2.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
 

--- a/sdk/eventhub/Microsoft.Azure.Management.EventHub/tests/Microsoft.Azure.Management.EventHub.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.Management.EventHub/tests/Microsoft.Azure.Management.EventHub.Tests.csproj
@@ -28,7 +28,7 @@
     <Folder Include="SessionRecords\EventHub.Tests.ScenarioTests.ScenarioTests\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.Management.KeyVault" Version="3.0.0" />

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/TimeSeriesInsightsClientSample.csproj
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/TimeSeriesInsightsClientSample.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.32.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.37.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the set of direct references to the `Azure.Identity` library used by a handful of stand-alone samples and legacy test projects.  The previous version referenced had been flagged as potentially having a security vulnerability.

# References and Resources

- [Grep view: Azure.Identity direct references](https://grep.app/search?q=%3CPackageReference%20Include%3D%22Azure.Identity%22%20Version%3D&filter[repo][0]=Azure/azure-sdk-for-net)