### PR TITLE
Fix the misspelling, discovery was missing the 'c'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -844,4 +844,4 @@
 /sdk/contentsafety/Azure.AI.ContentSafety/                     	   @bowgong @mengaims @JieZhou000
 
 # PRLabel: %Spring App Discovery
-/sdk/springappdisovery/Azure.ResourceManager.*/                    @sunkun99
+/sdk/springappdiscovery/Azure.ResourceManager.*/                    @sunkun99


### PR DESCRIPTION
This [PR](https://github.com/Azure/azure-sdk-for-net/pull/40680) added a new path to CODEOWNERS which had a misspelling. The springappdiscovery directory was missing the 'c'.