### PR TITLE
Azure OpenAI: changelog.md update for beta.12 release

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.0.0-beta.12 (Unreleased)
+## 1.0.0-beta.12 (2023-12-15)
+
+Like beta.11, beta.12 is another release that brings further refinements and fixes. It remains based on the `2023-12-01-preview` service API version for Azure OpenAI and does not add any new service capabilities.
 
 ### Features Added
 
@@ -32,9 +34,10 @@
 - Removed the parameterized constructor of the `ChatCompletionsOptions` class that only received the messages as a parameter in favor of the parameterized constructor that receives the deployment name as well. This makes it consistent with the implementation of other Options classes.
 - Removed the setter of the `Input` property of the `EmbeddingsOptions` class as per the guidelines for collection properties.
 
-### Bugs Fixed
+### Bugs fixed
 
-### Other Changes
+- [[QUERY] Azure.AI.OpenAI_1.0.0-beta.10 no longer exposes message content on base ChatRequestMessage](https://github.com/Azure/azure-sdk-for-net/issues/40634)
+- [[BUG] Null Reference Exception in OpenAIClient.GetChatCompletionsAsync](https://github.com/Azure/azure-sdk-for-net/issues/40810)
 
 ## 1.0.0-beta.11 (2023-12-07)
 

--- a/sdk/openai/Azure.AI.OpenAI/README.md
+++ b/sdk/openai/Azure.AI.OpenAI/README.md
@@ -708,7 +708,8 @@ ChatCompletionsOptions chatCompletionsOptions = new()
 ```
 
 Chat Completions will then proceed as usual, though the model may report the more informative `finish_details` in lieu
-of `finish_reason`:
+of `finish_reason`; this will converge as `gpt-4-vision-preview` is updated but checking for either one is recommended
+in the interim:
 
 ```C# Snippet:GetResponseFromImages
 Response<ChatCompletions> chatResponse = await client.GetChatCompletionsAsync(chatCompletionsOptions);

--- a/sdk/openai/Azure.AI.OpenAI/tsp-location.yaml
+++ b/sdk/openai/Azure.AI.OpenAI/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/cognitiveservices/OpenAI.Inference
-commit: 2aaf1e85a93733499230175b1a8a8b26af0cdf4d
+commit: 848070b3dab1b5e76eee3587e99dddad8f36d6d7
 repo: Azure/azure-rest-api-specs


### PR DESCRIPTION
This is a changelog-only PR to produce the snap point for beta.12.