### PR TITLE
Add ability to use non Json interface for json format

### DIFF
--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -21,7 +21,8 @@ namespace System.ClientModel
         /// <returns>A <see cref="BinaryData"/> representation of the model in the <see cref="ModelReaderWriterOptions.Format"/> specified by the <paramref name="options"/>.</returns>
         /// <exception cref="FormatException">If the model does not support the requested <see cref="ModelReaderWriterOptions.Format"/>.</exception>
         /// <exception cref="ArgumentNullException">If <paramref name="model"/> is null.</exception>
-        public static BinaryData Write<T>(T model, ModelReaderWriterOptions? options = default) where T : IPersistableModel<T>
+        public static BinaryData Write<T>(T model, ModelReaderWriterOptions? options = default)
+            where T : IPersistableModel<T>
         {
             if (model is null)
             {
@@ -30,13 +31,8 @@ namespace System.ClientModel
 
             options ??= ModelReaderWriterOptions.Json;
 
-            if (options.Format == "J" || (options.Format == "W" && model.GetFormatFromOptions(options) == "J"))
+            if ((options.Format == "J" || (options.Format == "W" && model.GetFormatFromOptions(options) == "J")) && model is IJsonModel<T> jsonModel)
             {
-                if (model is not IJsonModel<T> jsonModel)
-                {
-                    throw new FormatException($"The model {model.GetType().Name} does not support '{options.Format}' format.");
-                }
-
                 using (ModelWriter<T> writer = new ModelWriter<T>(jsonModel, options))
                 {
                     return writer.ToBinaryData();
@@ -72,13 +68,8 @@ namespace System.ClientModel
                 throw new InvalidOperationException($"{model.GetType().Name} does not implement {nameof(IPersistableModel<object>)}");
             }
 
-            if (options.Format == "J" || (options.Format == "W" && iModel.GetFormatFromOptions(options) == "J"))
+            if ((options.Format == "J" || (options.Format == "W" && iModel.GetFormatFromOptions(options) == "J")) && model is IJsonModel<object> jsonModel)
             {
-                if (model is not IJsonModel<object> jsonModel)
-                {
-                    throw new FormatException($"The model {model.GetType().Name} does not support '{options.Format}' format.");
-                }
-
                 using (ModelWriter<object> writer = new ModelWriter<object>(jsonModel, options))
                 {
                     return writer.ToBinaryData();
@@ -100,7 +91,8 @@ namespace System.ClientModel
         /// <exception cref="FormatException">If the model does not support the requested <see cref="ModelReaderWriterOptions.Format"/>.</exception>
         /// <exception cref="ArgumentNullException">If <paramref name="data"/> is null.</exception>
         /// <exception cref="MissingMethodException">If <typeparamref name="T"/> does not have a public or non public empty constructor.</exception>
-        public static T? Read<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(BinaryData data, ModelReaderWriterOptions? options = default) where T : IPersistableModel<T>
+        public static T? Read<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(BinaryData data, ModelReaderWriterOptions? options = default)
+            where T : IPersistableModel<T>
         {
             if (data is null)
             {
@@ -151,7 +143,8 @@ namespace System.ClientModel
             return model;
         }
 
-        private static IPersistableModel<T> GetInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>() where T : IPersistableModel<T>
+        private static IPersistableModel<T> GetInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>()
+            where T : IPersistableModel<T>
         {
             var model = GetObjectInstance(typeof(T)) as IPersistableModel<T>;
             if (model is null)

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.ClientModel.Primitives;
 using System.ClientModel.Internal;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace System.ClientModel
 {
@@ -31,7 +33,7 @@ namespace System.ClientModel
 
             options ??= ModelReaderWriterOptions.Json;
 
-            if ((options.Format == "J" || (options.Format == "W" && model.GetFormatFromOptions(options) == "J")) && model is IJsonModel<T> jsonModel)
+            if (IsJsonFormatRequested(model, options) && model is IJsonModel<T> jsonModel)
             {
                 using (ModelWriter<T> writer = new ModelWriter<T>(jsonModel, options))
                 {
@@ -68,7 +70,7 @@ namespace System.ClientModel
                 throw new InvalidOperationException($"{model.GetType().Name} does not implement {nameof(IPersistableModel<object>)}");
             }
 
-            if ((options.Format == "J" || (options.Format == "W" && iModel.GetFormatFromOptions(options) == "J")) && model is IJsonModel<object> jsonModel)
+            if (IsJsonFormatRequested(iModel, options) && model is IJsonModel<object> jsonModel)
             {
                 using (ModelWriter<object> writer = new ModelWriter<object>(jsonModel, options))
                 {
@@ -171,5 +173,13 @@ namespace System.ClientModel
             }
             return obj;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsJsonFormatRequested<T>(IPersistableModel<T> model, ModelReaderWriterOptions options)
+            => options.Format == "J" || (options.Format == "W" && model.GetFormatFromOptions(options) == "J");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsJsonFormatRequested(IPersistableModel<object> model, ModelReaderWriterOptions options)
+            => IsJsonFormatRequested<object>(model, options);
     }
 }

--- a/sdk/core/System.ClientModel/tests/ModelReaderWriter/Models/ModelWithPersistableOnlyTests.cs
+++ b/sdk/core/System.ClientModel/tests/ModelReaderWriter/Models/ModelWithPersistableOnlyTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+using System.IO;
+using System.ClientModel.Tests.Client;
+using System.ClientModel.Tests.Client.ModelReaderWriterTests.Models;
+
+namespace System.ClientModel.Tests.ModelReaderWriterTests.Models
+{
+    internal class ModelWithPersistableOnlyTests : ModelTests<ModelWithPersistableOnly>
+    {
+        protected override string JsonPayload => WirePayload;
+
+        protected override string WirePayload => File.ReadAllText(TestData.GetLocation("ModelWithPersistableOnly/ModelWithPersistableOnlyWireFormat.json")).TrimEnd();
+
+        protected override void CompareModels(ModelWithPersistableOnly model, ModelWithPersistableOnly model2, string format)
+        {
+            Assert.AreEqual(model.Name, model2.Name);
+
+            Assert.AreEqual(model.Fields, model2.Fields);
+            Assert.AreEqual(model.KeyValuePairs, model2.KeyValuePairs);
+            Assert.AreEqual(model.NullProperty, model2.NullProperty);
+
+            if (format == "J")
+            {
+                Assert.AreEqual(model.XProperty, model2.XProperty);
+                var rawData = GetRawData(model);
+                var rawData2 = GetRawData(model2);
+                Assert.IsNotNull(rawData);
+                Assert.IsNotNull(rawData2);
+                Assert.AreEqual(rawData.Count, rawData2.Count);
+                Assert.AreEqual(rawData["extra"].ToObjectFromJson<string>(), rawData2["extra"].ToObjectFromJson<string>());
+            }
+        }
+
+        protected override string GetExpectedResult(string format)
+        {
+            string expected = "{\"name\":\"xmodel\"";
+            expected += ",\"fields\":[\"testField\"]";
+            expected += ",\"keyValuePairs\":{\"color\":\"red\"}";
+            if (format == "J")
+                expected += ",\"xProperty\":100";
+            if (format == "J")
+                expected += ",\"extra\":\"stuff\"";
+            expected += "}";
+            return expected;
+        }
+
+        protected override void VerifyModel(ModelWithPersistableOnly model, string format)
+        {
+            Assert.AreEqual("xmodel", model.Name);
+
+            Assert.AreEqual(1, model.Fields.Count);
+            Assert.AreEqual("testField", model.Fields[0]);
+            Assert.AreEqual(1, model.KeyValuePairs.Count);
+            Assert.AreEqual("red", model.KeyValuePairs["color"]);
+            Assert.IsNull(model.NullProperty);
+
+            var rawData = GetRawData(model);
+            Assert.IsNotNull(rawData);
+            if (format == "J")
+            {
+                Assert.AreEqual(100, model.XProperty);
+                Assert.AreEqual("stuff", rawData["extra"].ToObjectFromJson<string>());
+            }
+        }
+    }
+}

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/Models/ModelWithPersistableOnly.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/Models/ModelWithPersistableOnly.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+using System.IO;
+
+namespace System.ClientModel.Tests.Client.ModelReaderWriterTests.Models
+{
+    public class ModelWithPersistableOnly : IPersistableModel<ModelWithPersistableOnly>
+    {
+        private Dictionary<string, BinaryData> _rawData;
+
+        public ModelWithPersistableOnly()
+        {
+        }
+
+        internal ModelWithPersistableOnly(string name, int xProperty, int? nullProperty, IList<string> fields, IDictionary<string, string> keyValuePairs, Dictionary<string, BinaryData> rawData)
+        {
+            Name = name;
+            XProperty = xProperty;
+            NullProperty = nullProperty;
+            Fields = fields;
+            KeyValuePairs = keyValuePairs;
+            _rawData = rawData;
+        }
+
+        public string Name { get; }
+        public int XProperty { get; }
+        public IList<string> Fields { get; }
+        public int? NullProperty = null;
+        public IDictionary<string, string> KeyValuePairs { get; }
+
+        private void Serialize(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            writer.WriteStartObject();
+            if (OptionalProperty.IsDefined(Name))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name);
+            }
+            if (OptionalProperty.IsCollectionDefined(Fields))
+            {
+                writer.WritePropertyName("fields"u8);
+                writer.WriteStartArray();
+                foreach (string field in Fields)
+                {
+                    writer.WriteStringValue(field);
+                }
+                writer.WriteEndArray();
+            }
+            if (OptionalProperty.IsDefined(NullProperty))
+            {
+                writer.WritePropertyName("nullProperty"u8);
+                writer.WriteNumberValue(NullProperty.Value);
+            }
+            if (OptionalProperty.IsCollectionDefined(KeyValuePairs))
+            {
+                writer.WritePropertyName("keyValuePairs"u8);
+                writer.WriteStartObject();
+                foreach (var item in KeyValuePairs)
+                {
+                    writer.WritePropertyName(item.Key);
+                    if (item.Value == null)
+                    {
+                        writer.WriteNullValue();
+                        continue;
+                    }
+                    writer.WriteObjectValue(item.Value);
+                }
+                writer.WriteEndObject();
+            }
+
+            if (options.Format == "J")
+            {
+                writer.WritePropertyName("xProperty"u8);
+                writer.WriteNumberValue(XProperty);
+            }
+            if (options.Format == "J")
+            {
+                SerializeRawData(writer);
+            }
+            writer.WriteEndObject();
+        }
+
+        private void SerializeRawData(Utf8JsonWriter writer)
+        {
+            //write out the raw data
+            foreach (var property in _rawData)
+            {
+                writer.WritePropertyName(property.Key);
+#if NET6_0_OR_GREATER
+                writer.WriteRawValue(property.Value);
+#else
+                JsonSerializer.Serialize(writer, JsonDocument.Parse(property.Value.ToString()).RootElement);
+#endif
+            }
+        }
+
+        internal static ModelWithPersistableOnly DeserializeModelX(JsonElement element, ModelReaderWriterOptions options = default)
+        {
+            options ??= ModelReaderWriterHelper.WireOptions;
+
+            if (element.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+            OptionalProperty<string> name = default;
+            int xProperty = default;
+            OptionalProperty<int> nullProperty = default;
+            OptionalProperty<IList<string>> fields = default;
+            OptionalProperty<IDictionary<string, string>> keyValuePairs = default;
+            Dictionary<string, BinaryData> rawData = new Dictionary<string, BinaryData>();
+
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("name"u8))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("fields"u8))
+                {
+                    fields = property.Value.EnumerateArray().Select(element => element.GetString()).ToList();
+                    continue;
+                }
+                if (property.NameEquals("nullProperty"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    nullProperty = property.Value.GetInt32();
+                    continue;
+                }
+                if (property.NameEquals("keyValuePairs"u8))
+                {
+                    Dictionary<string, string> dictionary = new Dictionary<string, string>();
+                    foreach (var property0 in property.Value.EnumerateObject())
+                    {
+                        dictionary.Add(property0.Name, property0.Value.GetString());
+                    }
+                    keyValuePairs = dictionary;
+                    continue;
+                }
+                if (property.NameEquals("xProperty"u8))
+                {
+                    xProperty = property.Value.GetInt32();
+                    continue;
+                }
+                if (options.Format == "J")
+                {
+                    //this means it's an unknown property we got
+                    rawData.Add(property.Name, BinaryData.FromString(property.Value.GetRawText()));
+                }
+            }
+            return new ModelWithPersistableOnly(name, xProperty, OptionalProperty.ToNullable(nullProperty), OptionalProperty.ToList(fields), OptionalProperty.ToDictionary(keyValuePairs), rawData);
+        }
+
+        ModelWithPersistableOnly IPersistableModel<ModelWithPersistableOnly>.Create(BinaryData data, ModelReaderWriterOptions options)
+        {
+            ModelReaderWriterHelper.ValidateFormat(this, options.Format);
+
+            return DeserializeModelX(JsonDocument.Parse(data.ToString()).RootElement, options);
+        }
+
+        BinaryData IPersistableModel<ModelWithPersistableOnly>.Write(ModelReaderWriterOptions options)
+        {
+            ModelReaderWriterHelper.ValidateFormat(this, options.Format);
+
+            using MemoryStream stream = new MemoryStream();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
+            Serialize(writer, options);
+            writer.Flush();
+            return new BinaryData(stream.GetBuffer().AsMemory(0, (int)stream.Position));
+        }
+
+        string IPersistableModel<ModelWithPersistableOnly>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+    }
+}

--- a/sdk/core/System.ClientModel/tests/client/System.ClientModel.Tests.Client.csproj
+++ b/sdk/core/System.ClientModel/tests/client/System.ClientModel.Tests.Client.csproj
@@ -30,6 +30,9 @@
     <None Update="TestData\AvailabilitySetData\AvailabilitySetDataWithVMsWireFormat.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\ModelWithPersistableOnly\ModelWithPersistableOnlyWireFormat.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\ModelXml.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/sdk/core/System.ClientModel/tests/client/TestData/ModelWithPersistableOnly/ModelWithPersistableOnlyWireFormat.json
+++ b/sdk/core/System.ClientModel/tests/client/TestData/ModelWithPersistableOnly/ModelWithPersistableOnlyWireFormat.json
@@ -1,0 +1,12 @@
+{
+    "name": "xmodel",
+    "xProperty": 100,
+    "fields": [
+        "testField"
+    ],
+    "nullProperty": null,
+    "keyValuePairs": {
+        "color": "red"
+    },
+    "extra": "stuff"
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/40154

If a client author only implements IPersistableModel writing json format should still work it just won't take advantage of the faster interface IJsonModel

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
