### PR TITLE
Tracing: ServiceBus processor throws when message contains invalid trace context

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestActivitySourceListener.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestActivitySourceListener.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
-#if NET5_0_OR_GREATER
     public class TestActivitySourceListener: IDisposable
     {
         private readonly ActivityListener _listener;
@@ -60,5 +59,4 @@ namespace Azure.Core.Tests
             _listener?.Dispose();
         }
     }
-#endif
 }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -513,19 +513,21 @@ namespace Azure.Core.Pipeline
                     _diagnosticSource?.Write(_activityName + ".Exception", exception);
                 }
 
-#if NETCOREAPP2_1
-                if (ActivityExtensions.SupportsActivitySource())
-                {
-                    _currentActivity?.SetErrorStatus(exception?.ToString());
-                }
-#endif
-#if NET6_0_OR_GREATER // SetStatus is only defined in NET 6 or greater
                 if (errorCode == null && exception != null)
                 {
                     errorCode = exception.GetType().FullName;
                 }
 
-                _currentActivity?.AddTag("error.type", errorCode ?? "_OTHER");
+                errorCode ??= "_OTHER";
+#if NETCOREAPP2_1
+                if (ActivityExtensions.SupportsActivitySource())
+                {
+                    _currentActivity?.AddTag("error.type", errorCode);
+                    _currentActivity?.SetErrorStatus(exception?.ToString());
+                }
+#else
+                // SetStatus is only defined in NET 6 or greater
+                _currentActivity?.SetTag("error.type", errorCode);
                 _currentActivity?.SetStatus(ActivityStatusCode.Error, exception?.ToString());
 #endif
             }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -148,7 +148,8 @@ namespace Azure.Core.Pipeline
                 // TODO (limolkova) when we start targeting .NET 8 we should put
                 // requestFailedException.InnerException.HttpRequestError into error.type
 
-                _activityAdapter?.MarkFailed(exception, requestFailedException.ErrorCode);
+                string? errorCode = string.IsNullOrEmpty(requestFailedException.ErrorCode) ? null : requestFailedException.ErrorCode;
+                _activityAdapter?.MarkFailed(exception, errorCode);
             }
             else
             {

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -478,6 +478,10 @@ namespace Azure.Core.Pipeline
 
             private Activity? StartActivitySourceActivity()
             {
+                if (_activitySource == null)
+                {
+                    return null;
+                }
 #if NETCOREAPP2_1
                 return ActivityExtensions.ActivitySourceStartActivity(
                     _activitySource,
@@ -491,7 +495,7 @@ namespace Azure.Core.Pipeline
 #else
                 // TODO(limolkova) set isRemote to true once we switch to DiagnosticSource 7.0
                 ActivityContext.TryParse(_traceparent, _tracestate, out ActivityContext context);
-                return _activitySource?.StartActivity(_activityName, _kind, context, _tagCollection, GetActivitySourceLinkCollection()!, _startTime);
+                return _activitySource.StartActivity(_activityName, _kind, context, _tagCollection, GetActivitySourceLinkCollection()!, _startTime);
 #endif
             }
 

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsActivitySourceTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsActivitySourceTests.cs
@@ -14,7 +14,7 @@ using OpenTelemetry.Trace;
 
 namespace Azure.Core.Tests
 {
-    public partial class ClientDiagnosticsTests
+    public class ClientDiagnosticsActivitySourceTests
     {
         [SetUp]
         [TearDown]

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsDiagnosticSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsDiagnosticSourceTests.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
-    public partial class ClientDiagnosticsTests
+    public partial class ClientDiagnosticsDiagnosticSourceTests
     {
         [Test]
         public void CreatesActivityWithNameAndTags()

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -420,8 +420,8 @@ namespace Azure.Core.Tests
             Assert.AreEqual(1, activityListener.Activities.Count);
             var activity = activityListener.Activities.Dequeue();
             Assert.AreEqual(traceparent, activity.ParentId);
-            Assert.AreEqual(traceId, Activity.Current.TraceId);
-            Assert.AreEqual(spanId, Activity.Current.ParentSpanId);
+            Assert.AreEqual(traceId, activity.TraceId.ToString());
+            Assert.AreEqual(spanId, activity.ParentSpanId.ToString());
             Assert.AreEqual(traceState, activity.TraceStateString);
         }
 
@@ -452,21 +452,20 @@ namespace Azure.Core.Tests
         [NonParallelizable]
         public void InvalidContextDoesNotThrow(string traceparent)
         {
-            using var testListener = new TestActivitySourceListener("Azure.Clients.ActivityName");
+            using var testListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
             DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory(
                 "Azure.Clients",
                 "Microsoft.Azure.Core.Cool.Tests",
                 true,
                 false,
-                false);
+                true);
 
-            using DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
+            using DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
             scope.SetTraceContext(traceparent, null);
             scope.Start();
 
             Assert.IsNull(Activity.Current.ParentId);
-            Assert.AreEqual(default, Activity.Current.ParentSpanId);
             Assert.IsNull(Activity.Current.TraceStateString);
         }
 

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -14,7 +14,6 @@ using OpenTelemetry.Trace;
 
 namespace Azure.Core.Tests
 {
-#if NET5_0_OR_GREATER
     public partial class ClientDiagnosticsTests
     {
         [SetUp]
@@ -314,6 +313,7 @@ namespace Azure.Core.Tests
         [Test]
         public void CanSetActivitySourceAndDiagnosticSourceActivitiesTogether()
         {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             using var testListener = new TestDiagnosticListener("Azure.Clients");
             using var activityListener = new TestActivitySourceListener("Azure.Clients.ClientName");
 
@@ -630,5 +630,4 @@ namespace Azure.Core.Tests
             }
         }
     }
-#endif
 }

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -206,11 +206,8 @@ namespace Azure.Core.Tests
 
             activity.Stop();
 
-#if NET5_0_OR_GREATER
-            Assert.True(transport.SingleRequest.TryGetHeader("traceparent", out string requestId));
-#else
-            Assert.True(transport.SingleRequest.TryGetHeader("Request-Id", out string requestId));
-#endif
+            string headerName = Activity.DefaultIdFormat == ActivityIdFormat.W3C ? "traceparent" : "Request-Id";
+            Assert.True(transport.SingleRequest.TryGetHeader(headerName, out string requestId));
             Assert.AreEqual(activity.Id, requestId);
         }
 


### PR DESCRIPTION
When an invalid trace context is supplied in the message ServiceBus (and probably EventHubs) processor throws.

In this PR, I
- use `ActivityContext.TryParse` instead of `Parse`
- enable `ActivitySource`-related tests to run on .NET 4.6.2 
  - they didn't run there before for historical reasons when we depended on earlier version of DiagnosticSource, but now we can run them
  - there were some unexpected failures which are fixed now