### PR TITLE
Update [CallerShouldAudit] usage to include classes and interfaces.

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/CallerShouldAuditAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/CallerShouldAuditAttribute.cs
@@ -9,13 +9,13 @@ namespace Azure.Core
 {
     /// <summary>
     /// Decorates an operation whose invocation should potentially be audited
-    /// by Azure service implementations.  Auditing could be recommended
+    /// by Azure service implementations. Auditing could be recommended
     /// because the operation changes critical service state, creates delegated
     /// access to a resource, affects data retention, etc.  It's a best guess
     /// from the service team that the operation should be audited to mitigate
     /// any potential future issues.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Method)]
     internal class CallerShouldAuditAttribute : Attribute
     {
         /// <summary>


### PR DESCRIPTION
As discussed with @heaths and @scottaddie, updated the [CallerShouldAudit] attribute usage to include classes and interfaces. Instead of adding the attribute to each individual method in a client class, it would be more beneficial to apply it at the class level. This approach not only offers greater flexibility but also ensures our solution is future-proof, especially as new methods are added to these classes. In scenarios where audit functionality is required only for specific methods, we can still apply the attribute at the individual method level.

Original PR by @tg-msft introducing [CallerShouldAudit] #39345.
