### PR TITLE
[AzureMonitorLiveMetrics] refactor Manager and remove timer

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
@@ -15,9 +16,10 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
     internal partial class Manager
     {
         internal readonly DoubleBuffer _documentBuffer = new();
+        internal static bool? s_isAzureWebApp = null;
 
-        private PerformanceCounter _performanceCounter_ProcessorTime = new PerformanceCounter(categoryName: "Processor", counterName: "% Processor Time", instanceName: "_Total");
-        private PerformanceCounter _performanceCounter_CommittedBytes = new PerformanceCounter(categoryName: "Memory", counterName: "Committed Bytes");
+        private readonly PerformanceCounter _performanceCounter_ProcessorTime = new(categoryName: "Processor", counterName: "% Processor Time", instanceName: "_Total");
+        private readonly PerformanceCounter _performanceCounter_CommittedBytes = new(categoryName: "Memory", counterName: "Committed Bytes");
 
         public MonitoringDataPoint GetDataPoint()
         {
@@ -115,6 +117,38 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                 Value = _performanceCounter_ProcessorTime.NextValue(),
                 Weight = 1
             };
+        }
+
+        /// <summary>
+        /// Searches for the environment variable specific to Azure Web App.
+        /// </summary>
+        /// <returns>Boolean, which is true if the current application is an Azure Web App.</returns>
+        internal static bool? IsWebAppRunningInAzure()
+        {
+            const string WebSiteEnvironmentVariable = "WEBSITE_SITE_NAME";
+            const string WebSiteIsolationEnvironmentVariable = "WEBSITE_ISOLATION";
+            const string WebSiteIsolationHyperV = "hyperv";
+
+            if (!s_isAzureWebApp.HasValue)
+            {
+                try
+                {
+                    // Presence of "WEBSITE_SITE_NAME" indicate web apps.
+                    // "WEBSITE_ISOLATION"!="hyperv" indicate premium containers. In this case, perf counters
+                    // can be read using regular mechanism and hence this method retuns false for
+                    // premium containers.
+                    // TODO: switch to platform. Not necessary for POC.
+                    s_isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable)) &&
+                                    Environment.GetEnvironmentVariable(WebSiteIsolationEnvironmentVariable) != WebSiteIsolationHyperV;
+                }
+                catch (Exception ex)
+                {
+                    LiveMetricsExporterEventSource.Log.AccessingEnvironmentVariableFailedWarning(WebSiteEnvironmentVariable, ex);
+                    return false;
+                }
+            }
+
+            return s_isAzureWebApp;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -27,8 +27,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             {
                 Version = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength),
                 InvariantVersion = 5,
-                Instance = liveMetricsResource?.RoleInstance ?? "UNKNOWN_INSTANCE",
-                RoleName = liveMetricsResource?.RoleName,
+                Instance = LiveMetricsResource?.RoleInstance ?? "UNKNOWN_INSTANCE",
+                RoleName = LiveMetricsResource?.RoleName,
                 MachineName = Environment.MachineName, // TODO: MOVE TO PLATFORM
                                                        // TODO: Is the Stream ID expected to be unique per post? Testing suggests this is not necessary.
                 StreamId = _streamId,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
+{
+    /// <summary>
+    /// This partial class encapsulates the Ping and Post methods.
+    /// This is the data that is sent to the Live Metrics service.
+    /// </summary>
+    internal partial class Manager
+    {
+        /// <summary>
+        /// This is a unique identifier that comes from the LiveMetrics service and identifies our connected session.
+        /// </summary>
+        private string _etag = string.Empty;
+
+        private void OnPing(object state)
+        {
+            try
+            {
+                Debug.WriteLine($"{DateTime.Now}: OnPing invoked.");
+
+                var response = _quickPulseSDKClientAPIsRestClient.PingCustom(
+                    ikey: _connectionVars.InstrumentationKey,
+                    apikey: null,
+                    xMsQpsTransmissionTime: null,
+                    xMsQpsMachineName: "Desktop-Name",
+                    xMsQpsInstanceName: "Desktop-Name",
+                    xMsQpsStreamId: _streamId,
+                    xMsQpsRoleName: null,
+                    xMsQpsInvariantVersion: "5",
+                    xMsQpsConfigurationEtag: _etag,
+                    monitoringDataPoint: null,
+                    cancellationToken: default);
+
+                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                {
+                    Debug.WriteLine($"OnPing: updated etag: {etagValue}");
+                    _etag = etagValue;
+                }
+
+                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && Convert.ToBoolean(subscribedValue))
+                {
+                    Debug.WriteLine($"OnPing: Subscribed: {subscribedValue}");
+                    SetPostTimer();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+        }
+
+        /// <summary>
+        /// Send data to LiveMetrics service.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <remarks>
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Requests/Sec", Value = 0, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Request Duration", Value = 0, Weight = 0 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Requests Failed/Sec", Value = 0, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Requests Succeeded/Sec", Value = 0, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Calls/Sec", Value = 0, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Call Duration", Value = 0, Weight = 0 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Calls Failed/Sec", Value = 0, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Calls Succeeded/Sec", Value = 0, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Exceptions/Sec", Value = 0, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\Memory\\Committed Bytes", Value = 41372430336, Weight = 1 });
+        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\Processor(_Total)\\% Processor Time", Value = 14.1891f, Weight = 1 });.
+        /// </remarks>
+        private void OnPost(object state)
+        {
+            try
+            {
+                Debug.WriteLine($"{DateTime.Now}: OnPost invoked.");
+
+                var dataPoint = GetDataPoint();
+
+                var response = _quickPulseSDKClientAPIsRestClient.PostCustom(
+                    ikey: _connectionVars.InstrumentationKey,
+                    apikey: null,
+                    xMsQpsConfigurationEtag: _etag,
+                    xMsQpsTransmissionTime: null,
+                    monitoringDataPoints: new MonitoringDataPoint[] { dataPoint },
+                    cancellationToken: default);
+
+                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                {
+                    Debug.WriteLine($"OnPost: updated etag: {etagValue}");
+                    _etag = etagValue;
+                }
+
+                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && !Convert.ToBoolean(subscribedValue))
+                {
+                    Debug.WriteLine($"OnPost: Subscribed: {subscribedValue}");
+                    _etag = string.Empty;
+                    SetPingTimer();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -18,7 +18,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         /// </summary>
         private string _etag = string.Empty;
 
-        private void OnPing(object state)
+        private void OnPing()
         {
             try
             {
@@ -46,7 +46,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                 if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && Convert.ToBoolean(subscribedValue))
                 {
                     Debug.WriteLine($"OnPing: Subscribed: {subscribedValue}");
-                    SetPostTimer();
+                    SetPostState();
                 }
             }
             catch (Exception ex)
@@ -58,7 +58,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         /// <summary>
         /// Send data to LiveMetrics service.
         /// </summary>
-        /// <param name="state"></param>
         /// <remarks>
         /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Requests/Sec", Value = 0, Weight = 1 });
         /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Request Duration", Value = 0, Weight = 0 });
@@ -72,7 +71,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\Memory\\Committed Bytes", Value = 41372430336, Weight = 1 });
         /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\Processor(_Total)\\% Processor Time", Value = 14.1891f, Weight = 1 });.
         /// </remarks>
-        private void OnPost(object state)
+        private void OnPost()
         {
             try
             {
@@ -85,7 +84,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     apikey: null,
                     xMsQpsConfigurationEtag: _etag,
                     xMsQpsTransmissionTime: null,
-                    monitoringDataPoints: new MonitoringDataPoint[] { dataPoint },
+                    monitoringDataPoints: new MonitoringDataPoint[] { dataPoint }, // TODO: CHECK WITH SERVICE TEAM. WHY DOES THIS NEED TO BE A COLLECITON?
                     cancellationToken: default);
 
                 if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
@@ -98,7 +97,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                 {
                     Debug.WriteLine($"OnPost: Subscribed: {subscribedValue}");
                     _etag = string.Empty;
-                    SetPingTimer();
+                    SetPingState();
                 }
             }
             catch (Exception ex)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
+{
+    /// <summary>
+    /// This partial class encapsulates the State.
+    /// This controls if we are in either the Ping or Post state.
+    /// </summary>
+    internal partial class Manager
+    {
+        private Timer _timer;
+
+        private Action<object> _callbackAction = obj => { };
+
+        internal readonly State _state = new();
+
+        private void SetPingTimer()
+        {
+            _state.Update(LiveMetricsState.Ping);
+            _callbackAction = OnPing;
+            _timer.Change(dueTime: 0, period: 5000);
+        }
+
+        private void SetPostTimer()
+        {
+            _state.Update(LiveMetricsState.Post);
+            _callbackAction = OnPost;
+            _timer.Change(dueTime: 0, period: 1000);
+        }
+
+        private void OnCallback(object state) => _callbackAction.Invoke(state);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
@@ -27,6 +27,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             SetPingState();
             Task.Run(() => Run(CancellationToken.None)); // TODO: USE AN ACTUAL CANCELLATION TOKEN
+            // TODO: Investigate use of a dedicated thread here.
         }
 
         private void SetPingState()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using Azure.Core.Pipeline;
-using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
-using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
@@ -19,13 +16,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         private readonly ConnectionVars _connectionVars;
         private readonly bool _isAadEnabled;
         private readonly string _streamId = Guid.NewGuid().ToString();
-        private Timer _timer;
-        private string _etag = string.Empty;
-        private Action<object> _callbackAction = obj => { };
-
-        internal static bool? s_isAzureWebApp = null;
-
-        internal readonly State _state = new();
 
         public Manager(LiveMetricsExporterOptions options, IPlatform platform)
         {
@@ -86,143 +76,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             }
 
             return new QuickPulseSDKClientAPIsRestClient(new ClientDiagnostics(options), pipeline, host: connectionVars.LiveEndpoint);
-        }
-
-        private void SetPingTimer()
-        {
-            _state.Update(LiveMetricsState.Ping);
-            _callbackAction = OnPing;
-            _timer.Change(dueTime: 0, period: 5000);
-        }
-
-        private void SetPostTimer()
-        {
-            _state.Update(LiveMetricsState.Post);
-            _callbackAction = OnPost;
-            _timer.Change(dueTime: 0, period: 1000);
-        }
-
-        private void OnCallback(object state) => _callbackAction.Invoke(state);
-
-        private void OnPing(object state)
-        {
-            try
-            {
-                Debug.WriteLine($"{DateTime.Now}: OnPing invoked.");
-
-                var response = _quickPulseSDKClientAPIsRestClient.PingCustom(
-                    ikey: _connectionVars.InstrumentationKey,
-                    apikey: null,
-                    xMsQpsTransmissionTime: null,
-                    xMsQpsMachineName: "Desktop-Name",
-                    xMsQpsInstanceName: "Desktop-Name",
-                    xMsQpsStreamId: _streamId,
-                    xMsQpsRoleName: null,
-                    xMsQpsInvariantVersion: "5",
-                    xMsQpsConfigurationEtag: _etag,
-                    monitoringDataPoint: null,
-                    cancellationToken: default);
-
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
-                {
-                    Debug.WriteLine($"OnPing: updated etag: {etagValue}");
-                    _etag = etagValue;
-                }
-
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && Convert.ToBoolean(subscribedValue))
-                {
-                    Debug.WriteLine($"OnPing: Subscribed: {subscribedValue}");
-                    SetPostTimer();
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex);
-            }
-        }
-
-        /// <summary>
-        /// Send data to LiveMetrics service.
-        /// </summary>
-        /// <param name="state"></param>
-        /// <remarks>
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Requests/Sec", Value = 0, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Request Duration", Value = 0, Weight = 0 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Requests Failed/Sec", Value = 0, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Requests Succeeded/Sec", Value = 0, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Calls/Sec", Value = 0, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Call Duration", Value = 0, Weight = 0 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Calls Failed/Sec", Value = 0, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Dependency Calls Succeeded/Sec", Value = 0, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\ApplicationInsights\\Exceptions/Sec", Value = 0, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\Memory\\Committed Bytes", Value = 41372430336, Weight = 1 });
-        /// dataPoint.Metrics.Add(new MetricPoint { Name = "\\Processor(_Total)\\% Processor Time", Value = 14.1891f, Weight = 1 });.
-        /// </remarks>
-        private void OnPost(object state)
-        {
-            try
-            {
-                Debug.WriteLine($"{DateTime.Now}: OnPost invoked.");
-
-                var dataPoint = GetDataPoint();
-
-                var response = _quickPulseSDKClientAPIsRestClient.PostCustom(
-                    ikey: _connectionVars.InstrumentationKey,
-                    apikey: null,
-                    xMsQpsConfigurationEtag: _etag,
-                    xMsQpsTransmissionTime: null,
-                    monitoringDataPoints: new MonitoringDataPoint[] { dataPoint },
-                    cancellationToken: default);
-
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
-                {
-                    Debug.WriteLine($"OnPost: updated etag: {etagValue}");
-                    _etag = etagValue;
-                }
-
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && !Convert.ToBoolean(subscribedValue))
-                {
-                    Debug.WriteLine($"OnPost: Subscribed: {subscribedValue}");
-                    _etag = string.Empty;
-                    SetPingTimer();
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex);
-            }
-        }
-
-        /// <summary>
-        /// Searches for the environment variable specific to Azure Web App.
-        /// </summary>
-        /// <returns>Boolean, which is true if the current application is an Azure Web App.</returns>
-        internal static bool? IsWebAppRunningInAzure()
-        {
-            const string WebSiteEnvironmentVariable = "WEBSITE_SITE_NAME";
-            const string WebSiteIsolationEnvironmentVariable = "WEBSITE_ISOLATION";
-            const string WebSiteIsolationHyperV = "hyperv";
-
-            if (!s_isAzureWebApp.HasValue)
-            {
-                try
-                {
-                    // Presence of "WEBSITE_SITE_NAME" indicate web apps.
-                    // "WEBSITE_ISOLATION"!="hyperv" indicate premium containers. In this case, perf counters
-                    // can be read using regular mechanism and hence this method retuns false for
-                    // premium containers.
-                    // TODO: switch to platform. Not necessary for POC.
-                    s_isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable)) &&
-                                    Environment.GetEnvironmentVariable(WebSiteIsolationEnvironmentVariable) != WebSiteIsolationHyperV;
-                }
-                catch (Exception ex)
-                {
-                    LiveMetricsExporterEventSource.Log.AccessingEnvironmentVariableFailedWarning(WebSiteEnvironmentVariable, ex);
-                    return false;
-                }
-            }
-
-            return s_isAzureWebApp;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Threading;
 using Azure.Core.Pipeline;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
@@ -24,11 +23,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             _connectionVars = InitializeConnectionVars(options, platform);
             _quickPulseSDKClientAPIsRestClient = InitializeRestClient(options, _connectionVars, out _isAadEnabled);
 
-            _timer = new Timer(callback: OnCallback, state: null, dueTime: Timeout.Infinite, period: Timeout.Infinite);
-
             if (options.EnableLiveMetrics)
             {
-                SetPingTimer();
+                InitializeState();
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.cs
@@ -29,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             }
         }
 
-        public LiveMetricsResource? liveMetricsResource { get; set; }
+        public LiveMetricsResource? LiveMetricsResource { get; set; }
 
         internal static ConnectionVars InitializeConnectionVars(LiveMetricsExporterOptions options, IPlatform platform)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
@@ -33,9 +33,10 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                 return;
             }
 
-            if (_manager.liveMetricsResource == null && LiveMetricsResource != null)
+            // Resource is not available at initialization and must be set later.
+            if (_manager.LiveMetricsResource == null && LiveMetricsResource != null)
             {
-                _manager.liveMetricsResource = LiveMetricsResource;
+                _manager.LiveMetricsResource = LiveMetricsResource;
             }
 
             string? statusCodeAttributeValue = null;


### PR DESCRIPTION
This PR accomplishes two things. 

First, the `Manager` class which is currently the heart of our implementation was broken up into smaller partial classes based on responsibility. For me, this immediately improved readability and allowed me to focus on one piece at a time.

Second, this removes the `Timer` implementation. This new implementation is using timestamps with `Task.Delay()`. This gives us more fine control over the timing of ticks and prevents ticks from occurring concurrently. 


## Changes
- Split `Manager` class into smaller partial classes. This improves maintainability.
  - `Manager` contains the constructor and initialization methods. (Almost identical to `Transmitter` in the Exporter project).
  - `Manager.Metrics` contains our metric and document buffers. This also creates the payload sent to LiveMetrics.
  - `Manager.RestClient` encapsulates our Ping and Post methods (sending to LiveMetrics).
  - `Manager.State` encapsulates our state manager and the `Task.Delay` implementation.