### PR TITLE
Potential flakey test fix

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TestEventsRaised.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/TestEventsRaised.cs
@@ -152,11 +152,12 @@ namespace Azure.Storage.DataMovement.Tests
         /// </summary>
         public async Task AssertSingleCompletedCheck()
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             AssertUnexpectedFailureCheck();
             Assert.IsEmpty(SkippedEvents);
             Assert.IsEmpty(SingleCompletedEvents);
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,
@@ -171,13 +172,14 @@ namespace Azure.Storage.DataMovement.Tests
         /// </summary>
         public async Task AssertSingleSkippedCheck()
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             AssertUnexpectedFailureCheck();
             Assert.IsEmpty(SingleCompletedEvents);
             Assert.AreEqual(1, SkippedEvents.Count);
             Assert.NotNull(SkippedEvents.First().SourceResource.Uri);
             Assert.NotNull(SkippedEvents.First().DestinationResource.Uri);
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,
@@ -192,6 +194,8 @@ namespace Azure.Storage.DataMovement.Tests
         /// </summary>
         public async Task AssertSingleFailedCheck(int failureCount)
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             Assert.IsEmpty(SkippedEvents);
             Assert.IsEmpty(SingleCompletedEvents);
             Assert.AreEqual(failureCount, FailedEvents.Count);
@@ -202,7 +206,6 @@ namespace Azure.Storage.DataMovement.Tests
                 Assert.NotNull(args.DestinationResource.Uri);
             }
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,
@@ -222,11 +225,12 @@ namespace Azure.Storage.DataMovement.Tests
         /// </param>
         public async Task AssertContainerCompletedCheck(int transferCount)
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             AssertUnexpectedFailureCheck();
             Assert.IsEmpty(SkippedEvents);
             Assert.AreEqual(transferCount, SingleCompletedEvents.Count);
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,
@@ -244,6 +248,8 @@ namespace Azure.Storage.DataMovement.Tests
         /// </param>
         public async Task AssertContainerCompletedWithFailedCheck(int expectedFailureCount)
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             if (expectedFailureCount != FailedEvents.Count)
             {
                 // We want to call this to print out to see
@@ -256,7 +262,6 @@ namespace Azure.Storage.DataMovement.Tests
             }
             Assert.IsEmpty(SkippedEvents);
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,
@@ -276,6 +281,8 @@ namespace Azure.Storage.DataMovement.Tests
         /// </param>
         public async Task AssertContainerCompletedWithFailedCheckContinue(int expectedFailureCount)
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             if (expectedFailureCount != FailedEvents.Count)
             {
                 // We want to call this to print out to see
@@ -288,7 +295,6 @@ namespace Azure.Storage.DataMovement.Tests
             }
             Assert.IsEmpty(SkippedEvents);
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,
@@ -306,10 +312,11 @@ namespace Azure.Storage.DataMovement.Tests
         /// </param>
         public async Task AssertContainerCompletedWithSkippedCheck(int expectedSkipCount)
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             AssertUnexpectedFailureCheck();
             Assert.AreEqual(expectedSkipCount, SkippedEvents.Count);
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,
@@ -320,10 +327,11 @@ namespace Azure.Storage.DataMovement.Tests
 
         public async Task AssertPausedCheck()
         {
+            await WaitForStatusEventsAsync().ConfigureAwait(false);
+
             AssertUnexpectedFailureCheck();
             Assert.IsEmpty(SkippedEvents);
 
-            await WaitForStatusEventsAsync().ConfigureAwait(false);
             AssertTransferStatusCollection(
                 new DataTransferStatus[] {
                     InProgressStatus,


### PR DESCRIPTION
Currently assertions for data transfer events have a delay baked in before some checks but not others. Bumping this delay to be before all checks for consistency.