### PR TITLE
[Storage] [DataMovement] Removed unused option parameters in ShareFileStorageResourceOptions

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.net6.0.cs
@@ -29,14 +29,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
     public partial class ShareFileStorageResourceOptions
     {
         public ShareFileStorageResourceOptions() { }
-        public bool? Archive { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions DestinationConditions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> DirectoryMetadata { get { throw null; } set { } }
         public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public string FilePermissions { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public Azure.Storage.Files.Shares.Models.ShareProtocols? Protocols { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.FileSmbProperties SmbProperties { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
         public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/api/Azure.Storage.DataMovement.Files.Shares.netstandard2.0.cs
@@ -29,14 +29,12 @@ namespace Azure.Storage.DataMovement.Files.Shares
     public partial class ShareFileStorageResourceOptions
     {
         public ShareFileStorageResourceOptions() { }
-        public bool? Archive { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions DestinationConditions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> DirectoryMetadata { get { throw null; } set { } }
         public Azure.Storage.DownloadTransferValidationOptions DownloadTransferValidationOptions { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> FileMetadata { get { throw null; } set { } }
         public string FilePermissions { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileHttpHeaders HttpHeaders { get { throw null; } set { } }
-        public Azure.Storage.Files.Shares.Models.ShareProtocols? Protocols { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.FileSmbProperties SmbProperties { get { throw null; } set { } }
         public Azure.Storage.Files.Shares.Models.ShareFileRequestConditions SourceConditions { get { throw null; } set { } }
         public Azure.Storage.UploadTransferValidationOptions UploadTransferValidationOptions { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/src/ShareFileStorageResourceOptions.cs
@@ -48,15 +48,6 @@ namespace Azure.Storage.DataMovement.Files.Shares
         public ShareFileRequestConditions DestinationConditions { get; set; }
 
         /// <summary>
-        /// Optional boolean Specifying to set archive attribute on a target file. True
-        /// means archive attribute will be set on a target file despite attribute
-        /// overrides or a source file state.
-        ///
-        /// Only valid on Service Copy on the destination.
-        /// </summary>
-        public bool? Archive { get; set; }
-
-        /// <summary>
         /// Optional. Defines custom metadata to set on the destination resource.
         ///
         /// Applies to upload and copy transfers.
@@ -73,11 +64,6 @@ namespace Azure.Storage.DataMovement.Files.Shares
 #pragma warning disable CA2227 // Collection properties should be readonly
         public Metadata FileMetadata { get; set; }
 #pragma warning restore CA2227 // Collection properties should be readonly
-
-        /// <summary>
-        /// The protocols to enable for the share.
-        /// </summary>
-        public ShareProtocols? Protocols { get; set; }
 
         /// <summary>
         /// Optional. Options for transfer validation settings on this operation.


### PR DESCRIPTION
- Removed unnecessary Share File Storage Resource Option bag members that weren't being used / can't be applied
- No need to update Changelog since this hasn't released yet