### PR TITLE
Serialize RoundaboutExitNumber String to conform to documentation

### DIFF
--- a/sdk/maps/Azure.Maps.Routing/src/Generated/Models/RouteInstruction.Serialization.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Generated/Models/RouteInstruction.Serialization.cs
@@ -144,7 +144,14 @@ namespace Azure.Maps.Routing.Models
                 }
                 if (property.NameEquals("roundaboutExitNumber"u8))
                 {
-                    roundaboutExitNumber = property.Value.GetString();
+                    try
+                    {
+                        roundaboutExitNumber = property.Value.GetString();
+                    }
+                    catch (System.Exception)
+                    {
+                        roundaboutExitNumber = property.Value.GetInt32().ToString();
+                    }
                     continue;
                 }
                 if (property.NameEquals("possibleCombineWithNext"u8))

--- a/sdk/maps/Azure.Maps.Routing/src/Generated/Models/RouteInstruction.Serialization.cs
+++ b/sdk/maps/Azure.Maps.Routing/src/Generated/Models/RouteInstruction.Serialization.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
@@ -148,7 +149,7 @@ namespace Azure.Maps.Routing.Models
                     {
                         roundaboutExitNumber = property.Value.GetString();
                     }
-                    catch (System.Exception)
+                    catch (System.InvalidOperationException)
                     {
                         roundaboutExitNumber = property.Value.GetInt32().ToString();
                     }


### PR DESCRIPTION
This should solve #38719

The documentation for RoundaboutExitNumber specifies it to be a string, but when running exceptions arise when calculating routes.

Change the RoundaboutExitNumber to be serialized as an int resolves the issue, but to comply with the documentation, someone should check if the documentation is right on this part or if it should be int.

Also, I'm not familiar with AutoRest I may be changing stuff that is generated
