### PR TITLE
[Storage][DataMovement] Additional fixes to address test failures

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/src/CommitChunkHandler.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CommitChunkHandler.cs
@@ -45,7 +45,6 @@ namespace Azure.Storage.DataMovement
         private readonly Channel<StageChunkEventArgs> _stageChunkChannel;
         private CancellationToken _cancellationToken;
 
-        private readonly SemaphoreSlim _currentBytesSemaphore;
         private long _bytesTransferred;
         private readonly long _expectedLength;
         private readonly long _blockSize;
@@ -93,7 +92,6 @@ namespace Azure.Storage.DataMovement
             _processStageChunkEvents = Task.Run(() => NotifyOfPendingStageChunkEvents());
 
             // Set bytes transferred to block size because we transferred the initial block
-            _currentBytesSemaphore = new SemaphoreSlim(1, 1);
             _bytesTransferred = blockSize;
 
             _blockSize = blockSize;
@@ -110,11 +108,6 @@ namespace Azure.Storage.DataMovement
         {
             // We no longer have to read from the channel. We are not expecting any more requests.
             _stageChunkChannel.Writer.TryComplete();
-
-            if (_currentBytesSemaphore != default)
-            {
-                _currentBytesSemaphore.Dispose();
-            }
             DisposeHandlers();
         }
 
@@ -157,15 +150,6 @@ namespace Azure.Storage.DataMovement
                 {
                     // Read one event argument at a time.
                     StageChunkEventArgs args = await _stageChunkChannel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
-                    try
-                    {
-                        await _currentBytesSemaphore.WaitAsync(_cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // We should not continue if waiting on the semaphore has cancelled out.
-                        return;
-                    }
 
                     Interlocked.Add(ref _bytesTransferred, args.BytesTransferred);
                     // Report the incremental bytes transferred
@@ -179,20 +163,13 @@ namespace Azure.Storage.DataMovement
                     else if (_bytesTransferred > _expectedLength)
                     {
                         throw Errors.MismatchLengthTransferred(
-                                expectedLength: _expectedLength,
-                                actualLength: _bytesTransferred);
+                            expectedLength: _expectedLength,
+                            actualLength: _bytesTransferred);
                     }
-                    _currentBytesSemaphore.Release();
                 }
             }
             catch (Exception ex)
             {
-                if (_currentBytesSemaphore.CurrentCount == 0)
-                {
-                    _currentBytesSemaphore.Release();
-                }
-                // Invoke the failed event argument here after we've released the semaphore
-                // or else we risk disposing the semaphore and releasing it after.
                 await _invokeFailedEventHandler(ex).ConfigureAwait(false);
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/DownloadChunkHandler.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DownloadChunkHandler.cs
@@ -54,7 +54,6 @@ namespace Azure.Storage.DataMovement
         private readonly Channel<DownloadRangeEventArgs> _downloadRangeChannel;
         private CancellationToken _cancellationToken;
 
-        private readonly SemaphoreSlim _currentBytesSemaphore;
         private long _bytesTransferred;
         private readonly long _expectedLength;
 
@@ -145,7 +144,6 @@ namespace Azure.Storage.DataMovement
 
             // Set bytes transferred to the length of bytes we got back from the initial
             // download request
-            _currentBytesSemaphore = new SemaphoreSlim(1, 1);
             _bytesTransferred = currentTransferred;
             _currentRangeIndex = 0;
             _rangesCount = ranges.Count;
@@ -159,12 +157,6 @@ namespace Azure.Storage.DataMovement
         public void Dispose()
         {
             _downloadRangeChannel.Writer.TryComplete();
-
-            if (_currentBytesSemaphore != default)
-            {
-                _currentBytesSemaphore.Dispose();
-            }
-
             DisposeHandlers();
         }
 
@@ -200,15 +192,6 @@ namespace Azure.Storage.DataMovement
                 while (await _downloadRangeChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
                 {
                     // Read one event argument at a time.
-                    try
-                    {
-                        await _currentBytesSemaphore.WaitAsync(_cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // We should not continue if waiting on the semaphore has cancelled out.
-                        return;
-                    }
                     DownloadRangeEventArgs args = await _downloadRangeChannel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
                     long currentRangeOffset = _ranges[_currentRangeIndex].Offset;
                     if (currentRangeOffset < args.Offset)
@@ -259,17 +242,10 @@ namespace Azure.Storage.DataMovement
                         // to be copied to the file
                         throw Errors.InvalidDownloadOffset(args.Offset, args.BytesTransferred);
                     }
-                    _currentBytesSemaphore.Release();
                 }
             }
             catch (Exception ex)
             {
-                if (_currentBytesSemaphore.CurrentCount == 0)
-                {
-                    _currentBytesSemaphore.Release();
-                }
-                // Invoke the failed event argument here after we've released the semaphore
-                // or else we risk disposing the semaphore and releasing it after.
                 await InvokeFailedEvent(ex).ConfigureAwait(false);
             }
         }

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPartInternal.cs
@@ -295,7 +295,7 @@ namespace Azure.Storage.DataMovement
                 await PartTransferStatusEventHandler.RaiseAsync(
                     new TransferStatusEventArgs(
                         _dataTransfer.Id,
-                        JobPartStatus,
+                        JobPartStatus.DeepCopy(),
                         false,
                         _cancellationToken),
                     nameof(JobPartInternal),
@@ -361,7 +361,7 @@ namespace Azure.Storage.DataMovement
                 await PartTransferStatusEventHandler.RaiseAsync(
                     new TransferStatusEventArgs(
                         _dataTransfer.Id,
-                        JobPartStatus,
+                        JobPartStatus.DeepCopy(),
                         false,
                         _cancellationToken),
                     nameof(JobPartInternal),
@@ -407,7 +407,7 @@ namespace Azure.Storage.DataMovement
                     await PartTransferStatusEventHandler.RaiseAsync(
                         new TransferStatusEventArgs(
                             _dataTransfer.Id,
-                            JobPartStatus,
+                            JobPartStatus.DeepCopy(),
                             false,
                             _cancellationToken),
                         nameof(JobPartInternal),

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -381,16 +381,21 @@ namespace Azure.Storage.DataMovement
                         },
                         cancellationToken: _cancellationToken).ConfigureAwait(false);
                 }
-                // Invoke event handler to keep track of all the stage blocks
-                await _commitBlockHandler.InvokeEvent(
-                    new StageChunkEventArgs(
-                        transferId: _dataTransfer.Id,
-                        success: true,
-                        offset: offset,
-                        bytesTransferred: blockLength,
-                        exception: default,
-                        isRunningSynchronously: true,
-                        cancellationToken: _cancellationToken)).ConfigureAwait(false);
+
+                // The chunk handler may have been disposed in failure case
+                if (_commitBlockHandler != null)
+                {
+                    // Invoke event handler to keep track of all the stage blocks
+                    await _commitBlockHandler.InvokeEvent(
+                        new StageChunkEventArgs(
+                            transferId: _dataTransfer.Id,
+                            success: true,
+                            offset: offset,
+                            bytesTransferred: blockLength,
+                            exception: default,
+                            isRunningSynchronously: true,
+                            cancellationToken: _cancellationToken)).ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {
@@ -437,10 +442,17 @@ namespace Azure.Storage.DataMovement
             // Partition the stream into individual blocks
             foreach ((long Offset, long Length) block in rangeList)
             {
+                if (_cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
                 // Queue partitioned block task
                 await QueueStageBlockRequest(block.Offset, block.Length, completeLength).ConfigureAwait(false);
             }
+
             _queueingTasks = false;
+            await CheckAndUpdateCancellationStateAsync().ConfigureAwait(false);
         }
 
         private Task QueueStageBlockRequest(long offset, long blockSize, long expectedLength)
@@ -509,6 +521,7 @@ namespace Azure.Storage.DataMovement
             if (_commitBlockHandler != default)
             {
                 _commitBlockHandler.Dispose();
+                _commitBlockHandler = null;
             }
         }
     }


### PR DESCRIPTION
- Deep copy status object when raising job part status events to avoid it being changed while the event is being processed.
- Null out the chunk handler after we dispose of it to prevent it being used after its disposed.
- Add an additional check for job completion due to pause or failure after enumerating all chunks in case the last chunk completed before enumerating boolean got set to false.
- Bail out early from chunk task creation if the job is cancelled. (Not a bug fix, just optimization)
- Remove semaphore completely from chunk handlers. It was not needed as the code being protected was only ever executed by a single thread and there was no need for synchronization. The channel ensures the synchronization for us already. This was to fix some `ObjectDisposedException`s from happening.