### PR TITLE
Add CODEOWNERS linter baseline error file

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,0 +1,297 @@
+khmic5 is not a public member of Azure.
+schaabs is not a public member of Azure.
+lirenhe is not a public member of Azure.
+adamedx is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Azure/aks-pm is an invalid team. Ensure the team exists and has write permissions.
+liadtal is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yairgil is not a public member of Azure.
+shenmuxiaosen is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Application Insights' is not a valid label for this repository.
+azmonapplicationinsights is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+armleads-azure is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+mjudeikis is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+julienstroheker is not a public member of Azure.
+amanohar is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+mojayara is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Prasanna-Padmanabhan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+athipp is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+taiwu is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+minghan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+miaojiang is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+antcp is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+AzureAppServiceCLI is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+anilba06 is not a public member of Azure.
+darshanhs90 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+AshishGargMicrosoft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jaspkaur28 is not a public member of Azure.
+omairabdullah is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+divka78 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+amitchat is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+aishu is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ilayrn is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+orhasban is not a public member of Azure.
+zoharHenMicrosoft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sagivf is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Aviv-Yaniv is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sijuman is not a public member of Azure.
+sarathys is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+rakku-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Azure.Spring - Cosmos' is not a valid label for this repository.
+rpsqrd is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+edyoung is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dpwatrous is not a public member of Azure.
+shilpigautam is not a public member of Azure.
+anand-rengasamy is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+alex-frankel is not a public member of Azure.
+filizt is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sgellock is not a public member of Azure.
+maertendMSFT is not a public member of Azure.
+wangyuantao is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+bowgong is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+areddish is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+tburns10 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ryogok is not a public member of Azure.
+TFR258 is not a public member of Azure.
+toothache is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+JinyuID is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dipidoo is not a public member of Azure.
+SteveMSFT is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+msyache is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+longli0 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ShaoAnLin is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+lulululululu is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ctstone is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vkurpad is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+conhua is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+mengaims is not a public member of Azure.
+juaduan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+moreOver0 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+gils-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Cognitive - Health Insights Cancer Profiling' is not a valid label for this repository.
+'Cognitive - Health Insights Clinical Matching' is not a valid label for this repository.
+bingisbestest is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+nerajput1607 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+assafi is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+swmachan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+cpoulain is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+robch is not a public member of Azure.
+cahann is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+kayousef is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+swiftarrow11 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dwaijam is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+metanMSFT is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+olduroja is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jaggerbodas-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+arwong is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ms-premp is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+acsdevx-msft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Azure/acs-identity-sdk is an invalid team. Ensure the team exists and has write permissions.
+ajpeacock0 is not a public member of Azure.
+miguhern is not a public member of Azure.
+RoyHerrod is not a public member of Azure.
+danielav7 is not a public member of Azure.
+guilhermeluizsp is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+DimaKolomiiets is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+phermanov-msft is not a public member of Azure.
+ilyapaliakou-msft is not a public member of Azure.
+alexokun is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Mrayyan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+shwali-msft is not a public member of Azure.
+allchiang-msft is not a public member of Azure.
+mikehang-msft is not a public member of Azure.
+TravisCragg-MSFT is not a public member of Azure.
+nikhilpatel909 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sandeepraichura is not a public member of Azure.
+hilaryw29 is not a public member of Azure.
+MsGabsta is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ushnaarshadkhan is not a public member of Azure.
+bilaakpan-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dkulkarni-ms is not a public member of Azure.
+haagha is not a public member of Azure.
+MS-syh2qs is not a public member of Azure.
+grizzlytheodore is not a public member of Azure.
+'Consumption' is not a valid label for this repository.
+ccmbpxpcrew is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ccmaxpcrew is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ccmixpdevs is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ccmshowbackdevs is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+TiagoCrewGitHubIssues is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+akashkeshari is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dkkapur is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+toddysm is not a public member of Azure.
+yugangw-MSFT is not a public member of Azure.
+qike-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jwilder is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+thomas1206 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+seanmck is not a public member of Azure.
+pjohari-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+MehaKaushik is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+shurd is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+anfeldma-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+zfoster is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Cost Management' is not a valid label for this repository.
+manoharp is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+MSEvanhi is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+shefymk is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+adriankjohnson is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yagupta is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+tmvishwajit is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+matdickson is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+manuaery is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+madhurinms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+anilman is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+a-t-mason is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ganzee is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+shawnxzq is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+lmy269 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sumantmehtams is not a public member of Azure.
+idear1203 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+rgreenMSFT is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+raedJarrar is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jifems is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yuzorMa is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+johnsta is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+greenie-msft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Tanmayeekamath is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+narula0781 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ashishonce is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+romil07 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Device Provisioning Service' is not a valid label for this repository.
+nberdy is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Device Update for IoT Hub' is not a valid label for this repository.
+dpokluda is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sedols is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+efriesner is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Aashish93-stack is not a public member of Azure.
+Satya-Kolluri is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Azure/azure-iot-cli-triage is an invalid team. Ensure the team exists and has write permissions.
+'IoT Models Repository' is not a valid label for this repository.
+brycewang-microsoft is not a public member of Azure.
+andyk-ms is not a public member of Azure.
+tmahmood-microsoft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yeskarthik is not a public member of Azure.
+rasidhan is not a public member of Azure.
+dmdenmsft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Kishp01 is not a public member of Azure.
+ahamad-MS is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+kasun04 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+saglodha is not a public member of Azure.
+ahmedelnably is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dkershaw10 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+baywet is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+mgreenegit is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vivlingaiah is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+deshriva is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+romahamu is not a public member of Azure.
+omzevall is not a public member of Azure.
+ethanann-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vighatke is not a public member of Azure.
+'IotHub' is not a valid label for this repository.
+'IotCentral' is not a valid label for this repository.
+iluican is not a public member of Azure.
+'IotDPS' is not a valid label for this repository.
+chieftn is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+RandalliLama is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jlichwa is not a public member of Azure.
+NarayanThiru is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+abranj1219 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ninallam is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Azure/azure-logicapps-team is an invalid team. Ensure the team exists and has write permissions.
+minamnmik is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+varunkch is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+azureml-github is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+aashishb is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Managed Services' is not a valid label for this repository.
+Lighthouse-Azure is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ajlam is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ambhatna is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+kummanish is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+prbansa is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+akucer is not a public member of Azure.
+naiteeks is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+bennage is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+giakas is not a public member of Azure.
+shijojoy is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+kpiteira is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+SameergMS is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dadunl is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+AzMonEssential is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+AzmonAlerts is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+AzmonActionG is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+AzmonLogA is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+omziv is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+anatse is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+raronen is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ischrei is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+danhadari is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+cijothomas is not a public member of Azure.
+rajkumar-rangaraj is not a public member of Azure.
+TimothyMothra is not a public member of Azure.
+crtreasu is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+rgarcia is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+aznetsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+appgwsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+bastionsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+cdnfdsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ddossuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+exrsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+fwsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vnetsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+slbsupportgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+netwatchsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dnssuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+nvasuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vwansuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vpngwsuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+privlinksuppgithub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+tjsomasundaram is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+trrwilson is not a public member of Azure.
+'Monitor - Operational Insights' is not a valid label for this repository.
+aperezcloud is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+kenieva is not a public member of Azure.
+sunilagarwal is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+lfittl-msft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sr-msft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+niklarin is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+xfield is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Daya-Patil is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Sharmistha-Rai is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yegu-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+corquiri is not a public member of Azure.
+chiragg4u is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+stephbaron is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+derek1ee is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+chlahav is not a public member of Azure.
+amirkeren is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+bleroy is not a public member of Azure.
+tjacobhi is not a public member of Azure.
+shankarsama is not a public member of Azure.
+DorothySun216 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+EldertGrootenboer is not a public member of Azure.
+QingChenmsft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vaishnavk is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+juhacket is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sffamily is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+chenkennt is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+azureSQLGitHub is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+xgithubtriage is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+anoobbacker is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+patelkunal is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+atpham256 is not a public member of Azure.
+anuragdalmia is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+shahbj79 is not a public member of Azure.
+aygoya is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ganganarayanan is not a public member of Azure.
+yanjungao718 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sakash279, is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sivethe, is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ThomasWeiss, is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+PaulCheng is not a public member of Azure.
+Shipra1Mishra is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'vFXT' is not a valid label for this repository.
+zhusijia26 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+JialinXin is not a public member of Azure.
+orenmichaely is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+tyclintw is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Cognitive - Content Safety' is not a valid label for this repository.
+JieZhou000 is not a public member of Azure.


### PR DESCRIPTION
CODEOWNERS is now going to be linted. _This PR contains the existing linter errors, deduped, which are used to filter results, otherwise this pipeline couldn't be run on PRs that contain CODEOWNERS changes without the several hundred issues being fixed, which is not ideal._ The linter will run daily and on every change to CODEOWNERS or the baseline file. Specific details of the linting can be found [here](https://github.com/Azure/azure-sdk-tools/tree/main/tools/codeowners-utils#linting) but here is what's being verified in a nutshell.

- Metadata tags - PRLabels, ServiceLabels, ServiceOwners (previously /&lt;NotInRepo&gt;/, both are still valid for the moment) and AzureSdkOwners (new, used for issue triage). 
- Source paths - Does the path exist? If the path is a glob, is it valid and does it have matches in the repository? 
- Owners - There are several verifications for owners:
    - Does the owner, individual or team, have write access (every team/individual in a CODEOWNERS file needs to have write access, this is a GitHub thing).
    - Is the owner public? Individuals need to set their Azure membership to public. This is explicitly mentioned in the [onboarding documents](https://eng.ms/docs/products/azure-developer-experience/onboard/access) for azure-sdk repositories.