### PR TITLE
[CODEOWNERS] Remove duplicate service label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -229,9 +229,6 @@
 # ServiceLabel: %Cognitive - Content Moderator %Service Attention
 #/<NotInRepo>/                                                     @swiftarrow11
 
-# ServiceLabel: %Cognitive - Personalizer %Service Attention
-/sdk/cognitiveservices/Personalizer/                               @dwaijam
-
 # ServiceLabel: %Cognitive - Immersive Reader %Service Attention
 #/<NotInRepo>/                                                     @metanMSFT
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the duplicate and outdated service label section for Personalizer.  The correct set of information can be found on L817.