### PR TITLE
[Messaging] No Retry for HostNotFound

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/BasicRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/BasicRetryPolicy.cs
@@ -158,10 +158,14 @@ namespace Azure.Messaging.EventHubs.Core
                     return ex.IsTransient;
 
                 case TimeoutException _:
-                case SocketException _:
                 case IOException _:
                 case UnauthorizedAccessException _:
                     return true;
+
+                case SocketException ex:
+                    return ex.SocketErrorCode != SocketError.HostUnreachable
+                        && ex.SocketErrorCode != SocketError.HostNotFound
+                        && ex.SocketErrorCode != SocketError.NoRecovery;
 
                 default:
                     return false;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/RetryPolicies/BasicRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/RetryPolicies/BasicRetryPolicyTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public static IEnumerable<object[]> RetriableExceptionTestCases()
         {
             yield return new object[] { new TimeoutException() };
-            yield return new object[] { new SocketException(500) };
+            yield return new object[] { new SocketException((int)SocketError.ConnectionReset) };
             yield return new object[] { new IOException() };
             yield return new object[] { new UnauthorizedAccessException() };
 
@@ -60,6 +60,8 @@ namespace Azure.Messaging.EventHubs.Tests
             yield return new object[] { new NullReferenceException() };
             yield return new object[] { new OutOfMemoryException() };
             yield return new object[] { new ObjectDisposedException("dummy") };
+            yield return new object[] { new SocketException((int)SocketError.HostNotFound) };
+            yield return new object[] { new SocketException((int)SocketError.HostUnreachable) };
 
             // Task/Operation Canceled should use the inner exception as the decision point.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Adjusted retries to consider an unreachable host address as terminal.  Previously, all socket-based errors were considered transient and would be retried.
+
 ### Other Changes
 
 ## 5.10.0 (2023-11-07)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Adjusted retries to consider an unreachable host address as terminal.  Previously, all socket-based errors were considered transient and would be retried.
+
 ### Other Changes
 
 ## 7.17.0 (2023-11-14)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/BasicRetryPolicy.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/BasicRetryPolicy.cs
@@ -145,10 +145,14 @@ namespace Azure.Messaging.ServiceBus.Core
                     return ex.IsTransient;
 
                 case TimeoutException _:
-                case SocketException _:
                 case IOException _:
                 case UnauthorizedAccessException _:
                     return true;
+
+                case SocketException ex:
+                    return ex.SocketErrorCode != SocketError.HostUnreachable
+                        && ex.SocketErrorCode != SocketError.HostNotFound
+                        && ex.SocketErrorCode != SocketError.NoRecovery;
 
                 default:
                     return false;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/BasicRetryPolicyTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/BasicRetryPolicyTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         public static IEnumerable<object[]> RetriableExceptionTestCases()
         {
             yield return new object[] { new TimeoutException() };
-            yield return new object[] { new SocketException(500) };
+            yield return new object[] { new SocketException((int)SocketError.ConnectionReset) };
             yield return new object[] { new IOException() };
             yield return new object[] { new UnauthorizedAccessException() };
 
@@ -61,6 +61,8 @@ namespace Azure.Messaging.ServiceBus.Tests
             yield return new object[] { new NullReferenceException() };
             yield return new object[] { new OutOfMemoryException() };
             yield return new object[] { new ObjectDisposedException("dummy") };
+            yield return new object[] { new SocketException((int)SocketError.HostNotFound) };
+            yield return new object[] { new SocketException((int)SocketError.HostUnreachable) };
 
             // Task/Operation Canceled should use the inner exception as the decision point.
 


### PR DESCRIPTION
# Summary

The focus of these changes adjusts the retry policy to consider socket errors where the host is not found or not reachable to be terminal errors.  Previously, all socket errors were considered transient and would be retried.