### PR TITLE
Update Azure.Core to 1.36.0 in  Packages.Data.props

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -83,9 +83,9 @@
     <!-- Azure SDK packages -->
     <PackageReference Update="Azure.Communication.Identity" Version="1.2.0" />
     <PackageReference Update="Azure.Communication.Common" Version="1.2.1" />
-    <PackageReference Update="Azure.Core" Version="1.35.0" />
+    <PackageReference Update="Azure.Core" Version="1.36.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.3.0" />
-    <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.30" />
+    <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.31" />
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0-beta.4" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.2.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.8.0" />


### PR DESCRIPTION
Unblock release of client libraries depending on Azure.Core 1.36.0.

Updates Azure.Core.Experimental version to 0.1.0-preview.31 as well.