### PR TITLE
Send user agent header as "acs-test"

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/assets.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.PhoneNumbers",
-  "Tag": "net/communication/Azure.Communication.PhoneNumbers_2ae3461e55"
+  "Tag": "net/communication/Azure.Communication.PhoneNumbers_x9ndpu0nad"
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/assets.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/communication/Azure.Communication.PhoneNumbers",
-  "Tag": "net/communication/Azure.Communication.PhoneNumbers_a2ce6fc537"
+  "Tag": "net/communication/Azure.Communication.PhoneNumbers_2ae3461e55"
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/MSUserAgentPolicy.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/MSUserAgentPolicy.cs
@@ -42,13 +42,13 @@ namespace Azure.Communication.PhoneNumbers
         /// <param name="message"></param>
         private static void addHeader(HttpMessage message)
         {
+            message.Request.Headers.Add("x-ms-useragent", "acs-test");
+
             var useragent = Environment.GetEnvironmentVariable("AZURE_USERAGENT_OVERRIDE");
             if (useragent != null)
             {
                 message.Request.Headers.Add("x-ms-useragent", useragent);
             }
-
-            message.Request.Headers.Add("x-ms-useragent", "acs-test");
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/MSUserAgentPolicy.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/MSUserAgentPolicy.cs
@@ -47,6 +47,8 @@ namespace Azure.Communication.PhoneNumbers
             {
                 message.Request.Headers.Add("x-ms-useragent", useragent);
             }
+
+            message.Request.Headers.Add("x-ms-useragent", "acs-test");
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/MSUserAgentPolicy.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/MSUserAgentPolicy.cs
@@ -42,8 +42,6 @@ namespace Azure.Communication.PhoneNumbers
         /// <param name="message"></param>
         private static void addHeader(HttpMessage message)
         {
-            message.Request.Headers.Add("x-ms-useragent", "acs-test");
-
             var useragent = Environment.GetEnvironmentVariable("AZURE_USERAGENT_OVERRIDE");
             if (useragent != null)
             {

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClient.cs
@@ -69,15 +69,15 @@ namespace Azure.Communication.PhoneNumbers.SipRouting
         #region private constructors
 
         private SipRoutingClient(ConnectionString connectionString, SipRoutingClientOptions options)
-            : this(connectionString.GetRequired("endpoint"), options.BuildHttpPipeline(connectionString), options)
+            : this(connectionString.GetRequired("endpoint"), options.BuildSipRoutingHttpPipeline(connectionString), options)
         { }
 
         private SipRoutingClient(string endpoint, AzureKeyCredential keyCredential, SipRoutingClientOptions options)
-            : this(endpoint, options.BuildHttpPipeline(keyCredential), options)
+            : this(endpoint, options.BuildSipRoutingHttpPipeline(keyCredential), options)
         { }
 
         private SipRoutingClient(string endpoint, TokenCredential tokenCredential, SipRoutingClientOptions options)
-            : this(endpoint, options.BuildHttpPipeline(tokenCredential), options)
+            : this(endpoint, options.BuildSipRoutingHttpPipeline(tokenCredential), options)
         { }
 
         private SipRoutingClient(string endpoint, HttpPipeline httpPipeline, SipRoutingClientOptions options)

--- a/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClientOptionsExtensions.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/src/SipRouting/SipRoutingClientOptionsExtensions.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Azure.Communication.Pipeline;
+using Azure.Core.Pipeline;
+using Azure.Core;
+
+namespace Azure.Communication.PhoneNumbers.SipRouting
+{
+    internal static class SipRoutingClientOptionsExtensions
+    {
+        public static HttpPipeline BuildSipRoutingHttpPipeline(this ClientOptions options, ConnectionString connectionString)
+        {
+            var pipelineOptions = new HttpPipelineOptions(options)
+            {
+                RequestFailedDetailsParser = new CommunicationRequestFailedDetailsParser(),
+                PerRetryPolicies =
+                {
+                    new HMACAuthenticationPolicy(new AzureKeyCredential(connectionString.GetRequired("accesskey"))),
+                    new MSUserAgentPolicy()
+                }
+            };
+            HttpPipelineTransportOptions httpPipelineTransportOptions = new() { IsClientRedirectEnabled = true };
+            return HttpPipelineBuilder.Build(pipelineOptions, httpPipelineTransportOptions);
+        }
+
+        public static HttpPipeline BuildSipRoutingHttpPipeline(this ClientOptions options, AzureKeyCredential keyCredential)
+        {
+            var pipelineOptions = new HttpPipelineOptions(options)
+            {
+                RequestFailedDetailsParser = new CommunicationRequestFailedDetailsParser(),
+                PerRetryPolicies =
+                {
+                    new HMACAuthenticationPolicy(keyCredential),
+                    new MSUserAgentPolicy()
+                }
+            };
+            HttpPipelineTransportOptions httpPipelineTransportOptions = new() { IsClientRedirectEnabled = true };
+            return HttpPipelineBuilder.Build(pipelineOptions, httpPipelineTransportOptions);
+        }
+
+        public static HttpPipeline BuildSipRoutingHttpPipeline(this ClientOptions options, TokenCredential tokenCredential)
+        {
+            var pipelineOptions = new HttpPipelineOptions(options)
+            {
+                RequestFailedDetailsParser = new CommunicationRequestFailedDetailsParser(),
+                PerRetryPolicies =
+                {
+                    new BearerTokenAuthenticationPolicy(tokenCredential, "https://communication.azure.com//.default"),
+                    new MSUserAgentPolicy()
+                }
+            };
+            return HttpPipelineBuilder.Build(pipelineOptions);
+        }
+    }
+}

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
@@ -17,12 +17,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
         private const string UrlEncodedPhoneNumberRegEx = @"[\\%2B]{0,3}[0-9]{11,15}";
         protected const string UnauthorizedNumber = "+14255550123";
         protected const string UnknownPhoneNumberSearchResultId = "01234567-0123-0123-0123-0123456789AB";
+        private const string URIDomainNameReplacerRegEx = @"https://([^/?]+)";
 
         public PhoneNumbersClientLiveTestBase(bool isAsync) : base(isAsync)
         {
             SanitizedHeaders.Add("location");
             BodyRegexSanitizers.Add(new BodyRegexSanitizer(PhoneNumberRegEx, SanitizeValue));
             UriRegexSanitizers.Add(new UriRegexSanitizer(UrlEncodedPhoneNumberRegEx, SanitizeValue));
+            UriRegexSanitizers.Add(new UriRegexSanitizer(URIDomainNameReplacerRegEx, "https://sanitized.communication.azure.com"));
             SanitizedHeaders.Add("x-ms-content-sha256");
         }
 

--- a/sdk/communication/Shared/tests/CommunicationTestEnvironment.cs
+++ b/sdk/communication/Shared/tests/CommunicationTestEnvironment.cs
@@ -26,7 +26,7 @@ namespace Azure.Communication.Tests
 
         public string LiveTestStaticConnectionString => GetRecordedVariable(
                 LiveTestStaticConnectionStringEnvironmentVariableName,
-                options => options.HasSecretConnectionStringParameter("accessKey", SanitizedValue.Base64));
+                options => options.IsSecret("endpoint=https://sanitized.communication.azure.com/;accesskey=Kg=="));
 
         public Uri LiveTestStaticEndpoint => new(Core.ConnectionString.Parse(LiveTestStaticConnectionString).GetRequired("endpoint"));
 


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

Send "x-ms-useragent" header so tests are filtered as test traffic on API side
