### PR TITLE
Merge generated NFS Support into STG93 Branch

### DIFF
--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/DirectoryRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/DirectoryRestClient.cs
@@ -33,7 +33,7 @@ namespace Azure.Storage.Files.Shares
         /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
         /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
         /// <param name="url"> The URL of the service account, share, directory or file that is the target of the desired operation. </param>
-        /// <param name="version"> Specifies the version of the operation to use for this request. The default value is "2024-02-04". </param>
+        /// <param name="version"> Specifies the version of the operation to use for this request. The default value is "2024-05-04". </param>
         /// <param name="allowTrailingDot"> If true, the trailing dot will not be trimmed from the target URI. </param>
         /// <param name="fileRequestIntent"> Valid value is backup. </param>
         /// <param name="allowSourceTrailingDot"> If true, the trailing dot will not be trimmed from the source URI. </param>

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/FileRestClient.cs
@@ -35,7 +35,7 @@ namespace Azure.Storage.Files.Shares
         /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
         /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
         /// <param name="url"> The URL of the service account, share, directory or file that is the target of the desired operation. </param>
-        /// <param name="version"> Specifies the version of the operation to use for this request. The default value is "2024-02-04". </param>
+        /// <param name="version"> Specifies the version of the operation to use for this request. The default value is "2024-05-04". </param>
         /// <param name="fileRangeWriteFromUrl"> Only update is supported: - Update: Writes the bytes downloaded from the source url into the specified range. The default value is "update". </param>
         /// <param name="allowTrailingDot"> If true, the trailing dot will not be trimmed from the target URI. </param>
         /// <param name="fileRequestIntent"> Valid value is backup. </param>

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/Models/SharePropertiesInternal.Serialization.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/Models/SharePropertiesInternal.Serialization.cs
@@ -33,6 +33,7 @@ namespace Azure.Storage.Files.Shares.Models
             ShareLeaseDuration? leaseDuration = default;
             string enabledProtocols = default;
             ShareRootSquash? rootSquash = default;
+            bool? enableSnapshotVirtualDirectoryAccess = default;
             if (element.Element("Last-Modified") is XElement lastModifiedElement)
             {
                 lastModified = lastModifiedElement.GetDateTimeOffsetValue("R");
@@ -105,7 +106,11 @@ namespace Azure.Storage.Files.Shares.Models
             {
                 rootSquash = rootSquashElement.Value.ToShareRootSquash();
             }
-            return new SharePropertiesInternal(lastModified, etag, quota, provisionedIops, provisionedIngressMBps, provisionedEgressMBps, provisionedBandwidthMiBps, nextAllowedQuotaDowngradeTime, deletedTime, remainingRetentionDays, accessTier, accessTierChangeTime, accessTierTransitionState, leaseStatus, leaseState, leaseDuration, enabledProtocols, rootSquash);
+            if (element.Element("EnableSnapshotVirtualDirectoryAccess") is XElement enableSnapshotVirtualDirectoryAccessElement)
+            {
+                enableSnapshotVirtualDirectoryAccess = (bool?)enableSnapshotVirtualDirectoryAccessElement;
+            }
+            return new SharePropertiesInternal(lastModified, etag, quota, provisionedIops, provisionedIngressMBps, provisionedEgressMBps, provisionedBandwidthMiBps, nextAllowedQuotaDowngradeTime, deletedTime, remainingRetentionDays, accessTier, accessTierChangeTime, accessTierTransitionState, leaseStatus, leaseState, leaseDuration, enabledProtocols, rootSquash, enableSnapshotVirtualDirectoryAccess);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/Models/SharePropertiesInternal.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/Models/SharePropertiesInternal.cs
@@ -46,7 +46,8 @@ namespace Azure.Storage.Files.Shares.Models
         /// <param name="leaseDuration"> When a share is leased, specifies whether the lease is of infinite or fixed duration. </param>
         /// <param name="enabledProtocols"></param>
         /// <param name="rootSquash"></param>
-        internal SharePropertiesInternal(DateTimeOffset lastModified, string etag, int quota, int? provisionedIops, int? provisionedIngressMBps, int? provisionedEgressMBps, int? provisionedBandwidthMiBps, DateTimeOffset? nextAllowedQuotaDowngradeTime, DateTimeOffset? deletedTime, int? remainingRetentionDays, string accessTier, DateTimeOffset? accessTierChangeTime, string accessTierTransitionState, ShareLeaseStatus? leaseStatus, ShareLeaseState? leaseState, ShareLeaseDuration? leaseDuration, string enabledProtocols, ShareRootSquash? rootSquash)
+        /// <param name="enableSnapshotVirtualDirectoryAccess"></param>
+        internal SharePropertiesInternal(DateTimeOffset lastModified, string etag, int quota, int? provisionedIops, int? provisionedIngressMBps, int? provisionedEgressMBps, int? provisionedBandwidthMiBps, DateTimeOffset? nextAllowedQuotaDowngradeTime, DateTimeOffset? deletedTime, int? remainingRetentionDays, string accessTier, DateTimeOffset? accessTierChangeTime, string accessTierTransitionState, ShareLeaseStatus? leaseStatus, ShareLeaseState? leaseState, ShareLeaseDuration? leaseDuration, string enabledProtocols, ShareRootSquash? rootSquash, bool? enableSnapshotVirtualDirectoryAccess)
         {
             LastModified = lastModified;
             Etag = etag;
@@ -66,6 +67,7 @@ namespace Azure.Storage.Files.Shares.Models
             LeaseDuration = leaseDuration;
             EnabledProtocols = enabledProtocols;
             RootSquash = rootSquash;
+            EnableSnapshotVirtualDirectoryAccess = enableSnapshotVirtualDirectoryAccess;
         }
 
         /// <summary> Gets the last modified. </summary>
@@ -104,5 +106,7 @@ namespace Azure.Storage.Files.Shares.Models
         public string EnabledProtocols { get; }
         /// <summary> Gets the root squash. </summary>
         public ShareRootSquash? RootSquash { get; }
+        /// <summary> Gets the enable snapshot virtual directory access. </summary>
+        public bool? EnableSnapshotVirtualDirectoryAccess { get; }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/ServiceRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/ServiceRestClient.cs
@@ -30,7 +30,7 @@ namespace Azure.Storage.Files.Shares
         /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
         /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
         /// <param name="url"> The URL of the service account, share, directory or file that is the target of the desired operation. </param>
-        /// <param name="version"> Specifies the version of the operation to use for this request. The default value is "2024-02-04". </param>
+        /// <param name="version"> Specifies the version of the operation to use for this request. The default value is "2024-05-04". </param>
         /// <exception cref="ArgumentNullException"> <paramref name="clientDiagnostics"/>, <paramref name="pipeline"/>, <paramref name="url"/> or <paramref name="version"/> is null. </exception>
         public ServiceRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string url, string version)
         {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/ShareGetPropertiesHeaders.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/ShareGetPropertiesHeaders.cs
@@ -54,5 +54,7 @@ namespace Azure.Storage.Files.Shares
         public string EnabledProtocols => _response.Headers.TryGetValue("x-ms-enabled-protocols", out string value) ? value : null;
         /// <summary> Valid for NFS shares only. </summary>
         public ShareRootSquash? RootSquash => _response.Headers.TryGetValue("x-ms-root-squash", out string value) ? value.ToShareRootSquash() : null;
+        /// <summary> Version 2023-08-03 and newer. Specifies whether the snapshot virtual directory should be accessible at the root of share mount point when NFS is enabled. This header is only returned for shares, not for snapshots. </summary>
+        public bool? EnabledSnapshotVirtualDirectoryAccess => _response.Headers.TryGetValue("x-ms-enable-snapshot-virtual-directory-access", out bool? value) ? value : null;
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/autorest.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/autorest.md
@@ -4,7 +4,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 
 ``` yaml
 input-file:
-    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/ef99caaf8f0de4f9a7898f486edb462a994b19b1/specification/storage/data-plane/Microsoft.FileStorage/preview/2024-02-04/file.json
+    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/46b2c9610415e6ae1f16bfd672210c4684abb078/specification/storage/data-plane/Microsoft.FileStorage/preview/2024-05-04/file.json
 generation1-convenience-client: true
 # https://github.com/Azure/autorest/issues/4075
 skip-semantics-validation: true


### PR DESCRIPTION
since the spec changes for nfs were merged into stg93 rest spec https://github.com/Azure/azure-rest-api-specs/pull/26870 need to merge its generated code here as well to avoid having these changes show up in every subsequent stg93 feature pr, subsequent prs should follow our usual approach of having .net prs link to rest spec pr swaggers.