### PR TITLE
[Storage][DataMovenet] Minor fixes to pause/resume tests

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/PauseResumeTransferTests.cs
@@ -993,9 +993,13 @@ namespace Azure.Storage.DataMovement.Tests
             // Assert - Confirm we've paused
             Assert.AreEqual(DataTransferState.Paused, transfer.TransferStatus.State);
             await testEventsRaised.AssertPausedCheck();
+            int completedBeforePause = testEventsRaised.SingleCompletedEvents.Count;
 
             // Act - Resume Job
-            DataTransferOptions resumeOptions = new DataTransferOptions();
+            DataTransferOptions resumeOptions = new()
+            {
+                CreationPreference = StorageResourceCreationPreference.OverwriteIfExists
+            };
             TestEventsRaised testEventRaised2 = new TestEventsRaised(resumeOptions);
             DataTransfer resumeTransfer = await transferManager.ResumeTransferAsync(
                 transferId: transfer.Id,
@@ -1005,7 +1009,7 @@ namespace Azure.Storage.DataMovement.Tests
             await resumeTransfer.WaitForCompletionAsync(waitTransferCompletion.Token);
 
             // Assert
-            await testEventRaised2.AssertContainerCompletedCheck(partCount);
+            await testEventRaised2.AssertContainerCompletedCheck(partCount - completedBeforePause);
             Assert.AreEqual(DataTransferState.Completed, resumeTransfer.TransferStatus.State);
             Assert.IsTrue(resumeTransfer.HasCompleted);
 
@@ -1072,9 +1076,13 @@ namespace Azure.Storage.DataMovement.Tests
             // Assert - Confirm we've paused
             Assert.AreEqual(DataTransferState.Paused, transfer.TransferStatus.State);
             await testEventsRaised.AssertPausedCheck();
+            int completedBeforePause = testEventsRaised.SingleCompletedEvents.Count;
 
             // Act - Resume Job
-            DataTransferOptions resumeOptions = new();
+            DataTransferOptions resumeOptions = new()
+            {
+                CreationPreference = StorageResourceCreationPreference.OverwriteIfExists
+            };
             TestEventsRaised testEventsRaised2 = new TestEventsRaised(resumeOptions);
             DataTransfer resumeTransfer = await transferManager.ResumeTransferAsync(
                 transfer.Id,
@@ -1084,7 +1092,7 @@ namespace Azure.Storage.DataMovement.Tests
             await resumeTransfer.WaitForCompletionAsync(waitTransferCompletion.Token);
 
             // Assert
-            await testEventsRaised2.AssertContainerCompletedCheck(partCount);
+            await testEventsRaised2.AssertContainerCompletedCheck(partCount - completedBeforePause);
             Assert.AreEqual(DataTransferState.Completed, resumeTransfer.TransferStatus.State);
             Assert.IsTrue(resumeTransfer.HasCompleted);
 


### PR DESCRIPTION
Fix pause/resume tests by adding overwrite option on resume as sometimes a job part is paused but the upload completes causing the resume to fail for `BlobAlreadyExists`. `Azure.Core` asserts on cancellation tokens after a response which causes the job part to still be marked as paused even if the upload completed successfully in this case.

One additional change to account for transfers completed before the pause in the assert completed count check. 