### PR TITLE
[Event Hubs] Error handling for disabled entities

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- When an Event Hub is disabled, it will now be detected and result in a terminal `EventHubsException` with its reason set to `FailureReason.ResourceNotFound`.
+
 ## 5.9.3 (2023-09-12)
 
 ### Other Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- When an Event Hub is disabled, it will now be detected and result in a terminal `EventHubsException` with its reason set to `FailureReason.ResourceNotFound`.
+
 ## 5.9.3 (2023-09-12)
 
 ### Bugs Fixed

--- a/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
@@ -71,7 +71,7 @@ The exception includes some contextual information to assist in understanding th
 
   - **Consumer Disconnected** : A consumer client was disconnected by the Event Hub service from the Event Hub instance.  This typically occurs when a consumer with a higher owner level asserts ownership over a partition and consumer group pairing.
 
-  - **Resource Not Found**: An Event Hubs resource, such as an Event Hub, consumer group, or partition, could not be found by the Event Hubs service.  This may indicate that it has been deleted from the service or that there is an issue with the Event Hubs service itself.
+  - **Resource Not Found**: An Event Hubs resource, such as an Event Hub, consumer group, or partition, could not be found by the Event Hubs service.  This may indicate that it has been disabled, is still in the process of being created, was deleted from the service, or that there is an issue with the Event Hubs service itself.
 
 Reacting to a specific failure reason for the [EventHubsException][EventHubsException] can be accomplished in several ways, the most common of which is by applying an exception filter clause as part of the `catch` block:
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
@@ -27,13 +27,13 @@ namespace Azure.Messaging.EventHubs
         ///   Indicates that a timeout occurred on the link.
         /// </summary>
         ///
-        public static AmqpSymbol TimeoutError { get; } = AmqpConstants.Vendor + ":entity-disabled";
+        public static AmqpSymbol TimeoutError { get; } = AmqpConstants.Vendor + ":timeout";
 
         /// <summary>
         ///   Indicates that an entity was disabled.
         /// </summary>
         ///
-        public static AmqpSymbol DisabledError { get; } = AmqpConstants.Vendor + ":timeout";
+        public static AmqpSymbol DisabledError { get; } = AmqpConstants.Vendor + ":entity-disabled";
 
         /// <summary>
         ///   Indicates that the server was busy and could not allow the requested operation.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
@@ -27,7 +27,13 @@ namespace Azure.Messaging.EventHubs
         ///   Indicates that a timeout occurred on the link.
         /// </summary>
         ///
-        public static AmqpSymbol TimeoutError { get; } = AmqpConstants.Vendor + ":timeout";
+        public static AmqpSymbol TimeoutError { get; } = AmqpConstants.Vendor + ":entity-disabled";
+
+        /// <summary>
+        ///   Indicates that an entity was disabled.
+        /// </summary>
+        ///
+        public static AmqpSymbol DisabledError { get; } = AmqpConstants.Vendor + ":timeout";
 
         /// <summary>
         ///   Indicates that the server was busy and could not allow the requested operation.
@@ -169,6 +175,13 @@ namespace Azure.Messaging.EventHubs
             if (string.Equals(condition, TimeoutError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
                 return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceTimeout, innerException);
+            }
+
+            // The Event Hubs resource was disabled.
+
+            if (string.Equals(condition, DisabledError.Value, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ResourceNotFound, innerException);
             }
 
             // The Event Hubs service was busy; this likely means that requests are being throttled.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
@@ -30,6 +30,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Custom conditions.
 
             yield return new object[] { AmqpError.TimeoutError, typeof(EventHubsException), EventHubsException.FailureReason.ServiceTimeout };
+            yield return new object[] { AmqpError.DisabledError, typeof(EventHubsException), EventHubsException.FailureReason.ResourceNotFound };
             yield return new object[] { AmqpError.ServerBusyError, typeof(EventHubsException), EventHubsException.FailureReason.ServiceBusy };
             yield return new object[] { AmqpError.ProducerStolenError, typeof(EventHubsException), EventHubsException.FailureReason.ProducerDisconnected };
             yield return new object[] { AmqpError.SequenceOutOfOrderError, typeof(EventHubsException), EventHubsException.FailureReason.InvalidClientState };


### PR DESCRIPTION
# Summary

The focus of these changes is to add dedicated handling when an Event Hub resource has been set to "disabled" status.  This is now treated as a terminal error with a "ResourceNotFound" status, as it requires manual intervention. Previously, this would result in a general communication error that was transient and triggered implicit retries.
