### PR TITLE
Adding a `Filter` property to the Cognitive Search OpenAI Chat Extensions

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -148,6 +148,7 @@ namespace Azure.AI.OpenAI
         public int? DocumentCount { get { throw null; } set { } }
         public System.Uri EmbeddingEndpoint { get { throw null; } set { } }
         public Azure.AI.OpenAI.AzureCognitiveSearchIndexFieldMappingOptions FieldMappingOptions { get { throw null; } set { } }
+        public string Filter { get { throw null; } set { } }
         public string IndexName { get { throw null; } set { } }
         public Azure.AI.OpenAI.AzureCognitiveSearchQueryType? QueryType { get { throw null; } set { } }
         public System.Uri SearchEndpoint { get { throw null; } set { } }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.Serialization.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.Serialization.cs
@@ -40,6 +40,11 @@ namespace Azure.AI.OpenAI
                 writer.WritePropertyName("queryType"u8);
                 writer.WriteStringValue(QueryType.Value.ToString());
             }
+            if (Optional.IsDefined(Filter))
+            {
+                writer.WritePropertyName("filter"u8);
+                writer.WriteStringValue(Filter);
+            }
             if (Optional.IsDefined(ShouldRestrictResultScope))
             {
                 writer.WritePropertyName("inScope"u8);

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
@@ -36,6 +36,8 @@ namespace Azure.AI.OpenAI
         public AzureCognitiveSearchQueryType? QueryType { get; set; }
         /// <summary> Whether queries should be restricted to use of indexed data. </summary>
         public bool? ShouldRestrictResultScope { get; set; }
+        /// <summary> The OData filter to use for the configured query.</summary>
+        public string? Filter { get; set; }
         /// <summary> The additional semantic configuration for the query. </summary>
         public string SemanticConfiguration { get; set; }
         /// <summary> When using embeddings for search, specifies the resource URL from which embeddings should be retrieved. </summary>

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureCognitiveSearchChatExtensionConfiguration.cs
@@ -37,7 +37,7 @@ namespace Azure.AI.OpenAI
         /// <summary> Whether queries should be restricted to use of indexed data. </summary>
         public bool? ShouldRestrictResultScope { get; set; }
         /// <summary> The OData filter to use for the configured query.</summary>
-        public string? Filter { get; set; }
+        public string Filter { get; set; }
         /// <summary> The additional semantic configuration for the query. </summary>
         public string SemanticConfiguration { get; set; }
         /// <summary> When using embeddings for search, specifies the resource URL from which embeddings should be retrieved. </summary>


### PR DESCRIPTION
Adding a `Filter` property to the `AzureCognitiveSearchChatExtensionsConfiguration` object to be able to better scope the chat completions to specific data in the search index being used.

* Useful for for example querying data for a specific file in the index, or to be able to do scope data to certain roles etc. or whatever properties the index has that can be used for filtering.
