### PR TITLE
[Messaging] AMQP transport updates

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -106,7 +106,7 @@
     <PackageReference Update="Azure.ResourceManager" Version="1.9.0" />
 
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.3" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.6.4" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.2.0" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.56.0" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.56.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Other Changes
 
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.4, which enables support for TLS 1.3.
+
+- Removed the custom sizes for the AMQP sending and receiving buffers, allowing the optimized defaults of the host platform to be used.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  Windows performance remains unchanged as the default and custom buffer sizes are equivalent.
+
 ## 5.10.0 (2023-11-08)
 
 ### Breaking Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Other Changes
 
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.4, which enables support for TLS 1.3.
+
+- Removed the custom sizes for the AMQP sending and receiving buffers, allowing the optimized defaults of the host platform to be used.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  Windows performance remains unchanged as the default and custom buffer sizes are equivalent.
+
 ## 5.10.0 (2023-11-07)
 
 ### Breaking Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
@@ -61,27 +61,31 @@ namespace Azure.Messaging.EventHubs
         ///   The size of the buffer used for sending information via the active transport.
         /// </summary>
         ///
-        /// <value>The size of the buffer, in bytes.  The default size is 8,192 bytes.</value>
+        /// <value>The size of the buffer, in bytes.  The default value is -1, which instructs the transport to use the host's default buffer size.</value>
         ///
         /// <remarks>
         ///   This value is used to configure the <see cref="Socket.SendBufferSize" /> used by
-        ///   the active transport.
+        ///   the active transport.  It is recommended that the host's default buffer size be used
+        ///   unless there is a specific application scenario that requires it to be adjusted and
+        ///   the new value has been tested thoroughly.
         /// </remarks>
         ///
-        public int SendBufferSizeInBytes { get; set; } = 8192;
+        public int SendBufferSizeInBytes { get; set; } = -1;
 
         /// <summary>
         ///   The size of the buffer used for receiving information via the active transport.
         /// </summary>
         ///
-        /// <value>The size of the buffer, in bytes.  The default size is 8,192 bytes.</value>
+        /// <value>The size of the buffer, in bytes.  The default value is -1, which instructs the transport to use the host's default buffer size.</value>
         ///
         /// <remarks>
         ///   This value is used to configure the <see cref="Socket.ReceiveBufferSize" /> used by
-        ///   the active transport.
+        ///   the active transport.  It is recommended that the host's default buffer size be used
+        ///   unless there is a specific application scenario that requires it to be adjusted and
+        ///   the new value has been tested thoroughly.
         /// </remarks>
         ///
-        public int ReceiveBufferSizeInBytes { get; set; } = 8192;
+        public int ReceiveBufferSizeInBytes { get; set; } = -1;
 
         /// <summary>
         ///   The proxy to use for communication over web sockets.

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated the `Azure.Messaging.EventHubs` dependency, which includes optimized defaults of the host platform to be used for AMQP buffers.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  This update also enables support for TLS 1.3.
+
 ## 6.0.2 (2023-11-13)
 
 ### Other Changes

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -9,10 +9,15 @@
 ### Bugs Fixed
 
 - Adjusted retries to consider an unreachable host address as terminal.  Previously, all socket-based errors were considered transient and would be retried.
+
 - Updated the `ServiceBusMessage` constructor that takes a `ServiceBusReceivedMessage` to no longer copy over the 
   `x-opt-partition-id` key as this is meant to apply only to the original message.
 
 ### Other Changes
+
+- Updated the `Microsoft.Azure.Amqp` dependency to 2.6.4, which enables support for TLS 1.3.
+
+- Removed the custom sizes for the AMQP sending and receiving buffers, allowing the optimized defaults of the host platform to be used.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  Windows performance remains unchanged as the default and custom buffer sizes are equivalent.
 
 ## 7.17.0 (2023-11-14)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -1320,12 +1320,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string hostName,
             int port)
         {
+            // Allow the host to control the size of the transport buffers for sending and
+            // receiving by setting the value to -1.  This results in much improved throughput
+            // across platforms, as different Linux distros have different needs to
+            // maximize efficiency, with Window having its own needs as well.
             var tcpSettings = new TcpTransportSettings
             {
                 Host = hostName,
                 Port = port < 0 ? AmqpConstants.DefaultSecurePort : port,
-                ReceiveBufferSize = AmqpConstants.TransportBufferSize,
-                SendBufferSize = AmqpConstants.TransportBufferSize
+                ReceiveBufferSize = -1,
+                SendBufferSize = -1
             };
 
             return new TlsTransportSettings(tcpSettings)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -207,11 +207,13 @@ namespace Azure.Messaging.ServiceBus
         ///   an exception will be triggered and the send will fail. In order to ensure that the messages
         ///   being sent will fit in a batch, use <see cref="SendMessagesAsync(ServiceBusMessageBatch, CancellationToken)"/> instead.
         /// </summary>
-        ///
         /// <param name="messages">The set of messages to send.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <remarks>
+        ///   When sending, the result is atomic; either all messages that belong to the set were successful or all
+        ///   have failed.  Partial success is not possible.
+        /// </remarks>
         /// <exception cref="ServiceBusException">
         ///   The set of messages exceeds the maximum size allowed in a single batch, as determined by the Service Bus service.
         ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded"/> in this case.
@@ -363,10 +365,13 @@ namespace Azure.Messaging.ServiceBus
         ///   containing a set of <see cref="ServiceBusMessage"/> to
         ///   the associated Service Bus entity.
         /// </summary>
-        ///
         /// <param name="messageBatch">The batch of messages to send. A batch may be created using <see cref="CreateMessageBatchAsync(CancellationToken)" />.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <remarks>
+        ///   When sending, the result is atomic; either all messages that belong to the batch were successful or all
+        ///   have failed.  Partial success is not possible.
+        /// </remarks>
         ///
         public virtual async Task SendMessagesAsync(
             ServiceBusMessageBatch messageBatch,
@@ -458,7 +463,10 @@ namespace Azure.Messaging.ServiceBus
         /// Messages can also be scheduled by setting <see cref="ServiceBusMessage.ScheduledEnqueueTime"/> and
         /// using <see cref="SendMessageAsync(ServiceBusMessage, CancellationToken)"/>,
         /// <see cref="SendMessagesAsync(IEnumerable{ServiceBusMessage}, CancellationToken)"/>, or
-        /// <see cref="SendMessagesAsync(ServiceBusMessageBatch, CancellationToken)"/>.</remarks>
+        /// <see cref="SendMessagesAsync(ServiceBusMessageBatch, CancellationToken)"/>.
+        ///
+        /// When scheduling, the result is atomic; either all messages that belong to the set were successful or all
+        /// have failed.  Partial success is not possible.</remarks>
         ///
         /// <returns>The sequence number of the message that was scheduled.</returns>
         ///

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated the `Azure.Messaging.ServiceBus` dependency, which includes optimized defaults of the host platform to be used for AMQP buffers.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  This update also enables support for TLS 1.3.
+
 ## 5.13.4 (2023-11-09)
 
 ### Other Changes


### PR DESCRIPTION
# Summary

The focus of these changes is to update the AMQP transport to unlock support for TLS v1.3 and allow the host to set defaults for send/receive buffer sizes.  Also included are some minor updates to the Service Bus sender docs to clarify whether or not partial success is possible.

## References and Related

- [Atomicity of sending a message batch to a queue (#40409)](https://github.com/Azure/azure-sdk-for-net/issues/40409)