### PR TITLE
[AzureMonitorLiveMetrics] add empty demo project

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo.csproj
@@ -12,8 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" VersionOverride="1.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="6.0.0" />
     <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.LiveMetrics.csproj" />
   </ItemGroup>
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="OTEL_DIAGNOSTICS.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" VersionOverride="1.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="6.0.0" />
+    <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.LiveMetrics.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/OTEL_DIAGNOSTICS.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/OTEL_DIAGNOSTICS.json
@@ -1,0 +1,7 @@
+// OpenTelemetry Self-diagnostics configuration.
+// For more information see: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/README.md#troubleshooting
+{
+    "LogDirectory": ".",
+    "FileSize": 1024,
+    "LogLevel": "Warning"
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Program.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/tests/Azure.Monitor.OpenTelemetry.LiveMetrics.Demo/Program.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Demo
+{
+    internal class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.sln
@@ -56,6 +56,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.LiveMetrics.Tests", "Azure.Monitor.OpenTelemetry.LiveMetrics\tests\Azure.Monitor.OpenTelemetry.LiveMetrics.Tests\Azure.Monitor.OpenTelemetry.LiveMetrics.Tests.csproj", "{EA90D06D-D272-4A65-8DDA-6412B3F14572}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Monitor.OpenTelemetry.LiveMetrics.Demo", "Azure.Monitor.OpenTelemetry.LiveMetrics\tests\Azure.Monitor.OpenTelemetry.LiveMetrics.Demo\Azure.Monitor.OpenTelemetry.LiveMetrics.Demo.csproj", "{945FEC31-100B-410D-81D0-A38830A98B80}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -126,6 +128,10 @@ Global
 		{EA90D06D-D272-4A65-8DDA-6412B3F14572}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA90D06D-D272-4A65-8DDA-6412B3F14572}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA90D06D-D272-4A65-8DDA-6412B3F14572}.Release|Any CPU.Build.0 = Release|Any CPU
+		{945FEC31-100B-410D-81D0-A38830A98B80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{945FEC31-100B-410D-81D0-A38830A98B80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{945FEC31-100B-410D-81D0-A38830A98B80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{945FEC31-100B-410D-81D0-A38830A98B80}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Creating an empty demo project. 
This will be used to test LiveMetrics scenarios