### PR TITLE
Remove live testing on China cloud

### DIFF
--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -10,7 +10,7 @@ extends:
     # TODO: change 'Preview' cloud back to public after search RP fixes deletion metadata issue
     # https://github.com/Azure/azure-sdk-tools/issues/2216
     Clouds: 'Preview'
-    SupportedClouds: 'Preview,UsGov,China'
+    SupportedClouds: 'Preview,UsGov'
     CloudConfig:
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)


### PR DESCRIPTION
Always times out in `net - search - tests-weekly`, and we want to reduce
the amount of live testing we do across SDKs anyway.
