### PR TITLE
Disable diagnostics checks in tests that use released version of Azure.MixedReality.Authentication

### DIFF
--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/tests/RemoteRenderingLiveTests.cs
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/tests/RemoteRenderingLiveTests.cs
@@ -14,6 +14,8 @@ namespace Azure.MixedReality.RemoteRendering.Tests
         public RemoteRenderingLiveTests(bool isAsync) :
             base(isAsync/*, RecordedTestMode.Record*/)
         {
+            // TODO (39914): enable after Azure.MixedReality.Authentication is released
+            TestDiagnostics = false;
         }
 
         [RecordedTest]


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-sdk-for-net/pull/39912, some diagnostic checks fail in tests against released versions of dependencies.
