### PR TITLE
100continue rst upload

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_0c10c0cf16"
+  "Tag": "net/storage/Azure.Storage.Blobs_7725668a06"
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -1350,37 +1350,7 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
-        [RecordedTest]
-        public async Task UploadAsync_ExpectContinue_RST_Detected()
-        {
-            AssertMessageContentsPolicy assertPolicy = new(checkRequest: req =>
-            {
-                Assert.That(req.Headers.TryGetValue("Expect", out string val), Is.True);
-                Assert.That(val, Is.EqualTo("100-continue"));
-            });
-
-            BlobClientOptions options = GetOptions();
-            options.ExpectContinueBehavior = new() { Mode = ExpectContinueMode.ApplyOnThrottle };
-            options.AddPolicy(assertPolicy, Core.HttpPipelinePosition.BeforeTransport);
-            await using DisposingContainer test = await GetTestContainerAsync(
-                BlobsClientBuilder.GetServiceClient_SharedKey(options));
-            BlobClient blob = InstrumentClient(test.Container.GetBlobClient(GetNewBlobName()));
-
-            Assert.That(
-                async () => await blob.UploadAsync(new FaultyStream(
-                    new RepeatingStream(17, 5000, true),
-                    500,
-                    1,
-                    new SocketException((int)SocketError.ConnectionReset),
-                    onFault: () => { })),
-                Throws.TypeOf<SocketException>());
-
-            using (assertPolicy.CheckRequestScope())
-            {
-                await blob.UploadAsync(BinaryData.FromBytes(GetRandomBuffer(1024)));
-            }
-        }
-        #endregion Upload
+#endregion Upload
 
         [Test]
         [Explicit]

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ExpectContinueOnThrottlePolicy.cs
@@ -10,7 +10,7 @@ using System.Net.Sockets;
 
 namespace Azure.Storage;
 
-internal class ExpectContinueOnThrottlePolicy : HttpPipelineSynchronousPolicy
+internal class ExpectContinueOnThrottlePolicy : HttpPipelinePolicy
 {
     private long _lastThrottleTicks = 0;
 

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageClientOptions.cs
@@ -131,7 +131,7 @@ namespace Azure.Storage
                 switch (expectContinue.Mode)
                 {
                     case ExpectContinueMode.ApplyOnThrottle:
-                        pipelineOptions.PerCallPolicies.Add(new ExpectContinueOnThrottlePolicy()
+                        pipelineOptions.PerRetryPolicies.Add(new ExpectContinueOnThrottlePolicy()
                         {
                             ThrottleInterval = expectContinue.ThrottleInterval,
                             ContentLengthThreshold = expectContinue.ContentLengthThreshold ?? 0,

--- a/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
@@ -10,7 +10,6 @@ using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Storage.Test.Shared;
 using Azure.Storage.Tests.Shared;
-using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 
 namespace Azure.Storage.Tests

--- a/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
@@ -180,6 +180,7 @@ namespace Azure.Storage.Tests
         public async Task ThrottlePolicyRevertsAfterBackoff()
         {
             TimeSpan backoff = TimeSpan.FromMilliseconds(10);
+            TimeSpan pause = TimeSpan.FromMilliseconds(50);
             ExpectContinueOnThrottlePolicy policy = new()
             {
                 ThrottleInterval = backoff,
@@ -207,7 +208,7 @@ namespace Azure.Storage.Tests
             Assert.That(value, Is.EqualTo("100-continue"));
 
             // wait out policy backoff
-            await Task.Delay(backoff);
+            await Task.Delay(pause);
 
             // message3 doesn't get expect header
             HttpMessage message3 = new(MakeRequest(), classifier);


### PR DESCRIPTION
- Converts the throttling policy to per-retry rather than per-call.
- Policy now observes RST failures and triggers on those as well.