### PR TITLE
[Storage] Update ARM template to allow blob public access

### DIFF
--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -114,7 +114,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {
@@ -163,7 +164,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {
@@ -181,7 +183,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {
@@ -200,7 +203,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {
@@ -244,7 +248,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {
@@ -294,7 +299,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {
@@ -312,7 +318,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {
@@ -330,7 +337,8 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": "[variables('encryption')]",
                 "accessTier": "Hot",
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": true
             }
         },
         {


### PR DESCRIPTION
Live tests have been failing as they are not able to create public access containers for some reason. Try explicitly setting `allowBlobPublicAccess: true` in our ARM template, even though that is the default, to see if that helps.