### PR TITLE
[Azure.Core] Adding suppression

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -160,6 +160,9 @@ namespace Azure.Core.Pipeline
         /// Marks the scope as failed with low-cardinality error.type attribute.
         /// </summary>
         /// <param name="errorCode">Error code to associate with the failed scope.</param>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "The public property System.Exception.TargetSite.get is not compatible with trimming and produces a warning when " +
+            "preserving all public properties. Since we do not use this property, and " +
+            "neither does Application Insights, we can suppress the warning coming from the inner method.")]
         public void Failed(string errorCode)
         {
             _activityAdapter?.MarkFailed((Exception?)null, errorCode);

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -161,8 +161,7 @@ namespace Azure.Core.Pipeline
         /// </summary>
         /// <param name="errorCode">Error code to associate with the failed scope.</param>
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "The public property System.Exception.TargetSite.get is not compatible with trimming and produces a warning when " +
-            "preserving all public properties. Since we do not use this property, and " +
-            "neither does Application Insights, we can suppress the warning coming from the inner method.")]
+            "preserving all public properties. Since we do not use this property, and neither does Application Insights, we can suppress the warning coming from the inner method.")]
         public void Failed(string errorCode)
         {
             _activityAdapter?.MarkFailed((Exception?)null, errorCode);


### PR DESCRIPTION
This PR adds the same warning suppression for the `DiagnosticScope.Failed(...)` overload on L141 to the new overload that was added in https://github.com/Azure/azure-sdk-for-net/pull/39617

cc/: @vitek-karas 