### PR TITLE
[AppConfiguration] Added support for service version 2023-10-01

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0-beta.4 (Unreleased)
+## 1.3.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added configuration settings snapshot feature which allow users to create a point-in-time snapshot of their configuration store.
 
 ## 1.3.0-beta.3 (2023-10-09)
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -66,11 +66,11 @@ namespace Azure.Data.AppConfiguration
     }
     public partial class ConfigurationClientOptions : Azure.Core.ClientOptions
     {
-        public ConfigurationClientOptions(Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion version = Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion.V2022_11_01_Preview) { }
+        public ConfigurationClientOptions(Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion version = Azure.Data.AppConfiguration.ConfigurationClientOptions.ServiceVersion.V2023_10_01) { }
         public enum ServiceVersion
         {
             V1_0 = 0,
-            V2022_11_01_Preview = 1,
+            V2023_10_01 = 1,
         }
     }
     public static partial class ConfigurationModelFactory

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_48bd1bc562"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_085db69a7d"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Application Configuration Service client library</Description>
     <AssemblyTitle>Microsoft Azure.Data.AppConfiguration client library</AssemblyTitle>
-    <Version>1.3.0-beta.4</Version>
+    <Version>1.3.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Application Configuration;Data;AppConfig;$(PackageCommonTags)</PackageTags>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientOptions.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.Data.AppConfiguration
     /// </summary>
     public partial class ConfigurationClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2022_11_01_Preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2023_10_01;
 
         /// <summary>
         /// The versions of the App Configuration service supported by this client library.
@@ -26,15 +26,9 @@ namespace Azure.Data.AppConfiguration
             V1_0 = 0,
 
             /// <summary>
-            /// Version 2022-11-01-preview.
+            /// Version 2023-10-01.
             /// </summary>
-            V2022_11_01_Preview = 1,
-
-            ///// <summary>
-            ///// Version 2023-10-01.
-            ///// </summary>
-            //V2023_10_01 = 2,
-#pragma warning restore CA1707 // Identifiers should not contain underscores
+            V2023_10_01 = 1
         }
 
         internal string Version { get; }
@@ -52,8 +46,7 @@ namespace Azure.Data.AppConfiguration
             Version = version switch
             {
                 ServiceVersion.V1_0 => "1.0",
-                ServiceVersion.V2022_11_01_Preview => "2022-11-01-preview",
-              //  ServiceVersion.V2023_10_01 => "2023-10-01",
+                ServiceVersion.V2023_10_01 => "2023-10-01",
 
                 _ => throw new NotSupportedException()
             };

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -13,12 +13,18 @@ using NUnit.Framework;
 
 namespace Azure.Data.AppConfiguration.Tests
 {
+    [ClientTestFixture(
+        ConfigurationClientOptions.ServiceVersion.V1_0,
+        ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
     public class ConfigurationLiveTests : RecordedTestBase<AppConfigurationTestEnvironment>
     {
+        private readonly ConfigurationClientOptions.ServiceVersion _serviceVersion;
+
         private string specialChars = "~`!@#$^&()_+=[]{}|;\"'<>./-";
 
-        public ConfigurationLiveTests(bool isAsync) : base(isAsync)
+        public ConfigurationLiveTests(bool isAsync, ConfigurationClientOptions.ServiceVersion serviceVersion) : base(isAsync)
         {
+            _serviceVersion = serviceVersion;
         }
 
         private string GenerateKeyId(string prefix = null)
@@ -37,7 +43,7 @@ namespace Azure.Data.AppConfiguration.Tests
             {
                 throw new TestRecordingMismatchException();
             }
-            var options = InstrumentClientOptions(new ConfigurationClientOptions());
+            var options = InstrumentClientOptions(new ConfigurationClientOptions(_serviceVersion));
             return InstrumentClient(new ConfigurationClient(TestEnvironment.ConnectionString, options));
         }
 
@@ -45,7 +51,7 @@ namespace Azure.Data.AppConfiguration.Tests
         {
             string endpoint = TestEnvironment.Endpoint;
             TokenCredential credential = TestEnvironment.Credential;
-            ConfigurationClientOptions options = InstrumentClientOptions(new ConfigurationClientOptions());
+            ConfigurationClientOptions options = InstrumentClientOptions(new ConfigurationClientOptions(_serviceVersion));
             return InstrumentClient(new ConfigurationClient(new Uri(endpoint), credential, options));
         }
 
@@ -1692,6 +1698,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task CreateSnapshotUsingAutomaticPolling()
         {
             var service = GetClient();
@@ -1719,6 +1726,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task CreateSnapshotUsingWaitForCompletion()
         {
             var service = GetClient();
@@ -1747,6 +1755,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task CreateSnapshotUsingManualPolling()
         {
             var service = GetClient();
@@ -1783,6 +1792,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task CreateSnapshotUsingWildCardKeyFilter()
         {
             var service = GetClient();
@@ -1823,6 +1833,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task ArchiveSnapshotStatus()
         {
             var service = GetClient();
@@ -1854,6 +1865,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task RecoverSnapshotStatus()
         {
             var service = GetClient();
@@ -1889,6 +1901,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task GetSnapshots()
         {
             var service = GetClient();
@@ -1923,6 +1936,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task GetSnapshotsUsingNameFilter()
         {
             var service = GetClient();
@@ -1962,6 +1976,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task GetConfigurationSettingsForSnapshot()
         {
             var service = GetClient();
@@ -1987,6 +2002,7 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        [ServiceVersion(Min = ConfigurationClientOptions.ServiceVersion.V2023_10_01)]
         public async Task UnchangedSnapshotAfterSettingsUpdate()
         {
             var service = GetClient();


### PR DESCRIPTION
This PR:
- Updates the client options to support service version 2023-10-01.
- Updates our test infrastructure to test both GA versions: 1.0 and 2023-10-01.