### PR TITLE
[Storage][DataMovement] Fixes/adjustments for initial transfer and chunk sizes

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/AppendBlobStorageResource.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <summary>
         /// Defines the maximum chunk size for the storage resource.
         /// </summary>
-        protected override long MaxChunkSize => Constants.Blob.Append.MaxAppendBlockBytes;
+        protected override long MaxSupportedChunkSize => Constants.Blob.Append.MaxAppendBlockBytes;
 
         /// <summary>
         /// Length of the storage resource. This information is obtained during a GetStorageResources API call.

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/BlockBlobStorageResource.cs
@@ -49,7 +49,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <summary>
         /// Defines the maximum chunk size for the storage resource.
         /// </summary>
-        protected override long MaxChunkSize => Constants.Blob.Block.MaxStageBytes;
+        protected override long MaxSupportedChunkSize => Constants.Blob.Block.MaxStageBytes;
 
         /// <summary>
         /// Length of the storage resource. This information is can obtained during a GetStorageResources API call.

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/PageBlobStorageResource.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.DataMovement.Blobs
         /// <summary>
         /// Defines the maximum chunk size for the storage resource.
         /// </summary>
-        protected override long MaxChunkSize => Constants.Blob.Page.MaxPageBlockBytes;
+        protected override long MaxSupportedChunkSize => Constants.Blob.Page.MaxPageBlockBytes;
 
         /// <summary>
         /// Length of the storage resource. This information is obtained during a GetStorageResources API call.

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/Azure.Storage.DataMovement.Blobs.Tests.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/Azure.Storage.DataMovement.Blobs.Tests.csproj
@@ -30,9 +30,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory> 
     </Content> 
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="Resources\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
 </Project>

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_02f417687f"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_876c524ce2"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResource.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.DataMovement.Files.Shares
 
         protected override DataTransferOrder TransferType => DataTransferOrder.Sequential;
 
-        protected override long MaxChunkSize => DataMovementShareConstants.MaxRange;
+        protected override long MaxSupportedChunkSize => DataMovementShareConstants.MaxRange;
 
         protected override long? Length => _length;
 

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net6.0.cs
@@ -151,7 +151,7 @@ namespace Azure.Storage.DataMovement
         protected StorageResourceItem() { }
         protected internal override bool IsContainer { get { throw null; } }
         protected internal abstract long? Length { get; }
-        protected internal abstract long MaxChunkSize { get; }
+        protected internal abstract long MaxSupportedChunkSize { get; }
         protected internal abstract string ResourceId { get; }
         protected internal abstract Azure.Storage.DataMovement.DataTransferOrder TransferType { get; }
         protected internal abstract System.Threading.Tasks.Task CompleteTransferAsync(bool overwrite, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -151,7 +151,7 @@ namespace Azure.Storage.DataMovement
         protected StorageResourceItem() { }
         protected internal override bool IsContainer { get { throw null; } }
         protected internal abstract long? Length { get; }
-        protected internal abstract long MaxChunkSize { get; }
+        protected internal abstract long MaxSupportedChunkSize { get; }
         protected internal abstract string ResourceId { get; }
         protected internal abstract Azure.Storage.DataMovement.DataTransferOrder TransferType { get; }
         protected internal abstract System.Threading.Tasks.Task CompleteTransferAsync(bool overwrite, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));

--- a/sdk/storage/Azure.Storage.DataMovement/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement",
-  "Tag": "net/storage/Azure.Storage.DataMovement_d8993077de"
+  "Tag": "net/storage/Azure.Storage.DataMovement_1d3b42ba88"
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferOptions.cs
@@ -13,20 +13,27 @@ namespace Azure.Storage.DataMovement
     public class DataTransferOptions : IEquatable<DataTransferOptions>
     {
         /// <summary>
-        /// The maximum length of a network transfer in bytes.
-        ///
-        /// On uploads, if the value is not set, it will be set at 4 MB if the total size is less than 100MB
-        /// or will default to 8 MB if the total size is greater than or equal to 100MB.
+        /// The maximum size to use for each chunk when transferring data in chunks.
+        /// The default value is 4 MiB.
+        /// <para/>
+        /// This value may be clamped to the maximum allowed for the particular transfer/resource type.
+        /// <para/>
+        /// This value is ignored when resuming a transfer as the value used when initially
+        /// starting the transfer will be used.
         /// </summary>
         public long? MaximumTransferChunkSize { get; set; }
 
         /// <summary>
         /// The size of the first range request in bytes. Single Transfer sizes smaller than this
-        /// limit will be Uploaded or Downloaded in a single request.
-        /// Transfers larger than this limit will continue being downloaded or uploaded
-        /// in chunks of size <see cref="MaximumTransferChunkSize"/>.
-        ///
-        /// On Uploads, if the value is not set, it will set at 256 MB. (TODO: We should lower to 32 MB)
+        /// limit will be Uploaded or Downloaded in a single request. Transfers larger than this
+        /// limit will continue being downloaded or uploaded in chunks of size
+        /// <see cref="MaximumTransferChunkSize"/>.
+        /// The default value is 32 MiB.
+        /// <para/>
+        /// This value may be clamped to the maximum allowed for the particular transfer/resource type.
+        /// <para/>
+        /// This value is ignored when resuming a transfer as the value used when initially
+        /// starting the transfer will be used.
         /// </summary>
         public long? InitialTransferSize { get; set; }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataTransferOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataTransferOptions.cs
@@ -16,10 +16,10 @@ namespace Azure.Storage.DataMovement
         /// The maximum size to use for each chunk when transferring data in chunks.
         /// The default value is 4 MiB.
         /// <para/>
-        /// This value may be clamped to the maximum allowed for the particular transfer/resource type.
+        /// When resuming a transfer, the default value will be the value specified
+        /// when the transfer was first started.
         /// <para/>
-        /// This value is ignored when resuming a transfer as the value used when initially
-        /// starting the transfer will be used.
+        /// This value may be clamped to the maximum allowed for the particular transfer/resource type.
         /// </summary>
         public long? MaximumTransferChunkSize { get; set; }
 
@@ -30,10 +30,10 @@ namespace Azure.Storage.DataMovement
         /// <see cref="MaximumTransferChunkSize"/>.
         /// The default value is 32 MiB.
         /// <para/>
-        /// This value may be clamped to the maximum allowed for the particular transfer/resource type.
+        /// When resuming a transfer, the default value will be the value specified
+        /// when the transfer was first started.
         /// <para/>
-        /// This value is ignored when resuming a transfer as the value used when initially
-        /// starting the transfer will be used.
+        /// This value may be clamped to the maximum allowed for the particular transfer/resource type.
         /// </summary>
         public long? InitialTransferSize { get; set; }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalFileStorageResource.cs
@@ -31,7 +31,7 @@ namespace Azure.Storage.DataMovement
         /// Defines the maximum chunk size for the storage resource.
         /// </summary>
         /// TODO: consider changing this.
-        protected internal override long MaxChunkSize => Constants.Blob.Block.MaxStageBytes;
+        protected internal override long MaxSupportedChunkSize => Constants.Blob.Block.MaxStageBytes;
 
         /// <summary>
         /// Length of the storage resource. This information is can obtained during a GetStorageResources API call.

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -79,13 +79,13 @@ namespace Azure.Storage.DataMovement
                   length: length)
         {
             // If transfer sizes null at the job level (from options bag) then
-            // override the default with checkpointed values.
+            // override the default with the provided values if present.
             // Else, they were set correctly by the base constructor.
-            if (!job._maximumTransferChunkSize.HasValue)
+            if (!job._maximumTransferChunkSize.HasValue && transferChunkSize.HasValue)
             {
                 _transferChunkSize = transferChunkSize.Value;
             }
-            if (!job._initialTransferSize.HasValue)
+            if (!job._initialTransferSize.HasValue && initialTransferSize.HasValue)
             {
                 _initialTransferSize = initialTransferSize.Value;
             }

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -28,7 +28,7 @@ namespace Azure.Storage.DataMovement
                   partNumber: partNumber,
                   sourceResource: job._sourceResource,
                   destinationResource: job._destinationResource,
-                  maximumTransferChunkSize: job._maximumTransferChunkSize,
+                  transferChunkSize: job._maximumTransferChunkSize,
                   initialTransferSize: job._initialTransferSize,
                   errorHandling: job._errorMode,
                   createMode: job._creationPreference,
@@ -54,12 +54,14 @@ namespace Azure.Storage.DataMovement
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
             DataTransferStatus jobPartStatus = default,
-            long? length = default)
+            long? length = default,
+            long? initialTransferSize = default,
+            long? transferChunkSize = default)
             : base(dataTransfer: job._dataTransfer,
                   partNumber: partNumber,
                   sourceResource: sourceResource,
-                  destinationResource :destinationResource,
-                  maximumTransferChunkSize: job._maximumTransferChunkSize,
+                  destinationResource: destinationResource,
+                  transferChunkSize: job._maximumTransferChunkSize,
                   initialTransferSize: job._initialTransferSize,
                   errorHandling: job._errorMode,
                   createMode: job._creationPreference,
@@ -76,6 +78,16 @@ namespace Azure.Storage.DataMovement
                   jobPartStatus: jobPartStatus,
                   length: length)
         {
+            // If transfer sizes were provided override ones from job.
+            // This will be the case when resuming from a checkpoint file.
+            if (initialTransferSize.HasValue)
+            {
+                _initialTransferSize = initialTransferSize.Value;
+            }
+            if (transferChunkSize.HasValue)
+            {
+                _transferChunkSize = transferChunkSize.Value;
+            }
         }
 
         public async ValueTask DisposeAsync()
@@ -83,6 +95,9 @@ namespace Azure.Storage.DataMovement
             await DisposeHandlers().ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when creating a job part from a single transfer.
+        /// </summary>
         public static async Task<ServiceToServiceJobPart> CreateJobPartAsync(
             ServiceToServiceTransferJob job,
             int partNumber)
@@ -93,28 +108,47 @@ namespace Azure.Storage.DataMovement
             return part;
         }
 
+        /// <summary>
+        /// Called when creating a job part from a container transfer.
+        /// </summary>
         public static async Task<ServiceToServiceJobPart> CreateJobPartAsync(
             ServiceToServiceTransferJob job,
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            DataTransferStatus jobPartStatus = default,
-            long? length = default,
-            bool partPlanFileExists = false)
+            long? length = default)
         {
             // Create Job Part file as we're initializing the job part
             ServiceToServiceJobPart part = new ServiceToServiceJobPart(
                 job: job,
                 partNumber: partNumber,
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
                 length: length);
-            if (!partPlanFileExists)
-            {
-                await part.AddJobPartToCheckpointerAsync().ConfigureAwait(false);
-            }
+            await part.AddJobPartToCheckpointerAsync().ConfigureAwait(false);
             return part;
+        }
+
+        /// <summary>
+        /// Called when creating a job part from a checkpoint file on resume.
+        /// </summary>
+        public static ServiceToServiceJobPart CreateJobPartFromCheckpoint(
+            ServiceToServiceTransferJob job,
+            int partNumber,
+            StorageResourceItem sourceResource,
+            StorageResourceItem destinationResource,
+            DataTransferStatus jobPartStatus,
+            long initialTransferSize,
+            long transferChunkSize)
+        {
+            return new ServiceToServiceJobPart(
+                job: job,
+                partNumber: partNumber,
+                sourceResource: sourceResource,
+                destinationResource: destinationResource,
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: initialTransferSize,
+                transferChunkSize: transferChunkSize);
         }
 
         public override async Task ProcessPartToChunkAsync()
@@ -156,7 +190,7 @@ namespace Azure.Storage.DataMovement
             }
 
             // Perform a series of chunk copies followed by a commit
-            long blockSize = CalculateBlockSize(length);
+            long blockSize = _transferChunkSize;
 
             _commitBlockHandler = GetCommitController(
                 expectedLength: length,
@@ -325,16 +359,6 @@ namespace Azure.Storage.DataMovement
                         block.Length,
                         expectedLength).ConfigureAwait(false)).ConfigureAwait(false);
             }
-        }
-
-        private static long ParseCopyProgress(string copyProgress)
-        {
-            string[] progress = copyProgress.Split('/');
-            if (progress.Length != 2)
-            {
-                throw new ArgumentException($"Invalid copy progress - {copyProgress}");
-            }
-            return long.Parse(progress[0], CultureInfo.InvariantCulture);
         }
 
         internal async Task PutBlockFromUri(

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -78,15 +78,16 @@ namespace Azure.Storage.DataMovement
                   jobPartStatus: jobPartStatus,
                   length: length)
         {
-            // If transfer sizes were provided override ones from job.
-            // This will be the case when resuming from a checkpoint file.
-            if (initialTransferSize.HasValue)
-            {
-                _initialTransferSize = initialTransferSize.Value;
-            }
-            if (transferChunkSize.HasValue)
+            // If transfer sizes null at the job level (from options bag) then
+            // override the default with checkpointed values.
+            // Else, they were set correctly by the base constructor.
+            if (!job._maximumTransferChunkSize.HasValue)
             {
                 _transferChunkSize = transferChunkSize.Value;
+            }
+            if (!job._initialTransferSize.HasValue)
+            {
+                _initialTransferSize = initialTransferSize.Value;
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Reflection;
-
 namespace Azure.Storage.DataMovement
 {
     internal class DataMovementConstants
@@ -17,6 +15,9 @@ namespace Azure.Storage.DataMovement
         internal const int MaxJobChunkTasks = 3000;
         internal const int StatusCheckInSec = 10;
         internal const int DefaultArrayPoolArraySize = 4 * 1024;
+
+        internal const long DefaultInitialTransferSize = 32 * Constants.MB;
+        internal const long DefaultChunkSize = 4 * Constants.MB;
 
         internal static class ConcurrencyTuner
         {

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementExtensions.cs
@@ -19,7 +19,7 @@ namespace Azure.Storage.DataMovement
                 lastAccessed: fileInfo.LastAccessTimeUtc);
         }
 
-        public static async Task<StreamToUriJobPart> ToJobPartAsync(
+        public static StreamToUriJobPart ToJobPartAsync(
             this StreamToUriTransferJob baseJob,
             Stream planFileStream,
             StorageResourceItem sourceResource,
@@ -28,15 +28,15 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            // Apply credentials to the saved transfer job path
             DataTransferStatus jobPartStatus = header.JobPartStatus;
-            StreamToUriJobPart jobPart = await StreamToUriJobPart.CreateJobPartAsync(
+            StreamToUriJobPart jobPart = StreamToUriJobPart.CreateJobPartFromCheckpoint(
                 job: baseJob,
                 partNumber: Convert.ToInt32(header.PartNumber),
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                partPlanFileExists: true).ConfigureAwait(false);
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: header.InitialTransferSize,
+                transferChunkSize: header.ChunkSize);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -44,7 +44,7 @@ namespace Azure.Storage.DataMovement
             return jobPart;
         }
 
-        public static async Task<ServiceToServiceJobPart> ToJobPartAsync(
+        public static ServiceToServiceJobPart ToJobPartAsync(
             this ServiceToServiceTransferJob baseJob,
             Stream planFileStream,
             StorageResourceItem sourceResource,
@@ -53,15 +53,15 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            // Apply credentials to the saved transfer job path
             DataTransferStatus jobPartStatus = header.JobPartStatus;
-            ServiceToServiceJobPart jobPart = await ServiceToServiceJobPart.CreateJobPartAsync(
+            ServiceToServiceJobPart jobPart = ServiceToServiceJobPart.CreateJobPartFromCheckpoint(
                 job: baseJob,
                 partNumber: Convert.ToInt32(header.PartNumber),
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                partPlanFileExists: true).ConfigureAwait(false);
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: header.InitialTransferSize,
+                transferChunkSize: header.ChunkSize);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -69,7 +69,7 @@ namespace Azure.Storage.DataMovement
             return jobPart;
         }
 
-        public static async Task<UriToStreamJobPart> ToJobPartAsync(
+        public static UriToStreamJobPart ToJobPartAsync(
             this UriToStreamTransferJob baseJob,
             Stream planFileStream,
             StorageResourceItem sourceResource,
@@ -78,15 +78,15 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            // Apply credentials to the saved transfer job path
             DataTransferStatus jobPartStatus = header.JobPartStatus;
-            UriToStreamJobPart jobPart = await UriToStreamJobPart.CreateJobPartAsync(
+            UriToStreamJobPart jobPart = UriToStreamJobPart.CreateJobPartFromCheckpoint(
                 job: baseJob,
                 partNumber: Convert.ToInt32(header.PartNumber),
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
-                partPlanFileExists: true).ConfigureAwait(false);
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: header.InitialTransferSize,
+                transferChunkSize: header.ChunkSize);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -94,7 +94,7 @@ namespace Azure.Storage.DataMovement
             return jobPart;
         }
 
-        public static async Task<StreamToUriJobPart> ToJobPartAsync(
+        public static StreamToUriJobPart ToJobPartAsync(
             this StreamToUriTransferJob baseJob,
             Stream planFileStream,
             StorageResourceContainer sourceResource,
@@ -103,19 +103,19 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
             string childSourceName = childSourcePath.Substring(sourceResource.Uri.AbsoluteUri.Length + 1);
             string childDestinationPath = header.DestinationPath;
             string childDestinationName = childDestinationPath.Substring(destinationResource.Uri.AbsoluteUri.Length + 1);
             DataTransferStatus jobPartStatus = header.JobPartStatus;
-            StreamToUriJobPart jobPart = await StreamToUriJobPart.CreateJobPartAsync(
+            StreamToUriJobPart jobPart = StreamToUriJobPart.CreateJobPartFromCheckpoint(
                 job: baseJob,
                 partNumber: Convert.ToInt32(header.PartNumber),
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource.GetStorageResourceReference(childSourceName),
                 destinationResource: destinationResource.GetStorageResourceReference(childDestinationName),
-                partPlanFileExists: true).ConfigureAwait(false);
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: header.InitialTransferSize,
+                transferChunkSize: header.ChunkSize);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -123,7 +123,7 @@ namespace Azure.Storage.DataMovement
             return jobPart;
         }
 
-        public static async Task<ServiceToServiceJobPart> ToJobPartAsync(
+        public static ServiceToServiceJobPart ToJobPartAsync(
             this ServiceToServiceTransferJob baseJob,
             Stream planFileStream,
             StorageResourceContainer sourceResource,
@@ -132,17 +132,17 @@ namespace Azure.Storage.DataMovement
             // Convert stream to job plan header
             JobPartPlanHeader header = JobPartPlanHeader.Deserialize(planFileStream);
 
-            // Apply credentials to the saved transfer job path
             string childSourcePath = header.SourcePath;
             string childDestinationPath = header.DestinationPath;
             DataTransferStatus jobPartStatus = header.JobPartStatus;
-            ServiceToServiceJobPart jobPart = await ServiceToServiceJobPart.CreateJobPartAsync(
+            ServiceToServiceJobPart jobPart = ServiceToServiceJobPart.CreateJobPartFromCheckpoint(
                 job: baseJob,
                 partNumber: Convert.ToInt32(header.PartNumber),
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource.GetStorageResourceReference(childSourcePath.Substring(sourceResource.Uri.AbsoluteUri.Length + 1)),
                 destinationResource: destinationResource.GetStorageResourceReference(childDestinationPath.Substring(destinationResource.Uri.AbsoluteUri.Length + 1)),
-                partPlanFileExists: true).ConfigureAwait(false);
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: header.InitialTransferSize,
+                transferChunkSize: header.ChunkSize);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -150,7 +150,7 @@ namespace Azure.Storage.DataMovement
             return jobPart;
         }
 
-        public static async Task<UriToStreamJobPart> ToJobPartAsync(
+        public static UriToStreamJobPart ToJobPartAsync(
             this UriToStreamTransferJob baseJob,
             Stream planFileStream,
             StorageResourceContainer sourceResource,
@@ -165,13 +165,14 @@ namespace Azure.Storage.DataMovement
             string childDestinationPath = header.DestinationPath;
             string childDestinationName = childDestinationPath.Substring(destinationResource.Uri.AbsoluteUri.Length + 1);
             DataTransferStatus jobPartStatus = header.JobPartStatus;
-            UriToStreamJobPart jobPart = await UriToStreamJobPart.CreateJobPartAsync(
+            UriToStreamJobPart jobPart = UriToStreamJobPart.CreateJobPartFromCheckpoint(
                 job: baseJob,
                 partNumber: Convert.ToInt32(header.PartNumber),
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource.GetStorageResourceReference(childSourceName),
                 destinationResource: destinationResource.GetStorageResourceReference(childDestinationName),
-                partPlanFileExists: true).ConfigureAwait(false);
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: header.InitialTransferSize,
+                transferChunkSize: header.ChunkSize);
 
             jobPart.VerifyJobPartPlanHeader(header);
 
@@ -198,7 +199,7 @@ namespace Azure.Storage.DataMovement
                 destinationPath: destinationPath,
                 overwrite: jobPart._createMode == StorageResourceCreationPreference.OverwriteIfExists,
                 initialTransferSize: jobPart._initialTransferSize,
-                chunkSize: jobPart._maximumTransferChunkSize,
+                chunkSize: jobPart._transferChunkSize,
                 priority: 0, // TODO: add priority feature
                 jobPartStatus: jobPart.JobPartStatus);
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceItem.cs
@@ -28,9 +28,9 @@ namespace Azure.Storage.DataMovement
         protected internal abstract DataTransferOrder TransferType { get; }
 
         /// <summary>
-        /// Defines the maximum chunk size for the storage resource.
+        /// Defines the maximum supported chunk size for the storage resource.
         /// </summary>
-        protected internal abstract long MaxChunkSize { get; }
+        protected internal abstract long MaxSupportedChunkSize { get; }
 
         /// <summary>
         /// Storage Resource is a container.

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -28,7 +28,7 @@ namespace Azure.Storage.DataMovement
                   partNumber: partNumber,
                   sourceResource: job._sourceResource,
                   destinationResource: job._destinationResource,
-                  maximumTransferChunkSize: job._maximumTransferChunkSize,
+                  transferChunkSize: job._maximumTransferChunkSize,
                   initialTransferSize: job._initialTransferSize,
                   errorHandling: job._errorMode,
                   createMode: job._creationPreference,
@@ -54,12 +54,14 @@ namespace Azure.Storage.DataMovement
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
             DataTransferStatus jobPartStatus = default,
-            long? length = default)
+            long? length = default,
+            long? initialTransferSize = default,
+            long? transferChunkSize = default)
             : base(dataTransfer: job._dataTransfer,
                   partNumber: partNumber,
                   sourceResource: sourceResource,
                   destinationResource: destinationResource,
-                  maximumTransferChunkSize: job._maximumTransferChunkSize,
+                  transferChunkSize: job._maximumTransferChunkSize,
                   initialTransferSize: job._initialTransferSize,
                   errorHandling: job._errorMode,
                   createMode: job._creationPreference,
@@ -76,6 +78,16 @@ namespace Azure.Storage.DataMovement
                   jobPartStatus: jobPartStatus,
                   length: length)
         {
+            // If transfer sizes were provided override ones from job.
+            // This will be the case when resuming from a checkpoint file.
+            if (initialTransferSize.HasValue)
+            {
+                _initialTransferSize = initialTransferSize.Value;
+            }
+            if (transferChunkSize.HasValue)
+            {
+                _transferChunkSize = transferChunkSize.Value;
+            }
         }
 
         public async ValueTask DisposeAsync()
@@ -83,6 +95,9 @@ namespace Azure.Storage.DataMovement
             await DisposeHandlers().ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when creating a job part from a single transfer.
+        /// </summary>
         public static async Task<StreamToUriJobPart> CreateJobPartAsync(
             StreamToUriTransferJob job,
             int partNumber)
@@ -93,28 +108,47 @@ namespace Azure.Storage.DataMovement
             return part;
         }
 
+        /// <summary>
+        /// Called when creating a job part from a container transfer.
+        /// </summary>
         public static async Task<StreamToUriJobPart> CreateJobPartAsync(
             StreamToUriTransferJob job,
             int partNumber,
             StorageResourceItem sourceResource,
             StorageResourceItem destinationResource,
-            DataTransferStatus jobPartStatus = default,
-            long? length = default,
-            bool partPlanFileExists = false)
+            long? length = default)
         {
             // Create Job Part file as we're initializing the job part
             StreamToUriJobPart part = new StreamToUriJobPart(
                 job: job,
                 partNumber: partNumber,
-                jobPartStatus: jobPartStatus,
                 sourceResource: sourceResource,
                 destinationResource: destinationResource,
                 length: length);
-            if (!partPlanFileExists)
-            {
-                await part.AddJobPartToCheckpointerAsync().ConfigureAwait(false);
-            }
+            await part.AddJobPartToCheckpointerAsync().ConfigureAwait(false);
             return part;
+        }
+
+        /// <summary>
+        /// Called when creating a job part from a checkpoint file on resume.
+        /// </summary>
+        public static StreamToUriJobPart CreateJobPartFromCheckpoint(
+            StreamToUriTransferJob job,
+            int partNumber,
+            StorageResourceItem sourceResource,
+            StorageResourceItem destinationResource,
+            DataTransferStatus jobPartStatus,
+            long initialTransferSize,
+            long transferChunkSize)
+        {
+            return new StreamToUriJobPart(
+                job: job,
+                partNumber: partNumber,
+                sourceResource: sourceResource,
+                destinationResource: destinationResource,
+                jobPartStatus: jobPartStatus,
+                initialTransferSize: initialTransferSize,
+                transferChunkSize: transferChunkSize);
         }
 
         /// <summary>
@@ -147,7 +181,7 @@ namespace Azure.Storage.DataMovement
                                 singleCall: true).ConfigureAwait(false)).ConfigureAwait(false);
                         return;
                     }
-                    long blockSize = CalculateBlockSize(length);
+                    long blockSize = _transferChunkSize;
 
                     _commitBlockHandler = GetCommitController(
                         expectedLength: length,

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -79,13 +79,13 @@ namespace Azure.Storage.DataMovement
                   length: length)
         {
             // If transfer sizes null at the job level (from options bag) then
-            // override the default with checkpointed values.
+            // override the default with the provided values if present.
             // Else, they were set correctly by the base constructor.
-            if (!job._maximumTransferChunkSize.HasValue)
+            if (!job._maximumTransferChunkSize.HasValue && transferChunkSize.HasValue)
             {
                 _transferChunkSize = transferChunkSize.Value;
             }
-            if (!job._initialTransferSize.HasValue)
+            if (!job._initialTransferSize.HasValue && initialTransferSize.HasValue)
             {
                 _initialTransferSize = initialTransferSize.Value;
             }

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -78,15 +78,16 @@ namespace Azure.Storage.DataMovement
                   jobPartStatus: jobPartStatus,
                   length: length)
         {
-            // If transfer sizes were provided override ones from job.
-            // This will be the case when resuming from a checkpoint file.
-            if (initialTransferSize.HasValue)
-            {
-                _initialTransferSize = initialTransferSize.Value;
-            }
-            if (transferChunkSize.HasValue)
+            // If transfer sizes null at the job level (from options bag) then
+            // override the default with checkpointed values.
+            // Else, they were set correctly by the base constructor.
+            if (!job._maximumTransferChunkSize.HasValue)
             {
                 _transferChunkSize = transferChunkSize.Value;
+            }
+            if (!job._initialTransferSize.HasValue)
+            {
+                _initialTransferSize = initialTransferSize.Value;
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -54,20 +54,19 @@ namespace Azure.Storage.DataMovement
         internal StorageResourceContainer _destinationResourceContainer;
 
         /// <summary>
-        /// The maximum length of an transfer in bytes.
+        /// The maximum size to use for each chunk when transferring data in chunks.
         ///
-        /// On uploads, if the value is not set, it will be set at 4 MB if the total size is less than 100MB
-        /// or will default to 8 MB if the total size is greater than or equal to 100MB.
+        /// This is the user specified value from options bag.
         /// </summary>
         internal long? _maximumTransferChunkSize { get; set; }
 
         /// <summary>
         /// The size of the first range request in bytes. Single Transfer sizes smaller than this
-        /// limit will be Uploaded or Downloaded in a single request.
-        /// Transfers larger than this limit will continue being downloaded or uploaded
-        /// in chunks of size <see cref="_maximumTransferChunkSize"/>.
+        /// limit will be Uploaded or Downloaded in a single request. Transfers larger than this
+        /// limit will continue being downloaded or uploaded in chunks of size
+        /// <see cref="_maximumTransferChunkSize"/>.
         ///
-        /// On Uploads, if the value is not set, it will set at 256 MB.
+        /// This is the user specified value from options bag.
         /// </summary>
         internal long? _initialTransferSize { get; set; }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -556,10 +556,10 @@ namespace Azure.Storage.DataMovement
                             cancellationToken: _cancellationToken).ConfigureAwait(false))
                         {
                             streamToUriJob.AppendJobPart(
-                                await streamToUriJob.ToJobPartAsync(
+                                streamToUriJob.ToJobPartAsync(
                                     stream,
                                     sourceResource,
-                                    destinationResource).ConfigureAwait(false));
+                                    destinationResource));
                         }
                     }
                     return streamToUriJob;
@@ -596,10 +596,10 @@ namespace Azure.Storage.DataMovement
                             cancellationToken: _cancellationToken).ConfigureAwait(false))
                         {
                             serviceToServiceJob.AppendJobPart(
-                                await serviceToServiceJob.ToJobPartAsync(
+                                serviceToServiceJob.ToJobPartAsync(
                                     stream,
                                     sourceResource,
-                                    destinationResource).ConfigureAwait(false));
+                                    destinationResource));
                         }
                     }
                     return serviceToServiceJob;
@@ -629,10 +629,10 @@ namespace Azure.Storage.DataMovement
                             cancellationToken: _cancellationToken).ConfigureAwait(false))
                         {
                             uriToStreamJob.AppendJobPart(
-                                await uriToStreamJob.ToJobPartAsync(
+                                uriToStreamJob.ToJobPartAsync(
                                     stream,
                                     sourceResource,
-                                    destinationResource).ConfigureAwait(false));
+                                    destinationResource));
                         }
                     }
                     return uriToStreamJob;
@@ -681,10 +681,10 @@ namespace Azure.Storage.DataMovement
                                 cancellationToken: _cancellationToken).ConfigureAwait(false))
                             {
                                 streamToUriJob.AppendJobPart(
-                                    await streamToUriJob.ToJobPartAsync(
+                                    streamToUriJob.ToJobPartAsync(
                                         stream,
                                         sourceResource,
-                                        destinationResource).ConfigureAwait(false));
+                                        destinationResource));
                             }
                         }
                     }
@@ -728,10 +728,10 @@ namespace Azure.Storage.DataMovement
                                 cancellationToken: _cancellationToken).ConfigureAwait(false))
                             {
                                 serviceToServiceJob.AppendJobPart(
-                                    await serviceToServiceJob.ToJobPartAsync(
-                                    stream,
-                                    sourceResource,
-                                    destinationResource).ConfigureAwait(false));
+                                    serviceToServiceJob.ToJobPartAsync(
+                                        stream,
+                                        sourceResource,
+                                        destinationResource));
                             }
                         }
                     }
@@ -768,10 +768,10 @@ namespace Azure.Storage.DataMovement
                                 cancellationToken: _cancellationToken).ConfigureAwait(false))
                             {
                                 uriToStreamJob.AppendJobPart(
-                                    await uriToStreamJob.ToJobPartAsync(
-                                    stream,
-                                    sourceResource,
-                                    destinationResource).ConfigureAwait(false));
+                                    uriToStreamJob.ToJobPartAsync(
+                                        stream,
+                                        sourceResource,
+                                        destinationResource));
                             }
                         }
                     }

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -80,15 +80,16 @@ namespace Azure.Storage.DataMovement
                   jobPartStatus: jobPartStatus,
                   length: length)
         {
-            // If transfer sizes were provided override ones from job.
-            // This will be the case when resuming from a checkpoint file.
-            if (initialTransferSize.HasValue)
-            {
-                _initialTransferSize = initialTransferSize.Value;
-            }
-            if (transferChunkSize.HasValue)
+            // If transfer sizes null at the job level (from options bag) then
+            // override the default provided values if present.
+            // Else, they were set correctly by the base constructor.
+            if (!job._maximumTransferChunkSize.HasValue && transferChunkSize.HasValue)
             {
                 _transferChunkSize = transferChunkSize.Value;
+            }
+            if (!job._initialTransferSize.HasValue && initialTransferSize.HasValue)
+            {
+                _initialTransferSize = initialTransferSize.Value;
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamJobPart.cs
@@ -81,7 +81,7 @@ namespace Azure.Storage.DataMovement
                   length: length)
         {
             // If transfer sizes null at the job level (from options bag) then
-            // override the default provided values if present.
+            // override the default with the provided values if present.
             // Else, they were set correctly by the base constructor.
             if (!job._maximumTransferChunkSize.HasValue && transferChunkSize.HasValue)
             {

--- a/sdk/storage/Azure.Storage.DataMovement/tests/MockStorageResource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/MockStorageResource.cs
@@ -22,14 +22,14 @@ namespace Azure.Storage.DataMovement.Tests
 
         protected internal override DataTransferOrder TransferType => DataTransferOrder.Sequential;
 
-        protected internal override long MaxChunkSize { get; }
+        protected internal override long MaxSupportedChunkSize { get; }
 
         protected internal override long? Length { get; }
 
         private MockStorageResource(long? length, long maxChunkSize, Uri uri = default)
         {
             Length = length;
-            MaxChunkSize = maxChunkSize;
+            MaxSupportedChunkSize = maxChunkSize;
             if (length.HasValue)
             {
                 _readStream = new RepeatingStream((int)(1234567 % length.Value), length.Value, revealsLength: true);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/MemoryStorageResourceItem.cs
@@ -20,7 +20,7 @@ namespace Azure.Storage.DataMovement.Tests
 
         protected internal override DataTransferOrder TransferType => DataTransferOrder.Unordered;
 
-        protected internal override long MaxChunkSize => long.MaxValue;
+        protected internal override long MaxSupportedChunkSize => long.MaxValue;
 
         protected internal override long? Length => Buffer.Length;
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/StartTransferUploadTests.cs
@@ -1462,6 +1462,7 @@ namespace Azure.Storage.DataMovement.Tests
         }
         #endregion
 
+        [Ignore("https://github.com/Azure/azure-sdk-for-net-pr/issues/2010")]
         [Test]
         public async Task SupportsLongFiles()
         {


### PR DESCRIPTION
The change contains a number of fixes/adjustments to how we handle initial transfer size and maximum chunk size. After this change, the intended behavior is as follows:

- `InitialzeTransferSize` and `MaximumTransferChunkSize` are the options exposed to the user on start/resume transfer. If unspecified we will now use the default of 32 MiB and 4 MiB respectively.
  - We had previous optimization to use 8 Mib if Blob size was over 100 MiB but I got rid of that for now since it only applied to Block Blob.
- Internally we use these values to calculate the actual values stored in `JobPartInternal`. The actual values get set to the default or what the user specified but then are clamped to the maximum supported chunk size for the particular destination resource. (4 GiB for Block Blob, 4 MiB for Page Blob, Append Blob, and File, etc.).
- For resume, the calculated values (from above) are stored in the checkpoint files for each job part. On resume, we now read these values out and use them.
  - ~~This does mean that we ignore the user-provided values on the call to resume. I have noted this in the docs. Currently we don't throw any error if the checkpoint file does not match the user-provided options. I mainly decided to do this for the case when no values are provided by the customer and then we change the defaults for some reason. We wouldn't want to break all existing checkpoint values when we change defaults.~~
  - If the user specifies the options on resume, they will override the options saved in the checkpointer.