### PR TITLE
[Search] Fix broken link

### DIFF
--- a/sdk/search/Azure.Search.Documents/CHANGELOG.md
+++ b/sdk/search/Azure.Search.Documents/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Features Added
 - Added support for [Vector Search](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch.md).
-- Added support for [Semantic Search](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/search/Azure.Search.Documents/samples/Sample08_SemanticSearch.md).
+- Added support for [Semantic Search](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/search/Azure.Search.Documents/samples).
 - Added support for [`PiiDetectionSkill`](https://learn.microsoft.com/azure/search/cognitive-search-skill-pii-detection). It allows you extracts personal information from an input text and gives you the option of masking it using the Text Analytics API.
 - Added new languages for `OcrSkill` and `ImageAnalysisSkill` as we have upgraded them to use Cognitive Services Computer Vision v3.2, which now includes support for additional languages. Refer to the language lists [here](https://docs.microsoft.com/azure/cognitive-services/computer-vision/language-support).
 - Added new languages for ` SplitSkill`. Language lists can be found [here](https://learn.microsoft.com/azure/search/cognitive-search-skill-textsplit#skill-parameters).


### PR DESCRIPTION
In [this](https://github.com/Azure/azure-sdk-for-net/pull/40954) PR, one of the samples(Sample08_SemanticSearch.md) was removed, causing the link in the changelog to break. I'm fixing the link for now, and I'll add back the sample in the next PR.