### PR TITLE
Make RequestContentHelper accept null value

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/RequestContentHelper.cs
+++ b/sdk/core/Azure.Core/src/Shared/RequestContentHelper.cs
@@ -11,8 +11,13 @@ namespace Azure.Core
 {
     internal static class RequestContentHelper
     {
-        public static RequestContent FromEnumerable<T>(IEnumerable<T> enumerable) where T: notnull
+        public static RequestContent? FromEnumerable<T>(IEnumerable<T> enumerable) where T: notnull
         {
+            if (enumerable == null)
+            {
+                return null;
+            }
+
             var content = new Utf8JsonRequestContent();
             content.JsonWriter.WriteStartArray();
             foreach (var item in enumerable)
@@ -24,8 +29,13 @@ namespace Azure.Core
             return content;
         }
 
-        public static RequestContent FromEnumerable(IEnumerable<BinaryData> enumerable)
+        public static RequestContent? FromEnumerable(IEnumerable<BinaryData> enumerable)
         {
+            if (enumerable == null)
+            {
+                return null;
+            }
+
             var content = new Utf8JsonRequestContent();
             content.JsonWriter.WriteStartArray();
             foreach (var item in enumerable)
@@ -48,8 +58,13 @@ namespace Azure.Core
             return content;
         }
 
-        public static RequestContent FromDictionary<T>(IDictionary<string, T> dictionary) where T : notnull
+        public static RequestContent? FromDictionary<T>(IDictionary<string, T> dictionary) where T : notnull
         {
+            if (dictionary == null)
+            {
+                return null;
+            }
+
             var content = new Utf8JsonRequestContent();
             content.JsonWriter.WriteStartObject();
             foreach (var item in dictionary)
@@ -62,8 +77,13 @@ namespace Azure.Core
             return content;
         }
 
-        public static RequestContent FromDictionary(IDictionary<string, BinaryData> dictionary)
+        public static RequestContent? FromDictionary(IDictionary<string, BinaryData> dictionary)
         {
+            if (dictionary == null)
+            {
+                return null;
+            }
+
             var content = new Utf8JsonRequestContent();
             content.JsonWriter.WriteStartObject();
             foreach (var item in dictionary)

--- a/sdk/core/Azure.Core/tests/RequestContentHelperTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestContentHelperTests.cs
@@ -71,6 +71,18 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public void TestNullableGenericFromEnumerable()
+        {
+            List<int> nullableList = null;
+            var content = RequestContentHelper.FromEnumerable(nullableList);
+            Assert.IsNull(content);
+
+            List<BinaryData> nullableBinaryList= null;
+            content = RequestContentHelper.FromEnumerable(nullableBinaryList);
+            Assert.IsNull(content);
+        }
+
+        [Test]
         public void TestBinaryDataFromEnumerable()
         {
             var expectedList = new List<BinaryData> { new BinaryData(1), new BinaryData("\"hello\""), null };
@@ -130,6 +142,18 @@ namespace Azure.Core.Tests
                     Assert.AreEqual(expectedDictionary["k" + count++], property.Value.GetBoolean());
                 }
             }
+        }
+
+        [Test]
+        public void TestNullableGenericFromDictionary()
+        {
+            Dictionary<string, int> nullableDictionary = null;
+            var content = RequestContentHelper.FromDictionary(nullableDictionary);
+            Assert.IsNull(content);
+
+            Dictionary<string, BinaryData> nullableBinaryDictionary = null;
+            content = RequestContentHelper.FromDictionary(nullableBinaryDictionary);
+            Assert.IsNull(content);
         }
 
         [Test]


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.csharp/issues/3878.

When passing `null` to `FromDictionary` and `FromEnumerable`, it throws NRE
