### PR TITLE
[AzureMonitorLiveMetrics] [PoC] Add Live Metrics Extraction Processor

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Azure.Monitor.OpenTelemetry.LiveMetrics.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Azure.Monitor.OpenTelemetry.LiveMetrics.csproj
@@ -13,14 +13,18 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" VersionOverride="1.6.0" />
   </ItemGroup>
 
   <!-- Shared sorce from Azure.Monitor.OpenTelemetry.Exporter -->
   <ItemGroup>
     <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\ConnectionString\*.cs" LinkBase="Internals\ConnectionString" />
     <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\Platform\*.cs" LinkBase="Internals\Platform" />
+    <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\AksResourceProcessor.cs" Link="AksResourceProcessor.cs" />
     <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\NullableAttributes.cs" LinkBase="Internals" />
     <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\ExceptionExtensions.cs" LinkBase="Internals" />
+    <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\SchemaConstants.cs" Link="SchemaConstants.cs" />
+    <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\SemanticConventions.cs" Link="SemanticConventions.cs" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricConstants.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics
+{
+    internal static class LiveMetricConstants
+    {
+        internal const string LiveMetricMeterName = "LiveMetricMeterName";
+        internal const string RequestDurationInstrumentName = "RequestDurationLiveMetric";
+        internal const string RequestsInstrumentName = "RequestsLiveMetric";
+        internal const string RequestsSucceededPerSecondInstrumentName = "RequestsSucceededPerSecondLiveMetric";
+        internal const string RequestsFailedPerSecondInstrumentName = "RequestsFailedPerSecondLiveMetric";
+        internal const string DependencyDurationInstrumentName = "DependencyDurationLiveMetric";
+        internal const string DependencyInstrumentName = "DependencyLiveMetric";
+        internal const string DependencySucceededPerSecondInstrumentName = "DependencySucceededPerSecondLiveMetric";
+        internal const string DependencyFailedPerSecondInstrumentName = "DependencyFailedPerSecondLiveMetric";
+        internal const string ExceptionsPerSecondInstrumentName = "ExceptionsPerSecondLiveMetric";
+        internal const string MemoryCommittedBytesInstrumentName = "CommittedBytesLiveMetric";
+        internal const string ProcessorTimeInstrumentName = "ProcessorTimeBytesLiveMetric";
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporter.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics
+{
+    internal sealed class LiveMetricsExporter : BaseExporter<Metric>
+    {
+        private readonly string _instrumentationKey;
+        private LiveMetricsResource? _resource;
+        private bool _disposed;
+
+        public LiveMetricsExporter(LiveMetricsExporterOptions options)
+        {
+            _instrumentationKey = "";
+        }
+
+        internal LiveMetricsResource? MetricResource => _resource ??= ParentProvider?.GetResource().CreateAzureMonitorResource(_instrumentationKey);
+
+        public override ExportResult Export(in Batch<Metric> batch)
+        {
+            return ExportResult.Success;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                }
+
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using Azure.Core;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics;
+
+/// <summary>
+/// Options that allow users to configure the Live Metrics.
+/// </summary>
+public class LiveMetricsExporterOptions : ClientOptions
+{
+    /// <summary>
+    /// The Connection String provides users with a single configuration setting to identify the Azure Monitor resource and endpoint.
+    /// </summary>
+    /// <remarks>
+    /// <see href="https://docs.microsoft.com/azure/azure-monitor/app/sdk-connection-string"/>.
+    /// </remarks>
+    public string ConnectionString { get; set; }
+
+    /// <summary>
+    /// Enables or disables the Live Metrics feature.
+    /// </summary>
+    public bool EnableLiveMetrics { get; set; }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExporterOptions.cs
@@ -10,7 +10,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics;
 /// <summary>
 /// Options that allow users to configure the Live Metrics.
 /// </summary>
-public class LiveMetricsExporterOptions : ClientOptions
+internal class LiveMetricsExporterOptions : ClientOptions
 {
     /// <summary>
     /// The Connection String provides users with a single configuration setting to identify the Azure Monitor resource and endpoint.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtensions.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics
+{
+    /// <summary>
+    /// Extension methods to register Live Metrics.
+    /// </summary>
+    internal static class LiveMetricsExtensions
+    {
+        /// <summary>
+        /// Adds Live Metrics to the TracerProvider.
+        /// </summary>
+        /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
+        /// <param name="configure">Callback action for configuring <see cref="LiveMetricsExporterOptions"/>.</param>
+        /// <param name="name">Name which is used when retrieving options.</param>
+        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+        public static TracerProviderBuilder AddLiveMetrics(
+            this TracerProviderBuilder builder,
+            Action<LiveMetricsExporterOptions> configure = null,
+            string name = null)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            var finalOptionsName = name ?? Options.DefaultName;
+
+            builder.ConfigureServices(services =>
+            {
+                if (name != null && configure != null)
+                {
+                    // If we are using named options we register the
+                    // configuration delegate into options pipeline.
+                    services.Configure(finalOptionsName, configure);
+                }
+            });
+
+            return builder.AddProcessor(sp =>
+            {
+                LiveMetricsExporterOptions exporterOptions;
+
+                if (name == null)
+                {
+                    // If we are NOT using named options we create a new
+                    // instance always. The reason for this is
+                    // OtlpExporterOptions is shared by all signals. Without a
+                    // name, delegates for all signals will mix together. See:
+                    // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4043
+                    exporterOptions = sp.GetRequiredService<IOptionsFactory<LiveMetricsExporterOptions>>().Create(finalOptionsName);
+
+                    // Configuration delegate is executed inline on the fresh instance.
+                    configure?.Invoke(exporterOptions);
+                }
+                else
+                {
+                    // When using named options we can properly utilize Options
+                    // API to create or reuse an instance.
+                    exporterOptions = sp.GetRequiredService<IOptionsMonitor<LiveMetricsExporterOptions>>().Get(finalOptionsName);
+                }
+
+                return new LiveMetricsExtractionProcessor(new LiveMetricsExporter(exporterOptions));
+            });
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtensions.cs
@@ -51,11 +51,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 
                 if (name == null)
                 {
-                    // If we are NOT using named options we create a new
-                    // instance always. The reason for this is
-                    // OtlpExporterOptions is shared by all signals. Without a
-                    // name, delegates for all signals will mix together. See:
-                    // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4043
                     exporterOptions = sp.GetRequiredService<IOptionsFactory<LiveMetricsExporterOptions>>().Create(finalOptionsName);
 
                     // Configuration delegate is executed inline on the fresh instance.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics
+{
+    internal sealed class LiveMetricsExtractionProcessor : BaseProcessor<Activity>
+    {
+        private bool _disposed;
+        private LiveMetricsResource? _resource;
+        internal readonly MeterProvider? _meterProvider;
+        private readonly Meter _meter;
+        private readonly Counter<long> _requests;
+        private readonly Histogram<double> _requestDuration;
+        private readonly Counter<long> _requestSucceededPerSecond;
+        private readonly Counter<long> _requestFailedPerSecond;
+        private readonly Counter<long> _dependency;
+        private readonly Histogram<double> _dependencyDuration;
+        private readonly Counter<long> _dependencySucceededPerSecond;
+        private readonly Counter<long> _dependencyFailedPerSecond;
+        private readonly Counter<long> _exceptionsPerSecond;
+        // TODO: Explore concurrent collections.
+        private readonly List<DocumentIngress> _documentIngress = new();
+
+        internal LiveMetricsResource? LiveMetricsResource => _resource ??= ParentProvider?.GetResource().CreateAzureMonitorResource();
+
+        internal LiveMetricsExtractionProcessor(LiveMetricsExporter liveMetricExporter)
+        {
+            _meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(LiveMetricConstants.LiveMetricMeterName)
+                .AddReader(new PeriodicExportingMetricReader(exporter: liveMetricExporter, exportIntervalMilliseconds:5000)
+                { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
+                // TODO: Remove Console Exporter
+                .AddConsoleExporter()
+                .Build();
+
+            _meter = new Meter(LiveMetricConstants.LiveMetricMeterName);
+            _requests = _meter.CreateCounter<long>(LiveMetricConstants.RequestsInstrumentName);
+            _requestDuration = _meter.CreateHistogram<double>(LiveMetricConstants.RequestDurationInstrumentName);
+            _requestSucceededPerSecond = _meter.CreateCounter<long>(LiveMetricConstants.RequestsSucceededPerSecondInstrumentName);
+            _requestFailedPerSecond = _meter.CreateCounter<long>(LiveMetricConstants.RequestsFailedPerSecondInstrumentName);
+            _dependency = _meter.CreateCounter<long>(LiveMetricConstants.DependencyInstrumentName);
+            _dependencyDuration = _meter.CreateHistogram<double>(LiveMetricConstants.DependencyDurationInstrumentName);
+            _dependencySucceededPerSecond = _meter.CreateCounter<long>(LiveMetricConstants.DependencySucceededPerSecondInstrumentName);
+            _dependencyFailedPerSecond = _meter.CreateCounter<long>(LiveMetricConstants.DependencyFailedPerSecondInstrumentName);
+            _exceptionsPerSecond = _meter.CreateCounter<long>(LiveMetricConstants.ExceptionsPerSecondInstrumentName);
+        }
+
+        public override void OnEnd(Activity activity)
+        {
+            // Validate if live metrics is enabled.
+            if (!_requests.Enabled)
+            {
+                return;
+            }
+
+            string? statusCodeAttributeValue = null;
+
+            foreach (ref readonly var tag in activity.EnumerateTagObjects())
+            {
+                if (tag.Key == SemanticConventions.AttributeHttpResponseStatusCode)
+                {
+                    statusCodeAttributeValue = tag.Value?.ToString();
+                    break;
+                }
+            }
+
+            if (activity.Kind == ActivityKind.Server || activity.Kind == ActivityKind.Consumer)
+            {
+                _requests.Add(1);
+                // Export needs to divide by count to get the average.
+                // this.AIRequestDurationAveInMs = requestCount > 0 ? (double)requestDurationInTicks / TimeSpan.TicksPerMillisecond / requestCount : 0;
+                _requestDuration.Record(activity.Duration.TotalMilliseconds);
+                if (IsSuccess(activity, statusCodeAttributeValue))
+                {
+                    _requestFailedPerSecond.Add(1);
+                }
+                else
+                {
+                    _requestSucceededPerSecond.Add(1);
+                }
+
+                AddRequestDocument(activity, statusCodeAttributeValue);
+            }
+            else
+            {
+                _dependency.Add(1);
+                // Export needs to divide by count to get the average.
+                // this.AIDependencyCallDurationAveInMs = dependencyCount > 0 ? (double)dependencyDurationInTicks / TimeSpan.TicksPerMillisecond / dependencyCount : 0;
+                // Export DependencyDurationLiveMetric, Meter: LiveMetricMeterName
+                // (2023 - 11 - 03T23: 20:56.0282406Z, 2023 - 11 - 03T23: 21:00.9830153Z] Histogram Value: Sum: 798.9463000000001 Count: 7 Min: 4.9172 Max: 651.8997
+                _dependencyDuration.Record(activity.Duration.TotalMilliseconds);
+                if (IsSuccess(activity, statusCodeAttributeValue))
+                {
+                    _dependencyFailedPerSecond.Add(1);
+                }
+                else
+                {
+                    _dependencySucceededPerSecond.Add(1);
+                }
+
+                AddRemoteDependencyDocument(activity);
+            }
+
+            if (activity.Events != null)
+            {
+                foreach (ref readonly var @event in activity.EnumerateEvents())
+                {
+                    if (@event.Name == SemanticConventions.AttributeExceptionEventName)
+                    {
+                        _exceptionsPerSecond.Add(1);
+                    }
+
+                    string? exceptionType = null;
+                    string? exceptionMessage = null;
+
+                    foreach (ref readonly var tag in @event.EnumerateTagObjects())
+                    {
+                        // TODO: see if these can be cached
+                        if (tag.Key == SemanticConventions.AttributeExceptionType)
+                        {
+                            exceptionType = tag.Value?.ToString();
+                            continue;
+                        }
+                        if (tag.Key == SemanticConventions.AttributeExceptionMessage)
+                        {
+                            exceptionMessage = tag.Value?.ToString();
+                            continue;
+                        }
+                    }
+
+                    AddExceptionDocument(exceptionType, exceptionMessage);
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    try
+                    {
+                        _meterProvider?.Dispose();
+                        _meter?.Dispose();
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void AddExceptionDocument(string? exceptionType, string? exceptionMessage)
+        {
+            ExceptionDocumentIngress exceptionDocumentIngress = new()
+            {
+                ExceptionType = exceptionType,
+                ExceptionMessage = exceptionMessage,
+                DocumentType = DocumentIngressDocumentType.Request,
+                // TODO: DocumentStreamIds = new List<string>(),
+                // TODO: Properties = new Dictionary<string, string>(), - Validate with UX team if this is needed.
+            };
+            _documentIngress.Add(exceptionDocumentIngress);
+        }
+
+        private void AddRemoteDependencyDocument(Activity activity)
+        {
+            RemoteDependencyDocumentIngress remoteDependencyDocumentIngress = new()
+            {
+                Name = activity.DisplayName,
+                // TODO: Implementation needs to be copied from Exporter.
+                // TODO: Value of dependencyTelemetry.Data
+                CommandName = "",
+                // TODO: Value of dependencyTelemetry.ResultCode
+                ResultCode = "",
+                Duration = activity.Duration < SchemaConstants.RequestData_Duration_LessThanDays
+                                                ? activity.Duration.ToString("c", CultureInfo.InvariantCulture)
+                                                : SchemaConstants.Duration_MaxValue,
+                DocumentType = DocumentIngressDocumentType.Request,
+                // TODO: DocumentStreamIds = new List<string>(),
+                // TODO: Properties = new Dictionary<string, string>(), - Validate with UX team if this is needed.
+            };
+            _documentIngress.Add(remoteDependencyDocumentIngress);
+        }
+
+        private void AddRequestDocument(Activity activity, string? statusCodeAttributeValue)
+        {
+            RequestDocumentIngress requestDocumentIngress = new()
+            {
+                Name = activity.DisplayName,
+                // TODO: Implementation needs to be copied from Exporter.
+                // Value of requestTelemetry.ResultCode
+                Url = "",
+                ResponseCode = statusCodeAttributeValue,
+                Duration = activity.Duration < SchemaConstants.RequestData_Duration_LessThanDays
+                                                ? activity.Duration.ToString("c", CultureInfo.InvariantCulture)
+                                                : SchemaConstants.Duration_MaxValue,
+                DocumentType = DocumentIngressDocumentType.Request,
+                // TODO: DocumentStreamIds = new List<string>(),
+                // TODO: Properties = new Dictionary<string, string>(), - Validate with UX team if this is needed.
+            };
+            _documentIngress.Add(requestDocumentIngress);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsSuccess(Activity activity, string? responseCode)
+        {
+            if (responseCode != null && int.TryParse(responseCode, out int statusCode))
+            {
+                bool isSuccessStatusCode = statusCode != 0 && statusCode < 400;
+                return activity.Status != ActivityStatusCode.Error && isSuccessStatusCode;
+            }
+            else
+            {
+                return activity.Status != ActivityStatusCode.Error;
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsResource.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics
+{
+    internal sealed class LiveMetricsResource
+    {
+        internal string? RoleName { get; set; }
+
+        internal string? RoleInstance { get; set; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/ResourceExtensions.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using OpenTelemetry.Resources;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics;
+
+internal static class ResourceExtensions
+{
+    private const string DefaultServiceName = "unknown_service";
+
+    internal static LiveMetricsResource? CreateAzureMonitorResource(this Resource resource, string? instrumentationKey = null)
+    {
+        if (resource == null)
+        {
+            return null;
+        }
+
+        LiveMetricsResource azureMonitorResource = new();
+        AksResourceProcessor? aksResourceProcessor = null;
+        string? serviceName = null;
+        string? serviceNamespace = null;
+        string? serviceInstance = null;
+        bool? hasDefaultServiceName = null;
+
+        foreach (var attribute in resource.Attributes)
+        {
+            switch (attribute.Key)
+            {
+                case SemanticConventions.AttributeServiceName when attribute.Value is string _serviceName:
+                    serviceName = _serviceName;
+                    if (serviceName.StartsWith(DefaultServiceName))
+                    {
+                        hasDefaultServiceName = true;
+                        break;
+                    }
+
+                    hasDefaultServiceName = false;
+                    break;
+                case SemanticConventions.AttributeServiceNamespace when attribute.Value is string _serviceNamespace:
+                    serviceNamespace = $"[{_serviceNamespace}]";
+                    break;
+                case SemanticConventions.AttributeServiceInstance when attribute.Value is string _serviceInstance:
+                    serviceInstance = _serviceInstance;
+                    break;
+                default:
+                    if (attribute.Key.StartsWith("k8s"))
+                    {
+                        aksResourceProcessor = aksResourceProcessor ?? new AksResourceProcessor();
+                        aksResourceProcessor.MapAttributeToProperty(attribute);
+                    }
+                    break;
+            }
+        }
+
+        // TODO: Check if service.name as unknown_service should be sent.
+        // (2023-07) we need to drop the "unknown_service."
+        if (serviceName != null && serviceNamespace != null)
+        {
+            azureMonitorResource.RoleName = string.Concat(serviceNamespace, "/", serviceName);
+        }
+        else
+        {
+            azureMonitorResource.RoleName = serviceName;
+        }
+
+        try
+        {
+            azureMonitorResource.RoleInstance = serviceInstance ?? Dns.GetHostName();
+        }
+        catch (Exception)
+        {
+            // AzureMonitorExporterEventSource.Log.ErrorInitializingRoleInstanceToHostName(ex);
+        }
+
+        if (aksResourceProcessor != null)
+        {
+            var aksRoleName = aksResourceProcessor.GetRoleName();
+            var aksRoleInstanceName = aksResourceProcessor.GetRoleInstance();
+
+            if (hasDefaultServiceName != false && aksRoleName != null)
+            {
+                azureMonitorResource.RoleName = aksRoleName;
+            }
+
+            if (serviceInstance == null && aksRoleInstanceName != null)
+            {
+                azureMonitorResource.RoleInstance = aksRoleInstanceName;
+            }
+        }
+
+        return azureMonitorResource;
+    }
+}


### PR DESCRIPTION
This proof of concept demonstrates the extraction of metrics using the OpenTelemetry Activity processor. The extracted metric is subsequently captured by the internal live metrics exporter, for which a base template has been added. Throughout the metric extraction process, requests, dependencies, and exceptions are appended to a document list. This list is intended to be later transformed into a concurrent data structure. Added Console exporter to validate the metrics flow. Set `exportIntervalMilliseconds` to 5 seconds, later this needs to be modified to 1 second.