### PR TITLE
[DataMovement] Single File Share to Blob Tests

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/AppendBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/AppendBlobToShareFileTests.cs
@@ -7,7 +7,7 @@ using System;
 using System.Threading.Tasks;
 using Azure.Storage.DataMovement.Tests;
 using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Tests;
+using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Files.Shares;
 using Azure.Storage.Test.Shared;
 using Azure.Storage.Blobs.Specialized;
@@ -20,7 +20,7 @@ using DMBlob::Azure.Storage.DataMovement.Blobs;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
-    [BlobsClientTestFixture]
+    [ShareClientTestFixture]
     public class AppendBlobToShareFileTests : StartTransferCopyTestBase
         <BlobServiceClient,
         BlobContainerClient,

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/BlockBlobToShareFileTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/BlockBlobToShareFileTests.cs
@@ -15,11 +15,11 @@ using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Storage.DataMovement.Files.Shares;
 using DMBlob::Azure.Storage.DataMovement.Blobs;
-using Azure.Storage.Blobs.Tests;
+using Azure.Storage.Files.Shares.Tests;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
-    [BlobsClientTestFixture]
+    [ShareClientTestFixture]
     public class BlockBlobToShareFileTests : StartTransferCopyTestBase
         <BlobServiceClient,
         BlobContainerClient,
@@ -58,15 +58,14 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
         /// <param name="objectClient">The object client to create the storage resource object.</param>
         /// <returns></returns>
         protected override StorageResourceItem GetSourceStorageResourceItem(BlockBlobClient blob)
-        {
-            return new BlockBlobStorageResource(blob);
-        }
+            => new BlockBlobStorageResource(blob);
 
         /// <summary>
         /// Calls the OpenRead method on the BlockBlobClient.
         ///
         /// This is mainly used to verify the contents of the Object Client.
         /// </summary>
+        ///
         /// <param name="objectClient">The object client to get the Open Read Stream from.</param>
         /// <returns></returns>
         protected override Task<Stream> SourceOpenReadAsync(BlockBlobClient objectClient)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToBlockBlobTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/BlobToFileSharesTests/ShareFileToBlockBlobTests.cs
@@ -15,74 +15,47 @@ using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Storage.DataMovement.Files.Shares;
 using DMBlob::Azure.Storage.DataMovement.Blobs;
-using NUnit.Framework;
 using Azure.Storage.Files.Shares.Tests;
-using Azure.Storage.Shared;
 
 namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 {
     [ShareClientTestFixture]
-    public class PageBlobToShareFileTests : StartTransferCopyTestBase
-        <BlobServiceClient,
-        BlobContainerClient,
-        PageBlobClient,
-        BlobClientOptions,
-        ShareServiceClient,
+    public class ShareFileToBlockBlobTests : StartTransferCopyTestBase
+        <ShareServiceClient,
         ShareClient,
         ShareFileClient,
         ShareClientOptions,
+        BlobServiceClient,
+        BlobContainerClient,
+        BlockBlobClient,
+        BlobClientOptions,
         StorageTestEnvironment>
     {
         public const int MaxReliabilityRetries = 5;
-        private const string _fileResourcePrefix = "test-file-";
-        private const string _expectedOverwriteExceptionMessage = "Cannot overwrite file.";
+        private const string _blobResourcePrefix = "test-blob-";
+        private const string _expectedOverwriteExceptionMessage = "BlobAlreadyExists";
         protected readonly object _serviceVersion;
 
-        public PageBlobToShareFileTests(
+        public ShareFileToBlockBlobTests(
             bool async,
             object serviceVersion)
-            : base(async, _expectedOverwriteExceptionMessage, _fileResourcePrefix, null /* RecordedTestMode.Record /* to re-record */)
+            : base(async, _expectedOverwriteExceptionMessage, _blobResourcePrefix, null /* RecordedTestMode.Record /* to re-record */)
         {
             _serviceVersion = serviceVersion;
-            SourceClientBuilder = ClientBuilderExtensions.GetNewBlobsClientBuilder(Tenants, (BlobClientOptions.ServiceVersion)serviceVersion);
-            DestinationClientBuilder = ClientBuilderExtensions.GetNewShareClientBuilder(Tenants, (ShareClientOptions.ServiceVersion)serviceVersion);
+            SourceClientBuilder = ClientBuilderExtensions.GetNewShareClientBuilder(Tenants, (ShareClientOptions.ServiceVersion)serviceVersion);
+            DestinationClientBuilder = ClientBuilderExtensions.GetNewBlobsClientBuilder(Tenants, (BlobClientOptions.ServiceVersion)serviceVersion);
         }
 
-        protected override async Task<IDisposingContainer<BlobContainerClient>> GetSourceDisposingContainerAsync(
-            BlobServiceClient service = default,
-            string containerName = default)
-            => await SourceClientBuilder.GetTestContainerAsync(service, containerName);
-
-        /// <summary>
-        /// Gets the specific storage resource from the given client
-        /// e.g. ShareFileClient to a ShareFileStorageResource, BlockBlobClient to a BlockBlobStorageResource.
-        /// </summary>
-        /// <param name="objectClient">The object client to create the storage resource object.</param>
-        /// <returns></returns>
-        protected override StorageResourceItem GetSourceStorageResourceItem(PageBlobClient blob)
-        {
-            return new PageBlobStorageResource(blob);
-        }
-
-        /// <summary>
-        /// Calls the OpenRead method on the client.
-        ///
-        /// This is mainly used to verify the contents of the Object Client.
-        /// </summary>
-        /// <param name="objectClient">The object client to get the Open Read Stream from.</param>
-        /// <returns></returns>
-        protected override Task<Stream> SourceOpenReadAsync(PageBlobClient objectClient)
-            => objectClient.OpenReadAsync();
-
-        /// <summary>
-        /// Checks if the Object Client exists.
-        /// </summary>
-        /// <param name="objectClient">Object Client to call exists on.</param>
-        /// <returns></returns>
-        protected override async Task<bool> SourceExistsAsync(PageBlobClient objectClient)
+        protected override async Task<bool> DestinationExistsAsync(BlockBlobClient objectClient)
             => await objectClient.ExistsAsync();
 
-        protected override async Task<PageBlobClient> GetSourceObjectClientAsync(
+        protected override Task<Stream> DestinationOpenReadAsync(BlockBlobClient objectClient)
+            => objectClient.OpenReadAsync();
+
+        protected override async Task<IDisposingContainer<BlobContainerClient>> GetDestinationDisposingContainerAsync(BlobServiceClient service = null, string containerName = null)
+            => await DestinationClientBuilder.GetTestContainerAsync(service, containerName);
+
+        protected override async Task<BlockBlobClient> GetDestinationObjectClientAsync(
             BlobContainerClient container,
             long? objectLength = null,
             bool createResource = false,
@@ -91,7 +64,7 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             Stream contents = null)
         {
             objectName ??= GetNewObjectName();
-            PageBlobClient blobClient = container.GetPageBlobClient(objectName);
+            BlockBlobClient blobClient = container.GetBlockBlobClient(objectName);
 
             if (createResource)
             {
@@ -102,38 +75,32 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
 
                 if (contents != default)
                 {
-                    await UploadPagesAsync(blobClient, contents);
+                    await blobClient.UploadAsync(contents);
                 }
                 else
                 {
                     var data = GetRandomBuffer(objectLength.Value);
                     using Stream originalStream = await CreateLimitedMemoryStream(objectLength.Value);
-                    await UploadPagesAsync(blobClient, originalStream);
+                    await blobClient.UploadAsync(originalStream);
                 }
             }
             Uri sourceUri = blobClient.GenerateSasUri(Sas.BlobSasPermissions.All, Recording.UtcNow.AddDays(1));
-            return InstrumentClient(new PageBlobClient(sourceUri, GetBlobOptions()));
+            return InstrumentClient(new BlockBlobClient(sourceUri, GetBlobOptions()));
         }
 
-        private async Task UploadPagesAsync(PageBlobClient blobClient, Stream contents)
-        {
-            long size = contents.Length;
-            Assert.IsTrue(size % (Constants.KB / 2) == 0, "Cannot create page blob that's not a multiple of 512");
-            await blobClient.CreateIfNotExistsAsync(size).ConfigureAwait(false);
-            long offset = 0;
-            long blockSize = Math.Min(Constants.DefaultBufferSize, size);
-            while (offset < size)
-            {
-                Stream partStream = WindowStream.GetWindow(contents, blockSize);
-                await blobClient.UploadPagesAsync(partStream, offset);
-                offset += blockSize;
-            }
-        }
+        protected override StorageResourceItem GetDestinationStorageResourceItem(BlockBlobClient objectClient)
+            => new BlockBlobStorageResource(objectClient);
 
-        protected override async Task<IDisposingContainer<ShareClient>> GetDestinationDisposingContainerAsync(ShareServiceClient service = null, string containerName = null)
-            => await DestinationClientBuilder.GetTestShareAsync(service, containerName);
+        protected override async Task<IDisposingContainer<ShareClient>> GetSourceDisposingContainerAsync(ShareServiceClient service = null, string containerName = null)
+            => await SourceClientBuilder.GetTestShareAsync(service, containerName);
 
-        protected override async Task<ShareFileClient> GetDestinationObjectClientAsync(ShareClient container, long? objectLength = null, bool createResource = false, string objectName = null, ShareClientOptions options = null, Stream contents = null)
+        protected override async Task<ShareFileClient> GetSourceObjectClientAsync(
+            ShareClient container,
+            long? objectLength = null,
+            bool createResource = false,
+            string objectName = null,
+            ShareClientOptions options = null,
+            Stream contents = null)
         {
             objectName ??= GetNewObjectName();
             ShareFileClient fileClient = container.GetRootDirectoryClient().GetFileClient(objectName);
@@ -154,14 +121,14 @@ namespace Azure.Storage.DataMovement.Blobs.Files.Shares.Tests
             return InstrumentClient(new ShareFileClient(sourceUri, GetShareOptions()));
         }
 
-        protected override StorageResourceItem GetDestinationStorageResourceItem(ShareFileClient objectClient)
+        protected override StorageResourceItem GetSourceStorageResourceItem(ShareFileClient objectClient)
             => new ShareFileStorageResource(objectClient);
 
-        protected override Task<Stream> DestinationOpenReadAsync(ShareFileClient objectClient)
-            => objectClient.OpenReadAsync();
-
-        protected override async Task<bool> DestinationExistsAsync(ShareFileClient objectClient)
+        protected override async Task<bool> SourceExistsAsync(ShareFileClient objectClient)
             => await objectClient.ExistsAsync();
+
+        protected override Task<Stream> SourceOpenReadAsync(ShareFileClient objectClient)
+            => objectClient.OpenReadAsync();
 
         public BlobClientOptions GetBlobOptions()
         {

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_dd46a65119"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_330a0b2660"
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferCopyTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/StartTransferCopyTestBase.cs
@@ -339,8 +339,8 @@ namespace Azure.Storage.DataMovement.Tests
 
             DataTransferOptions options = new DataTransferOptions()
             {
-                InitialTransferSize = 100,
-                MaximumTransferChunkSize = 200,
+                InitialTransferSize = Constants.KB / 2,
+                MaximumTransferChunkSize = Constants.KB / 2,
             };
 
             // Arrange


### PR DESCRIPTION
- Added tests for Single File Share to every Blob type
- Changed Attributes from Blob to Share File there seems to be a problem in running the tests
- Rerecorded the Blob to Share File tests as well.
- Changed small chunks to 512 increments to cover Page Blobs
