### PR TITLE
Disable diagnostics checks in tests that use released version of KeyVault

### DIFF
--- a/sdk/identity/Azure.Identity/tests/IdentityRecordedTestBase.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityRecordedTestBase.cs
@@ -12,6 +12,8 @@ namespace Azure.Identity.Tests
     {
         protected IdentityRecordedTestBase(bool isAsync, RecordedTestMode? mode = default) : base(isAsync, mode)
         {
+            // TODO: enable after new KeyValue is released (after Dec 2023)
+            TestDiagnostics = false;
             InitializeRecordingSettings();
         }
 

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialLiveTestBase.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialLiveTestBase.cs
@@ -15,6 +15,8 @@ namespace Azure.Identity.Tests
     {
         public ManagedIdentityCredentialLiveTestBase(bool isAsync) : base(isAsync)
         {
+            // TODO: enable after new KeyValue is released (after Dec 2023)
+            TestDiagnostics = false;
         }
 
         public ManagedIdentityCredentialLiveTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -37,6 +37,8 @@ namespace Azure.Storage.Blobs.Test
         public ClientSideEncryptionTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
             : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
+            // TODO: enable after new KeyValue is released (after Dec 2023)
+            TestDiagnostics = false;
         }
 
         private static IEnumerable<ClientSideEncryptionVersion> GetEncryptionVersions()

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
@@ -39,6 +39,8 @@ namespace Azure.Storage.Queues.Test
         public ClientSideEncryptionTests(bool async)
             : base(async, null /* RecordedTestMode.Record /* to re-record */)
         {
+            // TODO: enable after new KeyValue is released (after Dec 2023)
+            TestDiagnostics = false;
         }
 
         private static IEnumerable<ClientSideEncryptionVersion> GetEncryptionVersions()


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-net/pull/39637 added new checks for OTel attributes and also renamed some of the existing attributes.

This was an intentional breaking change, but it broke several CI pipelines that use KeyVault in tests or samples.

This PR disables diagnostics checks for such tests for the time being (until new KeyVault is released)