### PR TITLE
Annotation for NullableResponse

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -118,7 +118,8 @@ namespace Azure
     public abstract partial class NullableResponse<T>
     {
         protected NullableResponse() { }
-        public abstract bool HasValue { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Value")]
+        public abstract bool HasValue { [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Value")] get; }
         public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -118,7 +118,8 @@ namespace Azure
     public abstract partial class NullableResponse<T>
     {
         protected NullableResponse() { }
-        public abstract bool HasValue { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Value")]
+        public abstract bool HasValue { [System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute(true, "Value")] get; }
         public abstract T? Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }

--- a/sdk/core/Azure.Core/src/NullableResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/NullableResponseOfT.cs
@@ -19,7 +19,7 @@ namespace Azure
         /// <summary>
         /// Gets a value indicating whether the current instance has a valid value of its underlying type.
         /// </summary>
-#if NET5_0_OR_GREATER 
+#if NET5_0_OR_GREATER
         [MemberNotNullWhen(returnValue: true, member: nameof(Value))]
 #endif
         public abstract bool HasValue { get; }

--- a/sdk/core/Azure.Core/src/NullableResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/NullableResponseOfT.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Azure
 {
@@ -18,6 +19,9 @@ namespace Azure
         /// <summary>
         /// Gets a value indicating whether the current instance has a valid value of its underlying type.
         /// </summary>
+#if NET6_0_OR_GREATER // technically available since .NET 5.0 but there's no define for this
+        [MemberNotNullWhen(returnValue: true, member: nameof(Value))]
+#endif
         public abstract bool HasValue { get; }
 
         /// <summary>

--- a/sdk/core/Azure.Core/src/NullableResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/NullableResponseOfT.cs
@@ -19,7 +19,7 @@ namespace Azure
         /// <summary>
         /// Gets a value indicating whether the current instance has a valid value of its underlying type.
         /// </summary>
-#if NET6_0_OR_GREATER // technically available since .NET 5.0 but there's no define for this
+#if NET5_0_OR_GREATER 
         [MemberNotNullWhen(returnValue: true, member: nameof(Value))]
 #endif
         public abstract bool HasValue { get; }

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net462.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net462.cs
@@ -9,6 +9,6 @@ namespace Azure.Identity.Broker
     {
         public SharedTokenCacheCredentialBrokerOptions() { }
         public SharedTokenCacheCredentialBrokerOptions(Azure.Identity.TokenCachePersistenceOptions tokenCacheOptions) { }
-        public bool? IsMsaPassthroughEnabled { get { throw null; } set { } }
+        public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
     }
 }


### PR DESCRIPTION
At the moment, when using `NullableResponse` you need to do something like:

```csharp
if (response.HasValue) {
    x = response.Value!;
}
```

The `!` is required because the compiler doesn’t know anything about the relationship between the properties. This PR adds `MemberNotNullWhen` to `HasValue` so that the compiler knows that `Value` is not null if it is `true`.

I haven’t stated anything about the `false` case, because when that happens, `Value` throws if accessed. (This seems incorrect, to me, since the return type of `Value` is `T?` but it will never be `null`. But this can be addressed in a separate PR.)