### PR TITLE
[Storage] [DataMovement] [Files] Fixed share file container listing when directory is listed on download

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/UriToStreamTransferJob.cs
@@ -169,7 +169,8 @@ namespace Azure.Storage.DataMovement
                 }
 
                 StorageResource current = enumerator.Current;
-                if (!existingSources.Contains(current.Uri))
+                if (!current.IsContainer &&
+                    !existingSources.Contains(current.Uri))
                 {
                     string containerUriPath = _sourceResourceContainer.Uri.GetPath();
                     string sourceName = string.IsNullOrEmpty(containerUriPath)


### PR DESCRIPTION
- The share file listing was returning a directory however we weren't checking to make sure that we can skip over those.
- No need to update change log since the feature has not been released yet