### PR TITLE
[Event Hubs] Load balancing refactor

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
@@ -315,6 +315,17 @@ namespace Azure.Messaging.EventHubs.Primitives
         public virtual void ReportPartitionStolen(string partitionId) => InstanceOwnership.TryRemove(partitionId, out _);
 
         /// <summary>
+        ///   Determines whether the specified partition is owned by the load balancer.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition to consider.</param>
+        ///
+        /// <returns>
+        ///   <c>true</c> if <paramref name="partitionId"/> is owned; otherwise, <c>false</c>.</returns>
+        ///
+        public virtual bool IsPartitionOwned(string partitionId) => InstanceOwnership.ContainsKey(partitionId);
+
+        /// <summary>
         ///   Finds and tries to claim an ownership if this processor instance is eligible to increase its ownership list.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Load balancing is no longer blocked when event processing for a lost partition does not honor the cancellation token.  Previously, long-running processing could cause delays in load balancing that resulted in ownership not being renewed for all partitions.
+
 - Adjusted retries to consider an unreachable host address as terminal.  Previously, all socket-based errors were considered transient and would be retried.
 
 - Fixed a race condition that could lead to a synchronization primitive being double-released if `IsRunning` was called concurrently while starting or stopping an event processor.
@@ -19,6 +21,8 @@
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.4, which enables support for TLS 1.3.
 
 - Removed the custom sizes for the AMQP sending and receiving buffers, allowing the optimized defaults of the host platform to be used.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  Windows performance remains unchanged as the default and custom buffer sizes are equivalent.
+
+- Improved efficiency of partition management during load balancing, reducing the number of operations performed and deferring waiting for lost partitions until the processor is stopped or the partition is reclaimed.  Allocations were also non-trivially reduced.
 
 ## 5.10.0 (2023-11-07)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1535,9 +1535,13 @@ namespace Azure.Messaging.EventHubs.Primitives
                 // With the processing task having completed, perform the necessary cleanup of partition processing tasks
                 // and surrender ownership.
 
-                var stopPartitionProcessingTasks = ActivePartitionProcessors.Keys
-                    .Select(partitionId => TryStopProcessingPartitionAsync(partitionId, ProcessingStoppedReason.Shutdown, CancellationToken.None))
-                    .ToArray();
+                var stopPartitionProcessingTasks = new Task[ActivePartitionProcessors.Keys.Count];
+                var index = -1;
+
+                foreach (var partitionId in ActivePartitionProcessors.Keys)
+                {
+                    stopPartitionProcessingTasks[++index] = StopProcessingPartitionAsync(partitionId, ProcessingStoppedReason.Shutdown, CancellationToken.None);
+                };
 
                 if (async)
                 {
@@ -1768,34 +1772,51 @@ namespace Azure.Messaging.EventHubs.Primitives
                 }
             }
 
-            // Some ownership for some previously claimed partitions may have expired or have been stolen; stop the processing for partitions
-            // which are no longer owned.
+            // Some ownership for some previously claimed partitions may have expired or have been stolen; stop the processing
+            // for partitions which are no longer owned.
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+            var ownedPartitions = new HashSet<string>(LoadBalancer.OwnedPartitionIds);
 
-            await Task.WhenAll(ActivePartitionProcessors.Keys
-                .Except(LoadBalancer.OwnedPartitionIds)
-                .Select(partitionId => TryStopProcessingPartitionAsync(partitionId, ProcessingStoppedReason.OwnershipLost, cancellationToken)))
-                .ConfigureAwait(false);
+            foreach (var partitionId in ActivePartitionProcessors.Keys)
+            {
+                if (!ownedPartitions.Contains(partitionId))
+                {
+                   // The partition is no longer owned.  Stopping may take longer than a load balancing cycle
+                   // should run if event processing is active and chooses not to honor cancellation immediately, so
+                   // do not wait for the stop to complete.  Its continuation will ensure proper clean-up even when unobserved.
+                   // If the processor is stopped, the task will be awaited then to ensure that all processing is complete.
 
-            // The remaining processing tasks should be running.  To ensure that is the case, validate the status of the task
+                   _ = StopProcessingPartitionAsync(partitionId, ProcessingStoppedReason.OwnershipLost, cancellationToken);
+                }
+            }
+
+            // The tasks for owned partitions should be running.  To ensure that is the case, validate the status of the task
             // and restart processing if it has failed.  It is also possible that task creation failed when the processing was started,
             // in which case there would be no task; create them.
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-            await Task.WhenAll(LoadBalancer.OwnedPartitionIds
-                .Select(async partitionId =>
-                {
-                    if (!ActivePartitionProcessors.TryGetValue(partitionId, out var partitionProcessor) || partitionProcessor.ProcessingTask.IsCompleted)
-                    {
-                        await TryStopProcessingPartitionAsync(partitionId, ProcessingStoppedReason.OwnershipLost, cancellationToken).ConfigureAwait(false);
-                        TryStartProcessingPartition(partitionId, cancellationToken);
-                    }
-                }))
-                .ConfigureAwait(false);
+            foreach (var partitionId in ownedPartitions)
+            {
+                var processorFound = ActivePartitionProcessors.TryGetValue(partitionId, out var partitionProcessor);
 
-            // If load balancing is greedy and there was a partition claimed, then signal that there should be a very minimal delay before
+                if ((!processorFound) || (partitionProcessor.ProcessingTask.IsCompleted))
+                {
+                    // If there is a processing task, it is known to have been completed so awaiting will not be blocked by event
+                    // processing currently in flight.  Any time spent will be in the StopProcessingPartitionAsync handler, which
+                    // is expected to run quickly.
+
+                    if ((processorFound) && (partitionProcessor.ProcessingTask.IsCompleted))
+                    {
+                        await StopProcessingPartitionAsync(partitionId, ProcessingStoppedReason.OwnershipLost, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    TryStartProcessingPartition(partitionId, cancellationToken);
+                }
+            }
+
+            // If load balancing is greedy and ownership is not balanced, then signal that there should be a very minimal delay before
             // invoking the next load balancing cycle, to ensure a yield which allows the thread pool to manage its load.
 
             if ((Options.LoadBalancingStrategy == LoadBalancingStrategy.Greedy) && (!LoadBalancer.IsBalanced))
@@ -1918,14 +1939,12 @@ namespace Azure.Messaging.EventHubs.Primitives
         }
 
         /// <summary>
-        ///   Attempts to stop processing the requested partition.
+        ///   Stops processing the requested partition.
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the Event Hub partition whose processing should be stopped.</param>
         /// <param name="reason">The reason why the processing is being stopped.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
-        /// <returns><c>true</c> if the <paramref name="partitionId"/> was owned and was being processed; otherwise, <c>false</c>.</returns>
         ///
         /// <remarks>
         ///   Exceptions encountered when stopping processing for an owned partition will be logged and will result in the error handler
@@ -1933,9 +1952,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   as part of the load balancing cycle, which is failure-tolerant.
         /// </remarks>
         ///
-        private async Task<bool> TryStopProcessingPartitionAsync(string partitionId,
-                                                                 ProcessingStoppedReason reason,
-                                                                 CancellationToken cancellationToken)
+        private Task StopProcessingPartitionAsync(string partitionId,
+                                                  ProcessingStoppedReason reason,
+                                                  CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.EventProcessorPartitionProcessingStop(partitionId, Identifier, EventHubName, ConsumerGroup);
@@ -1944,12 +1963,20 @@ namespace Azure.Messaging.EventHubs.Primitives
 
             try
             {
-                // If the partition processor is not being tracked or could not be retrieved from the tracking items,
-                // then it cannot be stopped.
+                // If the partition processor is not being tracked, then there is no
+                // further work to be done.
 
-                if (!ActivePartitionProcessors.TryRemove(partitionId, out var partitionProcessor))
+                if (!ActivePartitionProcessors.TryGetValue(partitionId, out var partitionProcessor))
                 {
-                    return false;
+                    return Task.CompletedTask;
+                }
+
+                // If a cleanup task has already been registered, the processing task was updated and awaiting
+                // that will ensure stopping is complete.
+
+                if (partitionProcessor.CleanupRegistered)
+                {
+                    return partitionProcessor.ProcessingTask;
                 }
 
                 // Attempt to stop the processor; any exceptions should be treated as a problem with processing, not
@@ -1970,47 +1997,97 @@ namespace Azure.Messaging.EventHubs.Primitives
                     Logger.PartitionProcessorStoppingCancellationWarning(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
                 }
 
-                try
-                {
-                    await partitionProcessor.ProcessingTask.ConfigureAwait(false);
-                }
-                catch (TaskCanceledException)
-                {
-                    // This is expected; no action is needed.
-                }
-                catch
-                {
-                    // The processing task is in a failed state; any logging and dispatching
-                    // to the error handler happened in the processing task before the exception
-                    // was thrown.  All that remains is to override the reason for stopping.
+                // To ensure that callers do not have to wait until the processing task has fully stopped,
+                // schedule an explicit continuation for the task and return immediately.  This allows the
+                // cleanup to happen in the background.
 
-                    reason = ProcessingStoppedReason.OwnershipLost;
-                }
-
-                partitionProcessor.Dispose();
-
-                // Notify the handler of the now-closed partition, awaiting completion to allow for a more deterministic model
-                // for developers where the initialize and stop handlers will fire in a deterministic order and not interleave.
-                //
-                // Because the processor does not assume responsibility for observing or surfacing exceptions that may occur in the handler,
-                // errors are logged but the error handler is not invoked nor does an exception in the handler constitute a failure to stop
-                // processing the partition.  This also aims to prevent an infinite loop scenario where StopProcessing is called from the
-                // error handler, which calls the partition stopped handler, which has an exception that again calls the error handler.
-
-                try
+                var stopContinuation = partitionProcessor.ProcessingTask.ContinueWith(async (task, state) =>
                 {
-                    await OnPartitionProcessingStoppedAsync(partition, reason, cancellationToken).ConfigureAwait(false);
-                }
-                catch (TaskCanceledException)
-                {
-                    // This is expected; no action is needed.
-                }
-                catch (Exception ex)
-                {
-                    Logger.EventProcessorPartitionProcessingStopError(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
-                }
+                    var innerPartition = default(TPartition);
 
-                return true;
+                    try
+                    {
+                        var (innerId, innerReason) = ((string, ProcessingStoppedReason))state;
+
+                        // Await the processing task to ensure that any in-flight event processing
+                        // has completed.
+
+                        try
+                        {
+                            await task.ConfigureAwait(false);
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            // This is expected; no action is needed.
+                        }
+                        catch
+                        {
+                            // The processing task is in a failed state; any logging and dispatching
+                            // to the error handler happened in the processing task before the exception
+                            // was thrown.  All that remains is to override the reason for stopping.
+
+                            innerReason = ProcessingStoppedReason.OwnershipLost;
+                        }
+
+                        // There is no longer a need for the processing task; dispose it.
+
+                        task.Dispose();
+
+                        // If the partition processor is being tracked, dispose it and remove it from the
+                        // tracking items.
+
+                        if (ActivePartitionProcessors.TryRemove(innerId, out var innerProcessor))
+                        {
+                            innerPartition = innerProcessor.Partition;
+                            innerProcessor.Dispose();
+                        }
+                        else
+                        {
+                            innerPartition = new TPartition { PartitionId = innerId };
+                        }
+
+                        // Notify the handler of the now-closed partition, awaiting completion to allow for a more deterministic model
+                        // for developers where the initialize and stop handlers will fire in a deterministic order and not interleave.
+                        //
+                        // Because the processor does not assume responsibility for observing or surfacing exceptions that may occur in the handler,
+                        // errors are logged but the error handler is not invoked nor does an exception in the handler constitute a failure to stop
+                        // processing the partition.  This also aims to prevent an infinite loop scenario where StopProcessing is called from the
+                        // error handler, which calls the partition stopped handler, which has an exception that again calls the error handler.
+
+                        try
+                        {
+                            await OnPartitionProcessingStoppedAsync(innerPartition, innerReason, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            // This is expected; no action is needed.
+                        }
+                        catch (Exception ex)
+                        {
+                            // This is an error in handler code and does not get surfaced to the error handler.
+
+                            Logger.EventProcessorPartitionProcessingStopError(innerId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                        }
+                    }
+                    catch (Exception ex) when (ex.IsNotType<TaskCanceledException>())
+                    {
+                        // The error handler is invoked as a fire-and-forget task; the processor does not assume responsibility
+                        // for observing or surfacing exceptions that may occur in the handler.
+
+                        _ = InvokeOnProcessingErrorAsync(ex, innerPartition, Resources.OperationSurrenderOwnership, CancellationToken.None);
+                        Logger.EventProcessorPartitionProcessingStopError(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                    }
+                    finally
+                    {
+                        Logger.EventProcessorPartitionProcessingStopComplete(partitionId, Identifier, EventHubName, ConsumerGroup);
+                    }
+                }, (partitionId, reason), default, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Current);
+
+                // Set the processing task to the continuation, which allows it to be awaited when the processor is
+                // stopping or otherwise needs to be ensure completion.
+
+                partitionProcessor.RegisterCleanupTask(stopContinuation);
+                return stopContinuation;
             }
             catch (Exception ex) when (ex.IsNotType<TaskCanceledException>())
             {
@@ -2020,11 +2097,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                 _ = InvokeOnProcessingErrorAsync(ex, partition, Resources.OperationSurrenderOwnership, CancellationToken.None);
                 Logger.EventProcessorPartitionProcessingStopError(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
 
-                return false;
-            }
-            finally
-            {
-                Logger.EventProcessorPartitionProcessingStopComplete(partitionId, Identifier, EventHubName, ConsumerGroup);
+                return Task.CompletedTask;
             }
         }
 
@@ -2126,6 +2199,90 @@ namespace Azure.Messaging.EventHubs.Primitives
         private static int CalculateMaximumAdvisedOwnedPartitions() => (Environment.ProcessorCount * 2);
 
         /// <summary>
+        ///   The set of information needed to track and manage the active processing
+        ///   of a partition.
+        /// </summary>
+        ///
+        internal class PartitionProcessor : IDisposable
+        {
+            /// <summary>The partition that is being processed.</summary>
+            public readonly TPartition Partition;
+
+            /// <summary>The source token that can be used to cancel the processing for the associated <see cref="ProcessingTask" />.</summary>
+            public readonly CancellationTokenSource CancellationSource;
+
+            /// <summary>A function that can be used to read the information about the last enqueued event of the partition.</summary>
+            public readonly Func<LastEnqueuedEventProperties> ReadLastEnqueuedEventProperties;
+
+            /// <summary>
+            ///   Gets a value indicating whether a cleanup task has been registered.
+            /// </summary>
+            ///
+            /// <value> <c>true</c> if a cleanup task was registered; otherwise, <c>false</c>.</value>
+            ///
+            public bool CleanupRegistered { get; private set; }
+
+            /// <summary>
+            ///   The task that is performing the processing.
+            /// </summary>
+            ///
+            public Task ProcessingTask { get; private set; }
+
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="PartitionProcessor"/> class.
+            /// </summary>
+            ///
+            /// <param name="processingTask">The task that is performing the processing.</param>
+            /// <param name="partition">The partition that is being processed.</param>
+            /// <param name="readLastEnqueuedEventProperties">A function that can be used to read the information about the last enqueued event of the partition.</param>
+            /// <param name="cancellationSource">he source token that can be used to cancel the processing.</param>
+            ///
+            public PartitionProcessor(Task processingTask,
+                                      TPartition partition,
+                                      Func<LastEnqueuedEventProperties> readLastEnqueuedEventProperties,
+                                      CancellationTokenSource cancellationSource) => (ProcessingTask, Partition, ReadLastEnqueuedEventProperties, CancellationSource) = (processingTask, partition, readLastEnqueuedEventProperties, cancellationSource);
+
+            /// <summary>
+            ///   Updates the processing task instance with a task responsible for cleaning
+            ///   up the processor.  This is useful when adding an explicit continuation that
+            ///   will later be awaited to ensure cleanup, such as when stopping processing.
+            /// </summary>
+            ///
+            /// <param name="task">The new task to use as the <see cref="ProcessingTask"/>.</param>
+            ///
+            public void RegisterCleanupTask(Task task)
+            {
+                ProcessingTask = task;
+                CleanupRegistered = true;
+            }
+
+            /// <summary>
+            ///   Performs tasks needed to clean-up the disposable resources used by the processor.  This method does
+            ///   not assume responsibility for signaling the cancellation source or awaiting the <see cref="ProcessingTask" />.
+            /// </summary>
+            ///
+            public void Dispose()
+            {
+                CancellationSource?.Dispose();
+
+                // If there is a processing task and it is already completed,
+                // dispose it.  Generally, disposal of the partition processor takes
+                // place inside of this task and disposal will cause an error.
+                //
+                // Per the Task documentation, this pattern is safe.  Further discussion
+                // can be found in Stephen Toub's write-up "Do I need to dispose of tasks?"
+                //
+                // https://learn.microsoft.com/dotnet/api/system.threading.tasks.task.dispose
+                // https://devblogs.microsoft.com/pfxteam/do-i-need-to-dispose-of-tasks/
+
+                if (ProcessingTask?.IsCompleted == true)
+                {
+                    ProcessingTask.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
         ///   A virtual <see cref="CheckpointStore" /> instance that delegates calls to the
         ///   <see cref="EventProcessor{TPartition}" /> to which it is associated.
         /// </summary>
@@ -2217,51 +2374,6 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                              string clientIdentifier,
                                                              CheckpointPosition checkpointStartingPosition,
                                                              CancellationToken cancellationToken) => await Processor.UpdateCheckpointAsync(partitionId, checkpointStartingPosition, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        ///   The set of information needed to track and manage the active processing
-        ///   of a partition.
-        /// </summary>
-        ///
-        internal class PartitionProcessor : IDisposable
-        {
-            /// <summary>The task that is performing the processing.</summary>
-            public readonly Task ProcessingTask;
-
-            /// <summary>The partition that is being processed.</summary>
-            public readonly TPartition Partition;
-
-            /// <summary>The source token that can be used to cancel the processing for the associated <see cref="ProcessingTask" />.</summary>
-            public readonly CancellationTokenSource CancellationSource;
-
-            /// <summary>A function that can be used to read the information about the last enqueued event of the partition.</summary>
-            public readonly Func<LastEnqueuedEventProperties> ReadLastEnqueuedEventProperties;
-
-            /// <summary>
-            ///   Initializes a new instance of the <see cref="PartitionProcessor"/> class.
-            /// </summary>
-            ///
-            /// <param name="processingTask">The task that is performing the processing.</param>
-            /// <param name="partition">The partition that is being processed.</param>
-            /// <param name="readLastEnqueuedEventProperties">A function that can be used to read the information about the last enqueued event of the partition.</param>
-            /// <param name="cancellationSource">he source token that can be used to cancel the processing.</param>
-            ///
-            public PartitionProcessor(Task processingTask,
-                                      TPartition partition,
-                                      Func<LastEnqueuedEventProperties> readLastEnqueuedEventProperties,
-                                      CancellationTokenSource cancellationSource) => (ProcessingTask, Partition, ReadLastEnqueuedEventProperties, CancellationSource) = (processingTask, partition, readLastEnqueuedEventProperties, cancellationSource);
-
-            /// <summary>
-            ///   Performs tasks needed to clean-up the disposable resources used by the processor.  This method does
-            ///   not assume responsibility for signaling the cancellation source or awaiting the <see cref="ProcessingTask" />.
-            /// </summary>
-            ///
-            public void Dispose()
-            {
-                CancellationSource?.Dispose();
-                ProcessingTask?.Dispose();
-            }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -54,6 +54,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .Setup(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Callback(() =>
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -2379,6 +2380,152 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockLoadBalancer
                 .Verify(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()), Times.Once(), "The load balancer did not run a single cycle.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   background processing loop.
+        /// </summary>
+        ///
+        [Test]
+        public async Task LoadBalancingIsNotBlockedByLostPartitionOwnership()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var loadBalancingCount = 0;
+            var loadBalancingCountAtDelay = 0;
+            var firstPartiton = "27";
+            var secondPartition = "15";
+            var partitionIds = new[] { "0", secondPartition, firstPartiton };
+            var ownedPartitions = new List<string> { firstPartiton };
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(50), LoadBalancingStrategy = LoadBalancingStrategy.Greedy };
+            var processCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var stopCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
+            var mockConnection = new Mock<EventHubConnection>();
+            var mockConsumer = new Mock<TransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockLogger
+                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => stopCompletionSource.TrySetResult(true));
+
+            mockLogger
+                .Setup(log => log.EventProcessorLoadBalancingCycleComplete(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<double>(),
+                    It.IsAny<double>()))
+                .Callback(() => ++loadBalancingCount);
+
+            mockLoadBalancer
+                .SetupGet(lb => lb.OwnedPartitionIds)
+                .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = firstPartiton }))
+                .Returns(() =>
+                {
+                    ownedPartitions.Add(secondPartition);
+                    return new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = secondPartition });
+                })
+                .Returns(() =>
+                {
+                    ownedPartitions.Remove(firstPartiton);
+                    return default;
+                })
+                .Returns(() => default);
+
+            mockConnection
+                .Setup(connection => connection.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties(mockProcessor.Object.EventHubName, new DateTimeOffset(2015, 10, 27, 12, 0, 0, 0, TimeSpan.Zero), partitionIds));
+
+            mockConnection
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partitionIds);
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Enumerable.Range(0, 100).Select(index => new EventData(new byte[] { 0x34 })).ToArray());
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection.Object);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>(), It.IsAny<bool>()))
+                .Returns(mockConsumer.Object);
+
+            mockProcessor
+                .Protected()
+                .Setup<Task<EventProcessorCheckpoint>>("GetCheckpointAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(default(EventProcessorCheckpoint)));
+
+            mockProcessor
+                .Protected()
+                .Setup<Task>("OnProcessingEventBatchAsync",
+                    ItExpr.IsAny<IEnumerable<EventData>>(),
+                    ItExpr.Is<EventProcessorPartition>(part => part.PartitionId == firstPartiton),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback (() =>
+                {
+                    if (loadBalancingCountAtDelay == 0)
+                    {
+                        loadBalancingCountAtDelay = loadBalancingCount;
+                    }
+
+                    processCompletionSource.TrySetResult(true);
+                })
+                .Returns(Task.Delay(TimeSpan.FromSeconds(3)));
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should have started.");
+
+            await Task.WhenAny(Task.WhenAll(stopCompletionSource.Task, processCompletionSource.Task), Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            var activeProcessors = GetActivePartitionProcessors(mockProcessor.Object);
+            Assert.That(activeProcessors.ContainsKey(firstPartiton), Is.False, "The partition processing for the first partition should not be active.");
+            Assert.That(loadBalancingCount, Is.GreaterThan(loadBalancingCountAtDelay), "The load balancing cycle should not have been held up by the partition stopping.");
+
+            mockProcessor
+                .Verify(processor => processor.CreatePartitionProcessor(
+                    It.Is<EventProcessorPartition>(value => value.PartitionId == firstPartiton),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
+                Times.Once);
+
+            mockProcessor
+                .Verify(processor => processor.CreatePartitionProcessor(
+                    It.Is<EventProcessorPartition>(value => value.PartitionId == secondPartition),
+                    It.IsAny<CancellationTokenSource>(),
+                    It.IsAny<EventPosition?>()),
+                Times.Once);
+
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
+
+            mockProcessor
+                .Protected()
+                .Verify("OnPartitionProcessingStoppedAsync",
+                    Times.Once(),
+                    ItExpr.Is<EventProcessorPartition>(part => part.PartitionId == firstPartiton),
+                    ItExpr.IsAny<ProcessingStoppedReason>(),
+                    ItExpr.IsAny<CancellationToken>());
+
+            cancellationSource.Cancel();
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -806,6 +806,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(() =>
                 {
@@ -1042,6 +1046,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionId }))
                 .Returns(() => default);
@@ -1120,6 +1128,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionId }))
                 .Returns(() => default);
@@ -1193,6 +1205,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -1286,6 +1302,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -1401,6 +1421,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionId }))
                 .Returns(() => default);
@@ -1492,6 +1516,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                  .SetupGet(lb => lb.OwnedPartitionIds)
                  .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -1806,6 +1834,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionId }))
                 .Returns(async () =>
@@ -1882,6 +1914,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -1995,6 +2031,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(partitionIds);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => partitionIds.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.OwnedPartitionCount)
                 .Returns(partitionIds.Length - 1)
                 .Returns(partitionIds.Length);
@@ -2071,6 +2111,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(partitionIds);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => partitionIds.Contains(partition));
 
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionCount)
@@ -2154,6 +2198,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupGet(lb => lb.IsBalanced)
@@ -2245,6 +2293,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupGet(lb => lb.IsBalanced)
@@ -2339,6 +2391,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupGet(lb => lb.IsBalanced)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -540,6 +540,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = firstPartiton }))
                 .Returns(() =>
@@ -669,6 +673,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -930,6 +938,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -1577,6 +1589,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(ownedPartitions);
 
             mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
+
+            mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionId }))
                 .Returns(() => default);
@@ -1686,6 +1702,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -2429,6 +2449,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockLoadBalancer
                 .SetupGet(lb => lb.OwnedPartitionIds)
                 .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.IsPartitionOwned(It.IsAny<string>()))
+                .Returns<string>(partition => ownedPartitions.Contains(partition));
 
             mockLoadBalancer
                 .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -2032,8 +2032,8 @@ namespace Azure.Messaging.EventHubs.Tests
             await Task.WhenAny(handlerCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
-            Assert.That(async () => await InvokeTryStopProcessingPartitionAsync(mockProcessor.Object, partition.PartitionId, Processor.ProcessingStoppedReason.OwnershipLost, cancellationSource.Token), Is.True, "Processing should have been stopped.");
-            Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.InstanceOf<TaskCanceledException>(), "The partition processor should have been canceled.");
+            Assert.That(async () => await InvokeStopProcessingPartitionAsync(mockProcessor.Object, partition.PartitionId, Processor.ProcessingStoppedReason.OwnershipLost, cancellationSource.Token), Throws.Nothing, "Processing should have been stopped.");
+            Assert.That(partitionProcessor.CancellationSource.IsCancellationRequested, Is.True, "The partition processor should have been canceled.");
 
             mockLogger
                 .Verify(log => log.PartitionProcessorStoppingCancellationWarning(

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -149,13 +149,13 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns><c>true</c> if the <paramref name="partitionId"/> was owned and was being processed; otherwise, <c>false</c>.</returns>
         ///
-        private static Task<bool> InvokeTryStopProcessingPartitionAsync<T>(EventProcessor<T> processor,
-                                                                           string partitionId,
-                                                                           ProcessingStoppedReason reason,
-                                                                           CancellationToken cancellationToken) where T : EventProcessorPartition, new() =>
-            (Task<bool>)
+        private static Task InvokeStopProcessingPartitionAsync<T>(EventProcessor<T> processor,
+                                                                  string partitionId,
+                                                                  ProcessingStoppedReason reason,
+                                                                  CancellationToken cancellationToken) where T : EventProcessorPartition, new() =>
+            (Task)
                 typeof(EventProcessor<T>)
-                    .GetMethod("TryStopProcessingPartitionAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetMethod("StopProcessingPartitionAsync", BindingFlags.Instance | BindingFlags.NonPublic)
                     .Invoke(processor, new object[] { partitionId, reason, cancellationToken });
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to refactor the load balancing logic to defer awaiting partitions when ownership is lost until either the processor is stopping or that same partition has been reclaimed.  This reduces the number of operations that need to be performed and allows load balancing to continue running on a predictable schedule.

Previously, when event processing was long-running and did not honor the cancellation token when ownership was lost, load balancing would be delayed until the processing completed.  This could result in a pause in ownership renewals which could lead to partitions being stolen by another processor.

This also allowed removal of existing LINQ expressions and a more efficient approach to reconciling owned partitions.