### PR TITLE
[AzureMonitorExporter] refactor, prepping for LiveMetrics proj

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -9,6 +9,7 @@
     <!--NET6 is added here for trimming compatibility. This includes necessary annotations and System.Text.Json's "Source Generation" feature.-->
     <TargetFrameworks>net6.0;$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
+    <DefineConstants>$(DefineConstants);AZURE_MONITOR_EXPORTER;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ConnectionString/ConnectionStringParser.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+#if AZURE_MONITOR_EXPORTER
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+#endif
 
 // This alias is necessary because it will otherwise try to default to "Microsoft.Azure.Core" which doesn't exist.
 using AzureCoreConnectionString = Azure.Core.ConnectionString;
@@ -46,7 +48,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString
             }
             catch (Exception ex)
             {
+#if AZURE_MONITOR_EXPORTER
                 AzureMonitorExporterEventSource.Log.FailedToParseConnectionString(ex);
+#endif
                 throw new InvalidOperationException("Connection String Error: " + ex.Message, ex);
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/PersistentStorage/StorageHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
@@ -68,7 +69,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.PersistentStorage
 
             // these names need to be separate to use the correct OS specific DirectorySeparatorChar.
             createdDirectoryPath = Path.Combine(path, "Microsoft", "AzureMonitor");
-            return platform.CreateDirectory(createdDirectoryPath);
+            try
+            {
+                platform.CreateDirectory(createdDirectoryPath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorExporterEventSource.Log.ErrorCreatingStorageFolder(path, ex);
+                return false;
+            }
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
@@ -7,7 +7,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+
+#if AZURE_MONITOR_EXPORTER
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
+#endif
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
 {
@@ -23,7 +26,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
             }
             catch (Exception ex)
             {
+#if AZURE_MONITOR_EXPORTER
                 AzureMonitorExporterEventSource.Log.FailedToReadEnvironmentVariables(ex);
+#endif
                 _environmentVariables = new Dictionary<string, object>();
             }
         }
@@ -50,19 +55,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
 
         public bool IsOSPlatform(OSPlatform osPlatform) => RuntimeInformation.IsOSPlatform(osPlatform);
 
-        public bool CreateDirectory(string path)
-        {
-            try
-            {
-                Directory.CreateDirectory(path);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                AzureMonitorExporterEventSource.Log.ErrorCreatingStorageFolder(path, ex);
-                return false;
-            }
-        }
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
 
         public string GetEnvironmentUserName() => Environment.UserName;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/DefaultPlatform.cs
@@ -55,6 +55,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
 
         public bool IsOSPlatform(OSPlatform osPlatform) => RuntimeInformation.IsOSPlatform(osPlatform);
 
+        /// <summary>
+        /// Creates all directories and subdirectories in the specified path unless they already exist.
+        /// </summary>
+        /// <exception>This method does not catch any exceptions thrown by <see cref="Directory.CreateDirectory(string)"/>.</exception>
+        /// <param name="path">The directory to create</param>
         public void CreateDirectory(string path) => Directory.CreateDirectory(path);
 
         public string GetEnvironmentUserName() => Environment.UserName;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/IPlatform.cs
@@ -18,7 +18,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
 
         public string GetOSPlatformName();
 
-        public bool CreateDirectory(string path);
+        public void CreateDirectory(string path);
 
         public string GetEnvironmentUserName();
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/MockPlatform.cs
@@ -14,7 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
         public string OSPlatformName { get; set; } = "UnitTest";
         public Func<OSPlatform, bool> IsOsPlatformFunc { get; set; } = (OSPlatform) => false;
-        public Func<string, bool> CreateDirectoryFunc { get; set; } = (path) => true;
+        public Action<string> CreateDirectoryFunc { get; set; } = (path) => { };
         public string UserName { get; set; } = "UnitTestUser";
         public string ProcessName { get; set; } = "UnitTestProcess";
         public string ApplicationBaseDirectory { get; set; } = "UnitTestDirectory";
@@ -27,7 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
         public bool IsOSPlatform(OSPlatform osPlatform) => IsOsPlatformFunc(osPlatform);
 
-        public bool CreateDirectory(string path) => CreateDirectoryFunc(path);
+        public void CreateDirectory(string path) => CreateDirectoryFunc(path);
 
         public string GetEnvironmentUserName() => UserName;
 


### PR DESCRIPTION
I intend to import the ConnectionString Parsing and Platform Abstractions into the LiveMetrics project.
These classes have some EventSource logging that needs to be refactored.

The end goal is to have same EventSource methods in both projects. For example:
```
#if AZURE_MONITOR_EXPORTER
    AzureMonitorExporterEventSource.Log.FailedToParseConnectionString(ex);
#elif LIVE_METRICS_EXPORTER
    LiveMetricsExporterEventSource.Log.FailedToParseConnectionString(ex);
#endif
```

## Changes
- Add build constant `Azure_Monitor_Exporter` to the Azure.Monitor.OpenTelemetry.Exporter project.
- Edit the `ConnectionStringParser` to wrap the EventSource call.
- Edit `DefaultParser`
  - The initialization exception will be wrapped.
  - The CreateDirectory exception is specific to AzureMonitor. I pulled this try/catch out of the DefaultPlatform and into the `StorageHelper` instead.
- Minor refactor `IPlatform` and update unit tests.

## Follow up
This PR is part 1 of 2.
The second PR will add the build constant and EventSource class for the LiveMetrics project.