### PR TITLE
[AzureMonitorLiveMetrics] refactor doublebuffer

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/DocumentBuffer.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/DocumentBuffer.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         // Atomic counter for the number of documents in the queue.
         private int _count = 0;
 
-        public void Add(DocumentIngress document)
+        public void WriteDocument(DocumentIngress document)
         {
             // Ensure the queue does not exceed capacity.
             if (Interlocked.CompareExchange(ref _count, 0, 0) < _capacity)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/DoubleBuffer.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/DoubleBuffer.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
-using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
@@ -13,19 +13,14 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
     /// The 'FlipDocumentBuffers' method swaps the current buffer with a new one, allowing the
     /// consumer to process the documents in the returned buffer without interference from ongoing writes.
     /// </summary>
-    internal class DoubleBuffer
+    internal class DoubleBuffer<T> where T : class
     {
-        private DocumentBuffer _currentBuffer = new();
+        public T Instance = Activator.CreateInstance<T>();
 
-        public void WriteDocument(DocumentIngress document)
-        {
-            _currentBuffer.Add(document);
-        }
-
-        public DocumentBuffer FlipDocumentBuffers()
+        public T FlipBuffers()
         {
             // Atomically exchange the current buffer with a new empty buffer and return the old buffer
-            return Interlocked.Exchange(ref _currentBuffer, new DocumentBuffer());
+            return Interlocked.Exchange(ref Instance, Activator.CreateInstance<T>());
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
@@ -188,7 +188,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     // CollectionConfigurationErrors = null,
                 };
 
-                DocumentBuffer filledBuffer = _metricsContainer._doubleBuffer.FlipDocumentBuffers();
+                DocumentBuffer filledBuffer = _metricsContainer._documentBuffer.FlipBuffers();
                 foreach (var item in filledBuffer.ReadAllAndClear())
                 {
                     dataPoint.Documents.Add(item);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/MetricsContainer.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/MetricsContainer.cs
@@ -23,7 +23,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         private MeterProvider? _meterProvider;
         private BaseExportingMetricReader _metricReader;
 
-        internal readonly DoubleBuffer _doubleBuffer = new();
+        internal readonly DoubleBuffer<DocumentBuffer> _documentBuffer = new();
 
         private PerformanceCounter _performanceCounter_ProcessorTime = new PerformanceCounter(categoryName: "Processor", counterName: "% Processor Time", instanceName: "_Total");
         private PerformanceCounter _performanceCounter_CommittedBytes = new PerformanceCounter(categoryName: "Memory", counterName: "Committed Bytes");

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
@@ -150,7 +150,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                 // TODO: Properties = new Dictionary<string, string>(), - Validate with UX team if this is needed.
             };
 
-            _manager._metricsContainer._doubleBuffer.WriteDocument(exceptionDocumentIngress);
+            _manager._metricsContainer._documentBuffer.Instance.WriteDocument(exceptionDocumentIngress);
         }
 
         private void AddRemoteDependencyDocument(Activity activity)
@@ -171,7 +171,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                 // TODO: Properties = new Dictionary<string, string>(), - Validate with UX team if this is needed.
             };
 
-            _manager._metricsContainer._doubleBuffer.WriteDocument(remoteDependencyDocumentIngress);
+            _manager._metricsContainer._documentBuffer.Instance.WriteDocument(remoteDependencyDocumentIngress);
         }
 
         private void AddRequestDocument(Activity activity, string? statusCodeAttributeValue)
@@ -191,7 +191,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                 // TODO: Properties = new Dictionary<string, string>(), - Validate with UX team if this is needed.
             };
 
-            _manager._metricsContainer._doubleBuffer.WriteDocument(requestDocumentIngress);
+            _manager._metricsContainer._documentBuffer.Instance.WriteDocument(requestDocumentIngress);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Refactor the DoubleBuffer class to be Generic.
I want to use this for Metrics as well.