### PR TITLE
Expand Identity SDK token timeout from 13 to 60 seconds

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs
@@ -77,7 +77,7 @@ namespace Azure.Identity
             TenantId = Validations.ValidateTenantId(options?.TenantId, $"{nameof(options)}.{nameof(options.TenantId)}", true);
             TenantIdResolver = options?.TenantIdResolver ?? TenantIdResolverBase.Default;
             AdditionallyAllowedTenantIds = TenantIdResolver.ResolveAddionallyAllowedTenantIds((options as ISupportsAdditionallyAllowedTenants)?.AdditionallyAllowedTenants);
-            ProcessTimeout = options?.ProcessTimeout ?? TimeSpan.FromSeconds(13);
+            ProcessTimeout = options?.ProcessTimeout ?? TimeSpan.FromSeconds(60);
             _isChainedCredential = options?.IsChainedCredential ?? false;
         }
 

--- a/sdk/identity/Azure.Identity/src/Credentials/AzureDeveloperCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/AzureDeveloperCliCredential.cs
@@ -69,7 +69,7 @@ namespace Azure.Identity
             TenantId = Validations.ValidateTenantId(options?.TenantId, $"{nameof(options)}.{nameof(options.TenantId)}", true);
             TenantIdResolver = options?.TenantIdResolver ?? TenantIdResolverBase.Default;
             AdditionallyAllowedTenantIds = TenantIdResolver.ResolveAddionallyAllowedTenantIds((options as ISupportsAdditionallyAllowedTenants)?.AdditionallyAllowedTenants);
-            ProcessTimeout = options?.ProcessTimeout ?? TimeSpan.FromSeconds(13);
+            ProcessTimeout = options?.ProcessTimeout ?? TimeSpan.FromSeconds(60);
             _isChainedCredential = options?.IsChainedCredential ?? false;
         }
 

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
@@ -219,14 +219,14 @@ namespace Azure.Identity.Tests
 
                 AzureCliCredential cred = (AzureCliCredential)factory.CreateAzureCliCredential();
 
-                Assert.AreEqual(expTimeout ?? TimeSpan.FromSeconds(13), cred.ProcessTimeout);
+                Assert.AreEqual(expTimeout ?? TimeSpan.FromSeconds(60), cred.ProcessTimeout);
                 Assert.AreEqual(expTenantId, cred.TenantId);
                 CollectionAssert.AreEquivalent(expAdditionallyAllowedTenants, cred.AdditionallyAllowedTenantIds);
                 Assert.True(cred._isChainedCredential);
 
                 AzureDeveloperCliCredential credAzd = (AzureDeveloperCliCredential)factory.CreateAzureDeveloperCliCredential();
 
-                Assert.AreEqual(expTimeout ?? TimeSpan.FromSeconds(13), credAzd.ProcessTimeout);
+                Assert.AreEqual(expTimeout ?? TimeSpan.FromSeconds(60), credAzd.ProcessTimeout);
                 Assert.AreEqual(expTenantId, credAzd.TenantId);
                 CollectionAssert.AreEquivalent(expAdditionallyAllowedTenants, credAzd.AdditionallyAllowedTenantIds);
                 Assert.True(credAzd._isChainedCredential);

--- a/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
@@ -256,7 +256,7 @@ namespace Azure.Identity.Tests
                         MaxRetries = 15,
                         MaxDelay = TimeSpan.FromSeconds(29),
                         Mode = RetryMode.Fixed,
-                        NetworkTimeout = TimeSpan.FromSeconds(13)
+                        NetworkTimeout = TimeSpan.FromSeconds(60)
                     },
                     Diagnostics =
                     {


### PR DESCRIPTION
Recent widespread deployment pipeline failures occurred in our services because the timeout is too low. Increase to a level beyond what token retrieval is likely to need.
