### PR TITLE
Adds Json Mode to emit proper response_format to OpenAI

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -237,6 +237,7 @@ namespace Azure.AI.OpenAI
         public float? FrequencyPenalty { get { throw null; } set { } }
         public Azure.AI.OpenAI.FunctionDefinition FunctionCall { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.AI.OpenAI.FunctionDefinition> Functions { get { throw null; } set { } }
+        public bool? JsonMode { get { throw null; } set { } }
         public int? MaxTokens { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.AI.OpenAI.ChatMessage> Messages { get { throw null; } }
         public float? NucleusSamplingFactor { get { throw null; } set { } }
@@ -332,6 +333,7 @@ namespace Azure.AI.OpenAI
         public bool? Echo { get { throw null; } set { } }
         public float? FrequencyPenalty { get { throw null; } set { } }
         public int? GenerationSampleCount { get { throw null; } set { } }
+        public bool? JsonMode { get { throw null; } set { } }
         public int? LogProbabilityCount { get { throw null; } set { } }
         public int? MaxTokens { get { throw null; } set { } }
         public float? NucleusSamplingFactor { get { throw null; } set { } }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.Serialization.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.Serialization.cs
@@ -109,6 +109,15 @@ namespace Azure.AI.OpenAI
                 }
                 writer.WriteEndObject();
             }
+            // CUSTOM: serialize JsonMode to "response_format": { "type": "json_object" },
+            if (JsonMode == true)
+            {
+                writer.WritePropertyName("response_format"u8);
+                writer.WriteStartObject();
+                writer.WritePropertyName("type"u8);
+                writer.WriteStringValue("json_object");
+                writer.WriteEndObject();
+            }
             if (Optional.IsDefined(User))
             {
                 writer.WritePropertyName("user"u8);

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletionsOptions.cs
@@ -34,6 +34,9 @@ namespace Azure.AI.OpenAI
         /// <inheritdoc cref="CompletionsOptions.FrequencyPenalty"/>
         public float? FrequencyPenalty { get; set; }
 
+        /// <inheritdoc cref="CompletionsOptions.JsonMode"/>
+        public bool? JsonMode { get; set; }
+
         /// <inheritdoc cref="CompletionsOptions.MaxTokens"/>
         public int? MaxTokens { get; set; }
 

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/CompletionsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/CompletionsOptions.cs
@@ -74,6 +74,26 @@ namespace Azure.AI.OpenAI
         public int? GenerationSampleCount { get; set; }
 
         /// <summary>
+        ///     Gets or sets a value that controls whether the response will be formatted as a JSON object.
+        /// </summary>
+        /// <remarks>
+        ///     When JSON mode is enabled, the model is constrained to only generate strings that parse into valid JSON object.
+        ///
+        ///     Important notes:
+        ///     * When using JSON mode, always instruct the model to produce JSON via some message in the conversation,
+        ///       for example via your system message.If you don't include an explicit instruction to generate JSON,
+        ///       the model may generate an unending stream of whitespace and the request may run continually until
+        ///       it reaches the token limit. To help ensure you don't forget, the API will throw an error if the
+        ///       string "JSON" does not appear somewhere in the context.
+        ///     * The JSON in the message the model returns may be partial (i.e.cut off) if finish_reason is length,
+        ///       which indicates the generation exceeded max_tokens or the conversation exceeded the token limit.
+        ///       To guard against this, check finish_reason before parsing the response.
+        ///     * JSON mode will not guarantee the output matches any specific schema, only that it is valid and parses
+        ///       without errors.
+        /// </remarks>
+        public bool? JsonMode { get; set; }
+
+        /// <summary>
         ///     Gets or sets a value that controls generation of log probabilities on the
         ///     <see cref="LogProbabilityCount"/> most likely tokens.
         ///     Has a valid range of 0 to 5.


### PR DESCRIPTION
Having a simple boolean property instead of a potentially more complex and open-ended `ResponseFormat` when there is at the moment a single valid value, seems best. 

XML docs taken from https://platform.openai.com/docs/guides/text-generation/json-mode

Fixes #40225