### PR TITLE
Drain excess credits when using sessions to ensure FIFO

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Adjusted retries to consider an unreachable host address as terminal.  Previously, all socket-based errors were considered transient and would be retried.
 - Updated the `ServiceBusMessage` constructor that takes a `ServiceBusReceivedMessage` to no longer copy over the 
   `x-opt-partition-id` key as this is meant to apply only to the original message.
+- Drain excess credits when attempting to receive using sessions to ensure FIFO ordering.
 
 ### Other Changes
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -364,17 +365,18 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         .ConfigureAwait(false);
                 }
 
-                // Rely on the fact that the underlying IEnumerable is actually a collection. If this changes, our
-                // tests will fail.
-                var messagesReceived = (IReadOnlyCollection<AmqpMessage>) await link.ReceiveMessagesAsync(
+                var messagesReceived = await link.ReceiveMessagesAsync(
                     maxMessages,
                     TimeSpan.FromMilliseconds(20),
                     maxWaitTime ?? timeout,
                     cancellationToken).ConfigureAwait(false);
 
+                IReadOnlyCollection<AmqpMessage> messageList =
+                    messagesReceived as IReadOnlyCollection<AmqpMessage> ?? messagesReceived.ToList();
+
                 // If this is a session receiver and we didn't receive all requested messages, we need to drain the credits
                 // to ensure FIFO ordering within each session.
-                if (_isSessionReceiver && messagesReceived.Count < maxMessages)
+                if (_isSessionReceiver && messageList.Count < maxMessages)
                 {
                     await link.DrainAsyc(cancellationToken).ConfigureAwait(false);
                 }
@@ -382,10 +384,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 List<ServiceBusReceivedMessage> receivedMessages = null;
                 // If event messages were received, then package them for consumption and
                 // return them.
-                foreach (AmqpMessage message in messagesReceived)
+                foreach (AmqpMessage message in messageList)
                 {
                     // Getting the count of the underlying collection is good for performance/allocations to prevent the list from growing
-                    receivedMessages ??= new List<ServiceBusReceivedMessage>(messagesReceived.Count);
+                    receivedMessages ??= new List<ServiceBusReceivedMessage>(messageList.Count);
 
                     if (_receiveMode == ServiceBusReceiveMode.ReceiveAndDelete)
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -364,11 +364,20 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         .ConfigureAwait(false);
                 }
 
-                var messagesReceived = await link.ReceiveMessagesAsync(
+                // Rely on the fact that the underlying IEnumerable is actually a collection. If this changes, our
+                // tests will fail.
+                var messagesReceived = (IReadOnlyCollection<AmqpMessage>) await link.ReceiveMessagesAsync(
                     maxMessages,
                     TimeSpan.FromMilliseconds(20),
                     maxWaitTime ?? timeout,
                     cancellationToken).ConfigureAwait(false);
+
+                // If this is a session receiver and we didn't receive all requested messages, we need to drain the credits
+                // to ensure FIFO ordering within each session.
+                if (_isSessionReceiver && messagesReceived.Count < maxMessages)
+                {
+                    await link.DrainAsyc(cancellationToken).ConfigureAwait(false);
+                }
 
                 List<ServiceBusReceivedMessage> receivedMessages = null;
                 // If event messages were received, then package them for consumption and
@@ -376,9 +385,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 foreach (AmqpMessage message in messagesReceived)
                 {
                     // Getting the count of the underlying collection is good for performance/allocations to prevent the list from growing
-                    receivedMessages ??= messagesReceived is IReadOnlyCollection<AmqpMessage> readOnlyList
-                        ? new List<ServiceBusReceivedMessage>(readOnlyList.Count)
-                        : new List<ServiceBusReceivedMessage>();
+                    receivedMessages ??= new List<ServiceBusReceivedMessage>(messagesReceived.Count);
 
                     if (_receiveMode == ServiceBusReceiveMode.ReceiveAndDelete)
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeActivitySourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeActivitySourceLiveTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         [TestCase(false)]
         public async Task SenderReceiverActivitiesDisabled(bool useSessions)
         {
-            using var listener = new TestActivitySourceListener(DiagnosticProperty.DiagnosticNamespace);
+            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
 
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: useSessions))
             {
@@ -72,7 +72,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 }
                 else
                 {
-                    await receiver.RenewMessageLockAsync(received[-1]);
+                    await receiver.RenewMessageLockAsync(received[1]);
                 }
 
                 // schedule
@@ -262,7 +262,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var messages = ServiceBusTestUtilities.GetMessages(messageCt);
 
             using var listener = new TestActivitySourceListener(
-                DiagnosticProperty.DiagnosticNamespace,
+                source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace),
                 activityStartedCallback: activity =>
                 {
                     if (activity.OperationName == DiagnosticProperty.ProcessMessageActivityName)
@@ -321,7 +321,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var messages = ServiceBusTestUtilities.GetMessages(messageCt, "sessionId");
 
             using var listener = new TestActivitySourceListener(
-                DiagnosticProperty.DiagnosticNamespace,
+                source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace),
                 activityStartedCallback: activity =>
                 {
                     if (activity.OperationName == DiagnosticProperty.ProcessSessionMessageActivityName)
@@ -374,7 +374,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         public async Task RuleManagerActivities()
         {
             using var _ = SetAppConfigSwitch();
-            using var listener = new TestActivitySourceListener(DiagnosticProperty.DiagnosticNamespace);
+            using var listener = new TestActivitySourceListener(source => source.Name.StartsWith(DiagnosticProperty.DiagnosticNamespace));
 
             await using (var scope = await ServiceBusScope.CreateWithTopic(enablePartitioning: false, enableSession: false))
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -1154,7 +1154,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var receiver = await client.AcceptSessionAsync(scope.QueueName, "session");
                 var sender = client.CreateSender(scope.QueueName);
 
-                long lastSequenceNumber = 0;
                 CancellationTokenSource cts = new CancellationTokenSource();
                 cts.CancelAfter(TimeSpan.FromSeconds(60));
 
@@ -1175,6 +1174,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 async Task ReceiveMessagesAsync()
                 {
+                    long lastSequenceNumber = 0;
                     while (!cts.IsCancellationRequested)
                     {
                         var messages = await receiver.ReceiveMessagesAsync(10);
@@ -1186,7 +1186,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                                     $"Last sequence number: {lastSequenceNumber}, current sequence number: {message.SequenceNumber}");
                             }
 
-                            Interlocked.Exchange(ref lastSequenceNumber, message.SequenceNumber);
+                            lastSequenceNumber = message.SequenceNumber;
 
                             await receiver.CompleteMessageAsync(message);
                         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -1144,5 +1144,55 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         .EqualTo(ServiceBusFailureReason.SessionLockLost));
             }
         }
+
+        [Test]
+        public async Task SessionOrderingIsGuaranteed()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                var receiver = await client.AcceptSessionAsync(scope.QueueName, "session");
+                var sender = client.CreateSender(scope.QueueName);
+
+                long lastSequenceNumber = 0;
+                CancellationTokenSource cts = new CancellationTokenSource();
+                cts.CancelAfter(TimeSpan.FromSeconds(60));
+
+                var receive= ReceiveMessagesAsync();
+
+                var send = SendMessagesAsync();
+
+                await Task.WhenAll(send, receive);
+
+                async Task SendMessagesAsync()
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("session"));
+                        await Task.Delay(TimeSpan.FromMilliseconds(100));
+                    }
+                }
+
+                async Task ReceiveMessagesAsync()
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        var messages = await receiver.ReceiveMessagesAsync(10);
+                        foreach (var message in messages)
+                        {
+                            if (message.SequenceNumber != lastSequenceNumber + 1)
+                            {
+                                Assert.Fail(
+                                    $"Last sequence number: {lastSequenceNumber}, current sequence number: {message.SequenceNumber}");
+                            }
+
+                            Interlocked.Exchange(ref lastSequenceNumber, message.SequenceNumber);
+
+                            await receiver.CompleteMessageAsync(message);
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -1157,7 +1157,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 CancellationTokenSource cts = new CancellationTokenSource();
                 cts.CancelAfter(TimeSpan.FromSeconds(60));
 
-                var receive= ReceiveMessagesAsync();
+                var receive = ReceiveMessagesAsync();
 
                 var send = SendMessagesAsync();
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/35846

Considered using an optional parameter, but FIFO ordering is a core guarantee of using sessions so this really should be treated as a bug that should be fixed. 