### PR TITLE
[AzureMonitorExporter] Add missing 'telemetry.distro.name' to _OTELRESOURCE_

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -67,7 +67,7 @@ internal static class ResourceExtensions
                     {
                         SdkVersionUtils.IsDistro = true;
                     }
-                    continue;
+                    break;
                 default:
                     if (attribute.Key.StartsWith("k8s"))
                     {


### PR DESCRIPTION
`telemetry.distro.name` was dropped from the resource . It is a part of the spec and should get added to `_OTELRESOURCE_`

```json
{
	"name": "Metric",
	"time": "2023-11-03T17:05:09.3140630Z",
	"iKey": "00000000-0000-0000-0000-000000000000",
	"tags": {
		"ai.cloud.role": "StartupHook.Self-hosted",
		"ai.cloud.roleInstance": "DESKTOP",
		"ai.internal.sdkVersion": "uw_dotnet7.0.12:otel1.6.0:ext1.1.0-alpha.20231103"
	},
	"data": {
		"baseType": "MetricData",
		"baseData": {
			"metrics": [
				{
					"name": "_OTELRESOURCE_",
					"value": 0
				}
			],
			"properties": {
				"telemetry.distro.name": "opentelemetry-dotnet-instrumentation",
				"telemetry.distro.version": "1.1.0",
				"telemetry.sdk.name": "opentelemetry",
				"telemetry.sdk.language": "dotnet",
				"telemetry.sdk.version": "1.6.0",
				"service.name": "StartupHook.Self-hosted"
			},
			"ver": 2
		}
	}
}
```