### PR TITLE
Updated version of Microsoft.Extensions.Azure to 1.7.1

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -162,7 +162,7 @@
     <PackageReference Update="Microsoft.AspNetCore.Http.Connections" Version="1.0.15" />
     <PackageReference Update="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.6.3" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.7.1" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0" />


### PR DESCRIPTION
Looks like Microsoft.Extensions.Azure is still dependent on the Azure.Identity version 1.7.0, but we currently want it to depend on 1.10.3 because version 1.7.0 has a known vulnerability.

This will also update all our Microsoft.Azure.WebJobs.Extensions.* to depend on this newer version as well.