### PR TITLE
Correct TimeToLive calculation to use AbsoluteExpiryTime

### DIFF
--- a/sdk/core/Azure.Core.Amqp/CHANGELOG.md
+++ b/sdk/core/Azure.Core.Amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed the logic used to set the `TimeToLive` value of the `AmqpMessageHeader` for received messages to be based on the difference of the `AbsoluteExpiryTime` and `CreationTime` properties of the `AmqpMessageProperties`.
+
 ### Other Changes
 
 ## 1.3.0 (2023-03-02)

--- a/sdk/core/Azure.Core.Amqp/src/Properties/AssemblyInfo.cs
+++ b/sdk/core/Azure.Core.Amqp/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Azure.Core.Amqp.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]

--- a/sdk/core/Azure.Core.Amqp/src/Shared/AmqpAnnotatedMessageConverter.cs
+++ b/sdk/core/Azure.Core.Amqp/src/Shared/AmqpAnnotatedMessageConverter.cs
@@ -298,6 +298,11 @@ namespace Azure.Core.Amqp.Shared
                 {
                     message.Header.DeliveryCount = source.Header.DeliveryCount;
                 }
+
+                if (source.Header.Ttl.HasValue)
+                {
+                    message.Header.TimeToLive = TimeSpan.FromMilliseconds(source.Header.Ttl.Value);
+                }
             }
 
             // Properties

--- a/sdk/core/Azure.Core.Amqp/tests/AmqpAnnotatedMessageConverterTests.cs
+++ b/sdk/core/Azure.Core.Amqp/tests/AmqpAnnotatedMessageConverterTests.cs
@@ -72,16 +72,15 @@ namespace Azure.Core.Amqp.Tests
         public void CanRoundTripDataMessage()
         {
             var message = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(new ReadOnlyMemory<byte>[] { Encoding.UTF8.GetBytes("some data") }));
-            DateTimeOffset time = DateTimeOffset.Now.AddDays(1);
 
-            SetCommonProperties(message, time);
+            SetCommonProperties(message);
 
             message = AmqpAnnotatedMessage.FromBytes(message.ToBytes());
             Assert.AreEqual(AmqpMessageBodyType.Data, message.Body.BodyType);
             Assert.IsTrue(message.Body.TryGetData(out IEnumerable<ReadOnlyMemory<byte>> body));
             Assert.AreEqual("some data", Encoding.UTF8.GetString(body.First().ToArray()));
 
-            AssertCommonProperties(message, time);
+            AssertCommonProperties(message);
         }
 
         [Test]
@@ -90,13 +89,13 @@ namespace Azure.Core.Amqp.Tests
         {
             var message = new AmqpAnnotatedMessage(AmqpMessageBody.FromValue(value));
             DateTimeOffset time = DateTimeOffset.Now.AddDays(1);
-            SetCommonProperties(message, time);
+            SetCommonProperties(message);
 
             message = AmqpAnnotatedMessage.FromBytes(message.ToBytes());
 
             Assert.IsTrue(message.Body.TryGetValue(out var receivedData));
             Assert.AreEqual(value, receivedData);
-            AssertCommonProperties(message, time);
+            AssertCommonProperties(message);
         }
 
         [Test]
@@ -104,8 +103,7 @@ namespace Azure.Core.Amqp.Tests
         public void CanRoundTripSequenceBodyMessages(IEnumerable<IList<object>> sequence)
         {
             var message = new AmqpAnnotatedMessage(AmqpMessageBody.FromSequence(sequence));
-            DateTimeOffset time = DateTimeOffset.Now.AddDays(1);
-            SetCommonProperties(message, time);
+            SetCommonProperties(message);
 
             message = AmqpAnnotatedMessage.FromBytes(message.ToBytes());
 
@@ -121,11 +119,11 @@ namespace Azure.Core.Amqp.Tests
                     Assert.AreEqual(elem, innerEnum.Current);
                 }
             }
-            AssertCommonProperties(message, time);
+            AssertCommonProperties(message);
         }
 
         [Test]
-        public void TimeToLiveIsSetBasedOnAbsoluteExpiryTimeIfSet()
+        public void TimeToLiveIsOverriddenOnReceivedMessageByAbsoluteExpiryTime()
         {
             var amqpMessage =
                 AmqpAnnotatedMessageConverter.ToAmqpMessage(new AmqpAnnotatedMessage(AmqpMessageBody.FromValue(5)));
@@ -142,7 +140,7 @@ namespace Azure.Core.Amqp.Tests
         }
 
         [Test]
-        public void TimeToLiveIsRespectedWhenNoAbsoluteExpiryTimePresent()
+        public void TimeToLiveIsNotOverridenWhenNoAbsoluteExpiryTimePresent()
         {
             var amqpMessage =
                 AmqpAnnotatedMessageConverter.ToAmqpMessage(new AmqpAnnotatedMessage(AmqpMessageBody.FromValue(5)));
@@ -155,7 +153,68 @@ namespace Azure.Core.Amqp.Tests
             Assert.AreEqual(TimeSpan.FromDays(49), annotatedMessage.Header.TimeToLive);
         }
 
-        private static void AssertCommonProperties(AmqpAnnotatedMessage message, DateTimeOffset time)
+        [Test]
+        public void TimeToLiveRoundTripsCorrectlyWithGreaterThanMaxInt()
+        {
+            var input = new AmqpAnnotatedMessage(AmqpMessageBody.FromValue(5))
+                {
+                    Header =
+                    {
+                        TimeToLive = TimeSpan.FromDays(100)
+                    }
+                };
+            var amqpMessage = AmqpAnnotatedMessageConverter.ToAmqpMessage(input);
+
+            Assert.AreEqual(uint.MaxValue, amqpMessage.Header.Ttl);
+            Assert.AreEqual(amqpMessage.Properties.CreationTime + TimeSpan.FromDays(100), amqpMessage.Properties.AbsoluteExpiryTime);
+
+            var output = AmqpAnnotatedMessageConverter.FromAmqpMessage(amqpMessage);
+
+            Assert.AreEqual(TimeSpan.FromDays(100), output.Header.TimeToLive);
+            Assert.AreEqual(amqpMessage.Properties.CreationTime, output.Properties.CreationTime!.Value.UtcDateTime);
+            Assert.AreEqual(amqpMessage.Properties.AbsoluteExpiryTime, output.Properties.AbsoluteExpiryTime!.Value.UtcDateTime);
+        }
+
+        [Test]
+        public void AbsoluteExpiryTimeAndCreationTimeNotSetWhenNoTtl()
+        {
+            var input = new AmqpAnnotatedMessage(AmqpMessageBody.FromValue(5));
+            var amqpMessage = AmqpAnnotatedMessageConverter.ToAmqpMessage(input);
+
+            Assert.IsNull(amqpMessage.Header.Ttl);
+            Assert.IsNull(amqpMessage.Properties.CreationTime);
+            Assert.IsNull(amqpMessage.Properties.AbsoluteExpiryTime);
+        }
+
+        [Test]
+        public void AbsoluteExpiryTimeAndCreationTimeSetOnMessageWhenSetExplicitly()
+        {
+            var input = new AmqpAnnotatedMessage(AmqpMessageBody.FromValue(5));
+            var now = DateTime.UtcNow;
+            input.Properties.CreationTime = now;
+            input.Properties.AbsoluteExpiryTime = now + TimeSpan.FromDays(1);
+            var amqpMessage = AmqpAnnotatedMessageConverter.ToAmqpMessage(input);
+
+            Assert.IsNull(amqpMessage.Header.Ttl);
+            Assert.AreEqual(now, amqpMessage.Properties.CreationTime);
+            Assert.AreEqual(now + TimeSpan.FromDays(1), amqpMessage.Properties.AbsoluteExpiryTime);
+        }
+
+        [Test]
+        public void AbsoluteExpiryTimeAndCreationTimeAreOverridenBasedOnTtlWhenSending()
+        {
+            var input = new AmqpAnnotatedMessage(AmqpMessageBody.FromValue(5));
+            var now = DateTimeOffset.UtcNow;
+            input.Properties.CreationTime = now;
+            input.Properties.AbsoluteExpiryTime = now + TimeSpan.FromDays(1);
+            input.Header.TimeToLive = TimeSpan.FromDays(7);
+            var amqpMessage = AmqpAnnotatedMessageConverter.ToAmqpMessage(input);
+
+            Assert.AreEqual(TimeSpan.FromDays(7).TotalMilliseconds, amqpMessage.Header.Ttl);
+            Assert.AreEqual(amqpMessage.Properties.CreationTime + TimeSpan.FromDays(7), amqpMessage.Properties.AbsoluteExpiryTime);
+        }
+
+        private static void AssertCommonProperties(AmqpAnnotatedMessage message)
         {
             Assert.AreEqual("applicationValue", message.ApplicationProperties["applicationKey"]);
             Assert.AreEqual("deliveryValue", message.DeliveryAnnotations["deliveryKey"]);
@@ -165,14 +224,14 @@ namespace Azure.Core.Amqp.Tests
             Assert.IsTrue(message.Header.Durable);
             Assert.IsTrue(message.Header.FirstAcquirer);
             Assert.AreEqual(1, message.Header.Priority);
-            // TTL is based on AbsoluteExpiryTime and CreationTime
-            Assert.AreEqual(message.Properties.AbsoluteExpiryTime - message.Properties.CreationTime, message.Header.TimeToLive);
+            Assert.AreEqual(TimeSpan.FromSeconds(60), message.Header.TimeToLive);
             // because AMQP only has millisecond resolution, allow for up to a 1ms difference when round-tripping
-            Assert.That(time, Is.EqualTo(message.Properties.AbsoluteExpiryTime.Value).Within(1).Milliseconds);
+            Assert.IsNotNull(message.Properties.CreationTime);
+            // AbsoluteExpiryTime is set based on TTL and CreationTime for outgoing messages
+            Assert.That(message.Properties.CreationTime + TimeSpan.FromSeconds(60), Is.EqualTo(message.Properties.AbsoluteExpiryTime.Value).Within(1).Milliseconds);
             Assert.AreEqual("compress", message.Properties.ContentEncoding);
             Assert.AreEqual("application/json", message.Properties.ContentType);
             Assert.AreEqual("correlationId", message.Properties.CorrelationId.ToString());
-            Assert.That(time, Is.EqualTo(message.Properties.CreationTime.Value).Within(1).Milliseconds);
             Assert.AreEqual("groupId", message.Properties.GroupId);
             Assert.AreEqual(5, message.Properties.GroupSequence);
             Assert.AreEqual("messageId", message.Properties.MessageId.ToString());
@@ -183,7 +242,7 @@ namespace Azure.Core.Amqp.Tests
             Assert.AreEqual("userId", Encoding.UTF8.GetString(message.Properties.UserId.Value.ToArray()));
         }
 
-        private static void SetCommonProperties(AmqpAnnotatedMessage message, DateTimeOffset time)
+        private static void SetCommonProperties(AmqpAnnotatedMessage message)
         {
             message.ApplicationProperties.Add("applicationKey", "applicationValue");
             message.DeliveryAnnotations.Add("deliveryKey", "deliveryValue");
@@ -194,11 +253,9 @@ namespace Azure.Core.Amqp.Tests
             message.Header.FirstAcquirer = true;
             message.Header.Priority = 1;
             message.Header.TimeToLive = TimeSpan.FromSeconds(60);
-            message.Properties.AbsoluteExpiryTime = time;
             message.Properties.ContentEncoding = "compress";
             message.Properties.ContentType = "application/json";
             message.Properties.CorrelationId = new AmqpMessageId("correlationId");
-            message.Properties.CreationTime = time;
             message.Properties.GroupId = "groupId";
             message.Properties.GroupSequence = 5;
             message.Properties.MessageId = new AmqpMessageId("messageId");

--- a/sdk/core/Azure.Core.Amqp/tests/AmqpAnnotatedMessageConverterTests.cs
+++ b/sdk/core/Azure.Core.Amqp/tests/AmqpAnnotatedMessageConverterTests.cs
@@ -165,7 +165,8 @@ namespace Azure.Core.Amqp.Tests
             Assert.IsTrue(message.Header.Durable);
             Assert.IsTrue(message.Header.FirstAcquirer);
             Assert.AreEqual(1, message.Header.Priority);
-            Assert.AreEqual(TimeSpan.FromSeconds(60), message.Header.TimeToLive);
+            // TTL is based on AbsoluteExpiryTime and CreationTime
+            Assert.AreEqual(message.Properties.AbsoluteExpiryTime - message.Properties.CreationTime, message.Header.TimeToLive);
             // because AMQP only has millisecond resolution, allow for up to a 1ms difference when round-tripping
             Assert.That(time, Is.EqualTo(message.Properties.AbsoluteExpiryTime.Value).Within(1).Milliseconds);
             Assert.AreEqual("compress", message.Properties.ContentEncoding);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -1650,15 +1650,15 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(convertedMessage.Header.Durable, Is.EqualTo(sourceMessage.Header.Durable), "The durable flag should match.");
             Assert.That(convertedMessage.Header.FirstAcquirer, Is.EqualTo(sourceMessage.Header.FirstAcquirer), "The first acquirer flag should match.");
             Assert.That(convertedMessage.Header.Priority, Is.EqualTo(sourceMessage.Header.Priority), "The priority should match.");
-            Assert.That(convertedMessage.Header.TimeToLive, Is.EqualTo(sourceMessage.Properties.AbsoluteExpiryTime - sourceMessage.Properties.CreationTime), "The time to live should be the difference of AbsoluteExpiryTime and CreationTime.");
+            Assert.That(convertedMessage.Header.TimeToLive, Is.EqualTo(sourceMessage.Header.TimeToLive), "The time to live should match.");
 
             // Properties
 
-            Assert.That(convertedMessage.Properties.AbsoluteExpiryTime, Is.EqualTo(sourceMessage.Properties.AbsoluteExpiryTime), "The expiry time should match.");
+            Assert.That(convertedMessage.Properties.AbsoluteExpiryTime!.Value.UtcDateTime, Is.EqualTo(tempMessage.Properties.CreationTime + sourceMessage.Header.TimeToLive), "The expiry time should be based on creation time and TimeToLive.");
             Assert.That(convertedMessage.Properties.ContentEncoding, Is.EqualTo(sourceMessage.Properties.ContentEncoding), "The content encoding should match.");
             Assert.That(convertedMessage.Properties.ContentType, Is.EqualTo(sourceMessage.Properties.ContentType), "The content type should match.");
             Assert.That(convertedMessage.Properties.CorrelationId, Is.EqualTo(sourceMessage.Properties.CorrelationId), "The correlation identifier should match.");
-            Assert.That(convertedMessage.Properties.CreationTime, Is.EqualTo(sourceMessage.Properties.CreationTime), "The creation time should match.");
+            Assert.That(convertedMessage.Properties.CreationTime!.Value.UtcDateTime, Is.EqualTo(tempMessage.Properties.CreationTime), "The creation time should match the computed creation time.");
             Assert.That(convertedMessage.Properties.GroupId, Is.EqualTo(sourceMessage.Properties.GroupId), "The group identifier should match.");
             Assert.That(convertedMessage.Properties.GroupSequence, Is.EqualTo(sourceMessage.Properties.GroupSequence), "The group sequence should match.");
             Assert.That(convertedMessage.Properties.MessageId, Is.EqualTo(sourceMessage.Properties.MessageId), "The message identifier should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -1943,11 +1943,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 // Properties
 
-                Assert.That(readMessage.Properties.AbsoluteExpiryTime, Is.EqualTo(message.Properties.AbsoluteExpiryTime), "The expiry time should match.");
+                Assert.That(readMessage.Properties.AbsoluteExpiryTime, Is.EqualTo(readMessage.Properties.CreationTime + message.Header.TimeToLive), "The expiry time should be equal to the computed creation time plus the time to live.");
                 Assert.That(readMessage.Properties.ContentEncoding, Is.EqualTo(message.Properties.ContentEncoding), "The content encoding should match.");
                 Assert.That(readMessage.Properties.ContentType, Is.EqualTo(message.Properties.ContentType), "The content type should match.");
                 Assert.That(readMessage.Properties.CorrelationId, Is.EqualTo(message.Properties.CorrelationId), "The correlation identifier should match.");
-                Assert.That(readMessage.Properties.CreationTime, Is.EqualTo(message.Properties.CreationTime), "The creation time should match.");
+                // The creation time is overridden based on the current time when TimeToLive is set.
+                Assert.That(readMessage.Properties.CreationTime, Is.EqualTo(readMessage.Properties.AbsoluteExpiryTime - message.Header.TimeToLive), "The creation time should be equal to the difference of the expiry time and time to live.");
                 Assert.That(readMessage.Properties.GroupId, Is.EqualTo(message.Properties.GroupId), "The group identifier should match.");
                 Assert.That(readMessage.Properties.GroupSequence, Is.EqualTo(message.Properties.GroupSequence), "The group sequence should match.");
                 Assert.That(readMessage.Properties.MessageId, Is.EqualTo(message.Properties.MessageId), "The message identifier should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -1947,7 +1947,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 Assert.That(readMessage.Properties.ContentEncoding, Is.EqualTo(message.Properties.ContentEncoding), "The content encoding should match.");
                 Assert.That(readMessage.Properties.ContentType, Is.EqualTo(message.Properties.ContentType), "The content type should match.");
                 Assert.That(readMessage.Properties.CorrelationId, Is.EqualTo(message.Properties.CorrelationId), "The correlation identifier should match.");
-                // The creation time is overridden based on the current time when TimeToLive is set.
                 Assert.That(readMessage.Properties.CreationTime, Is.EqualTo(readMessage.Properties.AbsoluteExpiryTime - message.Header.TimeToLive), "The creation time should be equal to the difference of the expiry time and time to live.");
                 Assert.That(readMessage.Properties.GroupId, Is.EqualTo(message.Properties.GroupId), "The group identifier should match.");
                 Assert.That(readMessage.Properties.GroupSequence, Is.EqualTo(message.Properties.GroupSequence), "The group sequence should match.");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -176,41 +176,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public virtual AmqpMessage SBMessageToAmqpMessage(ServiceBusMessage sbMessage)
         {
             var annotatedMessage = sbMessage.AmqpMessage;
-            var message = AmqpAnnotatedMessageConverter.ToAmqpMessage(annotatedMessage);
-
-            // Reset the resultant TTL as there is special handling for Service Bus
-            if ((message.Sections & SectionFlag.Header) > 0)
-                message.Header.Ttl = null;
-
-            // If TTL is set, it is used to calculate AbsoluteExpiryTime and CreationTime
-            TimeSpan ttl = annotatedMessage.GetTimeToLive();
-            if (ttl != TimeSpan.MaxValue)
-            {
-               message.Header.Ttl = (uint)ttl.TotalMilliseconds;
-               message.Properties.CreationTime = DateTime.UtcNow;
-
-               if (AmqpConstants.MaxAbsoluteExpiryTime - message.Properties.CreationTime.Value > ttl)
-               {
-                   message.Properties.AbsoluteExpiryTime = message.Properties.CreationTime.Value + ttl;
-               }
-               else
-               {
-                   message.Properties.AbsoluteExpiryTime = AmqpConstants.MaxAbsoluteExpiryTime;
-               }
-            }
-            else
-            {
-               if (annotatedMessage.Properties.CreationTime.HasValue)
-               {
-                   message.Properties.CreationTime = annotatedMessage.Properties.CreationTime.Value.UtcDateTime;
-               }
-               if (annotatedMessage.Properties.AbsoluteExpiryTime.HasValue)
-               {
-                   message.Properties.AbsoluteExpiryTime = annotatedMessage.Properties.AbsoluteExpiryTime.Value.UtcDateTime;
-               }
-            }
-
-            return message;
+            return AmqpAnnotatedMessageConverter.ToAmqpMessage(annotatedMessage);
         }
 
         public virtual ServiceBusReceivedMessage AmqpMessageToSBReceivedMessage(AmqpMessage amqpMessage, bool isPeeked = false)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
@@ -61,7 +61,9 @@ namespace Azure.Messaging.ServiceBus.Tests
         /// <param name="enableSession">When <c>true</c>, a session will be enabled on the queue that is created.</param>
         /// <param name="forceQueueCreation">When <c>true</c>, forces creation of a new queue even if an environmental override was specified to use an existing one.</param>
         /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        ///
+        /// <param name="lockDuration">The lock duration for the queue.</param>
+        /// <param name="overrideNamespace">The namespace to use for the queue.</param>
+        /// <param name="defaultMessageTimeToLive">The default message time to live for the queue.</param>
         /// <returns>The requested Service Bus <see cref="QueueScope" />.</returns>
         ///
         /// <remarks>
@@ -75,6 +77,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                                                              bool forceQueueCreation = false,
                                                              TimeSpan? lockDuration = default,
                                                              string overrideNamespace = default,
+                                                             TimeSpan? defaultMessageTimeToLive = default,
                                                              [CallerMemberName] string caller = "")
         {
             // Create a new queue specific to the scope being created.
@@ -90,7 +93,7 @@ namespace Azure.Messaging.ServiceBus.Tests
 
             using (var client = new ServiceBusManagementClient(ResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = azureSubscription })
             {
-                var queueParameters = new SBQueue(enablePartitioning: enablePartitioning, requiresSession: enableSession, maxSizeInMegabytes: 1024, lockDuration: lockDuration);
+                var queueParameters = new SBQueue(enablePartitioning: enablePartitioning, requiresSession: enableSession, maxSizeInMegabytes: 1024, lockDuration: lockDuration, defaultMessageTimeToLive: defaultMessageTimeToLive);
                 var queue = await CreateRetryPolicy<SBQueue>().ExecuteAsync(() => client.Queues.CreateOrUpdateAsync(resourceGroup, serviceBusNamespace, CreateName(), queueParameters)).ConfigureAwait(false);
 
                 return new QueueScope(serviceBusNamespace, queue.Name, true);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -216,6 +216,55 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
         }
 
         [Test]
+        public async Task TimeToLiveSetBasedOnAbsoluteExpiryTimeAndQueueDefault()
+        {
+            // Use a message Time To Live of greater than 49 days so that we can verify the TTL is recalculated correctly on the client based on
+            // the absolute expiry time. 49 days is the largest number of milliseconds that can be sent over AMQP, so the recalculation is a workaround.
+            // See https://github.com/Azure/azure-sdk-for-net/issues/40915 for more details.
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false,
+                             enableSession: false, defaultMessageTimeToLive: TimeSpan.FromDays(100)))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                var sender = client.CreateSender(scope.QueueName);
+                var msg = new ServiceBusMessage();
+                await sender.SendMessageAsync(msg);
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var received = await receiver.ReceiveMessageAsync();
+
+                Assert.AreEqual(TimeSpan.FromDays(100), received.TimeToLive);
+                Assert.AreEqual(received.GetRawAmqpMessage().Properties.CreationTime + TimeSpan.FromDays(100),
+                    received.ExpiresAt);
+            }
+        }
+
+        [Test]
+        public async Task TimeToLiveSetBasedOnAbsoluteExpiryTimeAndMessageValue()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false,
+                             enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                var sender = client.CreateSender(scope.QueueName);
+                // Use a message Time To Live of greater than 49 days so that we can verify the TTL is recalculated correctly on the client based on
+                // the absolute expiry time. 49 days is the largest number of milliseconds that can be sent over AMQP, so the recalculation is a workaround.
+                // See https://github.com/Azure/azure-sdk-for-net/issues/40915 for more details.
+                var msg = new ServiceBusMessage
+                {
+                    TimeToLive = TimeSpan.FromDays(100)
+                };
+                await sender.SendMessageAsync(msg);
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var received = await receiver.ReceiveMessageAsync();
+
+                Assert.AreEqual(TimeSpan.FromDays(100), received.TimeToLive);
+                Assert.AreEqual(received.GetRawAmqpMessage().Properties.CreationTime + TimeSpan.FromDays(100),
+                    received.ExpiresAt);
+            }
+        }
+
+        [Test]
         public async Task CreateFromReceivedMessageCopiesPropertiesTopic()
         {
             await using (var scope = await ServiceBusScope.CreateWithTopic(enablePartitioning: true, enableSession: true))


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/40915 and https://github.com/Azure/azure-sdk-for-net/issues/38875

The logic involving the properties TimeToLive, AbsoluteExpiryTime, and CreationTime is fairly convoluted so here it is:

**Outgoing Messages**
  - If TimeToLive is set on AmqpAnnotatedMessage
    - Set CreationTime and AbsoluteExpiryTime of AmqpMessage based on it
    - Set Ttl of AmqpMessage to Min(uint32.MaxValue, AmqpAnnotatedMessage.TimeToLive)
  - Else
    - If CreationTime is set on AmqpAnnotatedMessage, set it on AmqpMessage
    - If AbsoluteExpiryTime is set on AmqpAnnotatedMessage, set it on AmqpMessage

**Incoming messages**

- If AbsoluteExpiryTime and CreationTime are set on AmqpMessage
  - Set TimeToLive on AmqpAnnotatedMessage to the difference
- Else
  - If AbsoluteExpiryTime set on AmqpMessage, set it on AmqpAnnotatedMessage
  - If CreationTime set on AmqpMessage, set it on AmqpAnnotatedMessage
  - If TimeToLive set on AmqpMessage, set it on AmqpAnnotatedMessage

The Outgoing Messages logic was already correct for Service Bus, but this PR moves the logic down to AmqpAnnotatedMessageConverter so that it works the same for Service Bus and Event Hubs.