### PR TITLE
Remove usage of shared secrets in Attestation

### DIFF
--- a/sdk/attestation/Azure.Security.Attestation/assets.json
+++ b/sdk/attestation/Azure.Security.Attestation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/attestation/Azure.Security.Attestation",
-  "Tag": "net/attestation/Azure.Security.Attestation_00f1882c07"
+  "Tag": "net/attestation/Azure.Security.Attestation_644fc2b231"
 }

--- a/sdk/attestation/Azure.Security.Attestation/tests/AttestationClientTestEnvironment.cs
+++ b/sdk/attestation/Azure.Security.Attestation/tests/AttestationClientTestEnvironment.cs
@@ -19,18 +19,18 @@ namespace Azure.Security.Attestation.Tests
 
         public string SharedAttestationUrl => "https://shared" + LocationShortName + "." + LocationShortName + ".test.attest.azure.net";
 
-        public X509Certificate2 PolicyCertificate0 => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("policySigningCertificate0")));
-        public X509Certificate2 PolicyCertificate1 => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("policySigningCertificate1")));
-        public X509Certificate2 PolicyCertificate2 => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("policySigningCertificate2")));
+        public X509Certificate2 PolicyCertificate0 => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("POLICYSIGNINGCERTIFICATE0")));
+        public X509Certificate2 PolicyCertificate1 => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("POLICYSIGNINGCERTIFICATE1")));
+        public X509Certificate2 PolicyCertificate2 => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("POLICYSIGNINGCERTIFICATE2")));
 
-        public RSA PolicySigningKey0 => GetRSACryptoServiceProvider("serializedPolicySigningKey0");
-        public RSA PolicySigningKey1 => GetRSACryptoServiceProvider("serializedPolicySigningKey1");
-        public RSA PolicySigningKey2 => GetRSACryptoServiceProvider("serializedPolicySigningKey2");
+        public RSA PolicySigningKey0 => GetRSACryptoServiceProvider("SERIALIZEDPOLICYSIGNINGKEY0");
+        public RSA PolicySigningKey1 => GetRSACryptoServiceProvider("SERIALIZEDPOLICYSIGNINGKEY1");
+        public RSA PolicySigningKey2 => GetRSACryptoServiceProvider("SERIALIZEDPOLICYSIGNINGKEY2");
 
         // Policy management keys.
-        public X509Certificate2 PolicyManagementCertificate => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("isolatedSigningCertificate")));
-        public RSA PolicyManagementKey => GetRSACryptoServiceProvider("serializedIsolatedSigningKey");
-        public string LocationShortName => GetRecordedVariable("locationShortName");
+        public X509Certificate2 PolicyManagementCertificate => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("ISOLATEDSIGNINGCERTIFICATE")));
+        public RSA PolicyManagementKey => GetRSACryptoServiceProvider("SERIALIZEDISOLATEDSIGNINGKEY");
+        public string LocationShortName => GetRecordedVariable("LOCATIONSHORTNAME");
 
         private static Uri DataPlaneScope => new Uri($"https://attest.azure.net");
 

--- a/sdk/attestation/tests.yml
+++ b/sdk/attestation/tests.yml
@@ -8,12 +8,3 @@ extends:
     EnvVars:
       ISOLATED_ATTESTATION_URL: $(ISOLATED_ATTESTATION_URL)
       AAD_ATTESTATION_URL: $(AAD_ATTESTATION_URL)
-      serializedPolicySigningKey0: $(serializedPolicySigningKey0)
-      serializedPolicySigningKey1: $(serializedPolicySigningKey1)
-      serializedPolicySigningKey2: $(serializedPolicySigningKey2)
-      policySigningCertificate0: $(policySigningCertificate0)
-      policySigningCertificate1: $(policySigningCertificate1)
-      policySigningCertificate2: $(policySigningCertificate2)
-      isolatedSigningCertificate: $(isolatedSigningCertificate)
-      serializedIsolatedSigningKey: $(serializedIsolatedSigningKey)
-      locationShortName: $(locationShortName)


### PR DESCRIPTION
_Originally copied from azure-sdk-for-java to see if there was an EngSys issue_

Removes usage of shared secrets in Attestation.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
