### PR TITLE
Add ctor in CallerShouldAuditAttribute class

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/CallerShouldAuditAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/CallerShouldAuditAttribute.cs
@@ -19,6 +19,23 @@ namespace Azure.Core
     internal class CallerShouldAuditAttribute : Attribute
     {
         /// <summary>
+        /// Creates a new instance of <see cref="CallerShouldAuditAttribute"/>.
+        /// </summary>
+        public CallerShouldAuditAttribute()
+            : this(reason: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="CallerShouldAuditAttribute"/>.
+        /// </summary>
+        /// <param name="reason"> Sets a description or link to the rationale for potentially auditing this operation </param>
+        public CallerShouldAuditAttribute(string? reason)
+        {
+            Reason = reason;
+        }
+
+        /// <summary>
         /// Gets or sets a description or link to the rationale for potentially
         /// auditing this operation.
         /// </summary>

--- a/sdk/core/Azure.Core/src/Shared/CallerShouldAuditAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/CallerShouldAuditAttribute.cs
@@ -29,7 +29,7 @@ namespace Azure.Core
         /// <summary>
         /// Creates a new instance of <see cref="CallerShouldAuditAttribute"/>.
         /// </summary>
-        /// <param name="reason"> Sets a description or link to the rationale for potentially auditing this operation </param>
+        /// <param name="reason"> Sets a description or link to the rationale for potentially auditing this operation. </param>
         public CallerShouldAuditAttribute(string? reason)
         {
             Reason = reason;


### PR DESCRIPTION
Add constructors into the CallerShouldAuditAttribute class so that we can use them directly when generating management plain SDK code like [CallerShouldAudit("some url with detail info")]. 

Generating attribute code using properties like [CallerShouldAudit(Reason = "...")] hasn't been supported in the mgmt plain codegen now and it will be much higher cost to change mgmt plain codegen to add that support.

Thanks.
