### PR TITLE
Revert "ClientModel: NullableResult<T> and Result<T> experiment"

### DIFF
--- a/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.net6.0.cs
+++ b/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.net6.0.cs
@@ -47,6 +47,7 @@ namespace System.Net.ClientModel
     public partial class NullableResult<T> : System.Net.ClientModel.Result
     {
         internal NullableResult() { }
+        public virtual bool HasValue { get { throw null; } }
         public virtual T? Value { get { throw null; } }
         public override System.Net.ClientModel.Core.MessageResponse GetRawResponse() { throw null; }
     }
@@ -63,14 +64,15 @@ namespace System.Net.ClientModel
         protected Result() { }
         public static System.Net.ClientModel.NullableResult<T> FromNullableValue<T>(T? value, System.Net.ClientModel.Core.MessageResponse response) { throw null; }
         public static System.Net.ClientModel.Result FromResponse(System.Net.ClientModel.Core.MessageResponse response) { throw null; }
-        public static System.Net.ClientModel.Result<T> FromValue<T>(T value, System.Net.ClientModel.Core.MessageResponse response) where T : notnull { throw null; }
+        public static System.Net.ClientModel.Result<T> FromValue<T>(T value, System.Net.ClientModel.Core.MessageResponse response) { throw null; }
         public abstract System.Net.ClientModel.Core.MessageResponse GetRawResponse();
     }
-    public partial class Result<T> : System.Net.ClientModel.Result where T : notnull
+    public partial class Result<T> : System.Net.ClientModel.NullableResult<T>
     {
         internal Result() { }
-        public T Value { get { throw null; } }
-        public override System.Net.ClientModel.Core.MessageResponse GetRawResponse() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
     }
     public partial class UnsuccessfulRequestException : System.Exception
     {

--- a/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.Net.ClientModel/api/System.Net.ClientModel.netstandard2.0.cs
@@ -47,6 +47,7 @@ namespace System.Net.ClientModel
     public partial class NullableResult<T> : System.Net.ClientModel.Result
     {
         internal NullableResult() { }
+        public virtual bool HasValue { get { throw null; } }
         public virtual T? Value { get { throw null; } }
         public override System.Net.ClientModel.Core.MessageResponse GetRawResponse() { throw null; }
     }
@@ -63,14 +64,15 @@ namespace System.Net.ClientModel
         protected Result() { }
         public static System.Net.ClientModel.NullableResult<T> FromNullableValue<T>(T? value, System.Net.ClientModel.Core.MessageResponse response) { throw null; }
         public static System.Net.ClientModel.Result FromResponse(System.Net.ClientModel.Core.MessageResponse response) { throw null; }
-        public static System.Net.ClientModel.Result<T> FromValue<T>(T value, System.Net.ClientModel.Core.MessageResponse response) where T : notnull { throw null; }
+        public static System.Net.ClientModel.Result<T> FromValue<T>(T value, System.Net.ClientModel.Core.MessageResponse response) { throw null; }
         public abstract System.Net.ClientModel.Core.MessageResponse GetRawResponse();
     }
-    public partial class Result<T> : System.Net.ClientModel.Result where T : notnull
+    public partial class Result<T> : System.Net.ClientModel.NullableResult<T>
     {
         internal Result() { }
-        public T Value { get { throw null; } }
-        public override System.Net.ClientModel.Core.MessageResponse GetRawResponse() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
     }
     public partial class UnsuccessfulRequestException : System.Exception
     {

--- a/sdk/core/System.Net.ClientModel/src/Experimental/PipelineProtocolExtensions.cs
+++ b/sdk/core/System.Net.ClientModel/src/Experimental/PipelineProtocolExtensions.cs
@@ -49,9 +49,9 @@ public static class PipelineProtocolExtensions
         switch (response.Status)
         {
             case >= 200 and < 300:
-                return Result.FromNullableValue(true, response);
+                return Result.FromValue(true, response);
             case >= 400 and < 500:
-                return Result.FromNullableValue(false, response);
+                return Result.FromValue(false, response);
             default:
                 return new ErrorResult<bool>(response, new UnsuccessfulRequestException(response));
         }
@@ -63,9 +63,9 @@ public static class PipelineProtocolExtensions
         switch (response.Status)
         {
             case >= 200 and < 300:
-                return Result.FromNullableValue(true, response);
+                return Result.FromValue(true, response);
             case >= 400 and < 500:
-                return Result.FromNullableValue(false, response);
+                return Result.FromValue(false, response);
             default:
                 return new ErrorResult<bool>(response, new UnsuccessfulRequestException(response));
         }
@@ -83,10 +83,9 @@ public static class PipelineProtocolExtensions
             _exception = exception;
         }
 
-        public override T? Value { get => throw _exception; }
+        public override T Value { get => throw _exception; }
 
-        // TODO: come back to as we decide what to do when ErrorBehavior=NoThrow.
-        //public override bool HasValue => false;
+        public override bool HasValue => false;
 
         public override MessageResponse GetRawResponse() => _response;
     }

--- a/sdk/core/System.Net.ClientModel/src/NullableResultOfT.cs
+++ b/sdk/core/System.Net.ClientModel/src/NullableResultOfT.cs
@@ -1,31 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.Net.ClientModel.Core;
 
 namespace System.Net.ClientModel;
 
 public class NullableResult<T> : Result
 {
-    private readonly T? _value;
-    private readonly MessageResponse _response;
+    private T? _value;
+    private MessageResponse _response;
 
     internal NullableResult(T? value, MessageResponse response)
     {
-        if (response is null) throw new ArgumentNullException(nameof(response));
-
+        Debug.Assert(response != null);
         _response = response!;
         _value = value;
     }
 
     public virtual T? Value => _value;
 
-    // TODO: Note that HasValue is needed if we decide we want to give callers
-    // a way to check whether Value is null without actually calling the Value
-    // getter.  We would want this if we decide to use an exploding response,
-    // but if we decide not to use an exploding response, HasValue is not strictly
-    // required because callers can always to do `response.Value is null` to check.
-    //public virtual bool HasValue => _value != null;
+    public virtual bool HasValue => _value != null;
 
     public override MessageResponse GetRawResponse() => _response;
 }

--- a/sdk/core/System.Net.ClientModel/src/Result.cs
+++ b/sdk/core/System.Net.ClientModel/src/Result.cs
@@ -13,7 +13,7 @@ public abstract class Result
     public static Result FromResponse(MessageResponse response)
         => new NoModelResult(response);
 
-    public static Result<T> FromValue<T>(T value, MessageResponse response) where T : notnull
+    public static Result<T> FromValue<T>(T value, MessageResponse response)
     {
         // Null values are required to use NullableResult<T>
         if (value is null)

--- a/sdk/core/System.Net.ClientModel/src/ResultOfT.cs
+++ b/sdk/core/System.Net.ClientModel/src/ResultOfT.cs
@@ -1,34 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Net.ClientModel.Core;
 
 namespace System.Net.ClientModel;
 
-public class Result<T> : Result where T : notnull
+public class Result<T> : NullableResult<T>
 {
-    private readonly T _value;
-    private readonly MessageResponse _response;
-
-    internal Result(T value, MessageResponse response)
+    internal Result(T value, MessageResponse response) : base(value, response)
     {
-        if (response is null) throw new ArgumentNullException(nameof(response));
+        Debug.Assert(value != null);
+        Debug.Assert(response != null);
 
-        // We throw here because the Result<T> contract is that Value will always
-        // be non-null.  This is because it is a convenience to client users that they
-        // never need to check result.Value for null.  If a client author needs to return
-        // a Result with a null Value, they a must use NullableResult<T> for the service
-        // method return value.
+        // Null values are required to use NullableResult<T>
         if (value is null)
         {
             throw new ArgumentException("Result<T> contract guarantees that Result<T>.Value is non-null.", nameof(value));
         }
-
-        _value = value;
-        _response = response;
     }
 
-    public T Value => _value;
+    public override T Value => base.Value!;
 
-    public override MessageResponse GetRawResponse() => _response;
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override bool HasValue => true;
 }


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#39683

Based on an offline discussion with @KrzysztofCwalina, we need inheritance to enable passing Result<T> as an input to any method that might take either NullableResult<T> or Result<T>.  This is important and we cannot take the base Result type instead because we wouldn't be able to downcast in the method since we wouldn't have the T.

We will need to follow up on this since we still don't have an answer for what happens to Result<T> when RequestOptions.ErrorBehavior is set to NoThrow, but we want to have the review with BCL team with Result<T> inheriting from NullableResult<T> in case we need it in the future, not share something that's easy to agree with an introduce something less ideal after the review.

@christothes  FYI