### PR TITLE
Include SMS specific int configuration to livetest pipeline

### DIFF
--- a/sdk/communication/Azure.Communication.Sms/tests.yml
+++ b/sdk/communication/Azure.Communication.Sms/tests.yml
@@ -16,6 +16,7 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-int-test-resources-common)
           - $(sub-config-communication-int-test-resources-net)
+          - $(sub-config-communication-sms-int-test-resources)
     Clouds: Public,Int
     TestResourceDirectories:
       - communication/test-resources/


### PR DESCRIPTION
Done as part of [Task 3499226](https://skype.visualstudio.com/SPOOL/_workitems/edit/3499226): [Reliability] Fix Int pipeline configuration for all SDKs.

Int pipeline yaml definition updated with the new configuration for int environment ([sample execution](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3251572&view=results))

![image](https://github.com/Azure/azure-sdk-for-net/assets/112948415/6db21523-f8e3-4dcd-b1e0-fa7f4ad13030)
