### PR TITLE
Fix to `CompletionOptions.cs` constructor in Azure OpenAI SDK to properly initialize the `DeploymentName` property

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/CompletionsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/CompletionsOptions.cs
@@ -180,7 +180,7 @@ namespace Azure.AI.OpenAI
             Argument.AssertNotNullOrEmpty(deploymentName, nameof(deploymentName));
             Argument.AssertNotNull(prompts, nameof(prompts));
 
-            DeploymentName = deploymentName
+            DeploymentName = deploymentName;
             Prompts = prompts.ToList();
         }
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/CompletionsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/CompletionsOptions.cs
@@ -180,6 +180,7 @@ namespace Azure.AI.OpenAI
             Argument.AssertNotNullOrEmpty(deploymentName, nameof(deploymentName));
             Argument.AssertNotNull(prompts, nameof(prompts));
 
+            DeploymentName = deploymentName
             Prompts = prompts.ToList();
         }
 


### PR DESCRIPTION
Fixed ussie where the constructor for `DeploymentOptions` takes a `deploymentName` parameter but does not initialize the `DeploymentName` property.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
