### PR TITLE
[Event Hubs] Processor fixes

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bugs Fixed
 
+- Fixed a race condition that could lead to a synchronization primitive being double-released if `IsRunning` was called concurrently while starting or stopping the processor.
+
+- Fixed an issue with event processor validation where a exception for quota exceeded may inappropriately be surfaced when starting the processor.
+
 ### Other Changes
 
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.4, which enables support for TLS 1.3.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed a race condition that could lead to a synchronization primitive being double-released if `IsRunning` was called concurrently while starting or stopping the processor.
 
-- Fixed an issue with event processor validation where a exception for quota exceeded may inappropriately be surfaced when starting the processor.
+- Fixed an issue with event processor validation where an exception for quota exceeded may inappropriately be surfaced when starting the processor.
 
 ### Other Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed a race condition that could lead to a synchronization primitive being double-released if `IsRunning` was called concurrently while starting or stopping an event processor.
 
-- Fixed an issue with event processor validation where a exception for quota exceeded may inappropriately be surfaced when starting the processor.
+- Fixed an issue with event processor validation where an exception for quota exceeded may inappropriately be surfaced when starting the processor.
 
 ### Other Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Adjusted retries to consider an unreachable host address as terminal.  Previously, all socket-based errors were considered transient and would be retried.
 
+- Fixed a race condition that could lead to a synchronization primitive being double-released if `IsRunning` was called concurrently while starting or stopping an event processor.
+
+- Fixed an issue with event processor validation where a exception for quota exceeded may inappropriately be surfaced when starting the processor.
+
 ### Other Changes
 
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.4, which enables support for TLS 1.3.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -761,8 +761,6 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if ((!IsPublishing) || (_producerManagementTask?.IsCompleted ?? false))
                 {
-                    var releaseGuard = false;
-
                     try
                     {
                         if (!_stateGuard.Wait(0, cancellationToken))
@@ -770,7 +768,6 @@ namespace Azure.Messaging.EventHubs.Producer
                             await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
                         }
 
-                        releaseGuard = true;
                         Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
                         // StartPublishingAsync will verify that publishing is not already taking
@@ -781,7 +778,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     }
                     finally
                     {
-                        if (releaseGuard)
+                        if (_stateGuard.CurrentCount == 0)
                         {
                             _stateGuard.Release();
                         }
@@ -923,8 +920,6 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if ((!IsPublishing) || (_producerManagementTask?.IsCompleted ?? false))
                 {
-                    var releaseGuard = false;
-
                     try
                     {
                         if (!_stateGuard.Wait(0, cancellationToken))
@@ -932,7 +927,6 @@ namespace Azure.Messaging.EventHubs.Producer
                             await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
                         }
 
-                        releaseGuard = true;
                         Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
                         // StartPublishingAsync will verify that publishing is not already taking
@@ -943,7 +937,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     }
                     finally
                     {
-                        if (releaseGuard)
+                        if (_stateGuard.CurrentCount == 0)
                         {
                             _stateGuard.Release();
                         }
@@ -1035,14 +1029,10 @@ namespace Azure.Messaging.EventHubs.Producer
         {
             Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
-            var releaseGuard = false;
-
             if (!_stateGuard.Wait(0, cancellationToken))
             {
                 await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
-
-            releaseGuard = true;
 
             try
             {
@@ -1055,7 +1045,7 @@ namespace Azure.Messaging.EventHubs.Producer
             }
             finally
             {
-                if (releaseGuard)
+                if (_stateGuard.CurrentCount == 0)
                 {
                     _stateGuard.Release();
                 }
@@ -1083,7 +1073,6 @@ namespace Azure.Messaging.EventHubs.Producer
                 return;
             }
 
-            var releaseGuard = false;
             var capturedExceptions = default(List<Exception>);
 
             try
@@ -1094,8 +1083,6 @@ namespace Azure.Messaging.EventHubs.Producer
                 }
 
                 // If we've reached this point without an exception, the guard is held.
-
-                releaseGuard = true;
 
                 if (_isClosed)
                 {
@@ -1195,7 +1182,7 @@ namespace Azure.Messaging.EventHubs.Producer
             }
             finally
             {
-                if (releaseGuard)
+                if (_stateGuard.CurrentCount == 0)
                 {
                     _stateGuard.Release();
                 }


### PR DESCRIPTION
# Summary

The focus of these changes is to address a race condition where calling `IsRunning` concurrently with starting/stopping the processor could cause a semaphore to be double-released.  As part of this fix, the approach used to detect when a semaphore should be released has been changed to consider the semaphore count rather than using a sentinel variable.

Also fixed was an issue where the processor would leak a quota exceeded exception during startup validation if there were more than 4 other processors starting concurrently.  The partition chosen for validation is now randomized and a quota exceeded response is now considered a successful validation.

## References and Related

- [[Event Hubs] Adjust processor startup validation (#38144)](https://github.com/Azure/azure-sdk-for-net/issues/38144)