### PR TITLE
Adding scaling throttling to avoid rebalancing.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             int partitionCount = latestMetric.PartitionCount;
 
             TargetScalerResult currentResult = GetScaleResultInternal(context, eventCount, partitionCount);
-            currentResult = _metricsStats.ThrottleIfNeeded(currentResult, latestMetric, DateTime.Now);
+            currentResult = _metricsStats.ThrottleIfNeeded(currentResult, latestMetric, DateTime.UtcNow);
 
             return currentResult;
         }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTriggerMetrics.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTriggerMetrics.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
         /// The number of partitions.
         /// </summary>
         public int PartitionCount { get; set; }
+
+        public Dictionary<string, long?> CheckpointSequences { get; set; }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTriggerMetrics.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTriggerMetrics.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Host.Scale;
-using System;
 using System.Collections.Generic;
-using System.Text;
+using static Azure.Messaging.EventHubs.Primitives.BlobCheckpointStoreInternal;
 
 namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 {
@@ -20,6 +19,6 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
         /// </summary>
         public int PartitionCount { get; set; }
 
-        public Dictionary<string, long?> CheckpointSequences { get; set; }
+        public List<BlobStorageCheckpoint> Checkpoints {get; set;}
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/TargetScaleThrottler.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/TargetScaleThrottler.cs
@@ -12,20 +12,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
 {
     internal class TargetScaleThrottler
     {
-        // Throttle scale in requests if last scale out time was within ThrottleScaleDownIntervalInSeconds.
+        // Throttle scale down requests if last scale up/scale down time was within ThrottleScaleDownIntervalInSeconds.
         private const int ThrottleScaleDownIntervalInSeconds = 180;
 
-        // Keep metrics and target scale resut history for ExpirationThresholdInseconds
-        private const int ExpirationThresholdInseconds = 60;
+        // Keep metrics in the history for ExpirationThresholdInseconds
+        private const int ExpirationThresholdInSeconds = 65;
 
-        private const int ScaleUpFactor = 10;
+        private const int ScaleUpFactor = 30;
 
-        private readonly List<EventHubTragetScalerReult> _history = new List<EventHubTragetScalerReult>();
+        private readonly List<EventHubTargetScalerResult> _history = new List<EventHubTargetScalerResult>();
         private readonly ILogger _logger;
         private object lockObject = new object();
 
         private TargetScalerResult _lastTargetScalerResult = new TargetScalerResult();
-        private DateTime _lastScaleUpTime = DateTime.MinValue;
+        private DateTime _lastScaleTime = DateTime.MinValue;
 
         public TargetScaleThrottler(ILogger logger)
         {
@@ -33,21 +33,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
         }
 
         // for tests
-        public TargetScaleThrottler(DateTime lastScaleUpTime, TargetScalerResult lastTargetScalerResult, ILogger logger)
+        public TargetScaleThrottler(DateTime lastScaleTime, TargetScalerResult lastTargetScalerResult, ILogger logger)
         {
-            _lastScaleUpTime = lastScaleUpTime;
+            _lastScaleTime = lastScaleTime;
             _lastTargetScalerResult = lastTargetScalerResult;
             _logger = logger;
         }
 
-        public TargetScalerResult ThrottleIfNeeded(TargetScalerResult result, EventHubsTriggerMetrics metric, DateTime executionTime)
+        public TargetScalerResult ThrottleIfNeeded(TargetScalerResult result, EventHubsTriggerMetrics metric, DateTime executionTime, out string scaleResultLog)
         {
+            // Throttle scale down if there was a scale operation or the same target worker count was voted within 180 seconds
+            // Throttle scale down if there was a scale up in the last 60 seconds
+            // Throttle scale up vote if backlog is less than 30% of the execution rate
+            // On scale down, pick the maximum of the following: the highest vote from the history, or one step back from the sorted valid worker count
+            // Allow scale down to 0 only if there were no executions in the last 60 seconds
+
+            scaleResultLog = string.Empty;
             try
             {
                 lock (lockObject)
                 {
                     // Removing expired items from history. We want to keep the history item around the threshold so adding 2 secs.
-                    var threshold = executionTime - TimeSpan.FromSeconds(ExpirationThresholdInseconds + 2);
+                    var threshold = executionTime - TimeSpan.FromSeconds(ExpirationThresholdInSeconds);
                     bool historyCleared = false;
                     for (int i = _history.Count - 1; i >= 0; i--)
                     {
@@ -59,62 +66,96 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
                     }
 
                     // Adding new history item
-                    EventHubTragetScalerReult currentResult = new EventHubTragetScalerReult
+                    EventHubTargetScalerResult currentResult = new EventHubTargetScalerResult
                     {
                         TargetScalerResult = result,
                         Metrics = metric,
-                        ChangeWorkerCount = result.TargetWorkerCount - _lastTargetScalerResult.TargetWorkerCount
                     };
                     _history.Add(currentResult);
-                    int changeWorkerCount = currentResult.ChangeWorkerCount;
+                    int changeWorkerCount = result.TargetWorkerCount - _lastTargetScalerResult.TargetWorkerCount;
 
-                    // Throttle scale down based on latest scale up
-                    if (changeWorkerCount < 0 && (executionTime - _lastScaleUpTime).TotalSeconds < ThrottleScaleDownIntervalInSeconds)
+                    // Calculate how many messages were processed and what's is the total backlog
+                    long totalProcessedMessages = 0;
+                    long totalBacklog = 0;
+                    var samplesCount = _history.Count - 1;
+                    for (int i = samplesCount; i > 0; i--)
                     {
-                        _logger.LogInformation($"Throttling scale down, since last scale up time was within {ThrottleScaleDownIntervalInSeconds} seconds. (LastScaleUpTime: '{_lastScaleUpTime}', LastTargetWorkerRequest: '{_lastTargetScalerResult.TargetWorkerCount}')");
+                        totalProcessedMessages += GetProcessedEventsCount(_history[i - 1].Metrics, _history[i].Metrics);
+                        totalBacklog += _history[i].Metrics.EventCount;
+                    }
+                    scaleResultLog = $", TotalProcessedMessages: '{totalProcessedMessages}', TotalBacklog: '{totalBacklog}', SamplesCount: '{samplesCount}'";
+
+                    // Throttle scale down based on latest scale operation
+                    if (changeWorkerCount < 0 && (executionTime - _lastScaleTime).TotalSeconds < ThrottleScaleDownIntervalInSeconds)
+                    {
+                        scaleResultLog += $", ThrottlingReason: Throttling scale down, since last scaling operation time was within {ThrottleScaleDownIntervalInSeconds} seconds. (LastScaleUpTime: '{_lastScaleTime}', LastTargetWorkerRequest: '{_lastTargetScalerResult.TargetWorkerCount}'";
                         return _lastTargetScalerResult;
                     }
 
                     // If there we have enough history try to throttle based on history
-                    if ((historyCleared) && (Math.Abs(changeWorkerCount) > 0))
+                    if (historyCleared && Math.Abs(changeWorkerCount) > 0)
                     {
-                        long totalProcessedMessages = 0;
-                        long totalBacklog = 0;
-                        var samplesCount = _history.Count - 1;
-                        for (int i = samplesCount; i > 0; i--)
-                        {
-                            totalProcessedMessages += GetProcessedEventsCount(_history[i - 1].Metrics, _history[i].Metrics);
-                            totalBacklog += _history[i].Metrics.EventCount;
-                        }
-
                         // Throttle scale up based average backlog and execution rate
-                        if (changeWorkerCount > 0 && totalBacklog < (double)totalProcessedMessages / ScaleUpFactor)
+                        if (changeWorkerCount > 0 && totalBacklog < (double)totalProcessedMessages * 100 / ScaleUpFactor && _lastTargetScalerResult.TargetWorkerCount != 0)
                         {
-                            _logger.LogInformation($"Throttling scale up due average backlog is less then '{ScaleUpFactor}%' of total processed messages. (TotalProcessedMessages: '{totalProcessedMessages}', TotalBackLog: '{totalBacklog}', SamplesCount: '{samplesCount}'");
+                            scaleResultLog += $", ThrottlingReason: Throttling scale up because average backlog is less than '{ScaleUpFactor}%' of total processed messages. (LastScaleTime: {_lastScaleTime}, LastTargetWorkerRequest: {_lastTargetScalerResult.TargetWorkerCount}";
                             return _lastTargetScalerResult;
                         }
 
                         // Throttle scale down based on history.
-                        if (changeWorkerCount < 0 && !_history.All(x => x.ChangeWorkerCount < 0))
+                        if (changeWorkerCount < 0)
                         {
-                            _logger.LogInformation($"Throttling scale down due there was at least one non-scale down vote");
-                            return _lastTargetScalerResult;
+                            // All votes in the history must be scale down
+                            if (!_history.All(x => x.TargetScalerResult.TargetWorkerCount == 0))
+                            {
+                                scaleResultLog += $", ThrottlingReason: Throttling scale down because there was at least one non-scale down vote. (LastScaleTime: {_lastScaleTime}, LastTargetWorkerRequest: {_lastTargetScalerResult.TargetWorkerCount}";
+                                return _lastTargetScalerResult;
+                            }
+                            else
+                            {
+                                long processedMessageCount = GetProcessedEventsCount(_history.First().Metrics, _history.Last().Metrics);
+                                if (processedMessageCount > 0)
+                                {
+                                    // TargetWorkerCount based on the history
+                                    var maxItem = _history.First(item => item.TargetScalerResult.TargetWorkerCount == _history.Max(i => i.TargetScalerResult.TargetWorkerCount));
+                                    // TargetWorkerCount based on valid worker list
+                                    int[] sortedValidWorkerCounts = EventHubsTargetScaler.GetSortedValidWorkerCountsForPartitionCount(metric.PartitionCount);
+                                    string sortedValidWorkerCountsAsString = string.Join(",", sortedValidWorkerCounts);
+                                    int index = Array.BinarySearch(sortedValidWorkerCounts, _lastTargetScalerResult.TargetWorkerCount);
+                                    if (index <= 0)
+                                    {
+                                        throw new InvalidOperationException($"Unexpected index for '{_lastTargetScalerResult.TargetWorkerCount}' in valid workers count array '{sortedValidWorkerCountsAsString}");
+                                    }
+                                    int newTargetWorkerCount= sortedValidWorkerCounts[index - 1];
+                                    if (newTargetWorkerCount == 0)
+                                    {
+                                        newTargetWorkerCount = 1;
+                                    }
+
+                                    if (maxItem.TargetScalerResult.TargetWorkerCount > sortedValidWorkerCounts[index])
+                                    {
+                                        scaleResultLog += $", ChangingReason: Change scale down TargetWorkerCount to the max from the history '{result.TargetWorkerCount}'->'{maxItem.TargetScalerResult.TargetWorkerCount}', Time: {maxItem.Metrics.Timestamp}";
+                                        result.TargetWorkerCount = maxItem.TargetScalerResult.TargetWorkerCount;
+                                    }
+                                    else
+                                    {
+                                        scaleResultLog += $", ChangingReason: Change scale down TargetWorkerCount based on value from valid sorted workers list: [{sortedValidWorkerCountsAsString}] '{result.TargetWorkerCount}'->'{newTargetWorkerCount}'";
+                                        result.TargetWorkerCount = newTargetWorkerCount;
+                                    }
+                                }
+                            }
                         }
                     }
 
                     _lastTargetScalerResult = currentResult.TargetScalerResult;
-
-                    if (changeWorkerCount > 0)
-                    {
-                        _lastScaleUpTime = DateTime.UtcNow;
-                    }
+                    _lastScaleTime = executionTime;
 
                     return _lastTargetScalerResult;
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Failed to throttle EvetnHubs");
+                _logger.LogError(ex, $"Failed to throttle EvetnHubs scalingю");
                 return result;
             }
         }
@@ -122,26 +163,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
         private static long GetProcessedEventsCount(EventHubsTriggerMetrics prev, EventHubsTriggerMetrics current)
         {
             long totalProcessedMessages = 0;
-            foreach (var partitionId in current.CheckpointSequences.Keys)
+            foreach (var currentCheckpoint in current.Checkpoints)
             {
-                if (prev.CheckpointSequences.TryGetValue(partitionId, out var count))
+                var previosCheckpoint = prev.Checkpoints.FirstOrDefault(x => x.PartitionId == currentCheckpoint.PartitionId);
+
+                if (previosCheckpoint != null)
                 {
-                    if (current.CheckpointSequences[partitionId].HasValue && prev.CheckpointSequences[partitionId].HasValue)
+                    if (currentCheckpoint.SequenceNumber.HasValue && previosCheckpoint.SequenceNumber.HasValue
+                        && currentCheckpoint.SequenceNumber.Value > previosCheckpoint.SequenceNumber.Value)
                     {
-                        totalProcessedMessages += current.CheckpointSequences[partitionId].Value - prev.CheckpointSequences[partitionId].Value;
+                        totalProcessedMessages += currentCheckpoint.SequenceNumber.Value - previosCheckpoint.SequenceNumber.Value;
                     }
                 }
             }
             return totalProcessedMessages;
         }
 
-        internal class EventHubTragetScalerReult
+        internal class EventHubTargetScalerResult
         {
             public TargetScalerResult TargetScalerResult { get; set; }
 
             public EventHubsTriggerMetrics Metrics { get; set; }
-
-            public int ChangeWorkerCount { get; set; }
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/TargetScaleThrottler.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/TargetScaleThrottler.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.EventHubs.Listeners;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
+{
+    internal class TargetScaleThrottler
+    {
+        // Throttle scale in requests if last scale out time was within ThrottleScaleDownIntervalInSeconds.
+        private const int ThrottleScaleDownIntervalInSeconds = 180;
+
+        // Keep metrics and target scale resut history for ExpirationThresholdInseconds
+        private const int ExpirationThresholdInseconds = 60;
+
+        private const int ScaleUpFactor = 10;
+
+        private readonly List<EventHubTragetScalerReult> _history = new List<EventHubTragetScalerReult>();
+        private readonly ILogger _logger;
+        private object lockObject = new object();
+
+        private TargetScalerResult _lastTargetScalerResult = new TargetScalerResult();
+        private DateTime _lastScaleUpTime = DateTime.MinValue;
+
+        public TargetScaleThrottler(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        // for tests
+        public TargetScaleThrottler(DateTime lastScaleUpTime, TargetScalerResult lastTargetScalerResult, ILogger logger)
+        {
+            _lastScaleUpTime = lastScaleUpTime;
+            _lastTargetScalerResult = lastTargetScalerResult;
+            _logger = logger;
+        }
+
+        public TargetScalerResult ThrottleIfNeeded(TargetScalerResult result, EventHubsTriggerMetrics metric, DateTime executionTime)
+        {
+            try
+            {
+                lock (lockObject)
+                {
+                    // Removing expired items from history. We want to keep the history item around the threshold so adding 2 secs.
+                    var threshold = executionTime - TimeSpan.FromSeconds(ExpirationThresholdInseconds + 2);
+                    bool historyCleared = false;
+                    for (int i = _history.Count - 1; i >= 0; i--)
+                    {
+                        if (_history[i].Metrics.Timestamp < threshold)
+                        {
+                            historyCleared = true;
+                            _history.RemoveAt(i);
+                        }
+                    }
+
+                    // Adding new history item
+                    EventHubTragetScalerReult currentResult = new EventHubTragetScalerReult
+                    {
+                        TargetScalerResult = result,
+                        Metrics = metric,
+                        ChangeWorkerCount = result.TargetWorkerCount - _lastTargetScalerResult.TargetWorkerCount
+                    };
+                    _history.Add(currentResult);
+                    int changeWorkerCount = currentResult.ChangeWorkerCount;
+
+                    // Throttle scale down based on latest scale up
+                    if (changeWorkerCount < 0 && (executionTime - _lastScaleUpTime).TotalSeconds < ThrottleScaleDownIntervalInSeconds)
+                    {
+                        _logger.LogInformation($"Throttling scale down, since last scale up time was within {ThrottleScaleDownIntervalInSeconds} seconds. (LastScaleUpTime: '{_lastScaleUpTime}', LastTargetWorkerRequest: '{_lastTargetScalerResult.TargetWorkerCount}')");
+                        return _lastTargetScalerResult;
+                    }
+
+                    // If there we have enough history try to throttle based on history
+                    if ((historyCleared) && (Math.Abs(changeWorkerCount) > 0))
+                    {
+                        long totalProcessedMessages = 0;
+                        long totalBacklog = 0;
+                        var samplesCount = _history.Count - 1;
+                        for (int i = samplesCount; i > 0; i--)
+                        {
+                            totalProcessedMessages += GetProcessedEventsCount(_history[i - 1].Metrics, _history[i].Metrics);
+                            totalBacklog += _history[i].Metrics.EventCount;
+                        }
+
+                        // Throttle scale up based average backlog and execution rate
+                        if (changeWorkerCount > 0 && totalBacklog < (double)totalProcessedMessages / ScaleUpFactor)
+                        {
+                            _logger.LogInformation($"Throttling scale up due average backlog is less then '{ScaleUpFactor}%' of total processed messages. (TotalProcessedMessages: '{totalProcessedMessages}', TotalBackLog: '{totalBacklog}', SamplesCount: '{samplesCount}'");
+                            return _lastTargetScalerResult;
+                        }
+
+                        // Throttle scale down based on history.
+                        if (changeWorkerCount < 0 && !_history.All(x => x.ChangeWorkerCount < 0))
+                        {
+                            _logger.LogInformation($"Throttling scale down due there was at least one non-scale down vote");
+                            return _lastTargetScalerResult;
+                        }
+                    }
+
+                    _lastTargetScalerResult = currentResult.TargetScalerResult;
+
+                    if (changeWorkerCount > 0)
+                    {
+                        _lastScaleUpTime = DateTime.UtcNow;
+                    }
+
+                    return _lastTargetScalerResult;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to throttle EvetnHubs");
+                return result;
+            }
+        }
+
+        private static long GetProcessedEventsCount(EventHubsTriggerMetrics prev, EventHubsTriggerMetrics current)
+        {
+            long totalProcessedMessages = 0;
+            foreach (var partitionId in current.CheckpointSequences.Keys)
+            {
+                if (prev.CheckpointSequences.TryGetValue(partitionId, out var count))
+                {
+                    if (current.CheckpointSequences[partitionId].HasValue && prev.CheckpointSequences[partitionId].HasValue)
+                    {
+                        totalProcessedMessages += current.CheckpointSequences[partitionId].Value - prev.CheckpointSequences[partitionId].Value;
+                    }
+                }
+            }
+            return totalProcessedMessages;
+        }
+
+        internal class EventHubTragetScalerReult
+        {
+            public TargetScalerResult TargetScalerResult { get; set; }
+
+            public EventHubsTriggerMetrics Metrics { get; set; }
+
+            public int ChangeWorkerCount { get; set; }
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsMetricsProviderTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             // Checkpointing is ahead of partition info and invalid (SequenceNumber > LastEnqueued)
             this._checkpoints = new EventProcessorCheckpoint[]
             {
-                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 999, SequenceNumber = 11 }
+                new BlobCheckpointStoreInternal.BlobStorageCheckpoint { Offset = 999, SequenceNumber = 11, PartitionId = "1" }
             };
 
             _partitions = new List<PartitionProperties>
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             metrics = await _metricsProvider.GetMetricsAsync();
 
-            Assert.AreEqual(0, metrics.EventCount);
+            Assert.AreEqual(11, metrics.EventCount);
             Assert.AreEqual(1, metrics.PartitionCount);
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
         }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
@@ -67,9 +67,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [TestCase(150, 10, 10, 10)]
         [TestCase(2147483650, 1, 1, 1)] // Testing eventCount > int.MaxInt is 2147483647
         [TestCase(21474836500, 1000, 1, 1000)] // Testing eventCount > int.MaxInt is 2147483647, with concurrency 1 to force overflow
-        public void GetScaleResultInternal_ReturnsExpected(long eventCount, int partitionCount, int? concurrency, int expectedTargetWorkerCount)
+        public void GetScaleResultInternal_ReturnsExpected(long eventCount, int partitionCount, int concurrency, int expectedTargetWorkerCount)
         {
-            TargetScalerResult result = _targetScaler.GetScaleResultInternal(new TargetScalerContext { InstanceConcurrency = concurrency }, eventCount, partitionCount);
+            TargetScalerResult result = _targetScaler.GetScaleResultInternal(concurrency, eventCount, partitionCount);
             Assert.AreEqual(expectedTargetWorkerCount, result.TargetWorkerCount);
         }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubsTargetScalerTests.cs
@@ -58,24 +58,6 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         }
 
         [Test]
-        [TestCase(10, 9, 100, 10)]
-        [TestCase(9, 10, 100, 10)] // Throttle scale down
-        [TestCase(9, 10, 179, 10)] // Throttle scale down
-        [TestCase(9, 10, 180, 9)] // Allow scale down
-        [TestCase(9, 10, 181, 9)] // Allow scale down
-        public void ThrottleScaleDownIfNecessaryInternal_ReturnsExpected(int currentTarget, int previousTarget, int secondsSinceLastScaleUp, int expectedTarget)
-        {
-            TargetScalerResult currrentResult = new TargetScalerResult() { TargetWorkerCount = currentTarget };
-            TargetScalerResult previousResult = new TargetScalerResult() { TargetWorkerCount = previousTarget };
-
-            DateTime lastScaleUp = DateTime.UtcNow.AddSeconds(-secondsSinceLastScaleUp);
-
-            TargetScalerResult finalResult = EventHubsTargetScaler.ThrottleScaleDownIfNecessaryInternal(currrentResult, previousResult, lastScaleUp, _loggerFactory.CreateLogger<EventHubsTargetScalerTests>());
-
-            Assert.AreEqual(finalResult.TargetWorkerCount, expectedTarget);
-        }
-
-        [Test]
         // Using default concurrency of 10.
         [TestCase(10, 10, 10, 1)]
         [TestCase(20, 10, 10, 2)]

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/TargetScaleThrottlerTest.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/TargetScaleThrottlerTest.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using static Azure.Messaging.EventHubs.Primitives.BlobCheckpointStoreInternal;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
 {
@@ -40,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
             new int[] { 5000, 5000, 0, 20 },
             new int[] { 6000, 6000, 0, 10 },
             new int[] { 7000, 7000, 0, 0 },
-            10, 120, 2, "Throttling scale down, since last scale up time was within")]
+            10, 120, 2, "Throttling scale down, since last scaling operation time was within")]
         [TestCase( // Scale down based on last scale up operation - no trottle
             new int[] { 0, 0, 0, 70 },
             new int[] { 1000, 1000, 0, 60 },
@@ -60,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
             new int[] { 5000, 5000, 200, 20 },
             new int[] { 6000, 6000, 200, 10 },
             new int[] { 7000, 7000, 210, 0 },
-            200, null, null, "Throttling scale up due average backlog")]
+            200, null, null, "Throttling scale up because average backlog")]
         [TestCase( // Scale up throttle based on executions - no trottle
             new int[] { 0, 0, 150, 70 },
             new int[] { 1000, 1000, 250, 60 },
@@ -76,11 +77,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
             new int[] { 1000, 1000, 0, 60 },
             new int[] { 2000, 2000, 0, 50 },
             new int[] { 3000, 3000, 0, 40 },
-            new int[] { 4000, 4000, 25, 30 },
+            new int[] { 4000, 4000, 5, 30 },
             new int[] { 5000, 5000, 0, 20 },
             new int[] { 6000, 6000, 0, 10 },
             new int[] { 7000, 7000, 0, 0 },
-            10, 182, 2, "Throttling scale down due there was at least one non-scale down vote")]
+            10, 182, 2, "Throttling scale down because there was at least one non-scale down vote")]
         public void ThrottleScaleDown_ReturnsExpected
             (int[] items0, int[] items1, int[] items2, int[] items3, int[] items4, int[] items5, int[] items6, int[] items7,
             int concurrecy,
@@ -93,56 +94,65 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
             var testStart = DateTime.UtcNow;
 
             TargetScaleThrottler throttler = new TargetScaleThrottler(
-                whenLastScaleUpInSec.HasValue ? testStart - TimeSpan.FromSeconds(whenLastScaleUpInSec.Value): DateTime.MinValue,
+                whenLastScaleUpInSec.HasValue ? testStart - TimeSpan.FromSeconds(whenLastScaleUpInSec.Value) : DateTime.MinValue,
                 targetWorkerCountOnLastScale.HasValue ? new TargetScalerResult() { TargetWorkerCount = targetWorkerCountOnLastScale.Value } : new TargetScalerResult(),
                 logger);
 
-            Mock<IEventHubConsumerClient> mockEventHubConsumerClient = new Mock<IEventHubConsumerClient>();
+            Mock <IEventHubConsumerClient> mockEventHubConsumerClient = new Mock<IEventHubConsumerClient>();
             mockEventHubConsumerClient.Setup(x => x.EventHubName).Returns("test");
 
             EventHubsTargetScaler scaler = new EventHubsTargetScaler("test", mockEventHubConsumerClient.Object, new EventHubOptions(), null, logger);
 
-            AddHistoryToThrotller(scaler, throttler, items0, concurrecy, testStart);
-            AddHistoryToThrotller(scaler, throttler, items1, concurrecy, testStart);
-            AddHistoryToThrotller(scaler, throttler, items2, concurrecy, testStart);
-            AddHistoryToThrotller(scaler, throttler, items3, concurrecy, testStart);
-            AddHistoryToThrotller(scaler, throttler, items4, concurrecy, testStart);
-            AddHistoryToThrotller(scaler, throttler, items5, concurrecy, testStart);
-            AddHistoryToThrotller(scaler, throttler, items6, concurrecy, testStart);
-            AddHistoryToThrotller(scaler, throttler, items7, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items0, concurrecy, testStart, logger);
+            AddHistoryToThrotller(scaler, throttler, items1, concurrecy, testStart, logger);
+            AddHistoryToThrotller(scaler, throttler, items2, concurrecy, testStart, logger);
+            AddHistoryToThrotller(scaler, throttler, items3, concurrecy, testStart, logger);
+            AddHistoryToThrotller(scaler, throttler, items4, concurrecy, testStart, logger);
+            AddHistoryToThrotller(scaler, throttler, items5, concurrecy, testStart, logger);
+            AddHistoryToThrotller(scaler, throttler, items6, concurrecy, testStart, logger);
+            AddHistoryToThrotller(scaler, throttler, items7, concurrecy, testStart, logger);
 
             var logs = _loggerProvider.GetAllLogMessages().ToArray();
             if (!string.IsNullOrEmpty(expectedMessage))
             {
-                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith(expectedMessage)).Count() > 0);
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.Contains(expectedMessage)).Count() > 0);
             }
             else
             {
-                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith("Throttling scale down, since last scale up time was within")).Count() == 0);
-                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith("Throttling scale up due average backlog")).Count() == 0);
-                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith("Throttling scale down due there was at least one non-scale down vote")).Count() == 0);
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.Contains("Throttling scale down because last scale up time was within")).Count() == 0);
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.Contains("Throttling scale up because average backlog is less than")).Count() == 0);
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.Contains("Throttling scale down because there was at least one non-scale down vote")).Count() == 0);
             }
         }
 
-        private void AddHistoryToThrotller(EventHubsTargetScaler scaler, TargetScaleThrottler throttler, int[] items, int concurrecy, DateTime testStart)
+        private void AddHistoryToThrotller(EventHubsTargetScaler scaler, TargetScaleThrottler throttler, int[] items, int concurrecy, DateTime testStart, Microsoft.Extensions.Logging.ILogger logger)
         {
             if (items != null)
             {
-                Dictionary<string, long?> checkpoints = new Dictionary<string, long?>();
-                checkpoints["0"] = items[0];
-                checkpoints["1"] = items[1];
+                List<BlobStorageCheckpoint> checkpoints = new List<BlobStorageCheckpoint>();
+                checkpoints.Add(new BlobStorageCheckpoint()
+                {
+                    PartitionId = "0",
+                    SequenceNumber = items[0]
+                });
+                checkpoints.Add(new BlobStorageCheckpoint()
+                {
+                    PartitionId = "1",
+                    SequenceNumber = items[1]
+                });
 
                 var executionTime = testStart - TimeSpan.FromSeconds(items[3]);
                 EventHubsTriggerMetrics metrics = new EventHubsTriggerMetrics()
                 {
-                    CheckpointSequences = checkpoints,
+                    Checkpoints = checkpoints,
                     PartitionCount = 2,
                     EventCount = items[2],
                     Timestamp = executionTime
                 };
-                TargetScalerResult targetScalerResult = scaler.GetScaleResultInternal(new TargetScalerContext() { InstanceConcurrency = concurrecy }, metrics.EventCount, metrics.PartitionCount);
+                TargetScalerResult targetScalerResult = scaler.GetScaleResultInternal(concurrecy, metrics.EventCount, metrics.PartitionCount);
 
-                throttler.ThrottleIfNeeded(targetScalerResult, metrics, executionTime);
+                throttler.ThrottleIfNeeded(targetScalerResult, metrics, executionTime,out string log);
+                logger.LogInformation(log);
             }
         }
     }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/TargetScaleThrottlerTest.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/TargetScaleThrottlerTest.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.EventHubs;
+using Microsoft.Azure.WebJobs.EventHubs.Listeners;
+using Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests
+{
+    internal class TargetScaleThrottlerTest
+    {
+        private TestLoggerProvider _loggerProvider;
+        private LoggerFactory _loggerFactory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _loggerFactory = new LoggerFactory();
+            _loggerProvider = new TestLoggerProvider();
+            _loggerFactory.AddProvider(_loggerProvider);
+        }
+
+        [Test]
+        [TestCase( // Scale down based on last scale up operation - trottle
+            new int[] { 0, 0, 0, 70 },
+            new int[] { 1000, 1000, 0, 60 },
+            new int[] { 2000, 2000, 0, 50 },
+            new int[] { 3000, 3000, 0, 40 },
+            new int[] { 4000, 4000, 0, 30 },
+            new int[] { 5000, 5000, 0, 20 },
+            new int[] { 6000, 6000, 0, 10 },
+            new int[] { 7000, 7000, 0, 0 },
+            10, 120, 2, "Throttling scale down, since last scale up time was within")]
+        [TestCase( // Scale down based on last scale up operation - no trottle
+            new int[] { 0, 0, 0, 70 },
+            new int[] { 1000, 1000, 0, 60 },
+            new int[] { 2000, 2000, 0, 50 },
+            new int[] { 3000, 3000, 0, 40 },
+            new int[] { 4000, 4000, 0, 30 },
+            new int[] { 5000, 5000, 0, 20 },
+            new int[] { 6000, 6000, 0, 10 },
+            new int[] { 7000, 7000, 0, 0 },
+            10, 260, 2, "")]
+        [TestCase( // Scale up throttle based on executions - trottle
+            new int[] { 0, 0, 150, 70 },
+            new int[] { 1000, 1000, 150, 60 },
+            new int[] { 2000, 2000, 180, 50 },
+            new int[] { 3000, 3000, 190, 40 },
+            new int[] { 4000, 4000, 170, 30 },
+            new int[] { 5000, 5000, 200, 20 },
+            new int[] { 6000, 6000, 200, 10 },
+            new int[] { 7000, 7000, 210, 0 },
+            200, null, null, "Throttling scale up due average backlog")]
+        [TestCase( // Scale up throttle based on executions - no trottle
+            new int[] { 0, 0, 150, 70 },
+            new int[] { 1000, 1000, 250, 60 },
+            new int[] { 2000, 2000, 280, 50 },
+            new int[] { 3000, 3000, 290, 40 },
+            new int[] { 4000, 4000, 170, 30 },
+            new int[] { 5000, 5000, 200, 20 },
+            new int[] { 6000, 6000, 200, 10 },
+            new int[] { 7000, 7000, 210, 0 },
+            10, null, null, "")]
+        [TestCase(
+            new int[] { 0, 0, 0, 70 },
+            new int[] { 1000, 1000, 0, 60 },
+            new int[] { 2000, 2000, 0, 50 },
+            new int[] { 3000, 3000, 0, 40 },
+            new int[] { 4000, 4000, 25, 30 },
+            new int[] { 5000, 5000, 0, 20 },
+            new int[] { 6000, 6000, 0, 10 },
+            new int[] { 7000, 7000, 0, 0 },
+            10, 182, 2, "Throttling scale down due there was at least one non-scale down vote")]
+        public void ThrottleScaleDown_ReturnsExpected
+            (int[] items0, int[] items1, int[] items2, int[] items3, int[] items4, int[] items5, int[] items6, int[] items7,
+            int concurrecy,
+            int? whenLastScaleUpInSec,
+            int? targetWorkerCountOnLastScale,
+            string expectedMessage)
+        {
+            var logger = _loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("EventHub"));
+
+            var testStart = DateTime.UtcNow;
+
+            TargetScaleThrottler throttler = new TargetScaleThrottler(
+                whenLastScaleUpInSec.HasValue ? testStart - TimeSpan.FromSeconds(whenLastScaleUpInSec.Value): DateTime.MinValue,
+                targetWorkerCountOnLastScale.HasValue ? new TargetScalerResult() { TargetWorkerCount = targetWorkerCountOnLastScale.Value } : new TargetScalerResult(),
+                logger);
+
+            Mock<IEventHubConsumerClient> mockEventHubConsumerClient = new Mock<IEventHubConsumerClient>();
+            mockEventHubConsumerClient.Setup(x => x.EventHubName).Returns("test");
+
+            EventHubsTargetScaler scaler = new EventHubsTargetScaler("test", mockEventHubConsumerClient.Object, new EventHubOptions(), null, logger);
+
+            AddHistoryToThrotller(scaler, throttler, items0, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items1, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items2, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items3, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items4, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items5, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items6, concurrecy, testStart);
+            AddHistoryToThrotller(scaler, throttler, items7, concurrecy, testStart);
+
+            var logs = _loggerProvider.GetAllLogMessages().ToArray();
+            if (!string.IsNullOrEmpty(expectedMessage))
+            {
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith(expectedMessage)).Count() > 0);
+            }
+            else
+            {
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith("Throttling scale down, since last scale up time was within")).Count() == 0);
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith("Throttling scale up due average backlog")).Count() == 0);
+                Assert.IsTrue(logs.Where(x => x.FormattedMessage.StartsWith("Throttling scale down due there was at least one non-scale down vote")).Count() == 0);
+            }
+        }
+
+        private void AddHistoryToThrotller(EventHubsTargetScaler scaler, TargetScaleThrottler throttler, int[] items, int concurrecy, DateTime testStart)
+        {
+            if (items != null)
+            {
+                Dictionary<string, long?> checkpoints = new Dictionary<string, long?>();
+                checkpoints["0"] = items[0];
+                checkpoints["1"] = items[1];
+
+                var executionTime = testStart - TimeSpan.FromSeconds(items[3]);
+                EventHubsTriggerMetrics metrics = new EventHubsTriggerMetrics()
+                {
+                    CheckpointSequences = checkpoints,
+                    PartitionCount = 2,
+                    EventCount = items[2],
+                    Timestamp = executionTime
+                };
+                TargetScalerResult targetScalerResult = scaler.GetScaleResultInternal(new TargetScalerContext() { InstanceConcurrency = concurrecy }, metrics.EventCount, metrics.PartitionCount);
+
+                throttler.ThrottleIfNeeded(targetScalerResult, metrics, executionTime);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dynamic scale does not work well with Event Hubs because of partition owner rebalancing. The Scale Controller votes to scale every 10 seconds. A scaling operation will assign/unassign workers, which leads to rebalancing. Rebalancing causes performance drops and duplicate executions.

To avoid frequent rebalancing, we want to introduce new throttling logic.

[Old throttling logic]
Throttle scale down if there was a scale up within last 60 seconds.

[New throttling logic]
Throttle scale down if there was a scale operation or the same target worker count was voted within 180 seconds.
Throttle scale down if there was a scale up in the last 60 seconds.
Throttle scale up if backlog is less than 30% of the execution rate.
On scale down, pick the maximum of the following: the highest vote from the history, or one step back from the sorted valid worker count.
Allow scale down to 0 if there were no executions in the last 60 seconds.
