### PR TITLE
[Event Hubs] Fix ETW arg type inference

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a parameter type mismatch in ETW #7 (ReceiveComplete) which caused the duration argument of the operation to be interpreted as a Unicode string and fail to render properly in the formatted message.
+
 ### Other Changes
 
 ## 5.9.3 (2023-09-12)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -396,9 +396,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                     operationId,
                     failedAttemptCount,
                     receivedEventCount,
+                    stopWatch.GetElapsedTime().TotalSeconds,
                     firstReceivedEvent?.SequenceNumber.ToString(),
-                    LastReceivedEvent?.SequenceNumber.ToString(),
-                    stopWatch.GetElapsedTime().TotalSeconds);
+                    LastReceivedEvent?.SequenceNumber.ToString());
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -106,7 +106,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="retryCount">The number of retries that were used for service communication.</param>
         /// <param name="durationSeconds">The total duration that the receive operation took to complete, in seconds.</param>
         ///
-        [Event(4, Level = EventLevel.Informational, Message = "Completed publishing events for Event Hub: {0} (Partition Id/Key: '{1}'), Operation Id: '{2}'.  Service Retry Count: {3}; Duration: '{4:0.00}' seconds")]
+        [Event(4, Level = EventLevel.Informational, Message = "Completed publishing events for Event Hub: {0} (Partition Id/Key: '{1}'), Operation Id: '{2}'.  Service Retry Count: {3}; Duration: '{4:0.00}' seconds.")]
         public virtual void EventPublishComplete(string eventHubName,
                                                  string partitionIdOrKey,
                                                  string operationId,
@@ -175,16 +175,16 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="endingSequenceNumber">The sequence number of the last event in the batch.</param>
         /// <param name="durationSeconds">The total duration that the receive operation took to complete, in seconds.</param>
         ///
-        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Starting sequence number: '{7}', Ending sequence number: '{8}'; Duration: '{6:0.00}' seconds")]
+        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Duration: '{6:0.00}' seconds; Starting sequence number: '{7}', Ending sequence number: '{8}'.")]
         public virtual void EventReceiveComplete(string eventHubName,
                                                  string consumerGroup,
                                                  string partitionId,
                                                  string operationId,
                                                  int retryCount,
                                                  int eventCount,
+                                                 double durationSeconds,
                                                  string startingSequenceNumber,
-                                                 string endingSequenceNumber,
-                                                 double durationSeconds)
+                                                 string endingSequenceNumber)
         {
             if (IsEnabled())
             {


### PR DESCRIPTION
# Summary 

The focus of these changes is to fix an issue with the inferred type for an ETW event argument, which was causing the event to be interpreted as a Unicode string rather than a double.  This caused the message text to display incorrectly and the value was represented as the wrong type in the structured arguments array.