### PR TITLE
Support "functions" SDKType

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -12,6 +12,7 @@
 
     <!-- Client in this context is any library that is following the new Azure SDK guidelines -->
     <IsClientLibrary Condition="'$(IsClientLibrary)' == '' and $(MSBuildProjectName.StartsWith('Azure.'))">true</IsClientLibrary>
+    <IsFunctionsLibrary Condition="'$(IsFunctionsLibrary)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Azure.WebJobs.Extensions.'))">true</IsFunctionsLibrary>
 
     <IsTestProject Condition="'$(IsTestProject)' == '' and $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
     <IsSamplesProject Condition="'$(IsSamplesProject)' == '' and $(MSBuildProjectName.EndsWith('.Samples'))">true</IsSamplesProject>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -365,10 +365,11 @@
   <Target Name="GetPackageInfo">
     <PropertyGroup>
       <PackageIsNewSdk>false</PackageIsNewSdk>
-      <PackageIsNewSdk Condition="'$(IsClientLibrary)' == 'true'">true</PackageIsNewSdk>
+      <PackageIsNewSdk Condition="'$(IsClientLibrary)' == 'true' or '$(IsFunctionsLibrary)' == 'true'">true</PackageIsNewSdk>
 
       <PackageSdkType>data</PackageSdkType>
       <PackageSdkType Condition="'$(IsClientLibrary)' == 'true'">client</PackageSdkType>
+      <PackageSdkType Condition="'$(IsFunctionsLibrary)' == 'true'">functions</PackageSdkType>
       <PackageSdkType Condition="'$(IsMgmtLibrary)' == 'true'">mgmt</PackageSdkType>
 
       <PackageRootDirectory>$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)/../).TrimEnd("/").TrimEnd("\\"))</PackageRootDirectory>

--- a/sdk/eventgrid/ci.functions.yml
+++ b/sdk/eventgrid/ci.functions.yml
@@ -9,8 +9,7 @@ trigger:
     - release/*
   paths:
     include:
-      - sdk/eventgrid/Azure.Messaging.EventGrid
-      - sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents
+      - sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid
       - sdk/eventgrid/service.projects
 
 pr:
@@ -22,20 +21,17 @@ pr:
     - release/*
   paths:
     include:
-      - sdk/eventgrid/Azure.Messaging.EventGrid
-      - sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents
+      - sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid
       - sdk/eventgrid/service.projects
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
-    SDKType: client
+    SDKType: functions
     ServiceDirectory: eventgrid
     ArtifactName: packages
     Artifacts:
-    - name: Azure.Messaging.EventGrid
-      safeName: AzureMessagingEventGrid
-    - name: Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents
-      safeName: MicrosoftAzureMessagingEventGridCloudNativeCloudEvents
+    - name: Microsoft.Azure.WebJobs.Extensions.EventGrid
+      safeName: MicrosoftAzureWebJobsExtensionsEventGrid
 
     

--- a/sdk/eventgrid/ci.functions.yml
+++ b/sdk/eventgrid/ci.functions.yml
@@ -11,6 +11,7 @@ trigger:
     include:
       - sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid
       - sdk/eventgrid/service.projects
+      - sdk/eventgrid/ci.functions.yml
 
 pr:
   branches:
@@ -23,6 +24,7 @@ pr:
     include:
       - sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid
       - sdk/eventgrid/service.projects
+      - sdk/eventgrid/ci.functions.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/eventgrid/ci.yml
+++ b/sdk/eventgrid/ci.yml
@@ -12,6 +12,7 @@ trigger:
       - sdk/eventgrid/Azure.Messaging.EventGrid
       - sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents
       - sdk/eventgrid/service.projects
+      - sdk/eventgrid/ci.yml
 
 pr:
   branches:
@@ -25,6 +26,7 @@ pr:
       - sdk/eventgrid/Azure.Messaging.EventGrid
       - sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents
       - sdk/eventgrid/service.projects
+      - sdk/eventgrid/ci.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/eventgrid/service.projects
+++ b/sdk/eventgrid/service.projects
@@ -9,6 +9,7 @@
   SDKType values
    - "all" will build all projects
    - "data" will build the Track 1 data plane library
+   - "functions" will build the functions libraries
    - "client" will build the Track 2 data plane libraries
    - "mgmtclient" will build the Track 2 mgmt libraries
 -->
@@ -21,6 +22,9 @@
   <ItemGroup Condition="'$(SDKType)' == 'client'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Messaging.EventGrid\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents\**\*.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(SDKType)' == 'functions'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.WebJobs.Extensions.EventGrid\**\*.csproj" />
   </ItemGroup>
 

--- a/sdk/eventgrid/tests.functions.yml
+++ b/sdk/eventgrid/tests.functions.yml
@@ -1,0 +1,7 @@
+trigger: none
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    ServiceDirectory: eventgrid
+    SDKType: functions

--- a/sdk/eventhub/ci.functions.yml
+++ b/sdk/eventhub/ci.functions.yml
@@ -8,8 +8,9 @@ trigger:
     - release/*
   paths:
     include:
-    - sdk/tables/Azure.Data.Tables
-    - sdk/tables/service.projects
+    - sdk/eventhub/ci.functions.yml
+    - sdk/eventhub/service.projects
+    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
 
 pr:
   branches:
@@ -20,15 +21,16 @@ pr:
     - release/*
   paths:
     include:
-    - sdk/tables/Azure.Data.Tables
-    - sdk/tables/service.projects
+    - sdk/eventhub/ci.functions.yml
+    - sdk/eventhub/service.projects
+    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
-    ServiceDirectory: tables
     SDKType: client
+    ServiceDirectory: eventhub
     ArtifactName: packages
     Artifacts:
-    - name: Azure.Data.Tables
-      safeName: AzureDataTables
+    - name: Microsoft.Azure.WebJobs.Extensions.EventHubs
+      safeName: MicrosoftAzureWebJobsExtensionsEventHubs

--- a/sdk/eventhub/ci.functions.yml
+++ b/sdk/eventhub/ci.functions.yml
@@ -28,7 +28,7 @@ pr:
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
-    SDKType: client
+    SDKType: functions
     ServiceDirectory: eventhub
     ArtifactName: packages
     Artifacts:

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -13,7 +13,6 @@ trigger:
     - sdk/eventhub/Azure.Messaging.EventHubs
     - sdk/eventhub/Azure.Messaging.EventHubs.Processor
     - sdk/eventhub/Azure.Messaging.EventHubs.Shared
-    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
 
 pr:
   branches:
@@ -29,7 +28,6 @@ pr:
     - sdk/eventhub/Azure.Messaging.EventHubs
     - sdk/eventhub/Azure.Messaging.EventHubs.Processor
     - sdk/eventhub/Azure.Messaging.EventHubs.Shared
-    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -42,5 +40,3 @@ extends:
       safeName: AzureMessagingEventHubs
     - name: Azure.Messaging.EventHubs.Processor
       safeName: AzureMessagingEventHubsProcessor
-    - name: Microsoft.Azure.WebJobs.Extensions.EventHubs
-      safeName: MicrosoftAzureWebJobsExtensionsEventHubs

--- a/sdk/eventhub/tests.functions.yml
+++ b/sdk/eventhub/tests.functions.yml
@@ -1,0 +1,11 @@
+trigger: none
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    MaxParallel: 6
+    ServiceDirectory: eventhub
+    SDKType: functions
+    TimeoutInMinutes: 240
+    Clouds: 'Public,Canary'
+    SupportedClouds: 'Public,UsGov,China,Canary'

--- a/sdk/servicebus/ci.functions.yml
+++ b/sdk/servicebus/ci.functions.yml
@@ -9,8 +9,8 @@ trigger:
   paths:
     include:
     - sdk/servicebus/service.projects
-    - sdk/servicebus/Azure.Messaging.ServiceBus
-    - sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
+    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
+    - sdk/servicebus/ci.functions.yml
 
 pr:
   branches:
@@ -22,16 +22,16 @@ pr:
   paths:
     include:
     - sdk/servicebus/service.projects
-    - sdk/servicebus/Azure.Messaging.ServiceBus
-    - sdk/servicebus/Azure.Messaging.ServiceBus/ci.yml
+    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
+    - sdk/servicebus/ci.functions.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
-    SDKType: client
+    SDKType: functions
     ServiceDirectory: servicebus
     BuildSnippets: false
     ArtifactName: packages
     Artifacts:
-    - name: Azure.Messaging.ServiceBus
-      safeName: AzureMessagingServiceBus
+    - name: Microsoft.Azure.WebJobs.Extensions.ServiceBus
+      safeName: MicrosoftAzureWebJobsExtensionsServiceBus

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -9,8 +9,8 @@ trigger:
   paths:
     include:
     - sdk/servicebus/service.projects
-    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
-    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
+    - sdk/servicebus/Azure.Messaging.ServiceBus
+    - sdk/servicebus/ci.yml
 
 pr:
   branches:
@@ -22,8 +22,8 @@ pr:
   paths:
     include:
     - sdk/servicebus/service.projects
-    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus
-    - sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ci.yml
+    - sdk/servicebus/Azure.Messaging.ServiceBus
+    - sdk/servicebus/ci.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -33,5 +33,5 @@ extends:
     BuildSnippets: false
     ArtifactName: packages
     Artifacts:
-    - name: Microsoft.Azure.WebJobs.Extensions.ServiceBus
-      safeName: MicrosoftAzureWebJobsExtensionsServiceBus
+    - name: Azure.Messaging.ServiceBus
+      safeName: AzureMessagingServiceBus

--- a/sdk/servicebus/service.projects
+++ b/sdk/servicebus/service.projects
@@ -9,6 +9,7 @@
   SDKType values
    - "all" will build all projects
    - "client" will build the new track 2 client/data libraries
+   - "functions" will build the functions libraries
    - "mgmtclient" will build the track 2 mgmt libraries
    - "data" will build the track 1 data plane libraries
 -->
@@ -20,10 +21,10 @@
 
   <ItemGroup Condition="'$(SDKType)' == 'client'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Messaging.*\**\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SDKType)' == 'functions'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.WebJobs.Extensions.ServiceBus\**\*.csproj" />
-    <ProjectReference Update="$(MSBuildThisFileDirectory)Azure.Messaging.*\tests\*.csproj">
-      <TestInParallel>false</TestInParallel>
-    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(SDKType)' == 'mgmtclient'">

--- a/sdk/servicebus/tests.functions.yml
+++ b/sdk/servicebus/tests.functions.yml
@@ -5,7 +5,7 @@ extends:
   parameters:
     MaxParallel: 4
     ServiceDirectory: servicebus
-    Project: Azure.Messaging.ServiceBus
+    SDKType: functions
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
     SupportedClouds: 'Public,UsGov,China,Canary'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -5,7 +5,7 @@ extends:
   parameters:
     MaxParallel: 4
     ServiceDirectory: servicebus
-    Project: Microsoft.Azure.WebJobs.Extensions.ServiceBus
+    SDKType: client
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
     SupportedClouds: 'Public,UsGov,China,Canary'

--- a/sdk/tables/ci.functions.yml
+++ b/sdk/tables/ci.functions.yml
@@ -10,6 +10,7 @@ trigger:
     include:
     - sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables
     - sdk/tables/service.projects
+    - sdk/tables/ci.functions.yml
 
 pr:
   branches:
@@ -22,6 +23,7 @@ pr:
     include:
       - sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables
       - sdk/tables/service.projects
+      - sdk/tables/ci.functions.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/tables/ci.functions.yml
+++ b/sdk/tables/ci.functions.yml
@@ -8,8 +8,7 @@ trigger:
     - release/*
   paths:
     include:
-    - sdk/tables/Azure.Data.Tables
-    - sdk/tables/service.projects
+    - sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables
 
 pr:
   branches:
@@ -20,15 +19,14 @@ pr:
     - release/*
   paths:
     include:
-    - sdk/tables/Azure.Data.Tables
-    - sdk/tables/service.projects
+      - sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: tables
-    SDKType: client
     ArtifactName: packages
+    SDKType: functions
     Artifacts:
-    - name: Azure.Data.Tables
-      safeName: AzureDataTables
+    - name: Microsoft.Azure.WebJobs.Extensions.Tables
+      safeName: MicrosoftAzureWebJobsExtensionsTables

--- a/sdk/tables/ci.functions.yml
+++ b/sdk/tables/ci.functions.yml
@@ -9,6 +9,7 @@ trigger:
   paths:
     include:
     - sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables
+    - sdk/tables/service.projects
 
 pr:
   branches:
@@ -20,6 +21,7 @@ pr:
   paths:
     include:
       - sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables
+      - sdk/tables/service.projects
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -10,6 +10,7 @@ trigger:
     include:
     - sdk/tables/Azure.Data.Tables
     - sdk/tables/service.projects
+    - sdk/tables/ci.yml
 
 pr:
   branches:
@@ -22,6 +23,7 @@ pr:
     include:
     - sdk/tables/Azure.Data.Tables
     - sdk/tables/service.projects
+    - sdk/tables/ci.yml
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/tables/service.projects
+++ b/sdk/tables/service.projects
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(SDKType)' == 'client'">
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Data.Tables.*\**\*.csproj" />
+    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Data.Tables\**\*.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SDKType)' == 'functions'">

--- a/sdk/tables/service.projects
+++ b/sdk/tables/service.projects
@@ -15,19 +15,16 @@
 -->
 
 <Project>
+  <ItemGroup Condition="'$(SDKType)' == 'all'">
+    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)**\*.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(SDKType)' == 'client'">
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Messaging.*\**\*.csproj" />
+    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Data.Tables.*\**\*.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(SDKType)' == 'functions'">
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.WebJobs.Extensions.EventHubs\**\*.csproj" />
+    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.WebJobs.Extensions.Tables\**\*.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SDKType)' == 'mgmtclient'">
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.ResourceManager.*\**\*.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(SDKType)' == 'data'">
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Microsoft.Azure.EventHubs*\**\*.csproj" />
-  </ItemGroup>
 </Project>

--- a/sdk/tables/tests.functions.yml
+++ b/sdk/tables/tests.functions.yml
@@ -1,0 +1,8 @@
+trigger: none
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    ServiceDirectory: tables
+    SDKType: functions
+    TimeoutInMinutes: 120


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-net/issues/38271

The goal of this PR is to enable functions libraries to be released and tested separately from their Track 2 Azure SDK counterparts. The reason for this is that the functions libraries have different ownership and testing methodology. Also, additional functions libraries will be moving into the repo soon to support shipping the dotnet isolated worker functions libraries from this repo which makes the split even more necessary.

Libraries starting with `Microsoft.Azure.WebJobs.Extensions` will be automatically tagged with `SDKType` of `functions`. To enable a separate pipeline for functions, follow the pattern used in this PR.