### PR TITLE
Update InteractiveBrowserCredential brokered auth docs

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/README.md
+++ b/sdk/identity/Azure.Identity.Broker/README.md
@@ -1,6 +1,6 @@
 # Azure Identity Brokered Authentication client library for .NET
 
-The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of an embedded web view, if available.
+The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of an embedded web view or the system browser.
 
 [Source code][source] | [Package (NuGet)][package] | [API reference documentation][identity_api_docs] | [Microsoft Entra ID documentation][aad_doc]
 

--- a/sdk/identity/Azure.Identity.Broker/README.md
+++ b/sdk/identity/Azure.Identity.Broker/README.md
@@ -1,6 +1,6 @@
 # Azure Identity Brokered Authentication client library for .NET
 
-The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of the embedded web view, if available.
+The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of an embedded web view, if available.
 
 [Source code][source] | [Package (NuGet)][package] | [API reference documentation][identity_api_docs] | [Microsoft Entra ID documentation][aad_doc]
 

--- a/sdk/identity/Azure.Identity.Broker/README.md
+++ b/sdk/identity/Azure.Identity.Broker/README.md
@@ -1,6 +1,6 @@
 # Azure Identity Brokered Authentication client library for .NET
 
-The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of the embedded web browser, if available.
+The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of the embedded web view, if available.
 
 [Source code][source] | [Package (NuGet)][package] | [API reference documentation][identity_api_docs] | [Microsoft Entra ID documentation][aad_doc]
 

--- a/sdk/identity/Azure.Identity.Broker/README.md
+++ b/sdk/identity/Azure.Identity.Broker/README.md
@@ -1,7 +1,8 @@
 # Azure Identity Brokered Authentication client library for .NET
- The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies, and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of the system browser when available.
 
-  [Source code][source] | [Package (nuget)][package] | [API reference documentation][identity_api_docs] | [Microsoft Entra ID documentation][aad_doc]
+The library extends the Azure.Identity library to provide authentication broker support. It includes the necessary dependencies and provides the `InteractiveBrowserCredentialBrokerOptions` class. This options class can be used to create an `InteractiveBrowserCredential` capable of using the system authentication broker in lieu of the embedded web browser, if available.
+
+[Source code][source] | [Package (NuGet)][package] | [API reference documentation][identity_api_docs] | [Microsoft Entra ID documentation][aad_doc]
 
 ## Getting started
 

--- a/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.Identity.Client.Broker;
 namespace Azure.Identity.Broker
 {
     /// <summary>
-    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of an embedded web view, if available.
+    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of an embedded web view or the system browser.
     /// </summary>
     public class InteractiveBrowserCredentialBrokerOptions : InteractiveBrowserCredentialOptions, IMsalPublicClientInitializerOptions
     {

--- a/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.Identity.Client.Broker;
 namespace Azure.Identity.Broker
 {
     /// <summary>
-    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of the embedded web view, if available.
+    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of an embedded web view, if available.
     /// </summary>
     public class InteractiveBrowserCredentialBrokerOptions : InteractiveBrowserCredentialOptions, IMsalPublicClientInitializerOptions
     {

--- a/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.Identity.Client.Broker;
 namespace Azure.Identity.Broker
 {
     /// <summary>
-    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of the embedded web browser, if available.
+    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of the embedded web view, if available.
     /// </summary>
     public class InteractiveBrowserCredentialBrokerOptions : InteractiveBrowserCredentialOptions, IMsalPublicClientInitializerOptions
     {

--- a/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/InteractiveBrowserCredentialBrokerOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.Identity.Client.Broker;
 namespace Azure.Identity.Broker
 {
     /// <summary>
-    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of the system browser if available.
+    /// Options to configure the <see cref="InteractiveBrowserCredential"/> to use the system authentication broker in lieu of the embedded web browser, if available.
     /// </summary>
     public class InteractiveBrowserCredentialBrokerOptions : InteractiveBrowserCredentialOptions, IMsalPublicClientInitializerOptions
     {


### PR DESCRIPTION
Update the docs to reflect product truth. If `IntPtr.Zero` is passed as the parent window handle, an embedded web view is launched in a WinForms app. See https://learn.microsoft.com/entra/msal/dotnet/acquiring-tokens/using-web-browsers#browser-availability, which indicates the result depends on the type of .NET app. However, the docs imply it's always the system default browser that launches. I confirmed that the Edge process isn't started, which proves the current docs are inaccurate.