### PR TITLE
Revert "Add support for custom objects within the dialogContext"

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallDialog.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallDialog.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -110,7 +109,7 @@ namespace Azure.Communication.CallAutomation
         {
             DialogOptionsInternal dialogOptionsInternal = new DialogOptionsInternal(
                 startDialogOptions.BotAppId,
-                startDialogOptions.DialogContext.ToDictionary(entry => entry.Key, entry => (object)JsonSerializer.Serialize(entry.Value)));
+                startDialogOptions.DialogContext);
             StartDialogRequestInternal startDialogRequestInternal = new StartDialogRequestInternal(dialogOptionsInternal, startDialogOptions.DialogInputType)
             {
                 OperationContext = startDialogOptions.OperationContext == default ? Guid.NewGuid().ToString() : startDialogOptions.OperationContext

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallDialogs/CallDialogTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallDialogs/CallDialogTests.cs
@@ -13,35 +13,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallDialogs
     public class CallDialogTests : CallAutomationTestBase
     {
         private const string dialogId = "92e08834-b6ee-4ede-8956-9fefa27a691c";
-        private static readonly Dictionary<string, object> dialogContextWithObject = new Dictionary<string, object>()
-        {
-            {
-                "context",
-                new
-                {
-                    contextName = "name",
-                    secondProperty = 1
-                }
-            }
-        };
-        private static readonly Dictionary<string, object> dialogContextWithString = new Dictionary<string, object>()
-        {
-            {
-                "context",
-                "context"
-            }
-        };
         private static readonly StartDialogOptions _startDialogOptions = new StartDialogOptions(DialogInputType.PowerVirtualAgents, "botAppId", new Dictionary<string, object>())
-        {
-            OperationContext = "context"
-        };
-
-        private static readonly StartDialogOptions _startDialogWithCustomObjectOptions = new StartDialogOptions(DialogInputType.PowerVirtualAgents, "botAppId", dialogContextWithObject)
-        {
-            OperationContext = "context"
-        };
-
-        private static readonly StartDialogOptions _startDialogWithStringOptions = new StartDialogOptions(DialogInputType.PowerVirtualAgents, "botAppId", dialogContextWithString)
         {
             OperationContext = "context"
         };
@@ -130,14 +102,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallDialogs
                 },
                 new Func<CallDialog, Task<Response<DialogResult>>>?[]
                 {
-                    callDialog => callDialog.StartDialogAsync(_startDialogWithCustomObjectOptions)
-                },
-                new Func<CallDialog, Task<Response<DialogResult>>>?[]
-                {
-                    callDialog => callDialog.StartDialogAsync(_startDialogWithStringOptions)
-                },
-                new Func<CallDialog, Task<Response<DialogResult>>>?[]
-                {
                     callDialog => callDialog.StartDialogAsync(_startDialogWithIdOptions)
                 },
             };
@@ -150,14 +114,6 @@ namespace Azure.Communication.CallAutomation.Tests.CallDialogs
                 new Func<CallDialog, Response<DialogResult>>?[]
                 {
                     callDialog => callDialog.StartDialog(_startDialogOptions)
-                },
-                new Func<CallDialog, Response<DialogResult>>?[]
-                {
-                    callDialog => callDialog.StartDialog(_startDialogWithCustomObjectOptions)
-                },
-                new Func<CallDialog, Response<DialogResult>>?[]
-                {
-                    callDialog => callDialog.StartDialog(_startDialogWithStringOptions)
                 },
                 new Func<CallDialog, Response<DialogResult>>?[]
                 {


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#37947 as it is causing unintentional double serialization in specific cases.