### PR TITLE
Fix model factory original name in customized model factory

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -13,7 +13,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Model factory that enables mocking for the Text Analytics library.
     /// </summary>
-    [CodeGenType(nameof(TextAnalyticsModelFactory))]
+    [CodeGenType("AITextAnalyticsModelFactory")]
     public static partial class TextAnalyticsModelFactory
     {
         #region Common


### PR DESCRIPTION
`CodeGenType` should specify "generated" name of the type.