### PR TITLE
Add RehydrationId for LRO rehydration

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -132,6 +132,7 @@ namespace Azure
         protected Operation() { }
         public abstract bool HasCompleted { get; }
         public abstract string Id { get; }
+        public virtual string RehydrationId { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -132,6 +132,7 @@ namespace Azure
         protected Operation() { }
         public abstract bool HasCompleted { get; }
         public abstract string Id { get; }
+        public virtual string RehydrationId { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net6.0.cs
@@ -132,6 +132,7 @@ namespace Azure
         protected Operation() { }
         public abstract bool HasCompleted { get; }
         public abstract string Id { get; }
+        public virtual string RehydrationId { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -132,6 +132,7 @@ namespace Azure
         protected Operation() { }
         public abstract bool HasCompleted { get; }
         public abstract string Id { get; }
+        public virtual string RehydrationId { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/src/Operation.cs
+++ b/sdk/core/Azure.Core/src/Operation.cs
@@ -19,7 +19,7 @@ namespace Azure
         /// <summary>
         /// Gets an ID representing the operation that can be used to rehydrate the operation.
         /// </summary>
-        public virtual string RehydrationId => string.Empty;
+        public virtual string RehydrationId => Id;
 
         /// <summary>
         /// Gets an ID representing the operation that can be used to poll for

--- a/sdk/core/Azure.Core/src/Operation.cs
+++ b/sdk/core/Azure.Core/src/Operation.cs
@@ -17,6 +17,11 @@ namespace Azure
 #pragma warning restore AZC0012 // Avoid single word type names
     {
         /// <summary>
+        /// Gets an ID representing the operation that can be used to rehydrate the operation.
+        /// </summary>
+        public virtual string RehydrationId => string.Empty;
+
+        /// <summary>
         /// Gets an ID representing the operation that can be used to poll for
         /// the status of the long-running operation.
         /// </summary>


### PR DESCRIPTION
The user can add public APIs to query an operation by the existing operation [Id](https://github.com/Azure/azure-sdk-for-net/blob/aad3be7a5488a95a8c2fbdb2c2610d5f540fcd77/sdk/core/Azure.Core/src/Operation.cs#L23C43-L23C43), which is a GUID. In this case, the user can get the operation status directly by Id. 

For LRO rehydration implementation in MPG, we are using the existing [Id](https://github.com/Azure/azure-sdk-for-net/blob/aad3be7a5488a95a8c2fbdb2c2610d5f540fcd77/sdk/core/Azure.Core/src/Operation.cs#L23C43-L23C43) to store the rehydration id. 
In the previous scenario, the user will not be able to get the GUID anymore, which is causing conflicts.
We should have a separate id for LRO rehydration.