### PR TITLE
[Azure OpenAI] Replace `SearchKey` and `EmbeddingKey` properties with `SetSearchKey` and `SetEmbeddingKey` methods

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -80,10 +80,18 @@ And *added* as replacements are:
 - `CompletionsOptions(string, IEnumerable<string>)`
 - `EmbeddingsOptions(string, IEnumerable<string>)`
 
-#### Embeddings
+#### Embeddings now represented as `ReadOnlyMemory<float>`
 
-To align representations of embeddings across Azure AI, the `Embeddings` type has been updated to use
-`ReadOnlyMemory<float>` instead of `IReadOnlyList<float>`.
+Changed the representation of embeddings (specifically, the type of the `Embedding` property of the `EmbeddingItem` class)
+from `IReadOnlyList<float>` to `ReadOnlyMemory<float>` as part of a broader effort to establish consistency across the
+.NET ecosystem.
+
+#### `SearchKey` and `EmbeddingKey` properties replaced by `SetSearchKey` and `SetEmbeddingKey` methods
+
+Replaced the `SearchKey` and `EmbeddingKey` properties of the `AzureCognitiveSearchChatExtensionConfiguration` class with
+new `SetSearchKey` and `SetEmbeddingKey` methods respectively. These methods simplify the configuration of the Azure Cognitive
+Search chat extension by receiving a plain string instead of an `AzureKeyCredential`, promote more sensible key and secret
+management, and align with the Azure SDK guidelines.
 
 ### Bugs Fixed
 

--- a/sdk/openai/Azure.AI.OpenAI/README.md
+++ b/sdk/openai/Azure.AI.OpenAI/README.md
@@ -418,13 +418,13 @@ See [the Azure OpenAI using your own data quickstart](https://learn.microsoft.co
 **NOTE:** The concurrent use of [Chat Functions](#use-chat-functions) and Azure Chat Extensions on a single request is not yet supported. Supplying both will result in the Chat Functions information being ignored and the operation behaving as if only the Azure Chat Extensions were provided. To address this limitation, consider separating the evaluation of Chat Functions and Azure Chat Extensions across multiple requests in your solution design.
 
 ```C# Snippet:ChatUsingYourOwnData
-AzureCognitiveSearchChatExtensionConfiguration config = new()
+AzureCognitiveSearchChatExtensionConfiguration contosoExtensionConfig = new()
 {
     SearchEndpoint = new Uri("https://your-contoso-search-resource.search.windows.net"),
     IndexName = "contoso-products-index",
 };
 
-config.SetSearchKey("<your Cognitive Search resource API key>");
+contosoExtensionConfig.SetSearchKey("<your Cognitive Search resource API key>");
 
 ChatCompletionsOptions chatCompletionsOptions = new()
 {
@@ -442,7 +442,7 @@ ChatCompletionsOptions chatCompletionsOptions = new()
     // with information from an Azure Cognitive Search resource with documents that have been indexed.
     AzureExtensionsOptions = new AzureChatExtensionsOptions()
     {
-        Extensions = { config }
+        Extensions = { contosoExtensionConfig }
     }
 };
 

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -154,7 +154,7 @@ namespace Azure.AI.OpenAI
         public string SemanticConfiguration { get { throw null; } set { } }
         public bool? ShouldRestrictResultScope { get { throw null; } set { } }
         public override Azure.AI.OpenAI.AzureChatExtensionType Type { get { throw null; } set { } }
-        public void SetEmbeddinghKey(string embeddingKey) { }
+        public void SetEmbeddingKey(string embeddingKey) { }
         public void SetSearchKey(string searchKey) { }
     }
     public partial class AzureCognitiveSearchIndexFieldMappingOptions

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -144,18 +144,18 @@ namespace Azure.AI.OpenAI
     public partial class AzureCognitiveSearchChatExtensionConfiguration : Azure.AI.OpenAI.AzureChatExtensionConfiguration
     {
         public AzureCognitiveSearchChatExtensionConfiguration() { }
-        public AzureCognitiveSearchChatExtensionConfiguration(Azure.AI.OpenAI.AzureChatExtensionType type, System.Uri searchEndpoint, Azure.AzureKeyCredential searchKey, string indexName) { }
+        public AzureCognitiveSearchChatExtensionConfiguration(Azure.AI.OpenAI.AzureChatExtensionType type, System.Uri searchEndpoint, string indexName) { }
         public int? DocumentCount { get { throw null; } set { } }
         public System.Uri EmbeddingEndpoint { get { throw null; } set { } }
-        public Azure.AzureKeyCredential EmbeddingKey { get { throw null; } set { } }
         public Azure.AI.OpenAI.AzureCognitiveSearchIndexFieldMappingOptions FieldMappingOptions { get { throw null; } set { } }
         public string IndexName { get { throw null; } set { } }
         public Azure.AI.OpenAI.AzureCognitiveSearchQueryType? QueryType { get { throw null; } set { } }
         public System.Uri SearchEndpoint { get { throw null; } set { } }
-        public Azure.AzureKeyCredential SearchKey { get { throw null; } set { } }
         public string SemanticConfiguration { get { throw null; } set { } }
         public bool? ShouldRestrictResultScope { get { throw null; } set { } }
         public override Azure.AI.OpenAI.AzureChatExtensionType Type { get { throw null; } set { } }
+        public void SetEmbeddinghKey(string embeddingKey) { }
+        public void SetSearchKey(string searchKey) { }
     }
     public partial class AzureCognitiveSearchIndexFieldMappingOptions
     {

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.Serialization.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.OpenAI
 
             writer.WritePropertyName("endpoint"u8);
             writer.WriteStringValue(SearchEndpoint.AbsoluteUri);
-            writer.WriteString("key"u8, SearchKey.Key);
+            writer.WriteString("key"u8, SearchKey);
             writer.WritePropertyName("indexName"u8);
             writer.WriteStringValue(IndexName);
             if (Optional.IsDefined(FieldMappingOptions))
@@ -57,7 +57,7 @@ namespace Azure.AI.OpenAI
             }
             if (Optional.IsDefined(EmbeddingKey))
             {
-                writer.WriteString("embeddingKey"u8, EmbeddingKey.Key);
+                writer.WriteString("embeddingKey"u8, EmbeddingKey);
             }
             // CUSTOM CODE NOTE: end of induced 'parameters' first, then the parent object
             writer.WriteEndObject();

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
@@ -84,7 +84,7 @@ namespace Azure.AI.OpenAI
         /// Sets the API key to use with the provided embeddings endpoint when using embeddings.
         /// </summary>
         /// <param name="embeddingKey"> The API key. </param>
-        public void SetEmbeddinghKey(string embeddingKey)
+        public void SetEmbeddingKey(string embeddingKey)
         {
             EmbeddingKey = embeddingKey;
         }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
@@ -26,12 +26,25 @@ namespace Azure.AI.OpenAI
 
         /// <summary> The absolute endpoint path for the Azure Cognitive Search resource to use. </summary>
         public Uri SearchEndpoint { get; set; }
-        /// <summary> The API key to use with the specified Azure Cognitive Search endpoint. </summary>
-        public AzureKeyCredential SearchKey { get; set; }
         /// <summary> The name of the index to use as available in the referenced Azure Cognitive Search resource. </summary>
         public string IndexName { get; set; }
+        /// <summary> Customized field mapping behavior to use when interacting with the search index. </summary>
+        public AzureCognitiveSearchIndexFieldMappingOptions FieldMappingOptions { get; set; }
+        /// <summary> The configured top number of documents to feature for the configured query. </summary>
+        public int? DocumentCount { get; set; }
+        /// <summary> The query type to use with Azure Cognitive Search. </summary>
+        public AzureCognitiveSearchQueryType? QueryType { get; set; }
+        /// <summary> Whether queries should be restricted to use of indexed data. </summary>
+        public bool? ShouldRestrictResultScope { get; set; }
+        /// <summary> The additional semantic configuration for the query. </summary>
+        public string SemanticConfiguration { get; set; }
+        /// <summary> When using embeddings for search, specifies the resource URL from which embeddings should be retrieved. </summary>
+        public Uri EmbeddingEndpoint { get; set; }
+
+        /// <summary> The API key to use with the specified Azure Cognitive Search endpoint. </summary>
+        private string SearchKey { get; set; }
         /// <summary> When using embeddings, specifies the API key to use with the provided embeddings endpoint. </summary>
-        public AzureKeyCredential EmbeddingKey { get; set; }
+        private string EmbeddingKey { get; set; }
 
         /// <summary>
         /// Initializes a new instance of AzureCognitiveSearchChatExtensionConfiguration.
@@ -46,61 +59,34 @@ namespace Azure.AI.OpenAI
         /// default value for Azure Cognitive Search.
         /// </param>
         /// <param name="searchEndpoint"> The absolute endpoint path for the Azure Cognitive Search resource to use. </param>
-        /// <param name="searchKey"> The API key to use with the specified Azure Cognitive Search endpoint. </param>
         /// <param name="indexName"> The name of the index to use as available in the referenced Azure Cognitive Search resource. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="searchEndpoint"/>, <paramref name="searchKey"/> or <paramref name="indexName"/> is null. </exception>
-        public AzureCognitiveSearchChatExtensionConfiguration(AzureChatExtensionType type, Uri searchEndpoint, AzureKeyCredential searchKey, string indexName)
+        /// <exception cref="ArgumentNullException"> <paramref name="searchEndpoint"/>, or <paramref name="indexName"/> is null. </exception>
+        public AzureCognitiveSearchChatExtensionConfiguration(AzureChatExtensionType type, Uri searchEndpoint, string indexName)
         {
             Argument.AssertNotNull(searchEndpoint, nameof(searchEndpoint));
-            Argument.AssertNotNull(searchKey, nameof(searchKey));
             Argument.AssertNotNull(indexName, nameof(indexName));
 
             Type = type;
             SearchEndpoint = searchEndpoint;
-            SearchKey = searchKey;
             IndexName = indexName;
         }
 
-        /// <summary> Initializes a new instance of AzureCognitiveSearchChatExtensionConfiguration. </summary>
-        /// <param name="type">
-        /// The type label to use when configuring Azure OpenAI chat extensions. This should typically not be changed from its
-        /// default value for Azure Cognitive Search.
-        /// </param>
-        /// <param name="searchEndpoint"> The absolute endpoint path for the Azure Cognitive Search resource to use. </param>
-        /// <param name="searchKey"> The API key to use with the specified Azure Cognitive Search endpoint. </param>
-        /// <param name="indexName"> The name of the index to use as available in the referenced Azure Cognitive Search resource. </param>
-        /// <param name="fieldMappingOptions"> Customized field mapping behavior to use when interacting with the search index. </param>
-        /// <param name="documentCount"> The configured top number of documents to feature for the configured query. </param>
-        /// <param name="queryType"> The query type to use with Azure Cognitive Search. </param>
-        /// <param name="shouldRestrictResultScope"> Whether queries should be restricted to use of indexed data. </param>
-        /// <param name="semanticConfiguration"> The additional semantic configuration for the query. </param>
-        /// <param name="embeddingEndpoint"> When using embeddings for search, specifies the resource URL from which embeddings should be retrieved. </param>
-        /// <param name="embeddingKey"> When using embeddings, specifies the API key to use with the provided embeddings endpoint. </param>
-        internal AzureCognitiveSearchChatExtensionConfiguration(AzureChatExtensionType type, Uri searchEndpoint, AzureKeyCredential searchKey, string indexName, AzureCognitiveSearchIndexFieldMappingOptions fieldMappingOptions, int? documentCount, AzureCognitiveSearchQueryType? queryType, bool? shouldRestrictResultScope, string semanticConfiguration, Uri embeddingEndpoint, AzureKeyCredential embeddingKey)
+        /// <summary>
+        /// Sets the API key to use with the specified Azure Cognitive Search endpoint.
+        /// </summary>
+        /// <param name="searchKey"> The API key. </param>
+        public void SetSearchKey(string searchKey)
         {
-            Type = type;
-            SearchEndpoint = searchEndpoint;
             SearchKey = searchKey;
-            IndexName = indexName;
-            FieldMappingOptions = fieldMappingOptions;
-            DocumentCount = documentCount;
-            QueryType = queryType;
-            ShouldRestrictResultScope = shouldRestrictResultScope;
-            SemanticConfiguration = semanticConfiguration;
-            EmbeddingEndpoint = embeddingEndpoint;
+        }
+
+        /// <summary>
+        /// Sets the API key to use with the provided embeddings endpoint when using embeddings.
+        /// </summary>
+        /// <param name="embeddingKey"> The API key. </param>
+        public void SetEmbeddinghKey(string embeddingKey)
+        {
             EmbeddingKey = embeddingKey;
         }
-        /// <summary> Customized field mapping behavior to use when interacting with the search index. </summary>
-        public AzureCognitiveSearchIndexFieldMappingOptions FieldMappingOptions { get; set; }
-        /// <summary> The configured top number of documents to feature for the configured query. </summary>
-        public int? DocumentCount { get; set; }
-        /// <summary> The query type to use with Azure Cognitive Search. </summary>
-        public AzureCognitiveSearchQueryType? QueryType { get; set; }
-        /// <summary> Whether queries should be restricted to use of indexed data. </summary>
-        public bool? ShouldRestrictResultScope { get; set; }
-        /// <summary> The additional semantic configuration for the query. </summary>
-        public string SemanticConfiguration { get; set; }
-        /// <summary> When using embeddings for search, specifies the resource URL from which embeddings should be retrieved. </summary>
-        public Uri EmbeddingEndpoint { get; set; }
     }
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Generated/AzureCognitiveSearchChatExtensionConfiguration.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Generated/AzureCognitiveSearchChatExtensionConfiguration.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using Azure;
 using Azure.Core;
 
 namespace Azure.AI.OpenAI
@@ -17,5 +16,55 @@ namespace Azure.AI.OpenAI
     /// </summary>
     public partial class AzureCognitiveSearchChatExtensionConfiguration
     {
+        /// <summary> Initializes a new instance of AzureCognitiveSearchChatExtensionConfiguration. </summary>
+        /// <param name="type">
+        /// The type label to use when configuring Azure OpenAI chat extensions. This should typically not be changed from its
+        /// default value for Azure Cognitive Search.
+        /// </param>
+        /// <param name="searchEndpoint"> The absolute endpoint path for the Azure Cognitive Search resource to use. </param>
+        /// <param name="searchKey"> The API admin key to use with the specified Azure Cognitive Search endpoint. </param>
+        /// <param name="indexName"> The name of the index to use as available in the referenced Azure Cognitive Search resource. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="searchEndpoint"/>, <paramref name="searchKey"/> or <paramref name="indexName"/> is null. </exception>
+        internal AzureCognitiveSearchChatExtensionConfiguration(AzureChatExtensionType type, Uri searchEndpoint, string searchKey, string indexName)
+        {
+            Argument.AssertNotNull(searchEndpoint, nameof(searchEndpoint));
+            Argument.AssertNotNull(searchKey, nameof(searchKey));
+            Argument.AssertNotNull(indexName, nameof(indexName));
+
+            Type = type;
+            SearchEndpoint = searchEndpoint;
+            SearchKey = searchKey;
+            IndexName = indexName;
+        }
+
+        /// <summary> Initializes a new instance of AzureCognitiveSearchChatExtensionConfiguration. </summary>
+        /// <param name="type">
+        /// The type label to use when configuring Azure OpenAI chat extensions. This should typically not be changed from its
+        /// default value for Azure Cognitive Search.
+        /// </param>
+        /// <param name="searchEndpoint"> The absolute endpoint path for the Azure Cognitive Search resource to use. </param>
+        /// <param name="searchKey"> The API admin key to use with the specified Azure Cognitive Search endpoint. </param>
+        /// <param name="indexName"> The name of the index to use as available in the referenced Azure Cognitive Search resource. </param>
+        /// <param name="fieldMappingOptions"> Customized field mapping behavior to use when interacting with the search index. </param>
+        /// <param name="documentCount"> The configured top number of documents to feature for the configured query. </param>
+        /// <param name="queryType"> The query type to use with Azure Cognitive Search. </param>
+        /// <param name="shouldRestrictResultScope"> Whether queries should be restricted to use of indexed data. </param>
+        /// <param name="semanticConfiguration"> The additional semantic configuration for the query. </param>
+        /// <param name="embeddingEndpoint"> When using embeddings for search, specifies the resource URL from which embeddings should be retrieved. </param>
+        /// <param name="embeddingKey"> When using embeddings, specifies the API key to use with the provided embeddings endpoint. </param>
+        internal AzureCognitiveSearchChatExtensionConfiguration(AzureChatExtensionType type, Uri searchEndpoint, string searchKey, string indexName, AzureCognitiveSearchIndexFieldMappingOptions fieldMappingOptions, int? documentCount, AzureCognitiveSearchQueryType? queryType, bool? shouldRestrictResultScope, string semanticConfiguration, Uri embeddingEndpoint, string embeddingKey)
+        {
+            Type = type;
+            SearchEndpoint = searchEndpoint;
+            SearchKey = searchKey;
+            IndexName = indexName;
+            FieldMappingOptions = fieldMappingOptions;
+            DocumentCount = documentCount;
+            QueryType = queryType;
+            ShouldRestrictResultScope = shouldRestrictResultScope;
+            SemanticConfiguration = semanticConfiguration;
+            EmbeddingEndpoint = embeddingEndpoint;
+            EmbeddingKey = embeddingKey;
+        }
     }
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/AzureChatExtensionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/AzureChatExtensionsTests.cs
@@ -38,28 +38,35 @@ public class AzureChatExtensionsTests : OpenAITestBase
             OpenAIClientScenario.ChatCompletions);
 
         AzureChatExtensionsOptions extensionsOptions = new();
-        extensionsOptions.Extensions.Add(extensionStrategy switch
+        switch (extensionStrategy)
         {
-            ExtensionObjectStrategy.WithGenericParentType => new AzureChatExtensionConfiguration()
-            {
-                Type = "AzureCognitiveSearch",
-                Parameters = BinaryData.FromObjectAsJson(new
+            case ExtensionObjectStrategy.WithGenericParentType:
+                AzureChatExtensionConfiguration genericConfig = new()
                 {
-                    Endpoint = "https://openaisdktestsearch.search.windows.net",
-                    IndexName = "openai-test-index-carbon-wiki",
-                    GetCognitiveSearchApiKey().Key,
-                },
-                new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }),
-            },
-            ExtensionObjectStrategy.WithScenarioSpecificHelperType
-                => new AzureCognitiveSearchChatExtensionConfiguration()
+                    Type = "AzureCognitiveSearch",
+                    Parameters = BinaryData.FromObjectAsJson(new
+                    {
+                        Endpoint = "https://openaisdktestsearch.search.windows.net",
+                        IndexName = "openai-test-index-carbon-wiki",
+                        GetCognitiveSearchApiKey().Key,
+                    },
+                    new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }),
+                };
+                extensionsOptions.Extensions.Add(genericConfig);
+                break;
+            case ExtensionObjectStrategy.WithScenarioSpecificHelperType:
+                AzureCognitiveSearchChatExtensionConfiguration helperTypeConfig = new()
                 {
+                    Type = "AzureCognitiveSearch",
                     SearchEndpoint = new Uri("https://openaisdktestsearch.search.windows.net"),
-                    IndexName = "openai-test-index-carbon-wiki",
-                    SearchKey = GetCognitiveSearchApiKey(),
-                },
-            _ => throw new NotImplementedException("Don't know how to add the extension config!"),
-        });
+                    IndexName = "openai-test-index-carbon-wiki"
+                };
+                helperTypeConfig.SetSearchKey(GetCognitiveSearchApiKey().Key);
+                extensionsOptions.Extensions.Add(helperTypeConfig);
+                break;
+            default:
+                throw new NotImplementedException("Don't know how to add the extension config!");
+        }
 
         var requestOptions = new ChatCompletionsOptions()
         {

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample08_UseYourOwnData.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample08_UseYourOwnData.cs
@@ -22,13 +22,13 @@ namespace Azure.AI.OpenAI.Tests.Samples
 
             #region Snippet:ChatUsingYourOwnData
 
-            AzureCognitiveSearchChatExtensionConfiguration config = new()
+            AzureCognitiveSearchChatExtensionConfiguration contosoExtensionConfig = new()
             {
                 SearchEndpoint = new Uri("https://your-contoso-search-resource.search.windows.net"),
                 IndexName = "contoso-products-index",
             };
 
-            config.SetSearchKey("<your Cognitive Search resource API key>");
+            contosoExtensionConfig.SetSearchKey("<your Cognitive Search resource API key>");
 
             ChatCompletionsOptions chatCompletionsOptions = new()
             {
@@ -46,7 +46,7 @@ namespace Azure.AI.OpenAI.Tests.Samples
                 // with information from an Azure Cognitive Search resource with documents that have been indexed.
                 AzureExtensionsOptions = new AzureChatExtensionsOptions()
                 {
-                    Extensions = { config }
+                    Extensions = { contosoExtensionConfig }
                 }
             };
 

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample08_UseYourOwnData.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/Sample08_UseYourOwnData.cs
@@ -21,7 +21,16 @@ namespace Azure.AI.OpenAI.Tests.Samples
             var client = new OpenAIClient(new Uri(endpoint), new DefaultAzureCredential());
 
             #region Snippet:ChatUsingYourOwnData
-            var chatCompletionsOptions = new ChatCompletionsOptions()
+
+            AzureCognitiveSearchChatExtensionConfiguration config = new()
+            {
+                SearchEndpoint = new Uri("https://your-contoso-search-resource.search.windows.net"),
+                IndexName = "contoso-products-index",
+            };
+
+            config.SetSearchKey("<your Cognitive Search resource API key>");
+
+            ChatCompletionsOptions chatCompletionsOptions = new()
             {
                 DeploymentName = "gpt-35-turbo-0613",
                 Messages =
@@ -31,29 +40,26 @@ namespace Azure.AI.OpenAI.Tests.Samples
                         "You are a helpful assistant that answers questions about the Contoso product database."),
                     new ChatMessage(ChatRole.User, "What are the best-selling Contoso products this month?")
                 },
+
                 // The addition of AzureChatExtensionsOptions enables the use of Azure OpenAI capabilities that add to
                 // the behavior of Chat Completions, here the "using your own data" feature to supplement the context
                 // with information from an Azure Cognitive Search resource with documents that have been indexed.
                 AzureExtensionsOptions = new AzureChatExtensionsOptions()
                 {
-                    Extensions =
-                    {
-                        new AzureCognitiveSearchChatExtensionConfiguration()
-                        {
-                            SearchEndpoint = new Uri("https://your-contoso-search-resource.search.windows.net"),
-                            IndexName = "contoso-products-index",
-                            SearchKey = new AzureKeyCredential("<your Cognitive Search resource API key>"),
-                        }
-                    }
+                    Extensions = { config }
                 }
             };
+
             Response<ChatCompletions> response = await client.GetChatCompletionsAsync(chatCompletionsOptions);
             ChatMessage message = response.Value.Choices[0].Message;
+
             // The final, data-informed response still appears in the ChatMessages as usual
             Console.WriteLine($"{message.Role}: {message.Content}");
+
             // Responses that used extensions will also have Context information that includes special Tool messages
             // to explain extension activity and provide supplemental information like citations.
             Console.WriteLine($"Citations and other information:");
+
             foreach (ChatMessage contextMessage in message.AzureExtensionsContext.Messages)
             {
                 // Note: citations and other extension payloads from the "tool" role are often encoded JSON documents


### PR DESCRIPTION
Replaced the `SearchKey` and `EmbeddingKey` properties of the `AzureCognitiveSearchChatExtensionConfiguration` class with  new `SetSearchKey` and `SetEmbeddingKey` methods respectively. These methods simplify the configuration of the Azure Cognitive Search chat extension by receiving a plain string instead of an `AzureKeyCredential`, promote more sensible key and secret management, and align with the Azure SDK guidelines.