### PR TITLE
[AzureMonitorExporter] prep exporter 1.1.0

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -12,13 +12,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Depending on monthly deliverables, we may switch between PackageReference or ProjectReference. Keeping both here to make the switch easier. -->
+    
+    <!--<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />-->
+    <ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
+  </ItemGroup>
+  
   <!-- Shared source from Exporter -->
   <ItemGroup>
     <Compile Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Internals\ExceptionExtensions.cs" LinkBase="Shared" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,14 +1,8 @@
 # Release History
 
-## 1.1.0 (2023-12-05)
-
-## 1.0.0 (2023-09-20)
+## 1.1.0 (2023-11-29)
 
 ### Bugs Fixed
-
-* Fixed an issue during network failures which prevented the exporter to store
-  the telemetry offline for retrying at a later time.
-  ([#38832](https://github.com/Azure/azure-sdk-for-net/pull/38832))
 
 * Fixed an issue where `OriginalFormat` persisted in TraceTelemetry properties
   with IncludeFormattedMessage set to true on [
@@ -41,6 +35,21 @@
   settings. The fix ensures uniform and culture-independent formatting of
   activity tag values, aligning with consistent data representation.
   ([#39470](https://github.com/Azure/azure-sdk-for-net/issues/39470))
+
+### Other Changes
+
+* Added NET6 target framework to support Trimming.
+  ([#38459](https://github.com/Azure/azure-sdk-for-net/pull/38459))
+* Added support for Trimming and AOT.
+  ([#38459](https://github.com/Azure/azure-sdk-for-net/pull/38459))
+
+## 1.0.0 (2023-09-20)
+
+### Bugs Fixed
+
+* Fixed an issue during network failures which prevented the exporter to store
+  the telemetry offline for retrying at a later time.
+  ([#38832](https://github.com/Azure/azure-sdk-for-net/pull/38832))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+## 1.1.0 (2023-12-05)
 
 ## 1.0.0 (2023-09-20)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.1.0 (2023-11-29)
 
+### Features Added
+
+* Added NET6 target framework to support Trimming.
+  ([#38459](https://github.com/Azure/azure-sdk-for-net/pull/38459))
+* Added support for Trimming and AOT.
+  ([#38459](https://github.com/Azure/azure-sdk-for-net/pull/38459))
+
 ### Bugs Fixed
 
 * Fixed an issue where `OriginalFormat` persisted in TraceTelemetry properties
@@ -35,13 +42,6 @@
   settings. The fix ensures uniform and culture-independent formatting of
   activity tag values, aligning with consistent data representation.
   ([#39470](https://github.com/Azure/azure-sdk-for-net/issues/39470))
-
-### Other Changes
-
-* Added NET6 target framework to support Trimming.
-  ([#38459](https://github.com/Azure/azure-sdk-for-net/pull/38459))
-* Added support for Trimming and AOT.
-  ([#38459](https://github.com/Azure/azure-sdk-for-net/pull/38459))
 
 ## 1.0.0 (2023-09-20)
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An OpenTelemetry .NET exporter that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry Exporter</AssemblyTitle>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.1.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">1.0.0</ApiCompatVersion>
     <PackageTags>Azure Monitor OpenTelemetry Exporter ApplicationInsights</PackageTags>


### PR DESCRIPTION
Preparing Azure Monitor Exporter for a 1.1.0 release. This includes support for AOT/Trimming.


- This is a follow up to #40350. Yesterday I also updated the Distro for 1.0.0 release. We want the Distro to take this latest version of the Exporter.
- This supersedes #39779. We abandoned the Exporter 1.1.0-beta1 release.
- This supersedes #40370. Sorry @vishweshbankwar, I was having merge conflicts and git wasn't cooperating. It was easier to create a new PR.