### PR TITLE
Update ConfidentialLedgerClient to pass VerifyConnection flag

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -6,16 +6,6 @@
 
 - Added `VerifyConnection` property to `ConfidentialLedgerClientOptions` to allow the option to have a client connection without validating the service certificate.
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.2.0 (2023-09-12)
 
 ### Bugs Fixed

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.3.0 (2023-12-05)
+
+### Features Added
+
+- Added `VerifyConnection` property to `ConfidentialLedgerClientOptions` to allow the option to have a client connection without validating the service certificate.
+
 ## 1.3.0-beta.1 (Unreleased)
 
 ### Features Added

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/api/Azure.Security.ConfidentialLedger.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/api/Azure.Security.ConfidentialLedger.netstandard2.0.cs
@@ -41,6 +41,7 @@ namespace Azure.Security.ConfidentialLedger
     {
         public ConfidentialLedgerClientOptions(Azure.Security.ConfidentialLedger.ConfidentialLedgerClientOptions.ServiceVersion version = Azure.Security.ConfidentialLedger.ConfidentialLedgerClientOptions.ServiceVersion.V2022_05_13) { }
         public System.Uri CertificateEndpoint { get { throw null; } set { } }
+        public bool VerifyConnection { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2022_05_13 = 1,

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/assets.json
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/confidentialledger/Azure.Security.ConfidentialLedger",
-  "Tag": "net/confidentialledger/Azure.Security.ConfidentialLedger_5657482b45"
+  "Tag": "net/confidentialledger/Azure.Security.ConfidentialLedger_d8f1bd9cd9"
 }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Client SDK for the Azure Confidential Ledger service</Description>
     <AssemblyTitle>Azure Confidential Ledger</AssemblyTitle>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.3.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.0</ApiCompatVersion>
     <PackageTags>Azure ConfidentialLedger</PackageTags>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
@@ -64,7 +64,7 @@ namespace Azure.Security.ConfidentialLedger
             var actualOptions = ledgerOptions ?? new ConfidentialLedgerClientOptions();
             X509Certificate2 serviceCert = identityServiceCert ?? GetIdentityServerTlsCert(ledgerEndpoint, certificateClientOptions ?? new ConfidentialLedgerCertificateClientOptions(), ledgerOptions: ledgerOptions).Cert;
 
-            var transportOptions = GetIdentityServerTlsCertAndTrust(serviceCert);
+            var transportOptions = GetIdentityServerTlsCertAndTrust(serviceCert, ledgerOptions?.VerifyConnection ?? false);
             if (clientCertificate != null)
             {
                 transportOptions.ClientCertificates.Add(clientCertificate);
@@ -201,7 +201,7 @@ namespace Azure.Security.ConfidentialLedger
             return (GetCertFromPEM(eccPem), eccPem);
         }
 
-        private static HttpPipelineTransportOptions GetIdentityServerTlsCertAndTrust(X509Certificate2 identityServiceCert = null)
+        private static HttpPipelineTransportOptions GetIdentityServerTlsCertAndTrust(X509Certificate2 identityServiceCert = null, bool verifyConnection = false)
         {
             X509Chain certificateChain = new();
             // Revocation is not required by CCF. Hence revocation checks must be skipped to avoid validation failing unnecessarily.
@@ -219,6 +219,11 @@ namespace Azure.Security.ConfidentialLedger
             // they are trusted by the ledger identity TLS certificate.
             bool CertValidationCheck(X509Certificate2 cert)
             {
+                if (!verifyConnection)
+                {
+                    return true;
+                }
+
                 // Validate the presented certificate chain, using the ChainPolicy defined above.
                 // Note: this check will allow certificates signed by standard CAs as well as those signed by the ledger identity TLS certificate.
                 bool isChainValid = certificateChain.Build(cert);

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
@@ -64,7 +64,7 @@ namespace Azure.Security.ConfidentialLedger
             var actualOptions = ledgerOptions ?? new ConfidentialLedgerClientOptions();
             X509Certificate2 serviceCert = identityServiceCert ?? GetIdentityServerTlsCert(ledgerEndpoint, certificateClientOptions ?? new ConfidentialLedgerCertificateClientOptions(), ledgerOptions: ledgerOptions).Cert;
 
-            var transportOptions = GetIdentityServerTlsCertAndTrust(serviceCert, ledgerOptions?.VerifyConnection ?? false);
+            var transportOptions = GetIdentityServerTlsCertAndTrust(serviceCert, ledgerOptions?.VerifyConnection ?? true);
             if (clientCertificate != null)
             {
                 transportOptions.ClientCertificates.Add(clientCertificate);
@@ -201,7 +201,7 @@ namespace Azure.Security.ConfidentialLedger
             return (GetCertFromPEM(eccPem), eccPem);
         }
 
-        private static HttpPipelineTransportOptions GetIdentityServerTlsCertAndTrust(X509Certificate2 identityServiceCert = null, bool verifyConnection = false)
+        private static HttpPipelineTransportOptions GetIdentityServerTlsCertAndTrust(X509Certificate2 identityServiceCert = null, bool verifyConnection = true)
         {
             X509Chain certificateChain = new();
             // Revocation is not required by CCF. Hence revocation checks must be skipped to avoid validation failing unnecessarily.

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClientOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClientOptions.cs
@@ -15,7 +15,7 @@ namespace Azure.Security.ConfidentialLedger
         public Uri CertificateEndpoint { get; set; }
 
         /// <summary>
-        /// Boolean determining whether or not a certificate validation is required to verify the client connection a the ledger.
+        /// Boolean determining whether certificate validation will be performed to verify the ledger identity TLS certificate is valid.
         /// </summary>
         /// <value></value>
         public bool VerifyConnection { get; set; }

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClientOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClientOptions.cs
@@ -13,5 +13,11 @@ namespace Azure.Security.ConfidentialLedger
         /// </summary>
         /// <value></value>
         public Uri CertificateEndpoint { get; set; }
+
+        /// <summary>
+        /// Boolean determining whether or not a certificate validation is required to verify the client connection a the ledger.
+        /// </summary>
+        /// <value></value>
+        public bool VerifyConnection { get; set; }
     }
 }


### PR DESCRIPTION
# Contributing to the Azure SDK

Added VerifyConnection property to ConfidentialLedgerClientOptions to allow the option to have a client connection without validating the service certificate.

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
