### PR TITLE
Clean up description for Azure.ResourceManager.Sphere

### DIFF
--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/ArmSphereModelFactory.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/ArmSphereModelFactory.cs
@@ -24,10 +24,7 @@ namespace Azure.ResourceManager.Sphere.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Catalog.properties.provisioningState
-        /// </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Sphere.SphereCatalogData"/> instance for mocking. </returns>
         public static SphereCatalogData SphereCatalogData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IDictionary<string, string> tags = null, AzureLocation location = default, SphereProvisioningState? provisioningState = null)
         {
@@ -41,34 +38,13 @@ namespace Azure.ResourceManager.Sphere.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="certificate">
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: Certificate.properties.certificate
-        /// </param>
-        /// <param name="status">
-        /// The certificate status.
-        /// Serialized Name: Certificate.properties.status
-        /// </param>
-        /// <param name="subject">
-        /// The certificate subject.
-        /// Serialized Name: Certificate.properties.subject
-        /// </param>
-        /// <param name="thumbprint">
-        /// The certificate thumbprint.
-        /// Serialized Name: Certificate.properties.thumbprint
-        /// </param>
-        /// <param name="expiryUtc">
-        /// The certificate expiry date.
-        /// Serialized Name: Certificate.properties.expiryUtc
-        /// </param>
-        /// <param name="notBeforeUtc">
-        /// The certificate not before date.
-        /// Serialized Name: Certificate.properties.notBeforeUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Certificate.properties.provisioningState
-        /// </param>
+        /// <param name="certificate"> The certificate as a UTF-8 encoded base 64 string. </param>
+        /// <param name="status"> The certificate status. </param>
+        /// <param name="subject"> The certificate subject. </param>
+        /// <param name="thumbprint"> The certificate thumbprint. </param>
+        /// <param name="expiryUtc"> The certificate expiry date. </param>
+        /// <param name="notBeforeUtc"> The certificate not before date. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Sphere.SphereCertificateData"/> instance for mocking. </returns>
         public static SphereCertificateData SphereCertificateData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string certificate = null, SphereCertificateStatus? status = null, string subject = null, string thumbprint = null, DateTimeOffset? expiryUtc = null, DateTimeOffset? notBeforeUtc = null, SphereProvisioningState? provisioningState = null)
         {
@@ -76,34 +52,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.SphereCertificateProperties"/>. </summary>
-        /// <param name="certificate">
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: CertificateProperties.certificate
-        /// </param>
-        /// <param name="status">
-        /// The certificate status.
-        /// Serialized Name: CertificateProperties.status
-        /// </param>
-        /// <param name="subject">
-        /// The certificate subject.
-        /// Serialized Name: CertificateProperties.subject
-        /// </param>
-        /// <param name="thumbprint">
-        /// The certificate thumbprint.
-        /// Serialized Name: CertificateProperties.thumbprint
-        /// </param>
-        /// <param name="expiryUtc">
-        /// The certificate expiry date.
-        /// Serialized Name: CertificateProperties.expiryUtc
-        /// </param>
-        /// <param name="notBeforeUtc">
-        /// The certificate not before date.
-        /// Serialized Name: CertificateProperties.notBeforeUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: CertificateProperties.provisioningState
-        /// </param>
+        /// <param name="certificate"> The certificate as a UTF-8 encoded base 64 string. </param>
+        /// <param name="status"> The certificate status. </param>
+        /// <param name="subject"> The certificate subject. </param>
+        /// <param name="thumbprint"> The certificate thumbprint. </param>
+        /// <param name="expiryUtc"> The certificate expiry date. </param>
+        /// <param name="notBeforeUtc"> The certificate not before date. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Models.SphereCertificateProperties"/> instance for mocking. </returns>
         public static SphereCertificateProperties SphereCertificateProperties(string certificate = null, SphereCertificateStatus? status = null, string subject = null, string thumbprint = null, DateTimeOffset? expiryUtc = null, DateTimeOffset? notBeforeUtc = null, SphereProvisioningState? provisioningState = null)
         {
@@ -111,10 +66,7 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.SphereCertificateChainResult"/>. </summary>
-        /// <param name="certificateChain">
-        /// The certificate chain.
-        /// Serialized Name: CertificateChainResponse.certificateChain
-        /// </param>
+        /// <param name="certificateChain"> The certificate chain. </param>
         /// <returns> A new <see cref="Models.SphereCertificateChainResult"/> instance for mocking. </returns>
         public static SphereCertificateChainResult SphereCertificateChainResult(string certificateChain = null)
         {
@@ -122,34 +74,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ProofOfPossessionNonceResponse"/>. </summary>
-        /// <param name="certificate">
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: CertificateProperties.certificate
-        /// </param>
-        /// <param name="status">
-        /// The certificate status.
-        /// Serialized Name: CertificateProperties.status
-        /// </param>
-        /// <param name="subject">
-        /// The certificate subject.
-        /// Serialized Name: CertificateProperties.subject
-        /// </param>
-        /// <param name="thumbprint">
-        /// The certificate thumbprint.
-        /// Serialized Name: CertificateProperties.thumbprint
-        /// </param>
-        /// <param name="expiryUtc">
-        /// The certificate expiry date.
-        /// Serialized Name: CertificateProperties.expiryUtc
-        /// </param>
-        /// <param name="notBeforeUtc">
-        /// The certificate not before date.
-        /// Serialized Name: CertificateProperties.notBeforeUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: CertificateProperties.provisioningState
-        /// </param>
+        /// <param name="certificate"> The certificate as a UTF-8 encoded base 64 string. </param>
+        /// <param name="status"> The certificate status. </param>
+        /// <param name="subject"> The certificate subject. </param>
+        /// <param name="thumbprint"> The certificate thumbprint. </param>
+        /// <param name="expiryUtc"> The certificate expiry date. </param>
+        /// <param name="notBeforeUtc"> The certificate not before date. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Models.ProofOfPossessionNonceResponse"/> instance for mocking. </returns>
         public static ProofOfPossessionNonceResponse ProofOfPossessionNonceResponse(string certificate = null, SphereCertificateStatus? status = null, string subject = null, string thumbprint = null, DateTimeOffset? expiryUtc = null, DateTimeOffset? notBeforeUtc = null, SphereProvisioningState? provisioningState = null)
         {
@@ -157,10 +88,7 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.CountDeviceResult"/>. </summary>
-        /// <param name="value">
-        /// Number of children resources in parent resource.
-        /// Serialized Name: CountElementsResponse.value
-        /// </param>
+        /// <param name="value"> Number of children resources in parent resource. </param>
         /// <returns> A new <see cref="Models.CountDeviceResult"/> instance for mocking. </returns>
         public static CountDeviceResult CountDeviceResult(int value = default)
         {
@@ -168,10 +96,7 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.CountElementsResult"/>. </summary>
-        /// <param name="value">
-        /// Number of children resources in parent resource.
-        /// Serialized Name: CountElementsResponse.value
-        /// </param>
+        /// <param name="value"> Number of children resources in parent resource. </param>
         /// <returns> A new <see cref="Models.CountElementsResult"/> instance for mocking. </returns>
         public static CountElementsResult CountElementsResult(int value = default)
         {
@@ -183,42 +108,15 @@ namespace Azure.ResourceManager.Sphere.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="image">
-        /// Image as a UTF-8 encoded base 64 string on image create. This field contains the image URI on image reads.
-        /// Serialized Name: Image.properties.image
-        /// </param>
-        /// <param name="imageId">
-        /// Image ID
-        /// Serialized Name: Image.properties.imageId
-        /// </param>
-        /// <param name="imageName">
-        /// Image name
-        /// Serialized Name: Image.properties.imageName
-        /// </param>
-        /// <param name="regionalDataBoundary">
-        /// Regional data boundary for an image
-        /// Serialized Name: Image.properties.regionalDataBoundary
-        /// </param>
-        /// <param name="uri">
-        /// Location the image
-        /// Serialized Name: Image.properties.uri
-        /// </param>
-        /// <param name="description">
-        /// The image description.
-        /// Serialized Name: Image.properties.description
-        /// </param>
-        /// <param name="componentId">
-        /// The image component id.
-        /// Serialized Name: Image.properties.componentId
-        /// </param>
-        /// <param name="imageType">
-        /// The image type.
-        /// Serialized Name: Image.properties.imageType
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Image.properties.provisioningState
-        /// </param>
+        /// <param name="image"> Image as a UTF-8 encoded base 64 string on image create. This field contains the image URI on image reads. </param>
+        /// <param name="imageId"> Image ID. </param>
+        /// <param name="imageName"> Image name. </param>
+        /// <param name="regionalDataBoundary"> Regional data boundary for an image. </param>
+        /// <param name="uri"> Location the image. </param>
+        /// <param name="description"> The image description. </param>
+        /// <param name="componentId"> The image component id. </param>
+        /// <param name="imageType"> The image type. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Sphere.SphereImageData"/> instance for mocking. </returns>
         public static SphereImageData SphereImageData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string image = null, string imageId = null, string imageName = null, RegionalDataBoundary? regionalDataBoundary = null, Uri uri = null, string description = null, string componentId = null, SphereImageType? imageType = null, SphereProvisioningState? provisioningState = null)
         {
@@ -230,22 +128,10 @@ namespace Azure.ResourceManager.Sphere.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="deploymentId">
-        /// Deployment ID
-        /// Serialized Name: Deployment.properties.deploymentId
-        /// </param>
-        /// <param name="deployedImages">
-        /// Images deployed
-        /// Serialized Name: Deployment.properties.deployedImages
-        /// </param>
-        /// <param name="deploymentDateUtc">
-        /// Deployment date UTC
-        /// Serialized Name: Deployment.properties.deploymentDateUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Deployment.properties.provisioningState
-        /// </param>
+        /// <param name="deploymentId"> Deployment ID. </param>
+        /// <param name="deployedImages"> Images deployed. </param>
+        /// <param name="deploymentDateUtc"> Deployment date UTC. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Sphere.SphereDeploymentData"/> instance for mocking. </returns>
         public static SphereDeploymentData SphereDeploymentData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string deploymentId = null, IEnumerable<SphereImageData> deployedImages = null, DateTimeOffset? deploymentDateUtc = null, SphereProvisioningState? provisioningState = null)
         {
@@ -259,34 +145,13 @@ namespace Azure.ResourceManager.Sphere.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="description">
-        /// Description of the device group.
-        /// Serialized Name: DeviceGroup.properties.description
-        /// </param>
-        /// <param name="osFeedType">
-        /// Operating system feed type of the device group.
-        /// Serialized Name: DeviceGroup.properties.osFeedType
-        /// </param>
-        /// <param name="updatePolicy">
-        /// Update policy of the device group.
-        /// Serialized Name: DeviceGroup.properties.updatePolicy
-        /// </param>
-        /// <param name="allowCrashDumpsCollection">
-        /// Flag to define if the user allows for crash dump collection.
-        /// Serialized Name: DeviceGroup.properties.allowCrashDumpsCollection
-        /// </param>
-        /// <param name="regionalDataBoundary">
-        /// Regional data boundary for the device group.
-        /// Serialized Name: DeviceGroup.properties.regionalDataBoundary
-        /// </param>
-        /// <param name="hasDeployment">
-        /// Deployment status for the device group.
-        /// Serialized Name: DeviceGroup.properties.hasDeployment
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: DeviceGroup.properties.provisioningState
-        /// </param>
+        /// <param name="description"> Description of the device group. </param>
+        /// <param name="osFeedType"> Operating system feed type of the device group. </param>
+        /// <param name="updatePolicy"> Update policy of the device group. </param>
+        /// <param name="allowCrashDumpsCollection"> Flag to define if the user allows for crash dump collection. </param>
+        /// <param name="regionalDataBoundary"> Regional data boundary for the device group. </param>
+        /// <param name="hasDeployment"> Deployment status for the device group. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Sphere.SphereDeviceGroupData"/> instance for mocking. </returns>
         public static SphereDeviceGroupData SphereDeviceGroupData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string description = null, SphereOSFeedType? osFeedType = null, SphereUpdatePolicy? updatePolicy = null, SphereAllowCrashDumpCollectionStatus? allowCrashDumpsCollection = null, RegionalDataBoundary? regionalDataBoundary = null, bool? hasDeployment = null, SphereProvisioningState? provisioningState = null)
         {
@@ -294,38 +159,14 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.SphereDeviceInsight"/>. </summary>
-        /// <param name="deviceId">
-        /// Device ID
-        /// Serialized Name: DeviceInsight.deviceId
-        /// </param>
-        /// <param name="description">
-        /// Event description
-        /// Serialized Name: DeviceInsight.description
-        /// </param>
-        /// <param name="startTimestampUtc">
-        /// Event start timestamp
-        /// Serialized Name: DeviceInsight.startTimestampUtc
-        /// </param>
-        /// <param name="endTimestampUtc">
-        /// Event end timestamp
-        /// Serialized Name: DeviceInsight.endTimestampUtc
-        /// </param>
-        /// <param name="eventCategory">
-        /// Event category
-        /// Serialized Name: DeviceInsight.eventCategory
-        /// </param>
-        /// <param name="eventClass">
-        /// Event class
-        /// Serialized Name: DeviceInsight.eventClass
-        /// </param>
-        /// <param name="eventType">
-        /// Event type
-        /// Serialized Name: DeviceInsight.eventType
-        /// </param>
-        /// <param name="eventCount">
-        /// Event count
-        /// Serialized Name: DeviceInsight.eventCount
-        /// </param>
+        /// <param name="deviceId"> Device ID. </param>
+        /// <param name="description"> Event description. </param>
+        /// <param name="startTimestampUtc"> Event start timestamp. </param>
+        /// <param name="endTimestampUtc"> Event end timestamp. </param>
+        /// <param name="eventCategory"> Event category. </param>
+        /// <param name="eventClass"> Event class. </param>
+        /// <param name="eventType"> Event type. </param>
+        /// <param name="eventCount"> Event count. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="deviceId"/>, <paramref name="description"/>, <paramref name="eventCategory"/>, <paramref name="eventClass"/> or <paramref name="eventType"/> is null. </exception>
         /// <returns> A new <see cref="Models.SphereDeviceInsight"/> instance for mocking. </returns>
         public static SphereDeviceInsight SphereDeviceInsight(string deviceId = null, string description = null, DateTimeOffset startTimestampUtc = default, DateTimeOffset endTimestampUtc = default, string eventCategory = null, string eventClass = null, string eventType = null, int eventCount = default)
@@ -359,34 +200,13 @@ namespace Azure.ResourceManager.Sphere.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="deviceId">
-        /// Device ID
-        /// Serialized Name: Device.properties.deviceId
-        /// </param>
-        /// <param name="chipSku">
-        /// SKU of the chip
-        /// Serialized Name: Device.properties.chipSku
-        /// </param>
-        /// <param name="lastAvailableOSVersion">
-        /// OS version available for installation when update requested
-        /// Serialized Name: Device.properties.lastAvailableOsVersion
-        /// </param>
-        /// <param name="lastInstalledOSVersion">
-        /// OS version running on device when update requested
-        /// Serialized Name: Device.properties.lastInstalledOsVersion
-        /// </param>
-        /// <param name="lastOSUpdateUtc">
-        /// Time when update requested and new OS version available
-        /// Serialized Name: Device.properties.lastOsUpdateUtc
-        /// </param>
-        /// <param name="lastUpdateRequestUtc">
-        /// Time when update was last requested
-        /// Serialized Name: Device.properties.lastUpdateRequestUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Device.properties.provisioningState
-        /// </param>
+        /// <param name="deviceId"> Device ID. </param>
+        /// <param name="chipSku"> SKU of the chip. </param>
+        /// <param name="lastAvailableOSVersion"> OS version available for installation when update requested. </param>
+        /// <param name="lastInstalledOSVersion"> OS version running on device when update requested. </param>
+        /// <param name="lastOSUpdateUtc"> Time when update requested and new OS version available. </param>
+        /// <param name="lastUpdateRequestUtc"> Time when update was last requested. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Sphere.SphereDeviceData"/> instance for mocking. </returns>
         public static SphereDeviceData SphereDeviceData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string deviceId = null, string chipSku = null, string lastAvailableOSVersion = null, string lastInstalledOSVersion = null, DateTimeOffset? lastOSUpdateUtc = null, DateTimeOffset? lastUpdateRequestUtc = null, SphereProvisioningState? provisioningState = null)
         {
@@ -398,14 +218,8 @@ namespace Azure.ResourceManager.Sphere.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="description">
-        /// Description of the product
-        /// Serialized Name: Product.properties.description
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Product.properties.provisioningState
-        /// </param>
+        /// <param name="description"> Description of the product. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         /// <returns> A new <see cref="Sphere.SphereProductData"/> instance for mocking. </returns>
         public static SphereProductData SphereProductData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string description = null, SphereProvisioningState? provisioningState = null)
         {
@@ -413,10 +227,7 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.SignedCapabilityImageResponse"/>. </summary>
-        /// <param name="image">
-        /// The signed device capability image as a UTF-8 encoded base 64 string.
-        /// Serialized Name: SignedCapabilityImageResponse.image
-        /// </param>
+        /// <param name="image"> The signed device capability image as a UTF-8 encoded base 64 string. </param>
         /// <returns> A new <see cref="Models.SignedCapabilityImageResponse"/> instance for mocking. </returns>
         public static SignedCapabilityImageResponse SignedCapabilityImageResponse(string image = null)
         {

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CatalogListResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CatalogListResult.cs
@@ -13,17 +13,11 @@ using Azure.ResourceManager.Sphere;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The response of a Catalog list operation.
-    /// Serialized Name: CatalogListResult
-    /// </summary>
+    /// <summary> The response of a Catalog list operation. </summary>
     internal partial class CatalogListResult
     {
         /// <summary> Initializes a new instance of <see cref="CatalogListResult"/>. </summary>
-        /// <param name="value">
-        /// The Catalog items on this page
-        /// Serialized Name: CatalogListResult.value
-        /// </param>
+        /// <param name="value"> The Catalog items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal CatalogListResult(IEnumerable<SphereCatalogData> value)
         {
@@ -33,29 +27,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="CatalogListResult"/>. </summary>
-        /// <param name="value">
-        /// The Catalog items on this page
-        /// Serialized Name: CatalogListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: CatalogListResult.nextLink
-        /// </param>
+        /// <param name="value"> The Catalog items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal CatalogListResult(IReadOnlyList<SphereCatalogData> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The Catalog items on this page
-        /// Serialized Name: CatalogListResult.value
-        /// </summary>
+        /// <summary> The Catalog items on this page. </summary>
         public IReadOnlyList<SphereCatalogData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: CatalogListResult.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CertificateListResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CertificateListResult.cs
@@ -13,17 +13,11 @@ using Azure.ResourceManager.Sphere;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The response of a Certificate list operation.
-    /// Serialized Name: CertificateListResult
-    /// </summary>
+    /// <summary> The response of a Certificate list operation. </summary>
     internal partial class CertificateListResult
     {
         /// <summary> Initializes a new instance of <see cref="CertificateListResult"/>. </summary>
-        /// <param name="value">
-        /// The Certificate items on this page
-        /// Serialized Name: CertificateListResult.value
-        /// </param>
+        /// <param name="value"> The Certificate items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal CertificateListResult(IEnumerable<SphereCertificateData> value)
         {
@@ -33,29 +27,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="CertificateListResult"/>. </summary>
-        /// <param name="value">
-        /// The Certificate items on this page
-        /// Serialized Name: CertificateListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: CertificateListResult.nextLink
-        /// </param>
+        /// <param name="value"> The Certificate items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal CertificateListResult(IReadOnlyList<SphereCertificateData> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The Certificate items on this page
-        /// Serialized Name: CertificateListResult.value
-        /// </summary>
+        /// <summary> The Certificate items on this page. </summary>
         public IReadOnlyList<SphereCertificateData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: CertificateListResult.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ClaimSphereDevicesContent.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ClaimSphereDevicesContent.cs
@@ -12,17 +12,11 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Request to the action call to bulk claim devices.
-    /// Serialized Name: ClaimDevicesRequest
-    /// </summary>
+    /// <summary> Request to the action call to bulk claim devices. </summary>
     public partial class ClaimSphereDevicesContent
     {
         /// <summary> Initializes a new instance of <see cref="ClaimSphereDevicesContent"/>. </summary>
-        /// <param name="deviceIdentifiers">
-        /// Device identifiers of the devices to be claimed.
-        /// Serialized Name: ClaimDevicesRequest.deviceIdentifiers
-        /// </param>
+        /// <param name="deviceIdentifiers"> Device identifiers of the devices to be claimed. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="deviceIdentifiers"/> is null. </exception>
         public ClaimSphereDevicesContent(IEnumerable<string> deviceIdentifiers)
         {
@@ -32,19 +26,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ClaimSphereDevicesContent"/>. </summary>
-        /// <param name="deviceIdentifiers">
-        /// Device identifiers of the devices to be claimed.
-        /// Serialized Name: ClaimDevicesRequest.deviceIdentifiers
-        /// </param>
+        /// <param name="deviceIdentifiers"> Device identifiers of the devices to be claimed. </param>
         internal ClaimSphereDevicesContent(IList<string> deviceIdentifiers)
         {
             DeviceIdentifiers = deviceIdentifiers;
         }
 
-        /// <summary>
-        /// Device identifiers of the devices to be claimed.
-        /// Serialized Name: ClaimDevicesRequest.deviceIdentifiers
-        /// </summary>
+        /// <summary> Device identifiers of the devices to be claimed. </summary>
         public IList<string> DeviceIdentifiers { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CountDeviceResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CountDeviceResult.cs
@@ -7,17 +7,11 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Response to the action call for count devices in a catalog.
-    /// Serialized Name: CountDeviceResponse
-    /// </summary>
+    /// <summary> Response to the action call for count devices in a catalog. </summary>
     public partial class CountDeviceResult : CountElementsResult
     {
         /// <summary> Initializes a new instance of <see cref="CountDeviceResult"/>. </summary>
-        /// <param name="value">
-        /// Number of children resources in parent resource.
-        /// Serialized Name: CountElementsResponse.value
-        /// </param>
+        /// <param name="value"> Number of children resources in parent resource. </param>
         internal CountDeviceResult(int value) : base(value)
         {
         }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CountElementsResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/CountElementsResult.cs
@@ -7,26 +7,17 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Response of the count for elements.
-    /// Serialized Name: CountElementsResponse
-    /// </summary>
+    /// <summary> Response of the count for elements. </summary>
     public partial class CountElementsResult
     {
         /// <summary> Initializes a new instance of <see cref="CountElementsResult"/>. </summary>
-        /// <param name="value">
-        /// Number of children resources in parent resource.
-        /// Serialized Name: CountElementsResponse.value
-        /// </param>
+        /// <param name="value"> Number of children resources in parent resource. </param>
         internal CountElementsResult(int value)
         {
             Value = value;
         }
 
-        /// <summary>
-        /// Number of children resources in parent resource.
-        /// Serialized Name: CountElementsResponse.value
-        /// </summary>
+        /// <summary> Number of children resources in parent resource. </summary>
         public int Value { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/DeploymentListResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/DeploymentListResult.cs
@@ -13,17 +13,11 @@ using Azure.ResourceManager.Sphere;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The response of a Deployment list operation.
-    /// Serialized Name: DeploymentListResult
-    /// </summary>
+    /// <summary> The response of a Deployment list operation. </summary>
     internal partial class DeploymentListResult
     {
         /// <summary> Initializes a new instance of <see cref="DeploymentListResult"/>. </summary>
-        /// <param name="value">
-        /// The Deployment items on this page
-        /// Serialized Name: DeploymentListResult.value
-        /// </param>
+        /// <param name="value"> The Deployment items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal DeploymentListResult(IEnumerable<SphereDeploymentData> value)
         {
@@ -33,29 +27,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="DeploymentListResult"/>. </summary>
-        /// <param name="value">
-        /// The Deployment items on this page
-        /// Serialized Name: DeploymentListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: DeploymentListResult.nextLink
-        /// </param>
+        /// <param name="value"> The Deployment items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal DeploymentListResult(IReadOnlyList<SphereDeploymentData> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The Deployment items on this page
-        /// Serialized Name: DeploymentListResult.value
-        /// </summary>
+        /// <summary> The Deployment items on this page. </summary>
         public IReadOnlyList<SphereDeploymentData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: DeploymentListResult.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/DeviceGroupListResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/DeviceGroupListResult.cs
@@ -13,17 +13,11 @@ using Azure.ResourceManager.Sphere;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The response of a DeviceGroup list operation.
-    /// Serialized Name: DeviceGroupListResult
-    /// </summary>
+    /// <summary> The response of a DeviceGroup list operation. </summary>
     internal partial class DeviceGroupListResult
     {
         /// <summary> Initializes a new instance of <see cref="DeviceGroupListResult"/>. </summary>
-        /// <param name="value">
-        /// The DeviceGroup items on this page
-        /// Serialized Name: DeviceGroupListResult.value
-        /// </param>
+        /// <param name="value"> The DeviceGroup items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal DeviceGroupListResult(IEnumerable<SphereDeviceGroupData> value)
         {
@@ -33,29 +27,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="DeviceGroupListResult"/>. </summary>
-        /// <param name="value">
-        /// The DeviceGroup items on this page
-        /// Serialized Name: DeviceGroupListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: DeviceGroupListResult.nextLink
-        /// </param>
+        /// <param name="value"> The DeviceGroup items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal DeviceGroupListResult(IReadOnlyList<SphereDeviceGroupData> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The DeviceGroup items on this page
-        /// Serialized Name: DeviceGroupListResult.value
-        /// </summary>
+        /// <summary> The DeviceGroup items on this page. </summary>
         public IReadOnlyList<SphereDeviceGroupData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: DeviceGroupListResult.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/DeviceListResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/DeviceListResult.cs
@@ -13,17 +13,11 @@ using Azure.ResourceManager.Sphere;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The response of a Device list operation.
-    /// Serialized Name: DeviceListResult
-    /// </summary>
+    /// <summary> The response of a Device list operation. </summary>
     internal partial class DeviceListResult
     {
         /// <summary> Initializes a new instance of <see cref="DeviceListResult"/>. </summary>
-        /// <param name="value">
-        /// The Device items on this page
-        /// Serialized Name: DeviceListResult.value
-        /// </param>
+        /// <param name="value"> The Device items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal DeviceListResult(IEnumerable<SphereDeviceData> value)
         {
@@ -33,29 +27,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="DeviceListResult"/>. </summary>
-        /// <param name="value">
-        /// The Device items on this page
-        /// Serialized Name: DeviceListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: DeviceListResult.nextLink
-        /// </param>
+        /// <param name="value"> The Device items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal DeviceListResult(IReadOnlyList<SphereDeviceData> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The Device items on this page
-        /// Serialized Name: DeviceListResult.value
-        /// </summary>
+        /// <summary> The Device items on this page. </summary>
         public IReadOnlyList<SphereDeviceData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: DeviceListResult.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/GenerateCapabilityImageContent.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/GenerateCapabilityImageContent.cs
@@ -12,17 +12,11 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Request of the action to create a signed device capability image
-    /// Serialized Name: GenerateCapabilityImageRequest
-    /// </summary>
+    /// <summary> Request of the action to create a signed device capability image. </summary>
     public partial class GenerateCapabilityImageContent
     {
         /// <summary> Initializes a new instance of <see cref="GenerateCapabilityImageContent"/>. </summary>
-        /// <param name="capabilities">
-        /// List of capabilities to create
-        /// Serialized Name: GenerateCapabilityImageRequest.capabilities
-        /// </param>
+        /// <param name="capabilities"> List of capabilities to create. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="capabilities"/> is null. </exception>
         public GenerateCapabilityImageContent(IEnumerable<SphereCapabilityType> capabilities)
         {
@@ -32,19 +26,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="GenerateCapabilityImageContent"/>. </summary>
-        /// <param name="capabilities">
-        /// List of capabilities to create
-        /// Serialized Name: GenerateCapabilityImageRequest.capabilities
-        /// </param>
+        /// <param name="capabilities"> List of capabilities to create. </param>
         internal GenerateCapabilityImageContent(IList<SphereCapabilityType> capabilities)
         {
             Capabilities = capabilities;
         }
 
-        /// <summary>
-        /// List of capabilities to create
-        /// Serialized Name: GenerateCapabilityImageRequest.capabilities
-        /// </summary>
+        /// <summary> List of capabilities to create. </summary>
         public IList<SphereCapabilityType> Capabilities { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ImageListResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ImageListResult.cs
@@ -13,17 +13,11 @@ using Azure.ResourceManager.Sphere;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The response of a Image list operation.
-    /// Serialized Name: ImageListResult
-    /// </summary>
+    /// <summary> The response of a Image list operation. </summary>
     internal partial class ImageListResult
     {
         /// <summary> Initializes a new instance of <see cref="ImageListResult"/>. </summary>
-        /// <param name="value">
-        /// The Image items on this page
-        /// Serialized Name: ImageListResult.value
-        /// </param>
+        /// <param name="value"> The Image items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal ImageListResult(IEnumerable<SphereImageData> value)
         {
@@ -33,29 +27,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ImageListResult"/>. </summary>
-        /// <param name="value">
-        /// The Image items on this page
-        /// Serialized Name: ImageListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: ImageListResult.nextLink
-        /// </param>
+        /// <param name="value"> The Image items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal ImageListResult(IReadOnlyList<SphereImageData> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The Image items on this page
-        /// Serialized Name: ImageListResult.value
-        /// </summary>
+        /// <summary> The Image items on this page. </summary>
         public IReadOnlyList<SphereImageData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: ImageListResult.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ListSphereDeviceGroupsContent.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ListSphereDeviceGroupsContent.cs
@@ -7,10 +7,7 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Request of the action to list device groups for a catalog.
-    /// Serialized Name: ListDeviceGroupsRequest
-    /// </summary>
+    /// <summary> Request of the action to list device groups for a catalog. </summary>
     public partial class ListSphereDeviceGroupsContent
     {
         /// <summary> Initializes a new instance of <see cref="ListSphereDeviceGroupsContent"/>. </summary>
@@ -19,19 +16,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ListSphereDeviceGroupsContent"/>. </summary>
-        /// <param name="deviceGroupName">
-        /// Device Group name.
-        /// Serialized Name: ListDeviceGroupsRequest.deviceGroupName
-        /// </param>
+        /// <param name="deviceGroupName"> Device Group name. </param>
         internal ListSphereDeviceGroupsContent(string deviceGroupName)
         {
             DeviceGroupName = deviceGroupName;
         }
 
-        /// <summary>
-        /// Device Group name.
-        /// Serialized Name: ListDeviceGroupsRequest.deviceGroupName
-        /// </summary>
+        /// <summary> Device Group name. </summary>
         public string DeviceGroupName { get; set; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/PagedDeviceInsight.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/PagedDeviceInsight.cs
@@ -12,17 +12,11 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Paged collection of DeviceInsight items
-    /// Serialized Name: PagedDeviceInsight
-    /// </summary>
+    /// <summary> Paged collection of DeviceInsight items. </summary>
     internal partial class PagedDeviceInsight
     {
         /// <summary> Initializes a new instance of <see cref="PagedDeviceInsight"/>. </summary>
-        /// <param name="value">
-        /// The DeviceInsight items on this page
-        /// Serialized Name: PagedDeviceInsight.value
-        /// </param>
+        /// <param name="value"> The DeviceInsight items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal PagedDeviceInsight(IEnumerable<SphereDeviceInsight> value)
         {
@@ -32,29 +26,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PagedDeviceInsight"/>. </summary>
-        /// <param name="value">
-        /// The DeviceInsight items on this page
-        /// Serialized Name: PagedDeviceInsight.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: PagedDeviceInsight.nextLink
-        /// </param>
+        /// <param name="value"> The DeviceInsight items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal PagedDeviceInsight(IReadOnlyList<SphereDeviceInsight> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The DeviceInsight items on this page
-        /// Serialized Name: PagedDeviceInsight.value
-        /// </summary>
+        /// <summary> The DeviceInsight items on this page. </summary>
         public IReadOnlyList<SphereDeviceInsight> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: PagedDeviceInsight.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ProductListResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ProductListResult.cs
@@ -13,17 +13,11 @@ using Azure.ResourceManager.Sphere;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The response of a Product list operation.
-    /// Serialized Name: ProductListResult
-    /// </summary>
+    /// <summary> The response of a Product list operation. </summary>
     internal partial class ProductListResult
     {
         /// <summary> Initializes a new instance of <see cref="ProductListResult"/>. </summary>
-        /// <param name="value">
-        /// The Product items on this page
-        /// Serialized Name: ProductListResult.value
-        /// </param>
+        /// <param name="value"> The Product items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal ProductListResult(IEnumerable<SphereProductData> value)
         {
@@ -33,29 +27,17 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ProductListResult"/>. </summary>
-        /// <param name="value">
-        /// The Product items on this page
-        /// Serialized Name: ProductListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: ProductListResult.nextLink
-        /// </param>
+        /// <param name="value"> The Product items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         internal ProductListResult(IReadOnlyList<SphereProductData> value, Uri nextLink)
         {
             Value = value;
             NextLink = nextLink;
         }
 
-        /// <summary>
-        /// The Product items on this page
-        /// Serialized Name: ProductListResult.value
-        /// </summary>
+        /// <summary> The Product items on this page. </summary>
         public IReadOnlyList<SphereProductData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: ProductListResult.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ProofOfPossessionNonceContent.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ProofOfPossessionNonceContent.cs
@@ -10,17 +10,11 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Request for the proof of possession nonce
-    /// Serialized Name: ProofOfPossessionNonceRequest
-    /// </summary>
+    /// <summary> Request for the proof of possession nonce. </summary>
     public partial class ProofOfPossessionNonceContent
     {
         /// <summary> Initializes a new instance of <see cref="ProofOfPossessionNonceContent"/>. </summary>
-        /// <param name="proofOfPossessionNonce">
-        /// The proof of possession nonce
-        /// Serialized Name: ProofOfPossessionNonceRequest.proofOfPossessionNonce
-        /// </param>
+        /// <param name="proofOfPossessionNonce"> The proof of possession nonce. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="proofOfPossessionNonce"/> is null. </exception>
         public ProofOfPossessionNonceContent(string proofOfPossessionNonce)
         {
@@ -29,10 +23,7 @@ namespace Azure.ResourceManager.Sphere.Models
             ProofOfPossessionNonce = proofOfPossessionNonce;
         }
 
-        /// <summary>
-        /// The proof of possession nonce
-        /// Serialized Name: ProofOfPossessionNonceRequest.proofOfPossessionNonce
-        /// </summary>
+        /// <summary> The proof of possession nonce. </summary>
         public string ProofOfPossessionNonce { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ProofOfPossessionNonceResponse.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/ProofOfPossessionNonceResponse.cs
@@ -9,10 +9,7 @@ using System;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Result of the action to generate a proof of possession nonce
-    /// Serialized Name: ProofOfPossessionNonceResponse
-    /// </summary>
+    /// <summary> Result of the action to generate a proof of possession nonce. </summary>
     public partial class ProofOfPossessionNonceResponse : SphereCertificateProperties
     {
         /// <summary> Initializes a new instance of <see cref="ProofOfPossessionNonceResponse"/>. </summary>
@@ -21,34 +18,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ProofOfPossessionNonceResponse"/>. </summary>
-        /// <param name="certificate">
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: CertificateProperties.certificate
-        /// </param>
-        /// <param name="status">
-        /// The certificate status.
-        /// Serialized Name: CertificateProperties.status
-        /// </param>
-        /// <param name="subject">
-        /// The certificate subject.
-        /// Serialized Name: CertificateProperties.subject
-        /// </param>
-        /// <param name="thumbprint">
-        /// The certificate thumbprint.
-        /// Serialized Name: CertificateProperties.thumbprint
-        /// </param>
-        /// <param name="expiryUtc">
-        /// The certificate expiry date.
-        /// Serialized Name: CertificateProperties.expiryUtc
-        /// </param>
-        /// <param name="notBeforeUtc">
-        /// The certificate not before date.
-        /// Serialized Name: CertificateProperties.notBeforeUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: CertificateProperties.provisioningState
-        /// </param>
+        /// <param name="certificate"> The certificate as a UTF-8 encoded base 64 string. </param>
+        /// <param name="status"> The certificate status. </param>
+        /// <param name="subject"> The certificate subject. </param>
+        /// <param name="thumbprint"> The certificate thumbprint. </param>
+        /// <param name="expiryUtc"> The certificate expiry date. </param>
+        /// <param name="notBeforeUtc"> The certificate not before date. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal ProofOfPossessionNonceResponse(string certificate, SphereCertificateStatus? status, string subject, string thumbprint, DateTimeOffset? expiryUtc, DateTimeOffset? notBeforeUtc, SphereProvisioningState? provisioningState) : base(certificate, status, subject, thumbprint, expiryUtc, notBeforeUtc, provisioningState)
         {
         }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/RegionalDataBoundary.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/RegionalDataBoundary.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Regional data boundary values.
-    /// Serialized Name: RegionalDataBoundary
-    /// </summary>
+    /// <summary> Regional data boundary values. </summary>
     public readonly partial struct RegionalDataBoundary : IEquatable<RegionalDataBoundary>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string NoneValue = "None";
         private const string EUValue = "EU";
 
-        /// <summary>
-        /// No data boundary
-        /// Serialized Name: RegionalDataBoundary.None
-        /// </summary>
+        /// <summary> No data boundary. </summary>
         public static RegionalDataBoundary None { get; } = new RegionalDataBoundary(NoneValue);
-        /// <summary>
-        /// EU data boundary
-        /// Serialized Name: RegionalDataBoundary.EU
-        /// </summary>
+        /// <summary> EU data boundary. </summary>
         public static RegionalDataBoundary EU { get; } = new RegionalDataBoundary(EUValue);
         /// <summary> Determines if two <see cref="RegionalDataBoundary"/> values are the same. </summary>
         public static bool operator ==(RegionalDataBoundary left, RegionalDataBoundary right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SignedCapabilityImageResponse.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SignedCapabilityImageResponse.cs
@@ -7,10 +7,7 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Signed device capability image response
-    /// Serialized Name: SignedCapabilityImageResponse
-    /// </summary>
+    /// <summary> Signed device capability image response. </summary>
     public partial class SignedCapabilityImageResponse
     {
         /// <summary> Initializes a new instance of <see cref="SignedCapabilityImageResponse"/>. </summary>
@@ -19,19 +16,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SignedCapabilityImageResponse"/>. </summary>
-        /// <param name="image">
-        /// The signed device capability image as a UTF-8 encoded base 64 string.
-        /// Serialized Name: SignedCapabilityImageResponse.image
-        /// </param>
+        /// <param name="image"> The signed device capability image as a UTF-8 encoded base 64 string. </param>
         internal SignedCapabilityImageResponse(string image)
         {
             Image = image;
         }
 
-        /// <summary>
-        /// The signed device capability image as a UTF-8 encoded base 64 string.
-        /// Serialized Name: SignedCapabilityImageResponse.image
-        /// </summary>
+        /// <summary> The signed device capability image as a UTF-8 encoded base 64 string. </summary>
         public string Image { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereAllowCrashDumpCollectionStatus.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereAllowCrashDumpCollectionStatus.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Allow crash dumps values.
-    /// Serialized Name: AllowCrashDumpCollection
-    /// </summary>
+    /// <summary> Allow crash dumps values. </summary>
     public readonly partial struct SphereAllowCrashDumpCollectionStatus : IEquatable<SphereAllowCrashDumpCollectionStatus>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Crash dump collection enabled
-        /// Serialized Name: AllowCrashDumpCollection.Enabled
-        /// </summary>
+        /// <summary> Crash dump collection enabled. </summary>
         public static SphereAllowCrashDumpCollectionStatus Enabled { get; } = new SphereAllowCrashDumpCollectionStatus(EnabledValue);
-        /// <summary>
-        /// Crash dump collection disabled
-        /// Serialized Name: AllowCrashDumpCollection.Disabled
-        /// </summary>
+        /// <summary> Crash dump collection disabled. </summary>
         public static SphereAllowCrashDumpCollectionStatus Disabled { get; } = new SphereAllowCrashDumpCollectionStatus(DisabledValue);
         /// <summary> Determines if two <see cref="SphereAllowCrashDumpCollectionStatus"/> values are the same. </summary>
         public static bool operator ==(SphereAllowCrashDumpCollectionStatus left, SphereAllowCrashDumpCollectionStatus right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCapabilityType.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCapabilityType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Capability image type
-    /// Serialized Name: CapabilityType
-    /// </summary>
+    /// <summary> Capability image type. </summary>
     public readonly partial struct SphereCapabilityType : IEquatable<SphereCapabilityType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string ApplicationDevelopmentValue = "ApplicationDevelopment";
         private const string FieldServicingValue = "FieldServicing";
 
-        /// <summary>
-        /// Application development capability
-        /// Serialized Name: CapabilityType.ApplicationDevelopment
-        /// </summary>
+        /// <summary> Application development capability. </summary>
         public static SphereCapabilityType ApplicationDevelopment { get; } = new SphereCapabilityType(ApplicationDevelopmentValue);
-        /// <summary>
-        /// Field servicing capability
-        /// Serialized Name: CapabilityType.FieldServicing
-        /// </summary>
+        /// <summary> Field servicing capability. </summary>
         public static SphereCapabilityType FieldServicing { get; } = new SphereCapabilityType(FieldServicingValue);
         /// <summary> Determines if two <see cref="SphereCapabilityType"/> values are the same. </summary>
         public static bool operator ==(SphereCapabilityType left, SphereCapabilityType right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCatalogPatch.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCatalogPatch.cs
@@ -10,10 +10,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The type used for update operations of the Catalog.
-    /// Serialized Name: CatalogUpdate
-    /// </summary>
+    /// <summary> The type used for update operations of the Catalog. </summary>
     public partial class SphereCatalogPatch
     {
         /// <summary> Initializes a new instance of <see cref="SphereCatalogPatch"/>. </summary>
@@ -23,19 +20,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SphereCatalogPatch"/>. </summary>
-        /// <param name="tags">
-        /// Resource tags.
-        /// Serialized Name: CatalogUpdate.tags
-        /// </param>
+        /// <param name="tags"> Resource tags. </param>
         internal SphereCatalogPatch(IDictionary<string, string> tags)
         {
             Tags = tags;
         }
 
-        /// <summary>
-        /// Resource tags.
-        /// Serialized Name: CatalogUpdate.tags
-        /// </summary>
+        /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCertificateChainResult.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCertificateChainResult.cs
@@ -7,10 +7,7 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The certificate chain response.
-    /// Serialized Name: CertificateChainResponse
-    /// </summary>
+    /// <summary> The certificate chain response. </summary>
     public partial class SphereCertificateChainResult
     {
         /// <summary> Initializes a new instance of <see cref="SphereCertificateChainResult"/>. </summary>
@@ -19,19 +16,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SphereCertificateChainResult"/>. </summary>
-        /// <param name="certificateChain">
-        /// The certificate chain.
-        /// Serialized Name: CertificateChainResponse.certificateChain
-        /// </param>
+        /// <param name="certificateChain"> The certificate chain. </param>
         internal SphereCertificateChainResult(string certificateChain)
         {
             CertificateChain = certificateChain;
         }
 
-        /// <summary>
-        /// The certificate chain.
-        /// Serialized Name: CertificateChainResponse.certificateChain
-        /// </summary>
+        /// <summary> The certificate chain. </summary>
         public string CertificateChain { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCertificateProperties.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCertificateProperties.cs
@@ -9,10 +9,7 @@ using System;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The properties of certificate
-    /// Serialized Name: CertificateProperties
-    /// </summary>
+    /// <summary> The properties of certificate. </summary>
     public partial class SphereCertificateProperties
     {
         /// <summary> Initializes a new instance of <see cref="SphereCertificateProperties"/>. </summary>
@@ -21,34 +18,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SphereCertificateProperties"/>. </summary>
-        /// <param name="certificate">
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: CertificateProperties.certificate
-        /// </param>
-        /// <param name="status">
-        /// The certificate status.
-        /// Serialized Name: CertificateProperties.status
-        /// </param>
-        /// <param name="subject">
-        /// The certificate subject.
-        /// Serialized Name: CertificateProperties.subject
-        /// </param>
-        /// <param name="thumbprint">
-        /// The certificate thumbprint.
-        /// Serialized Name: CertificateProperties.thumbprint
-        /// </param>
-        /// <param name="expiryUtc">
-        /// The certificate expiry date.
-        /// Serialized Name: CertificateProperties.expiryUtc
-        /// </param>
-        /// <param name="notBeforeUtc">
-        /// The certificate not before date.
-        /// Serialized Name: CertificateProperties.notBeforeUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: CertificateProperties.provisioningState
-        /// </param>
+        /// <param name="certificate"> The certificate as a UTF-8 encoded base 64 string. </param>
+        /// <param name="status"> The certificate status. </param>
+        /// <param name="subject"> The certificate subject. </param>
+        /// <param name="thumbprint"> The certificate thumbprint. </param>
+        /// <param name="expiryUtc"> The certificate expiry date. </param>
+        /// <param name="notBeforeUtc"> The certificate not before date. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereCertificateProperties(string certificate, SphereCertificateStatus? status, string subject, string thumbprint, DateTimeOffset? expiryUtc, DateTimeOffset? notBeforeUtc, SphereProvisioningState? provisioningState)
         {
             Certificate = certificate;
@@ -60,40 +36,19 @@ namespace Azure.ResourceManager.Sphere.Models
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: CertificateProperties.certificate
-        /// </summary>
+        /// <summary> The certificate as a UTF-8 encoded base 64 string. </summary>
         public string Certificate { get; }
-        /// <summary>
-        /// The certificate status.
-        /// Serialized Name: CertificateProperties.status
-        /// </summary>
+        /// <summary> The certificate status. </summary>
         public SphereCertificateStatus? Status { get; }
-        /// <summary>
-        /// The certificate subject.
-        /// Serialized Name: CertificateProperties.subject
-        /// </summary>
+        /// <summary> The certificate subject. </summary>
         public string Subject { get; }
-        /// <summary>
-        /// The certificate thumbprint.
-        /// Serialized Name: CertificateProperties.thumbprint
-        /// </summary>
+        /// <summary> The certificate thumbprint. </summary>
         public string Thumbprint { get; }
-        /// <summary>
-        /// The certificate expiry date.
-        /// Serialized Name: CertificateProperties.expiryUtc
-        /// </summary>
+        /// <summary> The certificate expiry date. </summary>
         public DateTimeOffset? ExpiryUtc { get; }
-        /// <summary>
-        /// The certificate not before date.
-        /// Serialized Name: CertificateProperties.notBeforeUtc
-        /// </summary>
+        /// <summary> The certificate not before date. </summary>
         public DateTimeOffset? NotBeforeUtc { get; }
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: CertificateProperties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCertificateStatus.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereCertificateStatus.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Certificate status values.
-    /// Serialized Name: CertificateStatus
-    /// </summary>
+    /// <summary> Certificate status values. </summary>
     public readonly partial struct SphereCertificateStatus : IEquatable<SphereCertificateStatus>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string ExpiredValue = "Expired";
         private const string RevokedValue = "Revoked";
 
-        /// <summary>
-        /// Certificate is active
-        /// Serialized Name: CertificateStatus.Active
-        /// </summary>
+        /// <summary> Certificate is active. </summary>
         public static SphereCertificateStatus Active { get; } = new SphereCertificateStatus(ActiveValue);
-        /// <summary>
-        /// Certificate is inactive
-        /// Serialized Name: CertificateStatus.Inactive
-        /// </summary>
+        /// <summary> Certificate is inactive. </summary>
         public static SphereCertificateStatus Inactive { get; } = new SphereCertificateStatus(InactiveValue);
-        /// <summary>
-        /// Certificate has expired
-        /// Serialized Name: CertificateStatus.Expired
-        /// </summary>
+        /// <summary> Certificate has expired. </summary>
         public static SphereCertificateStatus Expired { get; } = new SphereCertificateStatus(ExpiredValue);
-        /// <summary>
-        /// Certificate has been revoked
-        /// Serialized Name: CertificateStatus.Revoked
-        /// </summary>
+        /// <summary> Certificate has been revoked. </summary>
         public static SphereCertificateStatus Revoked { get; } = new SphereCertificateStatus(RevokedValue);
         /// <summary> Determines if two <see cref="SphereCertificateStatus"/> values are the same. </summary>
         public static bool operator ==(SphereCertificateStatus left, SphereCertificateStatus right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereDeviceGroupPatch.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereDeviceGroupPatch.cs
@@ -7,10 +7,7 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The type used for update operations of the DeviceGroup.
-    /// Serialized Name: DeviceGroupUpdate
-    /// </summary>
+    /// <summary> The type used for update operations of the DeviceGroup. </summary>
     public partial class SphereDeviceGroupPatch
     {
         /// <summary> Initializes a new instance of <see cref="SphereDeviceGroupPatch"/>. </summary>
@@ -19,26 +16,11 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SphereDeviceGroupPatch"/>. </summary>
-        /// <param name="description">
-        /// Description of the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.description
-        /// </param>
-        /// <param name="osFeedType">
-        /// Operating system feed type of the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.osFeedType
-        /// </param>
-        /// <param name="updatePolicy">
-        /// Update policy of the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.updatePolicy
-        /// </param>
-        /// <param name="allowCrashDumpsCollection">
-        /// Flag to define if the user allows for crash dump collection.
-        /// Serialized Name: DeviceGroupUpdate.properties.allowCrashDumpsCollection
-        /// </param>
-        /// <param name="regionalDataBoundary">
-        /// Regional data boundary for the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.regionalDataBoundary
-        /// </param>
+        /// <param name="description"> Description of the device group. </param>
+        /// <param name="osFeedType"> Operating system feed type of the device group. </param>
+        /// <param name="updatePolicy"> Update policy of the device group. </param>
+        /// <param name="allowCrashDumpsCollection"> Flag to define if the user allows for crash dump collection. </param>
+        /// <param name="regionalDataBoundary"> Regional data boundary for the device group. </param>
         internal SphereDeviceGroupPatch(string description, SphereOSFeedType? osFeedType, SphereUpdatePolicy? updatePolicy, SphereAllowCrashDumpCollectionStatus? allowCrashDumpsCollection, RegionalDataBoundary? regionalDataBoundary)
         {
             Description = description;
@@ -48,30 +30,15 @@ namespace Azure.ResourceManager.Sphere.Models
             RegionalDataBoundary = regionalDataBoundary;
         }
 
-        /// <summary>
-        /// Description of the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.description
-        /// </summary>
+        /// <summary> Description of the device group. </summary>
         public string Description { get; set; }
-        /// <summary>
-        /// Operating system feed type of the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.osFeedType
-        /// </summary>
+        /// <summary> Operating system feed type of the device group. </summary>
         public SphereOSFeedType? OSFeedType { get; set; }
-        /// <summary>
-        /// Update policy of the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.updatePolicy
-        /// </summary>
+        /// <summary> Update policy of the device group. </summary>
         public SphereUpdatePolicy? UpdatePolicy { get; set; }
-        /// <summary>
-        /// Flag to define if the user allows for crash dump collection.
-        /// Serialized Name: DeviceGroupUpdate.properties.allowCrashDumpsCollection
-        /// </summary>
+        /// <summary> Flag to define if the user allows for crash dump collection. </summary>
         public SphereAllowCrashDumpCollectionStatus? AllowCrashDumpsCollection { get; set; }
-        /// <summary>
-        /// Regional data boundary for the device group.
-        /// Serialized Name: DeviceGroupUpdate.properties.regionalDataBoundary
-        /// </summary>
+        /// <summary> Regional data boundary for the device group. </summary>
         public RegionalDataBoundary? RegionalDataBoundary { get; set; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereDeviceInsight.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereDeviceInsight.cs
@@ -10,45 +10,18 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Device insight report.
-    /// Serialized Name: DeviceInsight
-    /// </summary>
+    /// <summary> Device insight report. </summary>
     public partial class SphereDeviceInsight
     {
         /// <summary> Initializes a new instance of <see cref="SphereDeviceInsight"/>. </summary>
-        /// <param name="deviceId">
-        /// Device ID
-        /// Serialized Name: DeviceInsight.deviceId
-        /// </param>
-        /// <param name="description">
-        /// Event description
-        /// Serialized Name: DeviceInsight.description
-        /// </param>
-        /// <param name="startTimestampUtc">
-        /// Event start timestamp
-        /// Serialized Name: DeviceInsight.startTimestampUtc
-        /// </param>
-        /// <param name="endTimestampUtc">
-        /// Event end timestamp
-        /// Serialized Name: DeviceInsight.endTimestampUtc
-        /// </param>
-        /// <param name="eventCategory">
-        /// Event category
-        /// Serialized Name: DeviceInsight.eventCategory
-        /// </param>
-        /// <param name="eventClass">
-        /// Event class
-        /// Serialized Name: DeviceInsight.eventClass
-        /// </param>
-        /// <param name="eventType">
-        /// Event type
-        /// Serialized Name: DeviceInsight.eventType
-        /// </param>
-        /// <param name="eventCount">
-        /// Event count
-        /// Serialized Name: DeviceInsight.eventCount
-        /// </param>
+        /// <param name="deviceId"> Device ID. </param>
+        /// <param name="description"> Event description. </param>
+        /// <param name="startTimestampUtc"> Event start timestamp. </param>
+        /// <param name="endTimestampUtc"> Event end timestamp. </param>
+        /// <param name="eventCategory"> Event category. </param>
+        /// <param name="eventClass"> Event class. </param>
+        /// <param name="eventType"> Event type. </param>
+        /// <param name="eventCount"> Event count. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="deviceId"/>, <paramref name="description"/>, <paramref name="eventCategory"/>, <paramref name="eventClass"/> or <paramref name="eventType"/> is null. </exception>
         internal SphereDeviceInsight(string deviceId, string description, DateTimeOffset startTimestampUtc, DateTimeOffset endTimestampUtc, string eventCategory, string eventClass, string eventType, int eventCount)
         {
@@ -68,45 +41,21 @@ namespace Azure.ResourceManager.Sphere.Models
             EventCount = eventCount;
         }
 
-        /// <summary>
-        /// Device ID
-        /// Serialized Name: DeviceInsight.deviceId
-        /// </summary>
+        /// <summary> Device ID. </summary>
         public string DeviceId { get; }
-        /// <summary>
-        /// Event description
-        /// Serialized Name: DeviceInsight.description
-        /// </summary>
+        /// <summary> Event description. </summary>
         public string Description { get; }
-        /// <summary>
-        /// Event start timestamp
-        /// Serialized Name: DeviceInsight.startTimestampUtc
-        /// </summary>
+        /// <summary> Event start timestamp. </summary>
         public DateTimeOffset StartTimestampUtc { get; }
-        /// <summary>
-        /// Event end timestamp
-        /// Serialized Name: DeviceInsight.endTimestampUtc
-        /// </summary>
+        /// <summary> Event end timestamp. </summary>
         public DateTimeOffset EndTimestampUtc { get; }
-        /// <summary>
-        /// Event category
-        /// Serialized Name: DeviceInsight.eventCategory
-        /// </summary>
+        /// <summary> Event category. </summary>
         public string EventCategory { get; }
-        /// <summary>
-        /// Event class
-        /// Serialized Name: DeviceInsight.eventClass
-        /// </summary>
+        /// <summary> Event class. </summary>
         public string EventClass { get; }
-        /// <summary>
-        /// Event type
-        /// Serialized Name: DeviceInsight.eventType
-        /// </summary>
+        /// <summary> Event type. </summary>
         public string EventType { get; }
-        /// <summary>
-        /// Event count
-        /// Serialized Name: DeviceInsight.eventCount
-        /// </summary>
+        /// <summary> Event count. </summary>
         public int EventCount { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereDevicePatch.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereDevicePatch.cs
@@ -7,10 +7,7 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The type used for update operations of the Device.
-    /// Serialized Name: DeviceUpdate
-    /// </summary>
+    /// <summary> The type used for update operations of the Device. </summary>
     public partial class SphereDevicePatch
     {
         /// <summary> Initializes a new instance of <see cref="SphereDevicePatch"/>. </summary>
@@ -19,19 +16,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SphereDevicePatch"/>. </summary>
-        /// <param name="deviceGroupId">
-        /// Device group id
-        /// Serialized Name: DeviceUpdate.properties.deviceGroupId
-        /// </param>
+        /// <param name="deviceGroupId"> Device group id. </param>
         internal SphereDevicePatch(string deviceGroupId)
         {
             DeviceGroupId = deviceGroupId;
         }
 
-        /// <summary>
-        /// Device group id
-        /// Serialized Name: DeviceUpdate.properties.deviceGroupId
-        /// </summary>
+        /// <summary> Device group id. </summary>
         public string DeviceGroupId { get; set; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereImageType.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereImageType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Image type values.
-    /// Serialized Name: ImageType
-    /// </summary>
+    /// <summary> Image type values. </summary>
     public readonly partial struct SphereImageType : IEquatable<SphereImageType>
     {
         private readonly string _value;
@@ -50,125 +47,53 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string ManifestSetValue = "ManifestSet";
         private const string OtherValue = "Other";
 
-        /// <summary>
-        /// Invalid image.
-        /// Serialized Name: ImageType.InvalidImageType
-        /// </summary>
+        /// <summary> Invalid image. </summary>
         public static SphereImageType InvalidImageType { get; } = new SphereImageType(InvalidImageTypeValue);
-        /// <summary>
-        /// One Bl image type
-        /// Serialized Name: ImageType.OneBl
-        /// </summary>
+        /// <summary> One Bl image type. </summary>
         public static SphereImageType OneBl { get; } = new SphereImageType(OneBlValue);
-        /// <summary>
-        /// Pluton image type
-        /// Serialized Name: ImageType.PlutonRuntime
-        /// </summary>
+        /// <summary> Pluton image type. </summary>
         public static SphereImageType PlutonRuntime { get; } = new SphereImageType(PlutonRuntimeValue);
-        /// <summary>
-        /// Wifi firmware image type
-        /// Serialized Name: ImageType.WifiFirmware
-        /// </summary>
+        /// <summary> Wifi firmware image type. </summary>
         public static SphereImageType WifiFirmware { get; } = new SphereImageType(WifiFirmwareValue);
-        /// <summary>
-        /// Security monitor image type
-        /// Serialized Name: ImageType.SecurityMonitor
-        /// </summary>
+        /// <summary> Security monitor image type. </summary>
         public static SphereImageType SecurityMonitor { get; } = new SphereImageType(SecurityMonitorValue);
-        /// <summary>
-        /// Normal world loader image type
-        /// Serialized Name: ImageType.NormalWorldLoader
-        /// </summary>
+        /// <summary> Normal world loader image type. </summary>
         public static SphereImageType NormalWorldLoader { get; } = new SphereImageType(NormalWorldLoaderValue);
-        /// <summary>
-        /// Normal world dtb image type
-        /// Serialized Name: ImageType.NormalWorldDtb
-        /// </summary>
+        /// <summary> Normal world dtb image type. </summary>
         public static SphereImageType NormalWorldDtb { get; } = new SphereImageType(NormalWorldDtbValue);
-        /// <summary>
-        /// Normal world kernel image type
-        /// Serialized Name: ImageType.NormalWorldKernel
-        /// </summary>
+        /// <summary> Normal world kernel image type. </summary>
         public static SphereImageType NormalWorldKernel { get; } = new SphereImageType(NormalWorldKernelValue);
-        /// <summary>
-        /// Root FS image type
-        /// Serialized Name: ImageType.RootFs
-        /// </summary>
+        /// <summary> Root FS image type. </summary>
         public static SphereImageType RootFs { get; } = new SphereImageType(RootFsValue);
-        /// <summary>
-        /// Services image type
-        /// Serialized Name: ImageType.Services
-        /// </summary>
+        /// <summary> Services image type. </summary>
         public static SphereImageType Services { get; } = new SphereImageType(ServicesValue);
-        /// <summary>
-        /// Applications image type
-        /// Serialized Name: ImageType.Applications
-        /// </summary>
+        /// <summary> Applications image type. </summary>
         public static SphereImageType Applications { get; } = new SphereImageType(ApplicationsValue);
-        /// <summary>
-        /// FW config image type
-        /// Serialized Name: ImageType.FwConfig
-        /// </summary>
+        /// <summary> FW config image type. </summary>
         public static SphereImageType FwConfig { get; } = new SphereImageType(FwConfigValue);
-        /// <summary>
-        /// Boot manifest image type
-        /// Serialized Name: ImageType.BootManifest
-        /// </summary>
+        /// <summary> Boot manifest image type. </summary>
         public static SphereImageType BootManifest { get; } = new SphereImageType(BootManifestValue);
-        /// <summary>
-        /// Nwfs image type
-        /// Serialized Name: ImageType.Nwfs
-        /// </summary>
+        /// <summary> Nwfs image type. </summary>
         public static SphereImageType Nwfs { get; } = new SphereImageType(NwfsValue);
-        /// <summary>
-        /// Trusted key store image type
-        /// Serialized Name: ImageType.TrustedKeystore
-        /// </summary>
+        /// <summary> Trusted key store image type. </summary>
         public static SphereImageType TrustedKeystore { get; } = new SphereImageType(TrustedKeystoreValue);
-        /// <summary>
-        /// Policy image type
-        /// Serialized Name: ImageType.Policy
-        /// </summary>
+        /// <summary> Policy image type. </summary>
         public static SphereImageType Policy { get; } = new SphereImageType(PolicyValue);
-        /// <summary>
-        /// Customer board config image type
-        /// Serialized Name: ImageType.CustomerBoardConfig
-        /// </summary>
+        /// <summary> Customer board config image type. </summary>
         public static SphereImageType CustomerBoardConfig { get; } = new SphereImageType(CustomerBoardConfigValue);
-        /// <summary>
-        /// Update certificate store image type
-        /// Serialized Name: ImageType.UpdateCertStore
-        /// </summary>
+        /// <summary> Update certificate store image type. </summary>
         public static SphereImageType UpdateCertStore { get; } = new SphereImageType(UpdateCertStoreValue);
-        /// <summary>
-        /// Base system update manifest image type
-        /// Serialized Name: ImageType.BaseSystemUpdateManifest
-        /// </summary>
+        /// <summary> Base system update manifest image type. </summary>
         public static SphereImageType BaseSystemUpdateManifest { get; } = new SphereImageType(BaseSystemUpdateManifestValue);
-        /// <summary>
-        /// Firmware update manifest image type
-        /// Serialized Name: ImageType.FirmwareUpdateManifest
-        /// </summary>
+        /// <summary> Firmware update manifest image type. </summary>
         public static SphereImageType FirmwareUpdateManifest { get; } = new SphereImageType(FirmwareUpdateManifestValue);
-        /// <summary>
-        /// Customer update manifest image type
-        /// Serialized Name: ImageType.CustomerUpdateManifest
-        /// </summary>
+        /// <summary> Customer update manifest image type. </summary>
         public static SphereImageType CustomerUpdateManifest { get; } = new SphereImageType(CustomerUpdateManifestValue);
-        /// <summary>
-        /// Recovery manifest image type
-        /// Serialized Name: ImageType.RecoveryManifest
-        /// </summary>
+        /// <summary> Recovery manifest image type. </summary>
         public static SphereImageType RecoveryManifest { get; } = new SphereImageType(RecoveryManifestValue);
-        /// <summary>
-        /// manifest set image type
-        /// Serialized Name: ImageType.ManifestSet
-        /// </summary>
+        /// <summary> manifest set image type. </summary>
         public static SphereImageType ManifestSet { get; } = new SphereImageType(ManifestSetValue);
-        /// <summary>
-        /// Other image type
-        /// Serialized Name: ImageType.Other
-        /// </summary>
+        /// <summary> Other image type. </summary>
         public static SphereImageType Other { get; } = new SphereImageType(OtherValue);
         /// <summary> Determines if two <see cref="SphereImageType"/> values are the same. </summary>
         public static bool operator ==(SphereImageType left, SphereImageType right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereOSFeedType.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereOSFeedType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// OS feed type values.
-    /// Serialized Name: OSFeedType
-    /// </summary>
+    /// <summary> OS feed type values. </summary>
     public readonly partial struct SphereOSFeedType : IEquatable<SphereOSFeedType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string RetailValue = "Retail";
         private const string RetailEvalValue = "RetailEval";
 
-        /// <summary>
-        /// Retail OS feed type.
-        /// Serialized Name: OSFeedType.Retail
-        /// </summary>
+        /// <summary> Retail OS feed type. </summary>
         public static SphereOSFeedType Retail { get; } = new SphereOSFeedType(RetailValue);
-        /// <summary>
-        /// Retail evaluation OS feed type.
-        /// Serialized Name: OSFeedType.RetailEval
-        /// </summary>
+        /// <summary> Retail evaluation OS feed type. </summary>
         public static SphereOSFeedType RetailEval { get; } = new SphereOSFeedType(RetailEvalValue);
         /// <summary> Determines if two <see cref="SphereOSFeedType"/> values are the same. </summary>
         public static bool operator ==(SphereOSFeedType left, SphereOSFeedType right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereProductPatch.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereProductPatch.cs
@@ -7,10 +7,7 @@
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// The type used for update operations of the Product.
-    /// Serialized Name: ProductUpdate
-    /// </summary>
+    /// <summary> The type used for update operations of the Product. </summary>
     public partial class SphereProductPatch
     {
         /// <summary> Initializes a new instance of <see cref="SphereProductPatch"/>. </summary>
@@ -19,19 +16,13 @@ namespace Azure.ResourceManager.Sphere.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SphereProductPatch"/>. </summary>
-        /// <param name="description">
-        /// Description of the product
-        /// Serialized Name: ProductUpdate.properties.description
-        /// </param>
+        /// <param name="description"> Description of the product. </param>
         internal SphereProductPatch(string description)
         {
             Description = description;
         }
 
-        /// <summary>
-        /// Description of the product
-        /// Serialized Name: ProductUpdate.properties.description
-        /// </summary>
+        /// <summary> Description of the product. </summary>
         public string Description { get; set; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereProvisioningState.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereProvisioningState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Provisioning state of the resource.
-    /// Serialized Name: ProvisioningState
-    /// </summary>
+    /// <summary> Provisioning state of the resource. </summary>
     public readonly partial struct SphereProvisioningState : IEquatable<SphereProvisioningState>
     {
         private readonly string _value;
@@ -33,40 +30,19 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string DeletingValue = "Deleting";
         private const string AcceptedValue = "Accepted";
 
-        /// <summary>
-        /// Resource has been created.
-        /// Serialized Name: ProvisioningState.Succeeded
-        /// </summary>
+        /// <summary> Resource has been created. </summary>
         public static SphereProvisioningState Succeeded { get; } = new SphereProvisioningState(SucceededValue);
-        /// <summary>
-        /// Resource creation failed.
-        /// Serialized Name: ProvisioningState.Failed
-        /// </summary>
+        /// <summary> Resource creation failed. </summary>
         public static SphereProvisioningState Failed { get; } = new SphereProvisioningState(FailedValue);
-        /// <summary>
-        /// Resource creation was canceled.
-        /// Serialized Name: ProvisioningState.Canceled
-        /// </summary>
+        /// <summary> Resource creation was canceled. </summary>
         public static SphereProvisioningState Canceled { get; } = new SphereProvisioningState(CanceledValue);
-        /// <summary>
-        /// The resource is being provisioned
-        /// Serialized Name: ProvisioningState.Provisioning
-        /// </summary>
+        /// <summary> The resource is being provisioned. </summary>
         public static SphereProvisioningState Provisioning { get; } = new SphereProvisioningState(ProvisioningValue);
-        /// <summary>
-        /// The resource is being updated
-        /// Serialized Name: ProvisioningState.Updating
-        /// </summary>
+        /// <summary> The resource is being updated. </summary>
         public static SphereProvisioningState Updating { get; } = new SphereProvisioningState(UpdatingValue);
-        /// <summary>
-        /// The resource is being deleted
-        /// Serialized Name: ProvisioningState.Deleting
-        /// </summary>
+        /// <summary> The resource is being deleted. </summary>
         public static SphereProvisioningState Deleting { get; } = new SphereProvisioningState(DeletingValue);
-        /// <summary>
-        /// The resource create request has been accepted
-        /// Serialized Name: ProvisioningState.Accepted
-        /// </summary>
+        /// <summary> The resource create request has been accepted. </summary>
         public static SphereProvisioningState Accepted { get; } = new SphereProvisioningState(AcceptedValue);
         /// <summary> Determines if two <see cref="SphereProvisioningState"/> values are the same. </summary>
         public static bool operator ==(SphereProvisioningState left, SphereProvisioningState right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereUpdatePolicy.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/Models/SphereUpdatePolicy.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.Sphere.Models
 {
-    /// <summary>
-    /// Update policy values.
-    /// Serialized Name: UpdatePolicy
-    /// </summary>
+    /// <summary> Update policy values. </summary>
     public readonly partial struct SphereUpdatePolicy : IEquatable<SphereUpdatePolicy>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.Sphere.Models
         private const string UpdateAllValue = "UpdateAll";
         private const string No3RdPartyAppUpdatesValue = "No3rdPartyAppUpdates";
 
-        /// <summary>
-        /// Update all policy.
-        /// Serialized Name: UpdatePolicy.UpdateAll
-        /// </summary>
+        /// <summary> Update all policy. </summary>
         public static SphereUpdatePolicy UpdateAll { get; } = new SphereUpdatePolicy(UpdateAllValue);
-        /// <summary>
-        /// No update for 3rd party app policy.
-        /// Serialized Name: UpdatePolicy.No3rdPartyAppUpdates
-        /// </summary>
+        /// <summary> No update for 3rd party app policy. </summary>
         public static SphereUpdatePolicy No3RdPartyAppUpdates { get; } = new SphereUpdatePolicy(No3RdPartyAppUpdatesValue);
         /// <summary> Determines if two <see cref="SphereUpdatePolicy"/> values are the same. </summary>
         public static bool operator ==(SphereUpdatePolicy left, SphereUpdatePolicy right) => left.Equals(right);

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereCatalogData.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereCatalogData.cs
@@ -15,7 +15,6 @@ namespace Azure.ResourceManager.Sphere
     /// <summary>
     /// A class representing the SphereCatalog data model.
     /// An Azure Sphere catalog
-    /// Serialized Name: Catalog
     /// </summary>
     public partial class SphereCatalogData : TrackedResourceData
     {
@@ -32,19 +31,13 @@ namespace Azure.ResourceManager.Sphere
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Catalog.properties.provisioningState
-        /// </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereCatalogData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, string> tags, AzureLocation location, SphereProvisioningState? provisioningState) : base(id, name, resourceType, systemData, tags, location)
         {
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: Catalog.properties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereCertificateData.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereCertificateData.cs
@@ -15,7 +15,6 @@ namespace Azure.ResourceManager.Sphere
     /// <summary>
     /// A class representing the SphereCertificate data model.
     /// An certificate resource belonging to a catalog resource.
-    /// Serialized Name: Certificate
     /// </summary>
     public partial class SphereCertificateData : ResourceData
     {
@@ -29,34 +28,13 @@ namespace Azure.ResourceManager.Sphere
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="certificate">
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: Certificate.properties.certificate
-        /// </param>
-        /// <param name="status">
-        /// The certificate status.
-        /// Serialized Name: Certificate.properties.status
-        /// </param>
-        /// <param name="subject">
-        /// The certificate subject.
-        /// Serialized Name: Certificate.properties.subject
-        /// </param>
-        /// <param name="thumbprint">
-        /// The certificate thumbprint.
-        /// Serialized Name: Certificate.properties.thumbprint
-        /// </param>
-        /// <param name="expiryUtc">
-        /// The certificate expiry date.
-        /// Serialized Name: Certificate.properties.expiryUtc
-        /// </param>
-        /// <param name="notBeforeUtc">
-        /// The certificate not before date.
-        /// Serialized Name: Certificate.properties.notBeforeUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Certificate.properties.provisioningState
-        /// </param>
+        /// <param name="certificate"> The certificate as a UTF-8 encoded base 64 string. </param>
+        /// <param name="status"> The certificate status. </param>
+        /// <param name="subject"> The certificate subject. </param>
+        /// <param name="thumbprint"> The certificate thumbprint. </param>
+        /// <param name="expiryUtc"> The certificate expiry date. </param>
+        /// <param name="notBeforeUtc"> The certificate not before date. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereCertificateData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string certificate, SphereCertificateStatus? status, string subject, string thumbprint, DateTimeOffset? expiryUtc, DateTimeOffset? notBeforeUtc, SphereProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             Certificate = certificate;
@@ -68,40 +46,19 @@ namespace Azure.ResourceManager.Sphere
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// The certificate as a UTF-8 encoded base 64 string.
-        /// Serialized Name: Certificate.properties.certificate
-        /// </summary>
+        /// <summary> The certificate as a UTF-8 encoded base 64 string. </summary>
         public string Certificate { get; }
-        /// <summary>
-        /// The certificate status.
-        /// Serialized Name: Certificate.properties.status
-        /// </summary>
+        /// <summary> The certificate status. </summary>
         public SphereCertificateStatus? Status { get; }
-        /// <summary>
-        /// The certificate subject.
-        /// Serialized Name: Certificate.properties.subject
-        /// </summary>
+        /// <summary> The certificate subject. </summary>
         public string Subject { get; }
-        /// <summary>
-        /// The certificate thumbprint.
-        /// Serialized Name: Certificate.properties.thumbprint
-        /// </summary>
+        /// <summary> The certificate thumbprint. </summary>
         public string Thumbprint { get; }
-        /// <summary>
-        /// The certificate expiry date.
-        /// Serialized Name: Certificate.properties.expiryUtc
-        /// </summary>
+        /// <summary> The certificate expiry date. </summary>
         public DateTimeOffset? ExpiryUtc { get; }
-        /// <summary>
-        /// The certificate not before date.
-        /// Serialized Name: Certificate.properties.notBeforeUtc
-        /// </summary>
+        /// <summary> The certificate not before date. </summary>
         public DateTimeOffset? NotBeforeUtc { get; }
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: Certificate.properties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereDeploymentData.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereDeploymentData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.Sphere
     /// <summary>
     /// A class representing the SphereDeployment data model.
     /// An deployment resource belonging to a device group resource.
-    /// Serialized Name: Deployment
     /// </summary>
     public partial class SphereDeploymentData : ResourceData
     {
@@ -31,22 +30,10 @@ namespace Azure.ResourceManager.Sphere
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="deploymentId">
-        /// Deployment ID
-        /// Serialized Name: Deployment.properties.deploymentId
-        /// </param>
-        /// <param name="deployedImages">
-        /// Images deployed
-        /// Serialized Name: Deployment.properties.deployedImages
-        /// </param>
-        /// <param name="deploymentDateUtc">
-        /// Deployment date UTC
-        /// Serialized Name: Deployment.properties.deploymentDateUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Deployment.properties.provisioningState
-        /// </param>
+        /// <param name="deploymentId"> Deployment ID. </param>
+        /// <param name="deployedImages"> Images deployed. </param>
+        /// <param name="deploymentDateUtc"> Deployment date UTC. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereDeploymentData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string deploymentId, IList<SphereImageData> deployedImages, DateTimeOffset? deploymentDateUtc, SphereProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             DeploymentId = deploymentId;
@@ -55,25 +42,13 @@ namespace Azure.ResourceManager.Sphere
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// Deployment ID
-        /// Serialized Name: Deployment.properties.deploymentId
-        /// </summary>
+        /// <summary> Deployment ID. </summary>
         public string DeploymentId { get; set; }
-        /// <summary>
-        /// Images deployed
-        /// Serialized Name: Deployment.properties.deployedImages
-        /// </summary>
+        /// <summary> Images deployed. </summary>
         public IList<SphereImageData> DeployedImages { get; }
-        /// <summary>
-        /// Deployment date UTC
-        /// Serialized Name: Deployment.properties.deploymentDateUtc
-        /// </summary>
+        /// <summary> Deployment date UTC. </summary>
         public DateTimeOffset? DeploymentDateUtc { get; }
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: Deployment.properties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereDeviceData.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereDeviceData.cs
@@ -15,7 +15,6 @@ namespace Azure.ResourceManager.Sphere
     /// <summary>
     /// A class representing the SphereDevice data model.
     /// An device resource belonging to a device group resource.
-    /// Serialized Name: Device
     /// </summary>
     public partial class SphereDeviceData : ResourceData
     {
@@ -29,34 +28,13 @@ namespace Azure.ResourceManager.Sphere
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="deviceId">
-        /// Device ID
-        /// Serialized Name: Device.properties.deviceId
-        /// </param>
-        /// <param name="chipSku">
-        /// SKU of the chip
-        /// Serialized Name: Device.properties.chipSku
-        /// </param>
-        /// <param name="lastAvailableOSVersion">
-        /// OS version available for installation when update requested
-        /// Serialized Name: Device.properties.lastAvailableOsVersion
-        /// </param>
-        /// <param name="lastInstalledOSVersion">
-        /// OS version running on device when update requested
-        /// Serialized Name: Device.properties.lastInstalledOsVersion
-        /// </param>
-        /// <param name="lastOSUpdateUtc">
-        /// Time when update requested and new OS version available
-        /// Serialized Name: Device.properties.lastOsUpdateUtc
-        /// </param>
-        /// <param name="lastUpdateRequestUtc">
-        /// Time when update was last requested
-        /// Serialized Name: Device.properties.lastUpdateRequestUtc
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Device.properties.provisioningState
-        /// </param>
+        /// <param name="deviceId"> Device ID. </param>
+        /// <param name="chipSku"> SKU of the chip. </param>
+        /// <param name="lastAvailableOSVersion"> OS version available for installation when update requested. </param>
+        /// <param name="lastInstalledOSVersion"> OS version running on device when update requested. </param>
+        /// <param name="lastOSUpdateUtc"> Time when update requested and new OS version available. </param>
+        /// <param name="lastUpdateRequestUtc"> Time when update was last requested. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereDeviceData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string deviceId, string chipSku, string lastAvailableOSVersion, string lastInstalledOSVersion, DateTimeOffset? lastOSUpdateUtc, DateTimeOffset? lastUpdateRequestUtc, SphereProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             DeviceId = deviceId;
@@ -68,40 +46,19 @@ namespace Azure.ResourceManager.Sphere
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// Device ID
-        /// Serialized Name: Device.properties.deviceId
-        /// </summary>
+        /// <summary> Device ID. </summary>
         public string DeviceId { get; set; }
-        /// <summary>
-        /// SKU of the chip
-        /// Serialized Name: Device.properties.chipSku
-        /// </summary>
+        /// <summary> SKU of the chip. </summary>
         public string ChipSku { get; }
-        /// <summary>
-        /// OS version available for installation when update requested
-        /// Serialized Name: Device.properties.lastAvailableOsVersion
-        /// </summary>
+        /// <summary> OS version available for installation when update requested. </summary>
         public string LastAvailableOSVersion { get; }
-        /// <summary>
-        /// OS version running on device when update requested
-        /// Serialized Name: Device.properties.lastInstalledOsVersion
-        /// </summary>
+        /// <summary> OS version running on device when update requested. </summary>
         public string LastInstalledOSVersion { get; }
-        /// <summary>
-        /// Time when update requested and new OS version available
-        /// Serialized Name: Device.properties.lastOsUpdateUtc
-        /// </summary>
+        /// <summary> Time when update requested and new OS version available. </summary>
         public DateTimeOffset? LastOSUpdateUtc { get; }
-        /// <summary>
-        /// Time when update was last requested
-        /// Serialized Name: Device.properties.lastUpdateRequestUtc
-        /// </summary>
+        /// <summary> Time when update was last requested. </summary>
         public DateTimeOffset? LastUpdateRequestUtc { get; }
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: Device.properties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereDeviceGroupData.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereDeviceGroupData.cs
@@ -14,7 +14,6 @@ namespace Azure.ResourceManager.Sphere
     /// <summary>
     /// A class representing the SphereDeviceGroup data model.
     /// An device group resource belonging to a product resource.
-    /// Serialized Name: DeviceGroup
     /// </summary>
     public partial class SphereDeviceGroupData : ResourceData
     {
@@ -28,34 +27,13 @@ namespace Azure.ResourceManager.Sphere
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="description">
-        /// Description of the device group.
-        /// Serialized Name: DeviceGroup.properties.description
-        /// </param>
-        /// <param name="osFeedType">
-        /// Operating system feed type of the device group.
-        /// Serialized Name: DeviceGroup.properties.osFeedType
-        /// </param>
-        /// <param name="updatePolicy">
-        /// Update policy of the device group.
-        /// Serialized Name: DeviceGroup.properties.updatePolicy
-        /// </param>
-        /// <param name="allowCrashDumpsCollection">
-        /// Flag to define if the user allows for crash dump collection.
-        /// Serialized Name: DeviceGroup.properties.allowCrashDumpsCollection
-        /// </param>
-        /// <param name="regionalDataBoundary">
-        /// Regional data boundary for the device group.
-        /// Serialized Name: DeviceGroup.properties.regionalDataBoundary
-        /// </param>
-        /// <param name="hasDeployment">
-        /// Deployment status for the device group.
-        /// Serialized Name: DeviceGroup.properties.hasDeployment
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: DeviceGroup.properties.provisioningState
-        /// </param>
+        /// <param name="description"> Description of the device group. </param>
+        /// <param name="osFeedType"> Operating system feed type of the device group. </param>
+        /// <param name="updatePolicy"> Update policy of the device group. </param>
+        /// <param name="allowCrashDumpsCollection"> Flag to define if the user allows for crash dump collection. </param>
+        /// <param name="regionalDataBoundary"> Regional data boundary for the device group. </param>
+        /// <param name="hasDeployment"> Deployment status for the device group. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereDeviceGroupData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string description, SphereOSFeedType? osFeedType, SphereUpdatePolicy? updatePolicy, SphereAllowCrashDumpCollectionStatus? allowCrashDumpsCollection, RegionalDataBoundary? regionalDataBoundary, bool? hasDeployment, SphereProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             Description = description;
@@ -67,40 +45,19 @@ namespace Azure.ResourceManager.Sphere
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// Description of the device group.
-        /// Serialized Name: DeviceGroup.properties.description
-        /// </summary>
+        /// <summary> Description of the device group. </summary>
         public string Description { get; set; }
-        /// <summary>
-        /// Operating system feed type of the device group.
-        /// Serialized Name: DeviceGroup.properties.osFeedType
-        /// </summary>
+        /// <summary> Operating system feed type of the device group. </summary>
         public SphereOSFeedType? OSFeedType { get; set; }
-        /// <summary>
-        /// Update policy of the device group.
-        /// Serialized Name: DeviceGroup.properties.updatePolicy
-        /// </summary>
+        /// <summary> Update policy of the device group. </summary>
         public SphereUpdatePolicy? UpdatePolicy { get; set; }
-        /// <summary>
-        /// Flag to define if the user allows for crash dump collection.
-        /// Serialized Name: DeviceGroup.properties.allowCrashDumpsCollection
-        /// </summary>
+        /// <summary> Flag to define if the user allows for crash dump collection. </summary>
         public SphereAllowCrashDumpCollectionStatus? AllowCrashDumpsCollection { get; set; }
-        /// <summary>
-        /// Regional data boundary for the device group.
-        /// Serialized Name: DeviceGroup.properties.regionalDataBoundary
-        /// </summary>
+        /// <summary> Regional data boundary for the device group. </summary>
         public RegionalDataBoundary? RegionalDataBoundary { get; set; }
-        /// <summary>
-        /// Deployment status for the device group.
-        /// Serialized Name: DeviceGroup.properties.hasDeployment
-        /// </summary>
+        /// <summary> Deployment status for the device group. </summary>
         public bool? HasDeployment { get; }
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: DeviceGroup.properties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereImageData.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereImageData.cs
@@ -15,7 +15,6 @@ namespace Azure.ResourceManager.Sphere
     /// <summary>
     /// A class representing the SphereImage data model.
     /// An image resource belonging to a catalog resource.
-    /// Serialized Name: Image
     /// </summary>
     public partial class SphereImageData : ResourceData
     {
@@ -29,42 +28,15 @@ namespace Azure.ResourceManager.Sphere
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="image">
-        /// Image as a UTF-8 encoded base 64 string on image create. This field contains the image URI on image reads.
-        /// Serialized Name: Image.properties.image
-        /// </param>
-        /// <param name="imageId">
-        /// Image ID
-        /// Serialized Name: Image.properties.imageId
-        /// </param>
-        /// <param name="imageName">
-        /// Image name
-        /// Serialized Name: Image.properties.imageName
-        /// </param>
-        /// <param name="regionalDataBoundary">
-        /// Regional data boundary for an image
-        /// Serialized Name: Image.properties.regionalDataBoundary
-        /// </param>
-        /// <param name="uri">
-        /// Location the image
-        /// Serialized Name: Image.properties.uri
-        /// </param>
-        /// <param name="description">
-        /// The image description.
-        /// Serialized Name: Image.properties.description
-        /// </param>
-        /// <param name="componentId">
-        /// The image component id.
-        /// Serialized Name: Image.properties.componentId
-        /// </param>
-        /// <param name="imageType">
-        /// The image type.
-        /// Serialized Name: Image.properties.imageType
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Image.properties.provisioningState
-        /// </param>
+        /// <param name="image"> Image as a UTF-8 encoded base 64 string on image create. This field contains the image URI on image reads. </param>
+        /// <param name="imageId"> Image ID. </param>
+        /// <param name="imageName"> Image name. </param>
+        /// <param name="regionalDataBoundary"> Regional data boundary for an image. </param>
+        /// <param name="uri"> Location the image. </param>
+        /// <param name="description"> The image description. </param>
+        /// <param name="componentId"> The image component id. </param>
+        /// <param name="imageType"> The image type. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereImageData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string image, string imageId, string imageName, RegionalDataBoundary? regionalDataBoundary, Uri uri, string description, string componentId, SphereImageType? imageType, SphereProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             Image = image;
@@ -78,50 +50,23 @@ namespace Azure.ResourceManager.Sphere
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// Image as a UTF-8 encoded base 64 string on image create. This field contains the image URI on image reads.
-        /// Serialized Name: Image.properties.image
-        /// </summary>
+        /// <summary> Image as a UTF-8 encoded base 64 string on image create. This field contains the image URI on image reads. </summary>
         public string Image { get; set; }
-        /// <summary>
-        /// Image ID
-        /// Serialized Name: Image.properties.imageId
-        /// </summary>
+        /// <summary> Image ID. </summary>
         public string ImageId { get; set; }
-        /// <summary>
-        /// Image name
-        /// Serialized Name: Image.properties.imageName
-        /// </summary>
+        /// <summary> Image name. </summary>
         public string ImageName { get; }
-        /// <summary>
-        /// Regional data boundary for an image
-        /// Serialized Name: Image.properties.regionalDataBoundary
-        /// </summary>
+        /// <summary> Regional data boundary for an image. </summary>
         public RegionalDataBoundary? RegionalDataBoundary { get; set; }
-        /// <summary>
-        /// Location the image
-        /// Serialized Name: Image.properties.uri
-        /// </summary>
+        /// <summary> Location the image. </summary>
         public Uri Uri { get; }
-        /// <summary>
-        /// The image description.
-        /// Serialized Name: Image.properties.description
-        /// </summary>
+        /// <summary> The image description. </summary>
         public string Description { get; }
-        /// <summary>
-        /// The image component id.
-        /// Serialized Name: Image.properties.componentId
-        /// </summary>
+        /// <summary> The image component id. </summary>
         public string ComponentId { get; }
-        /// <summary>
-        /// The image type.
-        /// Serialized Name: Image.properties.imageType
-        /// </summary>
+        /// <summary> The image type. </summary>
         public SphereImageType? ImageType { get; }
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: Image.properties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereProductData.cs
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Generated/SphereProductData.cs
@@ -14,7 +14,6 @@ namespace Azure.ResourceManager.Sphere
     /// <summary>
     /// A class representing the SphereProduct data model.
     /// An product resource belonging to a catalog resource.
-    /// Serialized Name: Product
     /// </summary>
     public partial class SphereProductData : ResourceData
     {
@@ -28,29 +27,17 @@ namespace Azure.ResourceManager.Sphere
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="description">
-        /// Description of the product
-        /// Serialized Name: Product.properties.description
-        /// </param>
-        /// <param name="provisioningState">
-        /// The status of the last operation.
-        /// Serialized Name: Product.properties.provisioningState
-        /// </param>
+        /// <param name="description"> Description of the product. </param>
+        /// <param name="provisioningState"> The status of the last operation. </param>
         internal SphereProductData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string description, SphereProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             Description = description;
             ProvisioningState = provisioningState;
         }
 
-        /// <summary>
-        /// Description of the product
-        /// Serialized Name: Product.properties.description
-        /// </summary>
+        /// <summary> Description of the product. </summary>
         public string Description { get; set; }
-        /// <summary>
-        /// The status of the last operation.
-        /// Serialized Name: Product.properties.provisioningState
-        /// </summary>
+        /// <summary> The status of the last operation. </summary>
         public SphereProvisioningState? ProvisioningState { get; }
     }
 }

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/autorest.md
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/autorest.md
@@ -17,9 +17,6 @@ skip-csproj: true
 modelerfour:
   flatten-payloads: false
 
-mgmt-debug:
-  show-serialized-names: true
-
 format-by-name-rules:
   'tenantId': 'uuid'
   'ETag': 'etag'


### PR DESCRIPTION
Previously, the user forgot to remove below configuration, the description of all APIs contain additional serialized name.
```yaml
mgmt-debug:
  show-serialized-names: true
```
This should not be kept.