### PR TITLE
Update FaceOperationsExtensions.cs

### DIFF
--- a/sdk/cognitiveservices/Vision.Face/src/Generated/FaceOperationsExtensions.cs
+++ b/sdk/cognitiveservices/Vision.Face/src/Generated/FaceOperationsExtensions.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.CognitiveServices.Vision.Face
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<GroupResult> GroupAsync(this IFaceOperations operations, IList<System.Guid> faceIds, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<GroupResult> GroupAsync(this IFaceOperations operations, GroupRequest faceIds, CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GroupWithHttpMessagesAsync(faceIds, null, cancellationToken).ConfigureAwait(false))
                 {


### PR DESCRIPTION
Accordingly to the documentation(https://learn.microsoft.com/en-us/rest/api/faceapi/face/group?view=rest-faceapi-v1.0&tabs=HTTP), the body for "face/v1.0/group" need to be like this:
 {
  "faceIds": [
    "c5c24a82-6845-4031-9d5d-978df9175426",
    "015839fb-fbd9-4f79-ace9-7675fc2f1dd9"
  ]
}
But, in the SDK, "GroupAsync" requires you to insert IList<Guid>, which is different from what the documentation says. At the moment, the only way to call "GroupAsync" is making manual http call.

There is a need to change "GroupWithHttpMessagesAsync" too.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
