### PR TITLE
Fix exponential delay behavior

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fixed retry behavior so that delay milliseconds greater than `Int32.MaxValue` does not trigger an exception.
+- Fixed retry behavior to no longer double the initial delay for the first retry attempt.
+
 ### Other Changes
 
 ## 1.36.0 (2023-11-10)

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fixed exponential retry behavior so that delay milliseconds greater than `Int32.MaxValue` do not trigger an exception.
-- Fixed exponential retry behavior to no longer shift the delay to be used over by one attempt. Previously, the first delay would be what should have been used for the second, and the second was what should have been used for the third, etc.
+- Fixed `DelayStrategy` behavior to no longer shift the delay to be used over by one attempt. Previously, the first delay would be what should have been used for the second, and the second was what should have been used for the third, etc. Note, this would only be observed when using `DelayStrategy` outside of a `RetryPolicy` or `RetryOptions`.
 
 ### Other Changes
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### Bugs Fixed
 
-- Fixed retry behavior so that delay milliseconds greater than `Int32.MaxValue` does not trigger an exception.
-- Fixed retry behavior to no longer double the initial delay for the first retry attempt.
+- Fixed exponential retry behavior so that delay milliseconds greater than `Int32.MaxValue` do not trigger an exception.
+- Fixed exponential retry behavior to no longer shift the delay to be used over by one attempt. Previously, the first delay would be what should have been used for the second, and the second was what should have been used for the third, etc.
 
 ### Other Changes
 

--- a/sdk/core/Azure.Core/src/ExponentialDelayStrategy.cs
+++ b/sdk/core/Azure.Core/src/ExponentialDelayStrategy.cs
@@ -19,6 +19,6 @@ namespace Azure.Core
         }
 
         protected override TimeSpan GetNextDelayCore(Response? response, int retryNumber) =>
-            TimeSpan.FromMilliseconds((1 << retryNumber) * _delay.TotalMilliseconds);
+            TimeSpan.FromMilliseconds((1 << (retryNumber - 1)) * _delay.TotalMilliseconds);
     }
 }

--- a/sdk/core/Azure.Core/src/Pipeline/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RetryPolicy.cs
@@ -264,7 +264,7 @@ namespace Azure.Core.Pipeline
         {
             return _delayStrategy.GetNextDelay(
                 message.HasResponse ? message.Response : default,
-                message.RetryNumber);
+                message.RetryNumber + 1);
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/ExponentialDelayStrategyTests.cs
+++ b/sdk/core/Azure.Core/tests/ExponentialDelayStrategyTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class ExponentialDelayStrategyTests
+    {
+        [Test]
+        public void ExponentialDelayIsWithinBoundsOfJitter()
+        {
+            var initialDelay = TimeSpan.FromSeconds(1);
+            var strategy = DelayStrategy.CreateExponentialDelayStrategy(initialDelay, maxDelay: TimeSpan.MaxValue);
+            var response = new MockResponse(400);
+            for (int retryNumber = 1; retryNumber <= 30; retryNumber++)
+            {
+                AssertDelay(initialDelay, strategy.GetNextDelay(response, retryNumber), retryNumber);
+            }
+        }
+
+        [Test]
+        public void ExponentialDelayRespectsMaxValue()
+        {
+            var initialDelay = TimeSpan.FromSeconds(1);
+            var maxDelay = TimeSpan.FromSeconds(10);
+            var strategy = DelayStrategy.CreateExponentialDelayStrategy(initialDelay, maxDelay: maxDelay);
+            var response = new MockResponse(400);
+            var delay = strategy.GetNextDelay(response, 30);
+            Assert.LessOrEqual(delay.TotalMilliseconds, maxDelay.TotalMilliseconds);
+        }
+
+        [Test]
+        public void ExponentialDelayMillisecondsCanExceedMaxInt()
+        {
+            var initialDelay = TimeSpan.FromSeconds(1);
+            var strategy = DelayStrategy.CreateExponentialDelayStrategy(initialDelay, maxDelay: TimeSpan.MaxValue);
+            var response = new MockResponse(400);
+            AssertDelay(initialDelay, strategy.GetNextDelay(response, 30), 30);
+        }
+
+        private static void AssertDelay(TimeSpan initialDelay, TimeSpan currentDelay, int retryNumber, TimeSpan? maxDelay = default)
+        {
+            var max = maxDelay ?? TimeSpan.MaxValue;
+            Assert.GreaterOrEqual(
+                currentDelay.TotalMilliseconds,
+                Math.Pow((1 - DelayStrategy.DefaultJitterFactor), retryNumber) * (1 << (retryNumber - 1)) * initialDelay.TotalMilliseconds);
+            Assert.LessOrEqual(
+                currentDelay.TotalMilliseconds,
+                Math.Min(max.TotalMilliseconds, Math.Pow(1 + DelayStrategy.DefaultJitterFactor, retryNumber) * (1 << (retryNumber - 1)) * initialDelay.TotalMilliseconds));
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/40866 to prevent overflowing the int32 passed into Random.Next.

Additionally, fixes a bug in the exponential delay strategy so that the delays are not double what they should be. Note this wasn't really observable to users as the `RetryPolicy` was shifting the count to the left (while the delay strategy was shifting it to the right so they canceled out); it would only be noticeable when using a DelayStrategy on its own and consuming the value from GetNextDelay, which is probably very rare. LROs do NOT use ExponentialDelayStrategy so they were not impacted by the bug either.