### PR TITLE
Bug: Response<T>.Value is a StackOverflow

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public abstract override T Value { get { throw null; } }
+        public abstract override T Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public override T Value { get { throw null; } }
+        public abstract override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public abstract override T Value { get { throw null; } }
+        public abstract override T Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public override T Value { get { throw null; } }
+        public abstract override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public abstract override T Value { get { throw null; } }
+        public abstract override T Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public override T Value { get { throw null; } }
+        public abstract override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public abstract override T Value { get { throw null; } }
+        public abstract override T Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public override T Value { get { throw null; } }
+        public abstract override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public abstract override T Value { get { throw null; } }
+        public abstract override T Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public override T Value { get { throw null; } }
+        public abstract override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public abstract override T Value { get { throw null; } }
+        public abstract override T Value { get; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -267,7 +267,7 @@ namespace Azure
         protected Response() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool HasValue { get { throw null; } }
-        public override T Value { get { throw null; } }
+        public abstract override T Value { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/src/ApiCompatBaseline.txt
+++ b/sdk/core/Azure.Core/src/ApiCompatBaseline.txt
@@ -1,0 +1,4 @@
+Compat issues with assembly Azure.Core:
+CannotMakeMemberAbstract : Member 'public T Azure.Response<T>.Value' is abstract in the implementation but is not abstract in the contract.
+CannotMakeMemberAbstract : Member 'public T Azure.Response<T>.Value.get()' is abstract in the implementation but is not abstract in the contract.
+Total Issues: 2

--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Azure
 {
@@ -23,7 +24,7 @@ namespace Azure
         public override bool HasValue => true;
 
         /// <inheritdoc />
-        public override T Value => Value;
+        public abstract override T Value { get; }
 
         /// <summary>
         /// Returns the value of this <see cref="Response{T}"/> object.

--- a/sdk/core/Azure.Core/tests/ResponseOfTTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseOfTTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+using Moq;
+
+namespace Azure.Core.Tests
+{
+    public class ResponseOfTTests
+    {
+        private class MyResponse : Azure.Response<int> {
+            public override Response GetRawResponse() {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Test]
+        public void ValueIsAccessible()
+        {
+            var response = new MyResponse();
+
+            Assert.DoesNotThrow(() => response.Value);
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/ResponseOfTTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseOfTTests.cs
@@ -16,6 +16,8 @@ namespace Azure.Core.Tests
             public override Response GetRawResponse() {
                 throw new NotImplementedException();
             }
+
+            public override int Value => 42;
         }
 
         [Test]
@@ -23,7 +25,7 @@ namespace Azure.Core.Tests
         {
             var response = new MyResponse();
 
-            Assert.DoesNotThrow(() => response.Value);
+            Assert.Equals(42, response.Value);
         }
     }
 }

--- a/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net462.cs
+++ b/sdk/identity/Azure.Identity.Broker/api/Azure.Identity.Broker.net462.cs
@@ -9,6 +9,6 @@ namespace Azure.Identity.Broker
     {
         public SharedTokenCacheCredentialBrokerOptions() { }
         public SharedTokenCacheCredentialBrokerOptions(Azure.Identity.TokenCachePersistenceOptions tokenCacheOptions) { }
-        public bool? IsMsaPassthroughEnabled { get { throw null; } set { } }
+        public bool? IsLegacyMsaPassthroughEnabled { get { throw null; } set { } }
     }
 }


### PR DESCRIPTION
Noticed this while doing #40136.

Since the changes made in #35560 ([this line](https://github.com/Azure/azure-sdk-for-net/pull/35560/files#diff-8420d007044cda370d47686bc6b91ab5835f1ad36504487752fe1f51129338b1R26)), `Response<T>` has been a stack overflow as it references itself:

```
The active test run was aborted. Reason: Test host process crashed : Stack overflow.
Repeat 24212 times:
--------------------------------
   at Azure.Response`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].get_Value()    
--------------------------------
```

This PR fixes this by making the `Value` property re-abstract. This breaks ApiCompat so there is a new baseline.