### PR TITLE
Add a comment to Packages.Data.Props

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -57,6 +57,15 @@
   <!--
     Dependency versions for Track 2, Azure.* libraries.
     Only packages that are approved dependencies should go here.
+
+    Prior to making any updates to this section, potential version
+    conflicts with PowerShell or Functions need to be investigated.
+    
+    For any common dependencies with PowerShell, the most straightforward
+    way to avoid issues is to ensure the version used is lower than
+    the version used by PowerShell. In most cases it is adequate
+    to check the dependencies in the latest version.
+    https://github.com/PowerShell/PowerShell/releases
   -->
 
   <ItemGroup Condition="'$(IsClientLibrary)' == 'true'">

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -65,7 +65,20 @@
     way to avoid issues is to ensure the version used is lower than
     the version used by PowerShell. In most cases it is adequate
     to check the dependencies in the latest version.
-    https://github.com/PowerShell/PowerShell/releases
+    - These tags give information for specific release versions: https://github.com/PowerShell/PowerShell/releases
+    - These files show the dependencies and versions:
+        - https://github.com/PowerShell/PowerShell/blob/master/tools/cgmanifest.json
+        - https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/System.Management.Automation.csproj
+
+    For Functions, this file can be referenced: https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/runtimeassemblies.json
+      - If the assembly is not there or there is a resolutionPolicy of private,
+        there is no issue from the Functions perspective of upgrading the version.
+      - If the assembly is there and there is a resolutionPolicy of minorMatchOrLower
+        then the version needs to be less than or equal to the version listed here:
+        - https://github.com/Azure/azure-functions-host/blob/dev/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+      - If resolutionPolicy is runtimeVersion, then the version needs to match the
+        version in the file below exactly:
+        - https://github.com/Azure/azure-functions-host/blob/dev/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
   -->
 
   <ItemGroup Condition="'$(IsClientLibrary)' == 'true'">

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -57,7 +57,7 @@
   <!--
     Dependency versions for Track 2, Azure.* libraries.
     Only packages that are approved dependencies should go here.
-    Contact azuresdkengsysteam@microsoft.com for approval.
+    To add a new dependency, seek architect approval.
 
     Prior to making any updates to this section, potential version
     conflicts with PowerShell or Functions need to be investigated.

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -57,12 +57,13 @@
   <!--
     Dependency versions for Track 2, Azure.* libraries.
     Only packages that are approved dependencies should go here.
+    Contact azuresdkengsysteam@microsoft.com for approval.
 
     Prior to making any updates to this section, potential version
     conflicts with PowerShell or Functions need to be investigated.
     
     For any common dependencies with PowerShell, the most straightforward
-    way to avoid issues is to ensure the version used is lower than
+    way to avoid issues is to ensure the version used is less than or equal to
     the version used by PowerShell. In most cases it is adequate
     to check the dependencies in the latest version.
     - These tags give information for specific release versions: https://github.com/PowerShell/PowerShell/releases


### PR DESCRIPTION
Adding a comment about PowerShell version conflicts in the Packages.Data.Props file. This contributes to https://github.com/Azure/azure-sdk-for-net/issues/40978

There isn't any specific guidance about this anywhere I could find that we could just link to. This information is from my own personal investigation after talking to a number of people, reading various GitHub issues, and testing things out.