### PR TITLE
Split pipelines

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
@@ -11,7 +11,6 @@ trigger:
     - sdk/servicebus/ci.yml
     - sdk/servicebus/service.projects
     - sdk/servicebus/Azure.Messaging.ServiceBus
-    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
 
 pr:
   branches:
@@ -25,7 +24,6 @@ pr:
     - sdk/servicebus/ci.yml
     - sdk/servicebus/service.projects
     - sdk/servicebus/Azure.Messaging.ServiceBus
-    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -37,5 +35,3 @@ extends:
     Artifacts:
     - name: Azure.Messaging.ServiceBus
       safeName: AzureMessagingServiceBus
-    - name: Microsoft.Azure.WebJobs.Extensions.ServiceBus
-      safeName: MicrosoftAzureWebJobsExtensionsServiceBus

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
@@ -8,9 +8,9 @@ trigger:
     - release/*
   paths:
     include:
-    - sdk/servicebus/ci.yml
     - sdk/servicebus/service.projects
     - sdk/servicebus/Azure.Messaging.ServiceBus
+    - sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
 
 pr:
   branches:
@@ -21,9 +21,9 @@ pr:
     - release/*
   paths:
     include:
-    - sdk/servicebus/ci.yml
     - sdk/servicebus/service.projects
     - sdk/servicebus/Azure.Messaging.ServiceBus
+    - sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests.yml
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests.yml
@@ -1,0 +1,11 @@
+trigger: none
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    MaxParallel: 4
+    ServiceDirectory: servicebus
+    Project: Azure.Messaging.ServiceBus
+    TimeoutInMinutes: 240
+    Clouds: 'Public,Canary'
+    SupportedClouds: 'Public,UsGov,China,Canary'

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests.yml
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 extends:
-  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     MaxParallel: 4
     ServiceDirectory: servicebus

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
@@ -1,0 +1,37 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+
+trigger:
+  branches:
+    include:
+    - main
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/servicebus/ci.yml
+    - sdk/servicebus/service.projects
+    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
+
+pr:
+  branches:
+    include:
+    - main
+    - feature/*
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/servicebus/ci.yml
+    - sdk/servicebus/service.projects
+    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
+
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    SDKType: client
+    ServiceDirectory: servicebus
+    BuildSnippets: false
+    ArtifactName: packages
+    Artifacts:
+    - name: Microsoft.Azure.WebJobs.Extensions.ServiceBus
+      safeName: MicrosoftAzureWebJobsExtensionsServiceBus

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
@@ -8,9 +8,9 @@ trigger:
     - release/*
   paths:
     include:
-    - sdk/servicebus/ci.yml
     - sdk/servicebus/service.projects
     - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
+    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
 
 pr:
   branches:
@@ -21,9 +21,9 @@ pr:
     - release/*
   paths:
     include:
-    - sdk/servicebus/ci.yml
     - sdk/servicebus/service.projects
     - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
+    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests.yml
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests.yml
@@ -5,7 +5,7 @@ extends:
   parameters:
     MaxParallel: 4
     ServiceDirectory: servicebus
-    SDKType: client
+    Project: Microsoft.Azure.WebJobs.Extensions.ServiceBus
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
     SupportedClouds: 'Public,UsGov,China,Canary'

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests.yml
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 extends:
-  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     MaxParallel: 4
     ServiceDirectory: servicebus


### PR DESCRIPTION
The goal of this PR is to validate the approach needed to split the function extensions and client library pipelines into separate pipelines to help facilitate easier releases/testing/maintenance of these separate packages.

Once this merges and we verify there are no issues I will do a follow up PR for the other relevant pipelines from https://github.com/Azure/azure-sdk-for-net/issues/38271