### PR TITLE
Remove duplicate `to` in `AzureKeyVaultConfigurationExtensions.cs`

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Configuration
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="vaultUri">The Azure Key Vault uri.</param>
-        /// <param name="credential">The credential to to use for authentication.</param>
+        /// <param name="credential">The credential to use for authentication.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Configuration
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="vaultUri">Azure Key Vault uri.</param>
-        /// <param name="credential">The credential to to use for authentication.</param>
+        /// <param name="credential">The credential to use for authentication.</param>
         /// <param name="manager">The <see cref="KeyVaultSecretManager"/> instance used to control secret loading.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Configuration
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="vaultUri">Azure Key Vault uri.</param>
-        /// <param name="credential">The credential to to use for authentication.</param>
+        /// <param name="credential">The credential to use for authentication.</param>
         /// <param name="options">The <see cref="AzureKeyVaultConfigurationOptions"/> to use.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(


### PR DESCRIPTION
I stumbled upon this typo today, if I'm not mistaken.