### PR TITLE
Update CHANGELOGs for Key Vault beta release

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Release History
 
-## 4.4.0-beta.1 (Unreleased)
+## 4.4.0-beta.1 (2023-11-08)
 
 ### Features Added
 
-- TODO: sasToken vs. useManagedIdentity.
-
-### Breaking Changes
+- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartBackup` and `StartBackupAsync`. Managed Identity will be used instead of `sasToken` is null.
+- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartRestore` and `StartRestoreAsync`. Managed Identity will be used instead of `sasToken` is null.
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Features Added
 
-- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartBackup` and `StartBackupAsync`. Managed Identity will be used instead of `sasToken` is null.
-- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartRestore` and `StartRestoreAsync`. Managed Identity will be used instead of `sasToken` is null.
-- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartSelectiveKeyRestore` and `StartSelectiveKeyRestoreAsync`. Managed Identity will be used instead of `sasToken` is null.
+- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartBackup` and `StartBackupAsync`. Managed Identity will be used instead if `sasToken` is null.
+- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartRestore` and `StartRestoreAsync`. Managed Identity will be used instead if `sasToken` is null.
+- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartSelectiveKeyRestore` and `StartSelectiveKeyRestoreAsync`. Managed Identity will be used instead if `sasToken` is null.
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartBackup` and `StartBackupAsync`. Managed Identity will be used instead of `sasToken` is null.
 - The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartRestore` and `StartRestoreAsync`. Managed Identity will be used instead of `sasToken` is null.
+- The `sasToken` parameter is now optional in `KeyVaultBackupClient.StartSelectiveKeyRestore` and `StartSelectiveKeyRestoreAsync`. Managed Identity will be used instead of `sasToken` is null.
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.4.0-beta.1 (2023-11-08)
+## 4.4.0-beta.1 (2023-11-09)
 
 ### Features Added
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/autorest.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/autorest.md
@@ -9,9 +9,9 @@ Run `dotnet build /t:GenerateCode` in src directory to re-generate.
 ``` yaml
 title: Azure.Security.KeyVault.Administration
 input-file:
-- https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/rbac.json
-- https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/backuprestore.json
-- https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/settings.json
+- https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/rbac.json
+- https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/backuprestore.json
+- https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/settings.json
 namespace: Azure.Security.KeyVault.Administration
 generation1-convenience-client: true
 include-csproj: disable

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.6.0-beta.1 (2023-11-08)
+## 4.6.0-beta.1 (2023-11-09)
 
 ### Features Added
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.6.0-beta.1 (Unreleased)
+## 4.6.0-beta.1 (2023-11-08)
 
 ### Features Added
 
@@ -10,8 +10,8 @@
 ### Breaking Changes
 
 - Renamed tags reported on `CertificateClient` activities to following OpenTelemetry attribute naming conventions:
-  - `certificate` to `az.keyvault.certificate.name` 
-  - `version` to `az.keyvault.certificate.version` 
+  - `certificate` to `az.keyvault.certificate.name`
+  - `version` to `az.keyvault.certificate.version`
   - `issuer` to `az.keyvault.certificate.issuer.name`
 
 ### Bugs Fixed

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.6.0-beta.1 (Unreleased)
+## 4.6.0-beta.1 (2023-11-08)
 
 ### Features Added
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Release History
 
-## 4.6.0-beta.1 (2023-11-08)
+## 4.6.0-beta.1 (2023-11-09)
 
 ### Features Added
 
-- Added `CryptographyClient.CreateRSA` and `CreateRSAAsync` to create an `RSA` implementation backed by Key Vault or Managed HSM ([#3545](https://github.com/Azure/azure-sdk-for-net/issues/3545))
+- Added `CryptographyClient.CreateRSA` and `CreateRSAAsync` to create an `RSA` implementation backed by Key Vault or Managed HSM.
+  Use this anywhere an `RSA` or `AsymmetricAlgorithm` is required. ([#3545](https://github.com/Azure/azure-sdk-for-net/issues/3545))
 - Added `KeyProperties.HsmPlatform` to get the underlying HSM platform.
 
 ### Breaking Changes

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.6.0-beta.1 (2023-11-09)
 
+### Breaking Changes
+
 - Renamed tags reported on `SecretClient` activities to follow OpenTelemetry attribute naming conventions:
   - `secret` to `az.keyvault.secret.name`
   - `version` to `az.keyvault.secret.version`

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.6.0-beta.1 (2023-11-08)
+## 4.6.0-beta.1 (2023-11-09)
 
 - Renamed tags reported on `SecretClient` activities to follow OpenTelemetry attribute naming conventions:
   - `secret` to `az.keyvault.secret.name`

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 4.6.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.6.0-beta.1 (2023-11-08)
 
 - Renamed tags reported on `SecretClient` activities to follow OpenTelemetry attribute naming conventions:
   - `secret` to `az.keyvault.secret.name`


### PR DESCRIPTION
Uses service version 7.5-preview.1 by default.
