### PR TITLE
ClientModel: Remove types in .Internals.Primitives namespace

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
@@ -64,13 +64,6 @@ namespace Azure.Core.Pipeline
                 }
             }
 
-            public override string Method { get => throw new NotImplementedException();
-                set => throw new NotImplementedException(); }
-            public override InputContent? Content { get => throw new NotImplementedException();
-                set => throw new NotImplementedException(); }
-
-            public override MessageHeaders Headers => throw new NotImplementedException();
-
             private const string MessageForServerCertificateCallback = "MessageForServerCertificateCallback";
 
             internal static void AddAzureProperties(HttpMessage message, HttpRequestMessage httpRequest)
@@ -98,11 +91,6 @@ namespace Azure.Core.Pipeline
 #else
                 httpRequest.Properties[name] = value;
 #endif
-            }
-
-            public override void Dispose()
-            {
-                throw new NotImplementedException();
             }
         }
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
@@ -28,9 +28,18 @@ namespace Azure.Core.Pipeline
             return false;
         }
 
+        // Adapts an internal ClientModel HttpPipelineRequest.  Doing this instead
+        // of inheriting from HttpPipelineRequest allows us to keep HttpPipelineRequest
+        // internal in ClientModel.
         private sealed class HttpClientTransportRequest : PipelineRequest
         {
             private RequestUriBuilder? _uriBuilder;
+            private readonly PipelineRequest _httpPipelineRequest;
+
+            public HttpClientTransportRequest()
+            {
+                _httpPipelineRequest = Create();
+            }
 
             public override Uri Uri
             {
@@ -64,6 +73,20 @@ namespace Azure.Core.Pipeline
                 }
             }
 
+            public override string Method
+            {
+                get => _httpPipelineRequest.Method;
+                set => _httpPipelineRequest.Method = value;
+            }
+            public override InputContent? Content
+            {
+                get => _httpPipelineRequest.Content;
+                set => _httpPipelineRequest.Content = value;
+            }
+
+            public override MessageHeaders Headers
+                => _httpPipelineRequest.Headers;
+
             private const string MessageForServerCertificateCallback = "MessageForServerCertificateCallback";
 
             internal static void AddAzureProperties(HttpMessage message, HttpRequestMessage httpRequest)
@@ -92,6 +115,9 @@ namespace Azure.Core.Pipeline
                 httpRequest.Properties[name] = value;
 #endif
             }
+
+            public override void Dispose()
+                => _httpPipelineRequest.Dispose();
         }
 
         private class RequestAdapter : Request

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.ClientModel.Primitives;
-using System.ClientModel.Internal.Primitives;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 
@@ -28,7 +28,7 @@ namespace Azure.Core.Pipeline
             return false;
         }
 
-        private sealed class HttpClientTransportRequest : HttpPipelineRequest
+        private sealed class HttpClientTransportRequest : PipelineRequest
         {
             private RequestUriBuilder? _uriBuilder;
 
@@ -64,6 +64,13 @@ namespace Azure.Core.Pipeline
                 }
             }
 
+            public override string Method { get => throw new NotImplementedException();
+                set => throw new NotImplementedException(); }
+            public override InputContent? Content { get => throw new NotImplementedException();
+                set => throw new NotImplementedException(); }
+
+            public override MessageHeaders Headers => throw new NotImplementedException();
+
             private const string MessageForServerCertificateCallback = "MessageForServerCertificateCallback";
 
             internal static void AddAzureProperties(HttpMessage message, HttpRequestMessage httpRequest)
@@ -91,6 +98,11 @@ namespace Azure.Core.Pipeline
 #else
                 httpRequest.Properties[name] = value;
 #endif
+            }
+
+            public override void Dispose()
+            {
+                throw new NotImplementedException();
             }
         }
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Response.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Response.cs
@@ -29,35 +29,31 @@ namespace Azure.Core.Pipeline
 
         private sealed class HttpClientTransportResponse : PipelineResponse
         {
+            private readonly PipelineResponse _httpPipelineResponse;
+
             public HttpClientTransportResponse(string requestId, HttpResponseMessage httpResponse)
-                : base(httpResponse)
             {
-                ClientRequestId = requestId ?? throw new ArgumentNullException(nameof(requestId));
+                Argument.AssertNotNull(requestId, nameof(requestId));
+
+                ClientRequestId = requestId;
+                _httpPipelineResponse = Create(httpResponse);
             }
 
             public string ClientRequestId { get; internal set; }
 
-            public override int Status => throw new NotImplementedException();
+            public override int Status => _httpPipelineResponse.Status;
 
-            public override string ReasonPhrase => throw new NotImplementedException();
+            public override string ReasonPhrase => _httpPipelineResponse.ReasonPhrase;
 
-            public override MessageHeaders Headers => throw new NotImplementedException();
+            public override MessageHeaders Headers => _httpPipelineResponse.Headers;
 
             public override Stream? ContentStream
             {
-                get => throw new NotImplementedException();
-                protected set => throw new NotImplementedException();
+                get => _httpPipelineResponse?.ContentStream;
+                set => _httpPipelineResponse.ContentStream = value;
             }
 
-            public override void Dispose()
-            {
-                throw new NotImplementedException();
-            }
-
-            internal void SetContentStream(Stream? stream)
-            {
-                ContentStream = stream;
-            }
+            public override void Dispose() => _httpPipelineResponse.Dispose();
         }
 
         private sealed class ResponseAdapter : Response
@@ -84,7 +80,7 @@ namespace Azure.Core.Pipeline
             public override Stream? ContentStream
             {
                 get => _pipelineResponse.ContentStream;
-                set => _pipelineResponse.SetContentStream(value);
+                set => _pipelineResponse.ContentStream = value;
             }
 
             protected internal override bool ContainsHeader(string name)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Response.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Response.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.ClientModel.Primitives;
-using System.ClientModel.Internal;
-using System.ClientModel.Internal.Primitives;
 using System.Net.Http;
 
 namespace Azure.Core.Pipeline
@@ -29,7 +27,7 @@ namespace Azure.Core.Pipeline
             return false;
         }
 
-        private sealed class HttpClientTransportResponse : HttpPipelineResponse
+        private sealed class HttpClientTransportResponse : PipelineResponse
         {
             public HttpClientTransportResponse(string requestId, HttpResponseMessage httpResponse)
                 : base(httpResponse)
@@ -38,6 +36,23 @@ namespace Azure.Core.Pipeline
             }
 
             public string ClientRequestId { get; internal set; }
+
+            public override int Status => throw new NotImplementedException();
+
+            public override string ReasonPhrase => throw new NotImplementedException();
+
+            public override MessageHeaders Headers => throw new NotImplementedException();
+
+            public override Stream? ContentStream
+            {
+                get => throw new NotImplementedException();
+                protected set => throw new NotImplementedException();
+            }
+
+            public override void Dispose()
+            {
+                throw new NotImplementedException();
+            }
 
             internal void SetContentStream(Stream? stream)
             {

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Response.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Response.cs
@@ -27,6 +27,9 @@ namespace Azure.Core.Pipeline
             return false;
         }
 
+        // Adapts an internal ClientModel HttpPipelineResponse.  Doing this instead
+        // of inheriting from HttpPipelineResponse allows us to keep HttpPipelineResponse
+        // internal in ClientModel.
         private sealed class HttpClientTransportResponse : PipelineResponse
         {
             private readonly PipelineResponse _httpPipelineResponse;

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/PipelineResponseAdapter.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/PipelineResponseAdapter.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using System.ClientModel.Primitives;
-using Azure.Core.Pipeline;
+using System.IO;
 
 namespace Azure.Core
 {
@@ -27,7 +26,7 @@ namespace Azure.Core
         public override Stream? ContentStream
         {
             get => _response.ContentStream;
-            protected set => _response.ContentStream = value;
+            set => _response.ContentStream = value;
         }
 
         public override void Dispose()

--- a/sdk/core/Azure.Core/src/RequestFailedException.cs
+++ b/sdk/core/Azure.Core/src/RequestFailedException.cs
@@ -291,7 +291,7 @@ namespace Azure
             public override Stream? ContentStream
             {
                 get => throw new NotImplementedException();
-                protected set => throw new NotImplementedException();
+                set => throw new NotImplementedException();
             }
 
             public override string ReasonPhrase => throw new NotSupportedException();

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -93,26 +93,6 @@ namespace System.ClientModel.Internal.Primitives
         public override void Process(System.ClientModel.Primitives.PipelineMessage message) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
     }
-    public partial class HttpPipelineRequest : System.ClientModel.Primitives.PipelineRequest, System.IDisposable
-    {
-        protected internal HttpPipelineRequest() { }
-        public override System.ClientModel.InputContent? Content { get { throw null; } set { } }
-        public override System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
-        public override string Method { get { throw null; } set { } }
-        public override System.Uri Uri { get { throw null; } set { } }
-        public override void Dispose() { }
-        public override string ToString() { throw null; }
-    }
-    public partial class HttpPipelineResponse : System.ClientModel.Primitives.PipelineResponse, System.IDisposable
-    {
-        protected internal HttpPipelineResponse(System.Net.Http.HttpResponseMessage httpResponse) { }
-        public override System.IO.Stream? ContentStream { get { throw null; } protected internal set { } }
-        public override System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
-        public override string ReasonPhrase { get { throw null; } }
-        public override int Status { get { throw null; } }
-        public override void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-    }
 }
 namespace System.ClientModel.Primitives
 {
@@ -216,22 +196,23 @@ namespace System.ClientModel.Primitives
     }
     public abstract partial class PipelineRequest : System.IDisposable
     {
-        protected PipelineRequest() { }
-        public abstract System.ClientModel.InputContent? Content { get; set; }
-        public abstract System.ClientModel.Primitives.MessageHeaders Headers { get; }
-        public abstract string Method { get; set; }
-        public abstract System.Uri Uri { get; set; }
-        public abstract void Dispose();
+        public PipelineRequest() { }
+        public virtual System.ClientModel.InputContent? Content { get { throw null; } set { } }
+        public virtual System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
+        public virtual string Method { get { throw null; } set { } }
+        public virtual System.Uri Uri { get { throw null; } set { } }
+        public virtual void Dispose() { }
     }
     public abstract partial class PipelineResponse : System.IDisposable
     {
         protected PipelineResponse() { }
         public System.BinaryData Content { get { throw null; } }
-        public abstract System.IO.Stream? ContentStream { get; protected internal set; }
+        public abstract System.IO.Stream? ContentStream { get; set; }
         public abstract System.ClientModel.Primitives.MessageHeaders Headers { get; }
         public bool IsError { get { throw null; } }
         public abstract string ReasonPhrase { get; }
         public abstract int Status { get; }
+        public static System.ClientModel.Primitives.PipelineResponse Create(System.Net.Http.HttpResponseMessage response) { throw null; }
         public abstract void Dispose();
     }
     public abstract partial class PipelineTransport : System.ClientModel.Primitives.PipelinePolicy

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -196,12 +196,13 @@ namespace System.ClientModel.Primitives
     }
     public abstract partial class PipelineRequest : System.IDisposable
     {
-        public PipelineRequest() { }
-        public virtual System.ClientModel.InputContent? Content { get { throw null; } set { } }
-        public virtual System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
-        public virtual string Method { get { throw null; } set { } }
-        public virtual System.Uri Uri { get { throw null; } set { } }
-        public virtual void Dispose() { }
+        protected PipelineRequest() { }
+        public abstract System.ClientModel.InputContent? Content { get; set; }
+        public abstract System.ClientModel.Primitives.MessageHeaders Headers { get; }
+        public abstract string Method { get; set; }
+        public abstract System.Uri Uri { get; set; }
+        public static System.ClientModel.Primitives.PipelineRequest Create() { throw null; }
+        public abstract void Dispose();
     }
     public abstract partial class PipelineResponse : System.IDisposable
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -93,26 +93,6 @@ namespace System.ClientModel.Internal.Primitives
         public override void Process(System.ClientModel.Primitives.PipelineMessage message) { }
         public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
     }
-    public partial class HttpPipelineRequest : System.ClientModel.Primitives.PipelineRequest, System.IDisposable
-    {
-        protected internal HttpPipelineRequest() { }
-        public override System.ClientModel.InputContent? Content { get { throw null; } set { } }
-        public override System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
-        public override string Method { get { throw null; } set { } }
-        public override System.Uri Uri { get { throw null; } set { } }
-        public override void Dispose() { }
-        public override string ToString() { throw null; }
-    }
-    public partial class HttpPipelineResponse : System.ClientModel.Primitives.PipelineResponse, System.IDisposable
-    {
-        protected internal HttpPipelineResponse(System.Net.Http.HttpResponseMessage httpResponse) { }
-        public override System.IO.Stream? ContentStream { get { throw null; } protected internal set { } }
-        public override System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
-        public override string ReasonPhrase { get { throw null; } }
-        public override int Status { get { throw null; } }
-        public override void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-    }
 }
 namespace System.ClientModel.Primitives
 {
@@ -214,22 +194,23 @@ namespace System.ClientModel.Primitives
     }
     public abstract partial class PipelineRequest : System.IDisposable
     {
-        protected PipelineRequest() { }
-        public abstract System.ClientModel.InputContent? Content { get; set; }
-        public abstract System.ClientModel.Primitives.MessageHeaders Headers { get; }
-        public abstract string Method { get; set; }
-        public abstract System.Uri Uri { get; set; }
-        public abstract void Dispose();
+        public PipelineRequest() { }
+        public virtual System.ClientModel.InputContent? Content { get { throw null; } set { } }
+        public virtual System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
+        public virtual string Method { get { throw null; } set { } }
+        public virtual System.Uri Uri { get { throw null; } set { } }
+        public virtual void Dispose() { }
     }
     public abstract partial class PipelineResponse : System.IDisposable
     {
         protected PipelineResponse() { }
         public System.BinaryData Content { get { throw null; } }
-        public abstract System.IO.Stream? ContentStream { get; protected internal set; }
+        public abstract System.IO.Stream? ContentStream { get; set; }
         public abstract System.ClientModel.Primitives.MessageHeaders Headers { get; }
         public bool IsError { get { throw null; } }
         public abstract string ReasonPhrase { get; }
         public abstract int Status { get; }
+        public static System.ClientModel.Primitives.PipelineResponse Create(System.Net.Http.HttpResponseMessage response) { throw null; }
         public abstract void Dispose();
     }
     public abstract partial class PipelineTransport : System.ClientModel.Primitives.PipelinePolicy

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -194,12 +194,13 @@ namespace System.ClientModel.Primitives
     }
     public abstract partial class PipelineRequest : System.IDisposable
     {
-        public PipelineRequest() { }
-        public virtual System.ClientModel.InputContent? Content { get { throw null; } set { } }
-        public virtual System.ClientModel.Primitives.MessageHeaders Headers { get { throw null; } }
-        public virtual string Method { get { throw null; } set { } }
-        public virtual System.Uri Uri { get { throw null; } set { } }
-        public virtual void Dispose() { }
+        protected PipelineRequest() { }
+        public abstract System.ClientModel.InputContent? Content { get; set; }
+        public abstract System.ClientModel.Primitives.MessageHeaders Headers { get; }
+        public abstract string Method { get; set; }
+        public abstract System.Uri Uri { get; set; }
+        public static System.ClientModel.Primitives.PipelineRequest Create() { throw null; }
+        public abstract void Dispose();
     }
     public abstract partial class PipelineResponse : System.IDisposable
     {

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineRequest.cs
@@ -15,49 +15,9 @@ namespace System.ClientModel.Internal.Primitives;
 
 // This adds the Http dependency, and some implementation
 
-internal class HttpPipelineRequest : PipelineRequest, IDisposable
+internal class HttpPipelineRequest : PipelineRequest
 {
     private const string AuthorizationHeaderName = "Authorization";
-
-    private Uri? _uri;
-    private InputContent? _content;
-
-    private readonly PipelineRequestHeaders _headers;
-
-    protected internal HttpPipelineRequest()
-    {
-        Method = HttpMethod.Get.Method;
-        _headers = new PipelineRequestHeaders();
-    }
-
-    public override Uri Uri
-    {
-        get
-        {
-            if (_uri is null)
-            {
-                throw new InvalidOperationException("Uri has not be set on HttpMessageRequest instance.");
-            }
-
-            return _uri;
-        }
-
-        set => _uri = value;
-    }
-
-    public override InputContent? Content
-    {
-        get => _content;
-        set => _content = value;
-    }
-
-    public override string Method
-    {
-        get;
-        set;
-    }
-
-    public override MessageHeaders Headers => _headers;
 
     // PATCH value needed for compat with pre-net5.0 TFMs
     private static readonly HttpMethod _patchMethod = new HttpMethod("PATCH");
@@ -85,7 +45,7 @@ internal class HttpPipelineRequest : PipelineRequest, IDisposable
         Uri uri = Uri;
         HttpRequestMessage httpRequest = new HttpRequestMessage(method, uri);
 
-        MessageBodyAdapter? httpContent = _content != null ? new MessageBodyAdapter(_content, cancellationToken) : null;
+        MessageBodyAdapter? httpContent = Content != null ? new MessageBodyAdapter(Content, cancellationToken) : null;
         httpRequest.Content = httpContent;
 #if NETSTANDARD
         httpRequest.Headers.ExpectContinue = false;
@@ -155,18 +115,6 @@ internal class HttpPipelineRequest : PipelineRequest, IDisposable
         protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
             => _content.WriteTo(stream, cancellationToken);
 #endif
-    }
-
-    public override void Dispose()
-    {
-        var content = _content;
-        if (content != null)
-        {
-            _content = null;
-            content.Dispose();
-        }
-
-        GC.SuppressFinalize(this);
     }
 
     public override string ToString() => BuildRequestMessage(default).ToString();

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineRequest.cs
@@ -1,21 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.ClientModel.Primitives;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Net;
 
 namespace System.ClientModel.Internal.Primitives;
 
 // This adds the Http dependency, and some implementation
 
-public class HttpPipelineRequest : PipelineRequest, IDisposable
+internal class HttpPipelineRequest : PipelineRequest, IDisposable
 {
     private const string AuthorizationHeaderName = "Authorization";
 

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineRequest.cs
@@ -19,6 +19,46 @@ internal class HttpPipelineRequest : PipelineRequest
 {
     private const string AuthorizationHeaderName = "Authorization";
 
+    private Uri? _uri;
+    private InputContent? _content;
+
+    private readonly PipelineRequestHeaders _headers;
+
+    protected internal HttpPipelineRequest()
+    {
+        Method = HttpMethod.Get.Method;
+        _headers = new PipelineRequestHeaders();
+    }
+
+    public override Uri Uri
+    {
+        get
+        {
+            if (_uri is null)
+            {
+                throw new InvalidOperationException("Uri has not be set on HttpMessageRequest instance.");
+            }
+
+            return _uri;
+        }
+
+        set => _uri = value;
+    }
+
+    public override InputContent? Content
+    {
+        get => _content;
+        set => _content = value;
+    }
+
+    public override string Method
+    {
+        get;
+        set;
+    }
+
+    public override MessageHeaders Headers => _headers;
+
     // PATCH value needed for compat with pre-net5.0 TFMs
     private static readonly HttpMethod _patchMethod = new HttpMethod("PATCH");
 
@@ -45,7 +85,7 @@ internal class HttpPipelineRequest : PipelineRequest
         Uri uri = Uri;
         HttpRequestMessage httpRequest = new HttpRequestMessage(method, uri);
 
-        MessageBodyAdapter? httpContent = Content != null ? new MessageBodyAdapter(Content, cancellationToken) : null;
+        MessageBodyAdapter? httpContent = _content != null ? new MessageBodyAdapter(_content, cancellationToken) : null;
         httpRequest.Content = httpContent;
 #if NETSTANDARD
         httpRequest.Headers.ExpectContinue = false;
@@ -115,6 +155,18 @@ internal class HttpPipelineRequest : PipelineRequest
         protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
             => _content.WriteTo(stream, cancellationToken);
 #endif
+    }
+
+    public override void Dispose()
+    {
+        var content = _content;
+        if (content != null)
+        {
+            _content = null;
+            content.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
     }
 
     public override string ToString() => BuildRequestMessage(default).ToString();

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
@@ -80,14 +80,10 @@ internal class HttpPipelineResponse : PipelineResponse, IDisposable
             // intentionally left the network stream undisposed.
 
             var contentStream = _contentStream;
-            //if (content is not null && !content.IsBuffered)
-            if (contentStream is not null)
+            if (contentStream is not null && !TryGetBufferedContent(out _))
             {
-                if (contentStream is not MemoryStream)
-                {
-                    contentStream?.Dispose();
-                    _contentStream = null;
-                }
+                contentStream?.Dispose();
+                _contentStream = null;
             }
 
             _disposed = true;

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
@@ -22,7 +22,7 @@ internal class HttpPipelineResponse : PipelineResponse, IDisposable
 
     private bool _disposed;
 
-    protected internal HttpPipelineResponse(HttpResponseMessage httpResponse)
+    public HttpPipelineResponse(HttpResponseMessage httpResponse)
     {
         _httpResponse = httpResponse ?? throw new ArgumentNullException(nameof(httpResponse));
         _httpResponseContent = _httpResponse.Content;
@@ -39,7 +39,7 @@ internal class HttpPipelineResponse : PipelineResponse, IDisposable
     public override Stream? ContentStream
     {
         get => _contentStream;
-        protected internal set
+        set
         {
             // Make sure we don't dispose the content if the stream was replaced
             _httpResponse.Content = null;

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
@@ -36,34 +36,6 @@ internal class HttpPipelineResponse : PipelineResponse, IDisposable
     public override MessageHeaders Headers
         => new PipelineResponseHeaders(_httpResponse, _httpResponseContent);
 
-    //public override MessageBody? Body
-    //{
-    //    get
-    //    {
-    //        _content ??= MessageBody.Empty;
-    //        return _content;
-    //    }
-
-    //    protected internal set
-    //    {
-    //        _content = value;
-
-    //        // Setting _httpResponse.Content to null makes it so when this type
-    //        // disposes _httpResponse later, the content is not also disposed.
-    //        // This works because the transport sets _content to the value of
-    //        // _httpResponse.Content initially, so if this object is disposed
-    //        // without its content being buffered, calling dispose on _content will
-    //        // dispose the network stream.
-
-    //        // TODO: We could feasibly leak a network resource if this setter
-    //        // is called without the caller taking ownership of and disposing the
-    //        // network stream, since at that point, no one is holding a reference
-    //        // to it anymore.  Today, ResponseBufferingPolicy takes care of this.
-
-    //        _httpResponse.Content = null;
-    //    }
-    //}
-
     public override Stream? ContentStream
     {
         get => _contentStream;

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using System.ClientModel.Primitives;
+using System.IO;
 using System.Net.Http;
 
 namespace System.ClientModel.Internal.Primitives;
 
-public class HttpPipelineResponse : PipelineResponse, IDisposable
+internal class HttpPipelineResponse : PipelineResponse, IDisposable
 {
     private readonly HttpResponseMessage _httpResponse;
 

--- a/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/HttpPipelineResponse.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 
 namespace System.ClientModel.Internal.Primitives;
 
-internal class HttpPipelineResponse : PipelineResponse, IDisposable
+internal class HttpPipelineResponse : PipelineResponse
 {
     private readonly HttpResponseMessage _httpResponse;
 

--- a/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
@@ -1,18 +1,53 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Net.Http;
+
 namespace System.ClientModel.Primitives;
 
 public abstract class PipelineRequest : IDisposable
 {
-    public abstract string Method { get; set; }
+    private readonly PipelineRequestHeaders _headers;
 
-    public abstract Uri Uri { get; set; }
+    private Uri? _uri;
+    private InputContent? _content;
 
-    public abstract InputContent? Content { get; set; }
+    public PipelineRequest()
+    {
+        Method = HttpMethod.Get.Method;
+        _headers = new PipelineRequestHeaders();
+    }
 
-    public abstract MessageHeaders Headers { get; }
+    public virtual string Method { get; set; }
 
-    // TODO: this is required by Azure.Core RequestAdapter constraint.  Revisit?
-    public abstract void Dispose();
+    public virtual Uri Uri
+    {
+        get
+        {
+            if (_uri is null)
+            {
+                throw new InvalidOperationException("Uri has not be set on HttpMessageRequest instance.");
+            }
+
+            return _uri;
+        }
+
+        set => _uri = value;
+    }
+
+    public virtual InputContent? Content { get; set; }
+
+    public virtual MessageHeaders Headers => _headers;
+
+    public virtual void Dispose()
+    {
+        var content = _content;
+        if (content != null)
+        {
+            _content = null;
+            content.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
 }

--- a/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
@@ -7,6 +7,8 @@ namespace System.ClientModel.Primitives;
 
 public abstract class PipelineRequest : IDisposable
 {
+    // TODO: if we decide to implement more of Http rather than copy,
+    // Will more of this need to be abstract instead of virtual?
     private readonly PipelineRequestHeaders _headers;
 
     private Uri? _uri;

--- a/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineRequest.cs
@@ -1,55 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
+using System.ClientModel.Internal.Primitives;
 
 namespace System.ClientModel.Primitives;
 
 public abstract class PipelineRequest : IDisposable
 {
-    // TODO: if we decide to implement more of Http rather than copy,
-    // Will more of this need to be abstract instead of virtual?
-    private readonly PipelineRequestHeaders _headers;
+    public static PipelineRequest Create()
+        => new HttpPipelineRequest();
 
-    private Uri? _uri;
-    private InputContent? _content;
+    public abstract string Method { get; set; }
 
-    public PipelineRequest()
-    {
-        Method = HttpMethod.Get.Method;
-        _headers = new PipelineRequestHeaders();
-    }
+    public abstract Uri Uri { get; set; }
 
-    public virtual string Method { get; set; }
+    public abstract InputContent? Content { get; set; }
 
-    public virtual Uri Uri
-    {
-        get
-        {
-            if (_uri is null)
-            {
-                throw new InvalidOperationException("Uri has not be set on HttpMessageRequest instance.");
-            }
+    public abstract MessageHeaders Headers { get; }
 
-            return _uri;
-        }
-
-        set => _uri = value;
-    }
-
-    public virtual InputContent? Content { get; set; }
-
-    public virtual MessageHeaders Headers => _headers;
-
-    public virtual void Dispose()
-    {
-        var content = _content;
-        if (content != null)
-        {
-            _content = null;
-            content.Dispose();
-        }
-
-        GC.SuppressFinalize(this);
-    }
+    public abstract void Dispose();
 }

--- a/sdk/core/System.ClientModel/src/Message/PipelineRequestHeaders.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineRequestHeaders.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Internal;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.ClientModel.Internal;
 
 namespace System.ClientModel.Primitives;
 

--- a/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Internal.Primitives;
 using System.IO;
+using System.Net.Http;
 
 namespace System.ClientModel.Primitives;
 
@@ -10,13 +12,16 @@ public abstract class PipelineResponse : IDisposable
     // TODO(matell): The .NET Framework team plans to add BinaryData.Empty in dotnet/runtime#49670, and we can use it then.
     private static readonly BinaryData s_emptyBinaryData = new(Array.Empty<byte>());
 
+    public static PipelineResponse Create(HttpResponseMessage response)
+        => new HttpPipelineResponse(response);
+
     public abstract int Status { get; }
 
-    public abstract string ReasonPhrase {  get; }
+    public abstract string ReasonPhrase { get; }
 
     public abstract MessageHeaders Headers { get; }
 
-    public abstract Stream? ContentStream { get; protected internal set; }
+    public abstract Stream? ContentStream { get; set; }
 
     #region Meta-data properties set by the pipeline.
 

--- a/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineResponse.cs
@@ -16,6 +16,10 @@ public abstract class PipelineResponse : IDisposable
 
     public abstract MessageHeaders Headers { get; }
 
+    public abstract Stream? ContentStream { get; protected internal set; }
+
+    #region Meta-data properties set by the pipeline.
+
     public BinaryData Content
     {
         get
@@ -25,26 +29,21 @@ public abstract class PipelineResponse : IDisposable
                 return s_emptyBinaryData;
             }
 
-            // TODO: Keep this?
-            // Questions: what assumptions is this making and/or dependencies
-            // is it mandating?
-            MemoryStream? memoryContent = ContentStream as MemoryStream ??
-                throw new InvalidOperationException($"The response is not fully buffered.");
+            if (!TryGetBufferedContent(out MemoryStream bufferedContent))
+            {
+                throw new InvalidOperationException($"The response is not buffered.");
+            }
 
-            if (memoryContent.TryGetBuffer(out ArraySegment<byte> segment))
+            if (bufferedContent.TryGetBuffer(out ArraySegment<byte> segment))
             {
                 return new BinaryData(segment.AsMemory());
             }
             else
             {
-                return new BinaryData(memoryContent.ToArray());
+                return new BinaryData(bufferedContent.ToArray());
             }
         }
     }
-
-    public abstract Stream? ContentStream { get; protected internal set; }
-
-    #region Meta-data properties set by the pipeline.
 
     /// <summary>
     /// Indicates whether the status code of the returned response is considered
@@ -53,6 +52,18 @@ public abstract class PipelineResponse : IDisposable
     public bool IsError { get; internal set; }
 
     #endregion
+
+    internal bool TryGetBufferedContent(out MemoryStream bufferedContent)
+    {
+        if (ContentStream is MemoryStream content)
+        {
+            bufferedContent = content;
+            return true;
+        }
+
+        bufferedContent = default!;
+        return false;
+    }
 
     public abstract void Dispose();
 }

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
@@ -11,7 +11,7 @@ namespace System.ClientModel.Internal.Primitives;
 
 // Introduces the dependency on System.Net.Http;
 
-public class HttpClientPipelineTransport : PipelineTransport, IDisposable
+internal class HttpClientPipelineTransport : PipelineTransport, IDisposable
 {
     /// <summary>
     /// A shared instance of <see cref="HttpClientPipelineTransport"/> with default parameters.

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
@@ -194,12 +194,12 @@ public class HttpClientPipelineTransport : PipelineTransport, IDisposable
 
     private static HttpRequestMessage BuildRequestMessage(PipelineMessage message)
     {
-        if (message.Request is not HttpPipelineRequest messageRequest)
+        if (message.Request is not PipelineRequest request)
         {
             throw new InvalidOperationException($"The request type is not compatible with the transport: '{message.Request?.GetType()}'.");
         }
 
-        return messageRequest.BuildRequestMessage(message.CancellationToken);
+        return HttpPipelineRequest.BuildHttpRequestMessage(request, message.CancellationToken);
     }
 
     #region IDisposable

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
@@ -11,7 +11,7 @@ namespace System.ClientModel.Internal.Primitives;
 
 // Introduces the dependency on System.Net.Http;
 
-internal class HttpClientPipelineTransport : PipelineTransport, IDisposable
+public class HttpClientPipelineTransport : PipelineTransport, IDisposable
 {
     /// <summary>
     /// A shared instance of <see cref="HttpClientPipelineTransport"/> with default parameters.

--- a/sdk/core/System.ClientModel/src/Pipeline/ResponseBufferingPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ResponseBufferingPolicy.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Buffers;
-using System.IO;
 using System.ClientModel.Internal;
-using System.ClientModel.Internal.Primitives;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -238,4 +237,5 @@ public class ResponseBufferingPolicy : PipelinePolicy
     private struct NetworkTimeoutPropertyKey { }
 
     #endregion
+
 }

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using NUnit.Framework;
-using System.ClientModel.Internal.Primitives;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
@@ -116,9 +115,20 @@ public class ClientPipelineTests
             }
         }
 
-        private class TransportRequest : HttpPipelineRequest
+        private class TransportRequest : PipelineRequest
         {
             public TransportRequest() { }
+
+            public override string Method { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public override Uri Uri { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public override InputContent? Content { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public override MessageHeaders Headers => throw new NotImplementedException();
+
+            public override void Dispose()
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private class TransportResponse : PipelineResponse

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientPipelineTests.cs
@@ -142,7 +142,7 @@ public class ClientPipelineTests
             public override Stream? ContentStream
             {
                 get => null;
-                protected set => throw new NotImplementedException();
+                set => throw new NotImplementedException();
             }
 
             public override void Dispose()


### PR DESCRIPTION
This trades two of the types in System.ClientModel.Internal.Primitives for static factory methods on their corresponding abstract types:
- Removes HttpPipelineRequest
- Removes HttpPipelineResponse