### PR TITLE
Azure OpenAI: update tests/readme for parallel gpt-4-vision-preview finish{details,reason} 

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/README.md
+++ b/sdk/openai/Azure.AI.OpenAI/README.md
@@ -633,15 +633,21 @@ ReadOnlyMemory<float> embedding = item.Embedding;
 ### Generate images with DALL-E image generation models
 
 ```C# Snippet:GenerateImages
-Response<ImageGenerations> imageGenerations = await client.GetImageGenerationsAsync(
+Response<ImageGenerations> response = await client.GetImageGenerationsAsync(
     new ImageGenerationOptions()
     {
+        DeploymentName = usingAzure ? "my-azure-openai-dall-e-3-deployment" : "dall-e-3",
         Prompt = "a happy monkey eating a banana, in watercolor",
-        Size = ImageSize.Size256x256,
+        Size = ImageSize.Size1024x1024,
+        Quality = ImageGenerationQuality.Standard
     });
 
-// Image Generations responses provide URLs you can use to retrieve requested images
-Uri imageUri = imageGenerations.Value.Data[0].Url;
+ImageGenerationData generatedImage = response.Value.Data[0];
+if (!string.IsNullOrEmpty(generatedImage.RevisedPrompt))
+{
+    Console.WriteLine($"Input prompt automatically revised to: {generatedImage.RevisedPrompt}");
+}
+Console.WriteLine($"Generated image available at: {generatedImage.Url.AbsoluteUri}");
 ```
 
 ### Transcribe audio data with Whisper speech models
@@ -714,7 +720,7 @@ in the interim:
 ```C# Snippet:GetResponseFromImages
 Response<ChatCompletions> chatResponse = await client.GetChatCompletionsAsync(chatCompletionsOptions);
 ChatChoice choice = chatResponse.Value.Choices[0];
-if (choice.FinishDetails is StopFinishDetails stopDetails)
+if (choice.FinishDetails is StopFinishDetails stopDetails || choice.FinishReason == CompletionsFinishReason.Stopped)
 {
     Console.WriteLine($"{choice.Message.Role}: {choice.Message.Content}");
 }

--- a/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/openai/Azure.AI.OpenAI",
-  "Tag": "net/openai/Azure.AI.OpenAI_15abed989a"
+  "Tag": "net/openai/Azure.AI.OpenAI_992d20f50a"
 }

--- a/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/openai/Azure.AI.OpenAI",
-  "Tag": "net/openai/Azure.AI.OpenAI_f6776cdcf2"
+  "Tag": "net/openai/Azure.AI.OpenAI_15abed989a"
 }

--- a/sdk/openai/Azure.AI.OpenAI/tests/AudioTranscriptionTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/AudioTranscriptionTests.cs
@@ -32,7 +32,7 @@ public class AudioTranscriptionTests : OpenAITestBase
         string transcriptionFormat)
     {
         OpenAIClient client = GetTestClient(serviceTarget);
-        string deploymentOrModelName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.AudioTranscription);
+        string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget);
 
         using Stream audioFileStream = GetTestAudioInputStream();
 
@@ -40,6 +40,7 @@ public class AudioTranscriptionTests : OpenAITestBase
         {
             DeploymentName = deploymentOrModelName,
             AudioData = BinaryData.FromStream(audioFileStream),
+            Filename = "test.wav",
             Temperature = (float)0.25,
         };
 

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatCompletionsTests.cs
@@ -56,7 +56,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task ChatCompletionsContentFilterCategories(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget);
-            string deploymentOrModelName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.ChatCompletions);
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget);
             var requestOptions = new ChatCompletionsOptions()
             {
                 DeploymentName = deploymentOrModelName,

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatWithVisionTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatWithVisionTests.cs
@@ -16,7 +16,7 @@ public class ChatWithVisionTests : OpenAITestBase
     }
 
     [RecordedTest]
-    // [TestCase(Service.Azure)]
+    [TestCase(Service.Azure)]
     [TestCase(Service.NonAzure)]
     public async Task ChatWithImages(Service serviceTarget)
     {
@@ -45,7 +45,17 @@ public class ChatWithVisionTests : OpenAITestBase
         Assert.That(response.Value.Choices.Count, Is.EqualTo(1));
         ChatChoice choice = response.Value.Choices[0];
         Assert.That(choice.Index, Is.EqualTo(0));
-        Assert.That(choice.FinishDetails, Is.InstanceOf<StopFinishDetails>());
+
+        Assert.That(choice.FinishReason != null || choice.FinishDetails != null);
+        if (choice.FinishReason == null)
+        {
+            Assert.That(choice.FinishDetails, Is.InstanceOf<StopFinishDetails>());
+        }
+        else if (choice.FinishDetails == null)
+        {
+            Assert.That(choice.FinishReason == CompletionsFinishReason.Stopped);
+        }
+
         Assert.That(choice.Message.Role, Is.EqualTo(ChatRole.Assistant));
         Assert.That(choice.Message.Content, Is.Not.Null.Or.Empty);
     }

--- a/sdk/openai/Azure.AI.OpenAI/tests/CompletionsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/CompletionsTests.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task Completions(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget);
-            string deploymentOrModelName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
             Assert.That(client, Is.InstanceOf<OpenAIClient>());
             CompletionsOptions requestOptions = new()
             {
@@ -51,7 +51,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task CompletionsWithTokenCredential(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget, Scenario.Completions, TestAuthType.Token);
-            string deploymentName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
+            string deploymentName = GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
             var requestOptions = new CompletionsOptions()
             {
                 DeploymentName = deploymentName,
@@ -70,8 +70,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task CompletionsContentFilterCategories(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget);
-            string deploymentOrModelName
-                = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
             var requestOptions = new CompletionsOptions()
             {
                 DeploymentName = deploymentOrModelName,
@@ -100,7 +99,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task AdvancedCompletionsOptions(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget);
-            string deploymentOrModelName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
             string promptText = "Are bananas especially radioactive?";
             var requestOptions = new CompletionsOptions()
             {
@@ -168,7 +167,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task TokenCutoff(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget, Scenario.LegacyCompletions);
-            string deploymentOrModelName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
             var requestOptions = new CompletionsOptions()
             {
                 DeploymentName = deploymentOrModelName,
@@ -194,7 +193,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task StreamingCompletions(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget, Scenario.LegacyCompletions);
-            string deploymentOrModelName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.LegacyCompletions);
             var requestOptions = new CompletionsOptions()
             {
                 DeploymentName = deploymentOrModelName,

--- a/sdk/openai/Azure.AI.OpenAI/tests/EmbeddingsTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/EmbeddingsTests.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.OpenAI.Tests
         public async Task Embeddings(Service serviceTarget)
         {
             OpenAIClient client = GetTestClient(serviceTarget);
-            string deploymentOrModelName = OpenAITestBase.GetDeploymentOrModelName(serviceTarget, Scenario.Embeddings);
+            string deploymentOrModelName = GetDeploymentOrModelName(serviceTarget, Scenario.Embeddings);
             var embeddingsOptions = new EmbeddingsOptions()
             {
                 DeploymentName = deploymentOrModelName,

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
@@ -131,10 +131,12 @@ namespace Azure.AI.OpenAI.Tests
                     if (!string.IsNullOrEmpty(pair.Value.AzureDeploymentName))
                     {
                         string variableName = GetAzureEndpointVariableNameForScenario(pair.Key);
-                        string recordedRawUri = Recording.GetVariable(variableName, null)
-                            ?? throw new TestRecordingMismatchException($"Missing expected recording variable name: {variableName}");
-                        pair.Value.AzureResourceUri = new Uri(recordedRawUri);
-                        pair.Value.AzureResourceKey = new AzureKeyCredential("placeholder");
+                        string variableValue = Recording.GetVariable(variableName, null);
+                        if (!string.IsNullOrEmpty(variableValue))
+                        {
+                            pair.Value.AzureResourceUri = new Uri(variableValue);
+                            pair.Value.AzureResourceKey = new AzureKeyCredential("placeholder");
+                        }
                     }
                 }
             }
@@ -214,19 +216,6 @@ namespace Azure.AI.OpenAI.Tests
                         }
 
                         s_deploymentComplete = true;
-                    }
-                }
-            }
-
-            if (Recording.Mode == RecordedTestMode.Record)
-            {
-                foreach (KeyValuePair<Scenario, ModelDeploymentEntry> pair in s_deploymentEntriesByScenario)
-                {
-                    Uri azureResourceUri = pair.Value.AzureResourceUri;
-                    if (azureResourceUri != null)
-                    {
-                        string variableName = GetAzureEndpointVariableNameForScenario(pair.Key);
-                        Recording.SetVariable(variableName, azureResourceUri.ToString());
                     }
                 }
             }
@@ -500,9 +489,14 @@ namespace Azure.AI.OpenAI.Tests
             VisionPreview,
         }
 
-        protected static string GetDeploymentOrModelName(Service serviceTarget, Scenario defaultScenario)
+        protected string GetDeploymentOrModelName(Service serviceTarget, Scenario scenario)
         {
-            ModelDeploymentEntry entry = s_deploymentEntriesByScenario[defaultScenario];
+            ModelDeploymentEntry entry = s_deploymentEntriesByScenario[scenario];
+            if (serviceTarget == Service.Azure && Mode == RecordedTestMode.Record)
+            {
+                string variableName = GetAzureEndpointVariableNameForScenario(scenario);
+                Recording.SetVariable(variableName, entry.AzureResourceUri.AbsoluteUri);
+            }
             return (serviceTarget == Service.Azure) ? entry.AzureDeploymentName : entry.NonAzureModelName;
         }
 

--- a/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/OpenAITestBase.cs
@@ -411,9 +411,9 @@ namespace Azure.AI.OpenAI.Tests
 
             [Scenario.VisionPreview] = new()
             {
-                AzureResourceName = string.Empty,
+                AzureResourceName = "openai-sdk-test-automation-account-sweden-central",
                 AzureResourceLocation = AzureLocation.SwedenCentral,
-                AzureDeploymentName = string.Empty,
+                AzureDeploymentName = "gpt-4-vision-preview",
                 NonAzureModelName = "gpt-4-vision-preview",
             }
         };

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/ChatWithVision.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/ChatWithVision.cs
@@ -35,7 +35,7 @@ public partial class ChatWithVision
         #region Snippet:GetResponseFromImages
         Response<ChatCompletions> chatResponse = await client.GetChatCompletionsAsync(chatCompletionsOptions);
         ChatChoice choice = chatResponse.Value.Choices[0];
-        if (choice.FinishDetails is StopFinishDetails stopDetails)
+        if (choice.FinishDetails is StopFinishDetails stopDetails || choice.FinishReason == CompletionsFinishReason.Stopped)
         {
             Console.WriteLine($"{choice.Message.Role}: {choice.Message.Content}");
         }

--- a/sdk/openai/Azure.AI.OpenAI/tests/Samples/ImageGeneration.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Samples/ImageGeneration.cs
@@ -2,33 +2,38 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using Azure.Identity;
 using NUnit.Framework;
 
-namespace Azure.AI.OpenAI.Tests.Samples
+namespace Azure.AI.OpenAI.Tests.Samples;
+
+public partial class ImagesSamples
 {
-    public partial class ImagesSamples
+    [Test]
+    [Ignore("Only verifying that the sample builds")]
+    public async Task ImageGenerations()
     {
-        [Test]
-        [Ignore("Only verifying that the sample builds")]
-        public async Task ImageGenerations()
+        string endpoint = "https://myaccount.openai.azure.com/";
+        var client = new OpenAIClient(new Uri(endpoint), new DefaultAzureCredential());
+        const bool usingAzure = true;
+
+        #region Snippet:GenerateImages
+        Response<ImageGenerations> response = await client.GetImageGenerationsAsync(
+            new ImageGenerationOptions()
+            {
+                DeploymentName = usingAzure ? "my-azure-openai-dall-e-3-deployment" : "dall-e-3",
+                Prompt = "a happy monkey eating a banana, in watercolor",
+                Size = ImageSize.Size1024x1024,
+                Quality = ImageGenerationQuality.Standard
+            });
+
+        ImageGenerationData generatedImage = response.Value.Data[0];
+        if (!string.IsNullOrEmpty(generatedImage.RevisedPrompt))
         {
-            string endpoint = "https://myaccount.openai.azure.com/";
-            var client = new OpenAIClient(new Uri(endpoint), new DefaultAzureCredential());
-
-            #region Snippet:GenerateImages
-            Response<ImageGenerations> imageGenerations = await client.GetImageGenerationsAsync(
-                new ImageGenerationOptions()
-                {
-                    Prompt = "a happy monkey eating a banana, in watercolor",
-                    Size = ImageSize.Size256x256,
-                });
-
-            // Image Generations responses provide URLs you can use to retrieve requested images
-            Uri imageUri = imageGenerations.Value.Data[0].Url;
-            #endregion
+            Console.WriteLine($"Input prompt automatically revised to: {generatedImage.RevisedPrompt}");
         }
+        Console.WriteLine($"Generated image available at: {generatedImage.Url.AbsoluteUri}");
+        #endregion
     }
 }


### PR DESCRIPTION
At its introduction, `gpt-4-vision-preview` provided a new (and undocumented) `finish_details` result object in lieu of the conventional `finish_reason` enumeration.

OpenAI since addressed this on their service and now report a `finish_reason` when using `gpt-4-vision-preview`. Azure OpenAI continues to report `finish_details`, presumably until the next API version can snap.

This change:

- Adds Azure OpenAI test coverage for gpt-4-vision-preview, which wasn't yet available during authoring for 2023-12-01-preview
- Loosens the test restriction to test for either `finish_reason` or `finish_details`
- Updates the readme snippet to match the description (of checking either/both)