### PR TITLE
[AzureMonitorLiveMetrics] poc implement backoff

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -18,10 +18,16 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         /// </summary>
         private string _etag = string.Empty;
 
+        private bool _pingHasRun = false;
+        private bool _postHasRun = false;
+        private DateTimeOffset _lastSuccessfulPing = DateTimeOffset.UtcNow;
+        private DateTimeOffset _lastSuccessfulPost = DateTimeOffset.UtcNow;
+
         private void OnPing()
         {
             try
             {
+                _pingHasRun = true;
                 Debug.WriteLine($"{DateTime.Now}: OnPing invoked.");
 
                 var response = _quickPulseSDKClientAPIsRestClient.PingCustom(
@@ -37,16 +43,25 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     monitoringDataPoint: null,
                     cancellationToken: default);
 
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                if (IsResponseSuccess(response))
                 {
-                    Debug.WriteLine($"OnPing: updated etag: {etagValue}");
-                    _etag = etagValue;
-                }
+                    _lastSuccessfulPing = DateTimeOffset.UtcNow;
 
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && Convert.ToBoolean(subscribedValue))
+                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                    {
+                        Debug.WriteLine($"OnPing: updated etag: {etagValue}");
+                        _etag = etagValue;
+                    }
+
+                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && Convert.ToBoolean(subscribedValue))
+                    {
+                        Debug.WriteLine($"OnPing: Subscribed: {subscribedValue}");
+                        SetPostState();
+                    }
+                }
+                else
                 {
-                    Debug.WriteLine($"OnPing: Subscribed: {subscribedValue}");
-                    SetPostState();
+                    // TODO: NEED TO INSPECT THE ServiceError OBJECT AND LOG.
                 }
             }
             catch (Exception ex)
@@ -75,6 +90,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             try
             {
+                _postHasRun = true;
                 Debug.WriteLine($"{DateTime.Now}: OnPost invoked.");
 
                 var dataPoint = GetDataPoint();
@@ -87,23 +103,38 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     monitoringDataPoints: new MonitoringDataPoint[] { dataPoint }, // TODO: CHECK WITH SERVICE TEAM. WHY DOES THIS NEED TO BE A COLLECITON?
                     cancellationToken: default);
 
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                if (IsResponseSuccess(response))
                 {
-                    Debug.WriteLine($"OnPost: updated etag: {etagValue}");
-                    _etag = etagValue;
-                }
+                    _lastSuccessfulPost = DateTimeOffset.UtcNow;
 
-                if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && !Convert.ToBoolean(subscribedValue))
+                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                    {
+                        Debug.WriteLine($"OnPost: updated etag: {etagValue}");
+                        _etag = etagValue;
+                    }
+
+                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && !Convert.ToBoolean(subscribedValue))
+                    {
+                        Debug.WriteLine($"OnPost: Subscribed: {subscribedValue}");
+                        _etag = string.Empty;
+                        SetPingState();
+                    }
+                }
+                else
                 {
-                    Debug.WriteLine($"OnPost: Subscribed: {subscribedValue}");
-                    _etag = string.Empty;
-                    SetPingState();
+                    // TODO: NEED TO INSPECT THE ServiceError OBJECT AND LOG.
                 }
             }
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
             }
+        }
+
+        private bool IsResponseSuccess(Response response)
+        {
+            // TODO: COULD THIS BE MOVED INTO THE REST CLIENT CUSTOMIZATION? ie: avoid checking Status code twice?
+            return response.Status >= 200 && response.Status < 300;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -18,8 +18,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         /// </summary>
         private string _etag = string.Empty;
 
-        private bool _pingHasRun = false;
-        private bool _postHasRun = false;
         private DateTimeOffset _lastSuccessfulPing = DateTimeOffset.UtcNow;
         private DateTimeOffset _lastSuccessfulPost = DateTimeOffset.UtcNow;
 
@@ -27,7 +25,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             try
             {
-                _pingHasRun = true;
                 Debug.WriteLine($"{DateTime.Now}: OnPing invoked.");
 
                 var response = _quickPulseSDKClientAPIsRestClient.PingCustom(
@@ -90,7 +87,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         {
             try
             {
-                _postHasRun = true;
                 Debug.WriteLine($"{DateTime.Now}: OnPost invoked.");
 
                 var dataPoint = GetDataPoint();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
@@ -52,7 +52,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             _shouldCollect = false;
             _callbackAction = OnPing;
             _period = _pingPeriod;
-            _evaluateBackoff = () => _pingHasRun && DateTimeOffset.UtcNow - _lastSuccessfulPing > _maximumPingInterval;
+            _lastSuccessfulPing = DateTimeOffset.UtcNow;
+            _evaluateBackoff = () => DateTimeOffset.UtcNow - _lastSuccessfulPing > _maximumPingInterval;
         }
 
         private void SetPostState()
@@ -61,7 +62,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             _shouldCollect = true;
             _callbackAction = OnPost;
             _period = _postPeriod;
-            _evaluateBackoff = () => _postHasRun && DateTimeOffset.UtcNow - _lastSuccessfulPost > _maximumPostInterval;
+            _lastSuccessfulPost = DateTimeOffset.UtcNow;
+            _evaluateBackoff = () => DateTimeOffset.UtcNow - _lastSuccessfulPost > _maximumPostInterval;
         }
 
         private void SetBackoffState()
@@ -71,8 +73,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             _callbackAction = BackoffConcluded;
             _period = _backoffPeriod;
             _evaluateBackoff = () => false;
-
-            _pingHasRun = _postHasRun = false;
         }
 
         private void BackoffConcluded()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.State.cs
@@ -2,26 +2,42 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
     /// <summary>
-    /// This partial class encapsulates the State.
+    /// This partial class encapsulates the State Machine.
     /// This controls if we are in either the Ping or Post state.
     /// </summary>
+    /// <remarks>
+    /// RULES FOR BACKOFF:
+    /// POST: We expect to Post once every second, but no longer than once every 20 seconds.
+    /// If we exceed the 20 seconds, we consider this a failure and Stop Posting.
+    /// We will wait 60 seconds before Pinging again.
+    /// PING: We expect to Ping once every 5 seconds, but no longer than once every 60 seconds.
+    /// If we exceed the 60 seconds, we will wait 60 seconds before Pinging again.
+    /// </remarks>
     internal partial class Manager
     {
         private Action _callbackAction = () => { };
 
-        internal readonly State _state = new();
+        private readonly State _state = new();
 
-        internal TimeSpan _period;
+        private TimeSpan _period;
+        private bool _shouldCollect = false;
+        private Func<bool> _evaluateBackoff = () => false;
+
         private readonly TimeSpan _pingPeriod = TimeSpan.FromSeconds(5);
         private readonly TimeSpan _postPeriod = TimeSpan.FromSeconds(1);
-        // TODO: WILL NEED ADDITIONAL PERIODS DEFINED FOR BACKOFF.
+        private readonly TimeSpan _backoffPeriod = TimeSpan.FromMinutes(1);
+
+        private readonly TimeSpan _maximumPingInterval = TimeSpan.FromSeconds(60);
+        private readonly TimeSpan _maximumPostInterval = TimeSpan.FromSeconds(20);
+
+        internal bool ShouldCollect() => _shouldCollect;
 
         private void InitializeState()
         {
@@ -33,32 +49,65 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         private void SetPingState()
         {
             _state.Update(LiveMetricsState.Ping);
+            _shouldCollect = false;
             _callbackAction = OnPing;
             _period = _pingPeriod;
+            _evaluateBackoff = () => _pingHasRun && DateTimeOffset.UtcNow - _lastSuccessfulPing > _maximumPingInterval;
         }
 
         private void SetPostState()
         {
             _state.Update(LiveMetricsState.Post);
+            _shouldCollect = true;
             _callbackAction = OnPost;
             _period = _postPeriod;
+            _evaluateBackoff = () => _postHasRun && DateTimeOffset.UtcNow - _lastSuccessfulPost > _maximumPostInterval;
         }
 
-        [SuppressMessage("Usage", "AZC0102: Do not use GetAwaiter().GetResult().", Justification = "The EnsureCompleted() extension method is a wrapper around GetAwaiter().GetResult() without adding value. Worse, it breaks during Debug making it impossible to test Live Metrics.")]
+        private void SetBackoffState()
+        {
+            _state.Update(LiveMetricsState.Backoff);
+            _shouldCollect = false;
+            _callbackAction = BackoffConcluded;
+            _period = _backoffPeriod;
+            _evaluateBackoff = () => false;
+
+            _pingHasRun = _postHasRun = false;
+        }
+
+        private void BackoffConcluded()
+        {
+            // when the backoff period is complete, we switch to Ping.
+            SetPingState();
+        }
+
         private void Run(CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var callbackStarted = DateTime.UtcNow;
+                var callbackStarted = DateTimeOffset.UtcNow;
 
                 _callbackAction.Invoke();
 
                 // Subtract the time spent in this tick when scheduling the next tick so that the average period is close to the intended.
-                var timeSpentInThisTick = DateTime.UtcNow - callbackStarted;
-                var nextTick = _period - timeSpentInThisTick;
-                nextTick = nextTick > TimeSpan.Zero ? nextTick : TimeSpan.Zero;
+                var timeSpentInThisTick = DateTimeOffset.UtcNow - callbackStarted;
 
-                Task.Delay(nextTick, cancellationToken).GetAwaiter().GetResult();
+                TimeSpan nextTick;
+
+                // Check if we need to backoff.
+                if (_evaluateBackoff.Invoke())
+                {
+                    Debug.WriteLine($"{DateTime.Now}: Backing off.");
+                    SetBackoffState();
+                    nextTick = _period;
+                }
+                else
+                {
+                    nextTick = _period - timeSpentInThisTick;
+                    nextTick = nextTick > TimeSpan.Zero ? nextTick : TimeSpan.Zero;
+                }
+
+                Task.Delay(nextTick, cancellationToken).Wait();
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/State.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/State.cs
@@ -5,11 +5,10 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 {
     internal enum LiveMetricsState
     {
-        // TODO: THIS COULD BE A FLAGS SO LIVE METRICS CAN BE BOTH PING AND BACKOFF
-
         Disabled = 0,
         Ping,
         Post,
+        Backoff,
     }
 
     internal class State

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
@@ -27,8 +27,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 
         public override void OnEnd(Activity activity)
         {
-            // Validate if live metrics is enabled.
-            if (!_manager._state.IsEnabled())
+            // Check if live metrics is enabled.
+            if (!_manager.ShouldCollect())
             {
                 return;
             }


### PR DESCRIPTION
## Changes

This PR implements the Backoff logic, as described in the Application Insights .NET SDK:


- we expect to Post once every second, but no longer than once every 20 seconds.
If we exceed the 20 seconds, we consider this a failure and Stop Posting.
We will wait 60 seconds before Pinging again.
- we expect to Ping once every 5 seconds, but no longer than once every 60 seconds.
If we exceed the 60 seconds, we will wait 60 seconds before Pinging again.
- https://github.com/microsoft/ApplicationInsights-dotnet/blob/c420e04562876791f27a61644760d7b7512832d9/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs#L258
- https://github.com/microsoft/ApplicationInsights-dotnet/blob/c420e04562876791f27a61644760d7b7512832d9/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/Helpers/QuickPulseTimings.cs#L34



### Testing
**Future work:** This will certainly need to be redesigned to facilitate unit testing.

For now, the manual test is simple using the Demo app.

1) Demo without Connection String.

- Ping fails, 
- After 60 seconds, switches to Backoff.
- After 60 seconds, resumes Ping.
- Ping continues to fail, cycle repeats.

2) Demo with Connection String

- Ping 
- open Live Metrics in browser, Post begins.
- close Live Metrics in browser, wait ~3 minutes for session to timeout and switch back to Ping.
- open Live Metrics again, Post should begin again.

2) Part 2, Disconnect Internet
- Post will start to fail. after 20 seconds, switch to Backoff.
- After 60 seconds, resumes Ping.
- Ping will fail. after 60 seconds, switches to Backoff
- After 60 seconds, resumes Ping.

2) Part 3, Reconnect Internet
- Ping should resume
- open LiveMetrics in browser, Post begins.
