### PR TITLE
[Search] Fix "SearchOptions.SemanticSearch.MaxWait" Issue

### DIFF
--- a/sdk/search/Azure.Search.Documents/assets.json
+++ b/sdk/search/Azure.Search.Documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/search/Azure.Search.Documents",
-  "Tag": "net/search/Azure.Search.Documents_143851b981"
+  "Tag": "net/search/Azure.Search.Documents_c3ad072221"
 }

--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -223,10 +223,17 @@ namespace Azure.Search.Documents
         /// <summary> Allows the user to set an upper bound on the amount of time it takes for semantic enrichment to finish processing before the request fails. </summary>
         private int? SemanticMaxWaitInMilliseconds
         {
-            get { return (int)SemanticSearch?.MaxWait?.TotalMilliseconds; }
+            get
+            {
+                if (SemanticSearch?.MaxWait != null)
+                {
+                    return (int)SemanticSearch.MaxWait?.TotalMilliseconds;
+                }
+                return null;
+            }
             set
             {
-                if (SemanticSearch?.MaxWait?.TotalMilliseconds != null)
+                if (SemanticSearch?.MaxWait != null)
                 {
                     SemanticSearch.MaxWait = value.HasValue ? TimeSpan.FromMilliseconds(value.Value) : null;
                 }

--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -223,10 +223,10 @@ namespace Azure.Search.Documents
         /// <summary> Allows the user to set an upper bound on the amount of time it takes for semantic enrichment to finish processing before the request fails. </summary>
         private int? SemanticMaxWaitInMilliseconds
         {
-            get { return SemanticSearch?.MaxWait?.Milliseconds; }
+            get { return (int)SemanticSearch?.MaxWait?.TotalMilliseconds; }
             set
             {
-                if (SemanticSearch?.MaxWait?.Milliseconds != null)
+                if (SemanticSearch?.MaxWait?.TotalMilliseconds != null)
                 {
                     SemanticSearch.MaxWait = value.HasValue ? TimeSpan.FromMilliseconds(value.Value) : null;
                 }

--- a/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
+++ b/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs
@@ -225,11 +225,7 @@ namespace Azure.Search.Documents
         {
             get
             {
-                if (SemanticSearch?.MaxWait != null)
-                {
-                    return (int)SemanticSearch.MaxWait?.TotalMilliseconds;
-                }
-                return null;
+                return (int?)SemanticSearch?.MaxWait?.TotalMilliseconds;
             }
             set
             {

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/VectorSearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/VectorSearchTests.cs
@@ -173,10 +173,8 @@ namespace Azure.Search.Documents.Tests
                         QueryType = SearchQueryType.Semantic,
                     }));
 
+            Assert.AreEqual(400, ex.Status);
             Assert.AreEqual("InvalidRequestParameter", ex.ErrorCode);
-            StringAssert.StartsWith(
-                "The 'semanticMaxWaitInMilliseconds' parameter needs to be larger than 750.",
-                ex.Message);
         }
 
         [Test]


### PR DESCRIPTION
There is an issue in the Search SDK, specifically in [here](https://github.com/Azure/azure-sdk-for-net/blob/feature/ShivangiReja/search2023-11-01/sdk/search/Azure.Search.Documents/src/Options/SearchOptions.cs#L226). Instead of utilizing `SemanticSearch?.MaxWait?.Milliseconds`, it should be replaced with `(int)SemanticSearch?.MaxWait?.TotalMilliseconds`.

When a user sets MaxWait to `TimeSpan.FromMilliseconds(1000)`, `SemanticSearch?.MaxWait?.Milliseconds` returns 0, while `(int)SemanticSearch?.MaxWait?.TotalMilliseconds` returns 1000.

The reason behind this change is that the TimeSpan format {00:00:01} does not represent milliseconds. This format conveys a TimeSpan in HH:mm:ss format.

In summary:
- **Milliseconds** returns the milliseconds component within a TimeSpan.
- **TotalMilliseconds** returns the total number of milliseconds represented by the TimeSpan.