### PR TITLE
[Storage][DataMovement] Prevent `ChannelClosedException` during job part failures

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed a bug where `ChannelClosedException` could occur and be sent as an event to `ItemTransferFailed` when there was a failure during a transfer.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/CommitChunkHandler.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/CommitChunkHandler.cs
@@ -127,7 +127,7 @@ namespace Azure.Storage.DataMovement
                 if (args.Success)
                 {
                     // Let's add to the channel, and our notifier will handle the chunks.
-                    await _stageChunkChannel.Writer.WriteAsync(args, _cancellationToken).ConfigureAwait(false);
+                    _stageChunkChannel.Writer.TryWrite(args);
                 }
                 else
                 {

--- a/sdk/storage/Azure.Storage.DataMovement/src/DownloadChunkHandler.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DownloadChunkHandler.cs
@@ -171,7 +171,7 @@ namespace Azure.Storage.DataMovement
             {
                 if (args.Success)
                 {
-                    await _downloadRangeChannel.Writer.WriteAsync(args, _cancellationToken).ConfigureAwait(false);
+                    _downloadRangeChannel.Writer.TryWrite(args);
                 }
                 else
                 {


### PR DESCRIPTION
There are some race conditions when a job part is being disposed after a chunk failure that can cause some `ChannelClosedException`s to occur. These exceptions would then be forwarded to the customer's error event handler. This is because there is still a thread attempting to write to the chunk channel after it has been completed (disposed). This change switches writing to the channel to use `TryWrite` instead of `WriteAsync` which internally will check if the channel is closed before writing, preventing the exceptions from occurring.