### PR TITLE
Add Core v-team and architects to Packages.Data.props CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -838,6 +838,9 @@
 /sdk/eventhub/tests.data.yml                                       @serkantkaraca @sjkwak
 /sdk/servicebus/tests.data.yml                                     @shankarsama @DorothySun216
 
+# Add owners for package dependency changes
+/eng/Packages.Data.props                                           @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @tg-msft
+
 # ######## DPG ########
 
 # Onboarding Documentation and Quickstarts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -839,7 +839,7 @@
 /sdk/servicebus/tests.data.yml                                     @shankarsama @DorothySun216
 
 # Add owners for package dependency changes
-/eng/Packages.Data.props                                           @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @tg-msft
+/eng/Packages.Data.props                                           @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @tg-msft @jsquire @pallavit @m-nash @ArthurMa1978 
 
 # ######## DPG ########
 


### PR DESCRIPTION
As per the discussion in https://github.com/Azure/azure-sdk-for-net/pull/41011#discussion_r1443094832