### PR TITLE
100-continue

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.net6.0.cs
@@ -56,6 +56,7 @@ namespace Azure.Storage.Blobs
         public Azure.Storage.Blobs.Models.CustomerProvidedKey? CustomerProvidedKey { get { throw null; } set { } }
         public bool EnableTenantDiscovery { get { throw null; } set { } }
         public string EncryptionScope { get { throw null; } set { } }
+        public Azure.Storage.ExpectContinueOptions ExpectContinueBehavior { get { throw null; } set { } }
         public System.Uri GeoRedundantSecondaryUri { get { throw null; } set { } }
         public Azure.Storage.TransferValidationOptions TransferValidation { get { throw null; } }
         public bool TrimBlobNameSlashes { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -56,6 +56,7 @@ namespace Azure.Storage.Blobs
         public Azure.Storage.Blobs.Models.CustomerProvidedKey? CustomerProvidedKey { get { throw null; } set { } }
         public bool EnableTenantDiscovery { get { throw null; } set { } }
         public string EncryptionScope { get { throw null; } set { } }
+        public Azure.Storage.ExpectContinueOptions ExpectContinueBehavior { get { throw null; } set { } }
         public System.Uri GeoRedundantSecondaryUri { get { throw null; } set { } }
         public Azure.Storage.TransferValidationOptions TransferValidation { get { throw null; } }
         public bool TrimBlobNameSlashes { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.1.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.1.cs
@@ -56,6 +56,7 @@ namespace Azure.Storage.Blobs
         public Azure.Storage.Blobs.Models.CustomerProvidedKey? CustomerProvidedKey { get { throw null; } set { } }
         public bool EnableTenantDiscovery { get { throw null; } set { } }
         public string EncryptionScope { get { throw null; } set { } }
+        public Azure.Storage.ExpectContinueOptions ExpectContinueBehavior { get { throw null; } set { } }
         public System.Uri GeoRedundantSecondaryUri { get { throw null; } set { } }
         public Azure.Storage.TransferValidationOptions TransferValidation { get { throw null; } }
         public bool TrimBlobNameSlashes { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_7a3b810a8b"
+  "Tag": "net/storage/Azure.Storage.Blobs_0c10c0cf16"
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -56,6 +56,8 @@
     <Compile Include="$(AzureStorageSharedSources)DisposableBucket.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.Clients.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinuePolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinueOnThrottlePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)GeoRedundantReadPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IDownloadedContent.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -183,6 +183,11 @@ namespace Azure.Storage.Blobs
         /// </summary>
         public bool TrimBlobNameSlashes { get; set; } = Constants.DefaultTrimBlobNameSlashes;
 
+        /// <summary>
+        /// Behavior options for setting HTTP header <c>Expect: 100-continue</c> on requests.
+        /// </summary>
+        public ExpectContinueOptions ExpectContinueBehavior { get; set; }
+
         #region Advanced Options
         internal ClientSideEncryptionOptions _clientSideEncryptionOptions;
         #endregion

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -339,7 +339,7 @@ namespace Azure.Storage.Blobs
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
         internal HttpPipeline Build(HttpPipelinePolicy authentication = null)
         {
-            return this.Build(authentication, GeoRedundantSecondaryUri);
+            return this.Build(authentication, GeoRedundantSecondaryUri, ExpectContinueBehavior);
         }
 
         /// <summary>
@@ -349,7 +349,7 @@ namespace Azure.Storage.Blobs
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
         internal HttpPipeline Build(object credentials)
         {
-            return this.Build(credentials, GeoRedundantSecondaryUri);
+            return this.Build(credentials, GeoRedundantSecondaryUri, ExpectContinueBehavior);
         }
 
         /// <inheritdoc />

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -1337,7 +1337,7 @@ namespace Azure.Storage.Blobs.Test
             });
 
             BlobClientOptions options = GetOptions();
-            options.ExpectContinueBehavior = new() { Mode = ExpectContinueOptions.ApplyHeaderMode.On };
+            options.ExpectContinueBehavior = new() { Mode = ExpectContinueMode.On };
             options.AddPolicy(assertPolicy, Core.HttpPipelinePosition.BeforeTransport);
             await using DisposingContainer test = await GetTestContainerAsync(
                 BlobsClientBuilder.GetServiceClient_SharedKey(options));

--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net6.0.cs
@@ -20,18 +20,18 @@ namespace Azure.Storage
         public bool AutoValidateChecksum { get { throw null; } set { } }
         public Azure.Storage.StorageChecksumAlgorithm ChecksumAlgorithm { get { throw null; } set { } }
     }
+    public enum ExpectContinueMode
+    {
+        ApplyOnThrottle = 0,
+        On = 1,
+        Off = 2,
+    }
     public partial class ExpectContinueOptions
     {
         public ExpectContinueOptions() { }
-        public System.TimeSpan Backoff { get { throw null; } set { } }
-        public long ContentLengthThreshold { get { throw null; } set { } }
-        public Azure.Storage.ExpectContinueOptions.ApplyHeaderMode Mode { get { throw null; } set { } }
-        public enum ApplyHeaderMode
-        {
-            Auto = 0,
-            On = 1,
-            Off = 2,
-        }
+        public long? ContentLengthThreshold { get { throw null; } set { } }
+        public Azure.Storage.ExpectContinueMode Mode { get { throw null; } set { } }
+        public System.TimeSpan ThrottleInterval { get { throw null; } set { } }
     }
     public enum StorageChecksumAlgorithm
     {

--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net6.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.net6.0.cs
@@ -20,6 +20,19 @@ namespace Azure.Storage
         public bool AutoValidateChecksum { get { throw null; } set { } }
         public Azure.Storage.StorageChecksumAlgorithm ChecksumAlgorithm { get { throw null; } set { } }
     }
+    public partial class ExpectContinueOptions
+    {
+        public ExpectContinueOptions() { }
+        public System.TimeSpan Backoff { get { throw null; } set { } }
+        public long ContentLengthThreshold { get { throw null; } set { } }
+        public Azure.Storage.ExpectContinueOptions.ApplyHeaderMode Mode { get { throw null; } set { } }
+        public enum ApplyHeaderMode
+        {
+            Auto = 0,
+            On = 1,
+            Off = 2,
+        }
+    }
     public enum StorageChecksumAlgorithm
     {
         Auto = 0,

--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
@@ -20,18 +20,18 @@ namespace Azure.Storage
         public bool AutoValidateChecksum { get { throw null; } set { } }
         public Azure.Storage.StorageChecksumAlgorithm ChecksumAlgorithm { get { throw null; } set { } }
     }
+    public enum ExpectContinueMode
+    {
+        ApplyOnThrottle = 0,
+        On = 1,
+        Off = 2,
+    }
     public partial class ExpectContinueOptions
     {
         public ExpectContinueOptions() { }
-        public System.TimeSpan Backoff { get { throw null; } set { } }
-        public long ContentLengthThreshold { get { throw null; } set { } }
-        public Azure.Storage.ExpectContinueOptions.ApplyHeaderMode Mode { get { throw null; } set { } }
-        public enum ApplyHeaderMode
-        {
-            Auto = 0,
-            On = 1,
-            Off = 2,
-        }
+        public long? ContentLengthThreshold { get { throw null; } set { } }
+        public Azure.Storage.ExpectContinueMode Mode { get { throw null; } set { } }
+        public System.TimeSpan ThrottleInterval { get { throw null; } set { } }
     }
     public enum StorageChecksumAlgorithm
     {

--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
@@ -20,6 +20,19 @@ namespace Azure.Storage
         public bool AutoValidateChecksum { get { throw null; } set { } }
         public Azure.Storage.StorageChecksumAlgorithm ChecksumAlgorithm { get { throw null; } set { } }
     }
+    public partial class ExpectContinueOptions
+    {
+        public ExpectContinueOptions() { }
+        public System.TimeSpan Backoff { get { throw null; } set { } }
+        public long ContentLengthThreshold { get { throw null; } set { } }
+        public Azure.Storage.ExpectContinueOptions.ApplyHeaderMode Mode { get { throw null; } set { } }
+        public enum ApplyHeaderMode
+        {
+            Auto = 0,
+            On = 1,
+            Off = 2,
+        }
+    }
     public enum StorageChecksumAlgorithm
     {
         Auto = 0,

--- a/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
+++ b/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
@@ -35,6 +35,8 @@
     <!--we're defining the Shared Source in Common, but we only want to build in the files that Common names use of-->
     <Compile Include="Shared\Constants.cs" />
     <Compile Include="Shared\Errors.cs" />
+    <Compile Include="Shared\ExpectContinuePolicy.cs" />
+    <Compile Include="Shared\ExpectContinueOnThrottlePolicy.cs" />
     <Compile Include="Shared\GeoRedundantReadPolicy.cs" />
     <Compile Include="Shared\SasExtensions.cs" />
     <Compile Include="Shared\SasQueryParametersInternals.cs" />

--- a/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
+++ b/sdk/storage/Azure.Storage.Common/src/Azure.Storage.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);net6.0</TargetFrameworks>
   </PropertyGroup>
@@ -35,8 +35,6 @@
     <!--we're defining the Shared Source in Common, but we only want to build in the files that Common names use of-->
     <Compile Include="Shared\Constants.cs" />
     <Compile Include="Shared\Errors.cs" />
-    <Compile Include="Shared\ExpectContinuePolicy.cs" />
-    <Compile Include="Shared\ExpectContinueOnThrottlePolicy.cs" />
     <Compile Include="Shared\GeoRedundantReadPolicy.cs" />
     <Compile Include="Shared\SasExtensions.cs" />
     <Compile Include="Shared\SasQueryParametersInternals.cs" />

--- a/sdk/storage/Azure.Storage.Common/src/ExpectContinueMode.cs
+++ b/sdk/storage/Azure.Storage.Common/src/ExpectContinueMode.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Storage
+{
+    /// <summary>
+    /// Mode for applying expect-continue to a PUT request.
+    /// </summary>
+    public enum ExpectContinueMode
+    {
+        /// <summary>
+        /// If no options are provided, this is the default behavior.
+        /// <para>
+        /// Expect-continue will not be applied until specific errors are encountered from the
+        /// service, at which point they will be applied until a period of time after the last
+        /// of those errors occured.
+        /// </para>
+        /// <para>
+        /// Response codes that trigger this behavior are 429, 500, and 503.
+        /// </para>
+        /// </summary>
+        ApplyOnThrottle = 0,
+
+        /// <summary>
+        /// Expect-continue will be applied regardless of recent error status. There may be
+        /// some additionally defined thresholds for applying the header.
+        /// </summary>
+        On = 1,
+
+        /// <summary>
+        /// Expect-Continue will never be applied.
+        /// </summary>
+        Off = 2,
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
@@ -11,39 +11,9 @@ namespace Azure.Storage
     public class ExpectContinueOptions
     {
         /// <summary>
-        /// Mode for applying expect-continue to a PUT request.
-        /// </summary>
-        public enum ApplyHeaderMode
-        {
-            /// <summary>
-            /// If no options are provided, this is the default behavior.
-            /// <para>
-            /// Expect-continue will not be applied until specific errors are encountered from the
-            /// service, at which point they will be applied until a period of time after the last
-            /// of those errors occured.
-            /// </para>
-            /// <para>
-            /// Response codes that trigger this behavior are 429, 500, and 503.
-            /// </para>
-            /// </summary>
-            ApplyOnThrottle = 0,
-
-            /// <summary>
-            /// Expect-continue will be applied regardless of recent error status. There may be
-            /// some additionally defined thresholds for applying the header.
-            /// </summary>
-            On = 1,
-
-            /// <summary>
-            /// Expect-Continue will never be applied.
-            /// </summary>
-            Off = 2,
-        }
-
-        /// <summary>
         /// Mode for these options.
         /// </summary>
-        public ApplyHeaderMode Mode { get; set; }
+        public ExpectContinueMode Mode { get; set; }
 
         /// <summary>
         /// The minimum value of HTTP request Content-Length for applying expect-continue.
@@ -51,7 +21,7 @@ namespace Azure.Storage
         public long ContentLengthThreshold { get; set; }
 
         /// <summary>
-        /// In mode <see cref="ApplyHeaderMode.ApplyOnThrottle"/>, the time interval to apply the header
+        /// In mode <see cref="ExpectContinueMode.ApplyOnThrottle"/>, the time interval to apply the header
         /// after recieving a triggering error. The default time is one minute.
         /// </summary>
         public TimeSpan ThrottleInterval { get; set; } = TimeSpan.FromMinutes(1);

--- a/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage
             /// Response codes that trigger this behavior are 429, 500, and 503.
             /// </para>
             /// </summary>
-            Auto = 0,
+            ApplyOnThrottle = 0,
 
             /// <summary>
             /// Expect-continue will be applied regardless of recent error status. There may be
@@ -51,9 +51,9 @@ namespace Azure.Storage
         public long ContentLengthThreshold { get; set; }
 
         /// <summary>
-        /// In mode <see cref="ApplyHeaderMode.Auto"/>, the time interval to apply the header
+        /// In mode <see cref="ApplyHeaderMode.ApplyOnThrottle"/>, the time interval to apply the header
         /// after recieving a triggering error. The default time is one minute.
         /// </summary>
-        public TimeSpan AutoEnabledInterval { get; set; } = TimeSpan.FromMinutes(1);
+        public TimeSpan ThrottleInterval { get; set; } = TimeSpan.FromMinutes(1);
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
@@ -18,7 +18,7 @@ namespace Azure.Storage
         /// <summary>
         /// The minimum value of HTTP request Content-Length for applying expect-continue.
         /// </summary>
-        public long ContentLengthThreshold { get; set; }
+        public long? ContentLengthThreshold { get; set; }
 
         /// <summary>
         /// In mode <see cref="ExpectContinueMode.ApplyOnThrottle"/>, the time interval to apply the header

--- a/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
@@ -51,9 +51,9 @@ namespace Azure.Storage
         public long ContentLengthThreshold { get; set; }
 
         /// <summary>
-        /// In mode <see cref="ApplyHeaderMode.Auto"/>, the amount of time to apply the header
+        /// In mode <see cref="ApplyHeaderMode.Auto"/>, the time interval to apply the header
         /// after recieving a triggering error. The default time is one minute.
         /// </summary>
-        public TimeSpan Backoff { get; set; } = TimeSpan.FromMinutes(1);
+        public TimeSpan AutoEnabledInterval { get; set; } = TimeSpan.FromMinutes(1);
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/ExpectContinueOptions.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage
+{
+    /// <summary>
+    /// Options for applying HTTP header <c>Expect: 100-continue</c> to PUT operations.
+    /// </summary>
+    public class ExpectContinueOptions
+    {
+        /// <summary>
+        /// Mode for applying expect-continue to a PUT request.
+        /// </summary>
+        public enum ApplyHeaderMode
+        {
+            /// <summary>
+            /// If no options are provided, this is the default behavior.
+            /// <para>
+            /// Expect-continue will not be applied until specific errors are encountered from the
+            /// service, at which point they will be applied until a period of time after the last
+            /// of those errors occured.
+            /// </para>
+            /// <para>
+            /// Response codes that trigger this behavior are 429, 500, and 503.
+            /// </para>
+            /// </summary>
+            Auto = 0,
+
+            /// <summary>
+            /// Expect-continue will be applied regardless of recent error status. There may be
+            /// some additionally defined thresholds for applying the header.
+            /// </summary>
+            On = 1,
+
+            /// <summary>
+            /// Expect-Continue will never be applied.
+            /// </summary>
+            Off = 2,
+        }
+
+        /// <summary>
+        /// Mode for these options.
+        /// </summary>
+        public ApplyHeaderMode Mode { get; set; }
+
+        /// <summary>
+        /// The minimum value of HTTP request Content-Length for applying expect-continue.
+        /// </summary>
+        public long ContentLengthThreshold { get; set; }
+
+        /// <summary>
+        /// In mode <see cref="ApplyHeaderMode.Auto"/>, the amount of time to apply the header
+        /// after recieving a triggering error. The default time is one minute.
+        /// </summary>
+        public TimeSpan Backoff { get; set; } = TimeSpan.FromMinutes(1);
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+internal class ExpectContinueOnThrottlePolicy : HttpPipelineSynchronousPolicy
+{
+    private long _lastThrottleTicks = 0;
+
+    private long _backoffTicks = TimeSpan.TicksPerMinute;
+    public TimeSpan Backoff
+    {
+        get => TimeSpan.FromTicks(_backoffTicks);
+        set => _backoffTicks = value.Ticks;
+    }
+
+    public override void OnSendingRequest(HttpMessage message)
+    {
+        if (message.Request.Method == RequestMethod.Put)
+        {
+            long lastThrottleTicks = Interlocked.Read(ref _lastThrottleTicks);
+            if (DateTimeOffset.UtcNow.Ticks - lastThrottleTicks < _backoffTicks)
+            {
+                message.Request.Headers.SetValue("Expect", "100-continue");
+            }
+        }
+    }
+
+    public override void OnReceivedResponse(HttpMessage message)
+    {
+        base.OnReceivedResponse(message);
+        if (message.HasResponse && (
+            message.Response.Status == 429 ||
+            message.Response.Status == 500 ||
+            message.Response.Status == 503))
+        {
+            Interlocked.Exchange(ref _lastThrottleTicks, DateTimeOffset.UtcNow.Ticks);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
@@ -12,11 +12,11 @@ internal class ExpectContinueOnThrottlePolicy : HttpPipelineSynchronousPolicy
 {
     private long _lastThrottleTicks = 0;
 
-    private long _autoEnabledIntervalTicks = TimeSpan.TicksPerMinute;
-    public TimeSpan AutoEnabledInterval
+    private long _throttleIntervalTicks = TimeSpan.TicksPerMinute;
+    public TimeSpan ThrottleInterval
     {
-        get => TimeSpan.FromTicks(_autoEnabledIntervalTicks);
-        set => _autoEnabledIntervalTicks = value.Ticks;
+        get => TimeSpan.FromTicks(_throttleIntervalTicks);
+        set => _throttleIntervalTicks = value.Ticks;
     }
 
     public long ContentLengthThreshold { get; set; }
@@ -29,7 +29,7 @@ internal class ExpectContinueOnThrottlePolicy : HttpPipelineSynchronousPolicy
             return;
         }
         long lastThrottleTicks = Interlocked.Read(ref _lastThrottleTicks);
-        if (DateTimeOffset.UtcNow.Ticks - lastThrottleTicks < _autoEnabledIntervalTicks)
+        if (DateTimeOffset.UtcNow.Ticks - lastThrottleTicks < _throttleIntervalTicks)
         {
             message.Request.Headers.SetValue("Expect", "100-continue");
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
@@ -6,15 +6,17 @@ using System;
 using Azure.Core;
 using Azure.Core.Pipeline;
 
+namespace Azure.Storage;
+
 internal class ExpectContinueOnThrottlePolicy : HttpPipelineSynchronousPolicy
 {
     private long _lastThrottleTicks = 0;
 
-    private long _backoffTicks = TimeSpan.TicksPerMinute;
-    public TimeSpan Backoff
+    private long _autoEnabledIntervalTicks = TimeSpan.TicksPerMinute;
+    public TimeSpan AutoEnabledInterval
     {
-        get => TimeSpan.FromTicks(_backoffTicks);
-        set => _backoffTicks = value.Ticks;
+        get => TimeSpan.FromTicks(_autoEnabledIntervalTicks);
+        set => _autoEnabledIntervalTicks = value.Ticks;
     }
 
     public long ContentLengthThreshold { get; set; }
@@ -27,7 +29,7 @@ internal class ExpectContinueOnThrottlePolicy : HttpPipelineSynchronousPolicy
             return;
         }
         long lastThrottleTicks = Interlocked.Read(ref _lastThrottleTicks);
-        if (DateTimeOffset.UtcNow.Ticks - lastThrottleTicks < _backoffTicks)
+        if (DateTimeOffset.UtcNow.Ticks - lastThrottleTicks < _autoEnabledIntervalTicks)
         {
             message.Request.Headers.SetValue("Expect", "100-continue");
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinuePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinuePolicy.cs
@@ -4,6 +4,8 @@
 using Azure.Core;
 using Azure.Core.Pipeline;
 
+namespace Azure.Storage;
+
 internal class ExpectContinuePolicy : HttpPipelineSynchronousPolicy
 {
     public long ContentLengthThreshold { get; set; }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinuePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinuePolicy.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+internal class ExpectContinuePolicy : HttpPipelineSynchronousPolicy
+{
+    public override void OnSendingRequest(HttpMessage message)
+    {
+        if (message.Request.Method == RequestMethod.Put)
+        {
+            message.Request.Headers.SetValue("Expect", "100-continue");
+        }
+        base.OnSendingRequest(message);
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinuePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinuePolicy.cs
@@ -1,19 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading;
-using System;
 using Azure.Core;
 using Azure.Core.Pipeline;
 
 internal class ExpectContinuePolicy : HttpPipelineSynchronousPolicy
 {
+    public long ContentLengthThreshold { get; set; }
+
     public override void OnSendingRequest(HttpMessage message)
     {
-        if (message.Request.Method == RequestMethod.Put)
+        if (message.Request.Content == null)
+        {
+            return;
+        }
+        if (!message.Request.Content.TryComputeLength(out long contentLength) || contentLength >= ContentLengthThreshold)
         {
             message.Request.Headers.SetValue("Expect", "100-continue");
         }
-        base.OnSendingRequest(message);
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -130,13 +130,20 @@ namespace Azure.Storage
             {
                 switch (expectContinue.Mode)
                 {
-                    case ExpectContinueOptions.ApplyHeaderMode.ApplyOnThrottle:
-                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { ThrottleInterval = expectContinue.ThrottleInterval });
+                    case ExpectContinueMode.ApplyOnThrottle:
+                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy()
+                        {
+                            ThrottleInterval = expectContinue.ThrottleInterval,
+                            ContentLengthThreshold = expectContinue.ContentLengthThreshold ?? 0,
+                        });
                         break;
-                    case ExpectContinueOptions.ApplyHeaderMode.On:
-                        pipelineOptions.PerCallPolicies.Add(new ExpectContinuePolicy());
+                    case ExpectContinueMode.On:
+                        pipelineOptions.PerCallPolicies.Add(new ExpectContinuePolicy()
+                        {
+                            ContentLengthThreshold = expectContinue.ContentLengthThreshold ?? 0,
+                        });
                         break;
-                    case ExpectContinueOptions.ApplyHeaderMode.Off:
+                    case ExpectContinueMode.Off:
                         break;
                 }
             }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -132,7 +132,7 @@ namespace Azure.Storage
                 switch (expectContinue.Mode)
                 {
                     case ExpectContinueOptions.ApplyHeaderMode.Auto:
-                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { Backoff = expectContinue.Backoff });
+                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { AutoEnabledInterval = expectContinue.AutoEnabledInterval });
                         break;
                     case ExpectContinueOptions.ApplyHeaderMode.On:
                         pipelineOptions.PerCallPolicies.Add(new ExpectContinuePolicy());
@@ -144,7 +144,7 @@ namespace Azure.Storage
             else
             {
                 // TODO get env config for whether to disable
-                pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { Backoff = TimeSpan.FromMinutes(1) });
+                pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { AutoEnabledInterval = TimeSpan.FromMinutes(1) });
             }
 
             pipelineOptions.PerRetryPolicies.Add(new StorageRequestValidationPipelinePolicy());

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -159,8 +159,13 @@ namespace Azure.Storage
         /// <param name="options">The Storage ClientOptions.</param>
         /// <param name="credentials">Optional authentication credentials.</param>
         /// <param name="geoRedundantSecondaryStorageUri">The secondary URI to be used for retries on failed read requests</param>
+        /// <param name="expectContinue">Options for selecting expect continue policy.</param>
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
-        public static HttpPipeline Build(this ClientOptions options, object credentials, Uri geoRedundantSecondaryStorageUri = null) =>
-            Build(options, GetAuthenticationPolicy(credentials), geoRedundantSecondaryStorageUri);
+        public static HttpPipeline Build(
+            this ClientOptions options,
+            object credentials,
+            Uri geoRedundantSecondaryStorageUri = null,
+            ExpectContinueOptions expectContinue = null) =>
+            Build(options, GetAuthenticationPolicy(credentials), geoRedundantSecondaryStorageUri, expectContinue);
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -131,8 +131,8 @@ namespace Azure.Storage
             {
                 switch (expectContinue.Mode)
                 {
-                    case ExpectContinueOptions.ApplyHeaderMode.Auto:
-                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { AutoEnabledInterval = expectContinue.AutoEnabledInterval });
+                    case ExpectContinueOptions.ApplyHeaderMode.ApplyOnThrottle:
+                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { ThrottleInterval = expectContinue.ThrottleInterval });
                         break;
                     case ExpectContinueOptions.ApplyHeaderMode.On:
                         pipelineOptions.PerCallPolicies.Add(new ExpectContinuePolicy());
@@ -144,7 +144,7 @@ namespace Azure.Storage
             else
             {
                 // TODO get env config for whether to disable
-                pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { AutoEnabledInterval = TimeSpan.FromMinutes(1) });
+                pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy() { ThrottleInterval = TimeSpan.FromMinutes(1) });
             }
 
             pipelineOptions.PerRetryPolicies.Add(new StorageRequestValidationPipelinePolicy());

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Shared;

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -30,6 +30,8 @@
     <Compile Include="$(AzureStorageSharedSources)ChecksumCalculatingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ContentHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)DisposableBucket.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinuePolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinueOnThrottlePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IDownloadedContent.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Storage.Tests
+{
+    public class ExpectContinueTests
+    {
+        [Test]
+        public void PolicyAddsHeaderOnContentBody([Values(true, false)] bool hasBody)
+        {
+            ExpectContinuePolicy policy = new();
+            MockRequest request = new()
+            {
+                Content = hasBody ? RequestContent.Create("foo") : null
+            };
+            HttpMessage message = new(request, default);
+
+            policy.OnSendingRequest(message);
+
+            if (hasBody)
+            {
+                Assert.That(request.Headers.TryGetValue("Expect", out string value), Is.True);
+                Assert.That(value, Is.EqualTo("100-continue"));
+            }
+            else
+            {
+                Assert.That(request.Headers.Contains("Expect"), Is.False);
+            }
+        }
+
+        [TestCase(1024, 2048, true)]
+        [TestCase(2048, 1024, false)]
+        [TestCase(1024, 1024, true)]
+        public void PolicyRespectsThreshold(int threshold, int bodyLength, bool expectHeader)
+        {
+            ExpectContinuePolicy policy = new()
+            {
+                ContentLengthThreshold = threshold
+            };
+            MockRequest request = new()
+            {
+                Content = RequestContent.Create(new Random().NextMemoryInline(bodyLength))
+            };
+            HttpMessage message = new(request, default);
+
+            policy.OnSendingRequest(message);
+
+            if (expectHeader)
+            {
+                Assert.That(request.Headers.TryGetValue("Expect", out string value), Is.True);
+                Assert.That(value, Is.EqualTo("100-continue"));
+            }
+            else
+            {
+                Assert.That(request.Headers.Contains("Expect"), Is.False);
+            }
+        }
+
+        [Test]
+        public void ThrottlePolicyAddsHeaderOnlyAfterError([Values(429, 500, 503)] int errorStatusCode)
+        {
+            ExpectContinueOnThrottlePolicy policy = new();
+            MockRequest MakeRequest() => new()
+            {
+                Content = RequestContent.Create(RequestContent.Create("foo"))
+            };
+            MockResponse responseOk = new(202);
+            MockResponse responseError = new(errorStatusCode);
+
+            // message1 doesn't get expect header
+            HttpMessage message1 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message1);
+            Assert.That(message1.Request.Headers.Contains("Expect"), Is.False);
+            message1.Response = responseOk;
+            policy.OnReceivedResponse(message1);
+
+            // message2 doesn't get expect header but will trigger future messages
+            HttpMessage message2 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message2);
+            Assert.That(message2.Request.Headers.Contains("Expect"), Is.False);
+            message2.Response = responseError;
+            policy.OnReceivedResponse(message2);
+
+            // message3 gets expect header
+            HttpMessage message3 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message3);
+            Assert.That(message3.Request.Headers.TryGetValue("Expect", out string value), Is.True);
+            Assert.That(value, Is.EqualTo("100-continue"));
+        }
+
+        [TestCase(1024, 2048, true)]
+        [TestCase(2048, 1024, false)]
+        [TestCase(1024, 1024, true)]
+        public void ThrottlePolicyRespectsThreshold(int threshold, int bodyLength, bool expectHeader)
+        {
+            Random r = new();
+            ExpectContinueOnThrottlePolicy policy = new()
+            {
+                ContentLengthThreshold = threshold,
+            };
+            MockRequest MakeRequest() => new()
+            {
+                Content = RequestContent.Create(r.NextMemoryInline(bodyLength))
+            };
+            MockResponse responseError = new(429);
+
+            // message1 doesn't get expect header but will trigger future messages
+            HttpMessage message1 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message1);
+            Assert.That(message1.Request.Headers.Contains("Expect"), Is.False);
+            message1.Response = responseError;
+            policy.OnReceivedResponse(message1);
+
+            // message2 gets expect header
+            HttpMessage message2 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message2);
+            if (expectHeader)
+            {
+                Assert.That(message2.Request.Headers.TryGetValue("Expect", out string value), Is.True);
+                Assert.That(value, Is.EqualTo("100-continue"));
+            }
+            else
+            {
+                Assert.That(message2.Request.Headers.Contains("Expect"), Is.False);
+            }
+        }
+
+        [Test]
+        public async Task ThrottlePolicyRevertsAfterBackoff()
+        {
+            TimeSpan backoff = TimeSpan.FromMilliseconds(10);
+            ExpectContinueOnThrottlePolicy policy = new()
+            {
+                Backoff = backoff,
+            };
+            MockRequest MakeRequest() => new()
+            {
+                Content = RequestContent.Create(RequestContent.Create("foo"))
+            };
+            MockResponse responseOk = new(202);
+            MockResponse responseError = new(429);
+
+            // message1 doesn't get expect header but will trigger future messages
+            HttpMessage message1 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message1);
+            Assert.That(message1.Request.Headers.Contains("Expect"), Is.False);
+            message1.Response = responseError;
+            policy.OnReceivedResponse(message1);
+
+            // message2 gets expect header
+            HttpMessage message2 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message2);
+            Assert.That(message2.Request.Headers.TryGetValue("Expect", out string value), Is.True);
+            Assert.That(value, Is.EqualTo("100-continue"));
+            message1.Response = responseOk;
+            policy.OnReceivedResponse(message2);
+
+            // wait out policy backoff
+            await Task.Delay(backoff);
+
+            // message3 doesn't get expect header
+            HttpMessage message3 = new(MakeRequest(), null);
+            policy.OnSendingRequest(message3);
+            Assert.That(message3.Request.Headers.Contains("Expect"), Is.False);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
@@ -137,7 +137,7 @@ namespace Azure.Storage.Tests
             TimeSpan backoff = TimeSpan.FromMilliseconds(10);
             ExpectContinueOnThrottlePolicy policy = new()
             {
-                AutoEnabledInterval = backoff,
+                ThrottleInterval = backoff,
             };
             MockRequest MakeRequest() => new()
             {

--- a/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
@@ -137,7 +137,7 @@ namespace Azure.Storage.Tests
             TimeSpan backoff = TimeSpan.FromMilliseconds(10);
             ExpectContinueOnThrottlePolicy policy = new()
             {
-                Backoff = backoff,
+                AutoEnabledInterval = backoff,
             };
             MockRequest MakeRequest() => new()
             {

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/RandomExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/RandomExtensions.cs
@@ -27,6 +27,13 @@ namespace Azure.Storage.Tests
             return new Span<byte>(buffer);
         }
 
+        public static Memory<byte> NextMemoryInline(this Random random, int length)
+        {
+            var buffer = new byte[length];
+            random.NextBytes(buffer);
+            return new Memory<byte>(buffer);
+        }
+
         public static string NextBase64(this Random random, int length)
         {
             var buffer = new byte[length];

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
@@ -47,6 +47,8 @@
     <Compile Include="$(AzureStorageSharedSources)DisposableBucket.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.Clients.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinuePolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinueOnThrottlePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)GeoRedundantReadPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
@@ -47,6 +47,8 @@
     <Compile Include="$(AzureStorageSharedSources)DisposableBucket.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.Clients.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinuePolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinueOnThrottlePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)GeoRedundantReadPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)LoggingExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
+++ b/sdk/storage/Azure.Storage.Queues/src/Azure.Storage.Queues.csproj
@@ -50,6 +50,8 @@
     <Compile Include="$(AzureStorageSharedSources)CompatSwitches.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)Errors.Clients.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinuePolicy.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ExpectContinueOnThrottlePolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)GeoRedundantReadPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)LoggingExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)SasExtensions.cs" LinkBase="Shared" />


### PR DESCRIPTION
Enables a strategy for adding `Expect: 100-continue` to requests when the service may be under load.

- On/off/auto modes for adding these headers to requests that container a content body.
  - On always adds the header when a content body reaches a length threshold.
  - Off never adds the header.
  - Auto will add the header when a content body reaches a length threshold, and the client has received a 429, 500, or 503 response within a recent time span.
- Default auto timespan is 1 minute.
- Default length threshold is 0.
- Default mode is auto

Future PR work:
- Compat switch for getting old behavior without code change
- Achieve this behavior on RST