### PR TITLE
Ignore rare Key Vault service issue

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -999,7 +999,15 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             CertificateOperation operation = await Client.StartCreateCertificateAsync(name, policy);
             RegisterForCleanup(name);
 
-            await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
+            try
+            {
+                await operation.WaitForCompletionAsync(DefaultCertificateOperationPollingInterval, default);
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("An internal error has occurred"))
+            {
+                // This test fails often enough with an internal HTTP 500 to ignore.
+                Assert.Inconclusive("The service encountered an internal error");
+            }
 
             // Download the certificate and sign data locally.
             byte[] plaintext = Encoding.UTF8.GetBytes(nameof(DownloadECDsaCertificateSignRemoteVerifyLocal));


### PR DESCRIPTION
Work around rare service issue in Key Vault Certificates SDK.
