### PR TITLE
[Event Hubs] Logging improvements

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 - Improved efficiency of partition management during load balancing, reducing the number of operations performed and deferring waiting for lost partitions until the processor is stopped or the partition is reclaimed.  Allocations were also non-trivially reduced.
 
+- The "Event Receive Completed" log now includes the maximum batch size and wait time that were used for the operation.
+
+- A new log has been added to capture the end-to-end performance of the cycle to read and process events for a partition owned by an event processor type.  This is emitted as a verbose ETW event with the Id 129 and is highly recommended to capture when troubleshooting processor scenarios.
+
 ## 5.10.0 (2023-11-07)
 
 ### Breaking Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/TROUBLESHOOTING.md
@@ -421,6 +421,7 @@ When filing GitHub issues, the following details are requested for all scenarios
   - 123 (EventProcessorProcessingHandlerStart)
   - 124 (EventProcessorProcessingHandlerComplete)
   - 125 (EventProcessorProcessingHandlerError)
+  - 129 (EventProcessorPartitionProcessingCycleComplete)
 
 ### Consuming issues
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -398,7 +398,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                     receivedEventCount,
                     stopWatch.GetElapsedTime().TotalSeconds,
                     firstReceivedEvent?.SequenceNumber.ToString(),
-                    LastReceivedEvent?.SequenceNumber.ToString());
+                    LastReceivedEvent?.SequenceNumber.ToString(),
+                    maximumEventCount,
+                    waitTime.TotalSeconds);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -3534,7 +3534,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Writes an event with four string arguments and two value type arguments into a stack allocated
+        ///   Writes an event with four string arguments and a value type argument into a stack allocated
         ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Globalization;
 using System.IO.Pipes;
 using System.Runtime.CompilerServices;
 using Azure.Core.Diagnostics;
@@ -175,8 +176,10 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="startingSequenceNumber">The sequence number of the first event in the batch.</param>
         /// <param name="endingSequenceNumber">The sequence number of the last event in the batch.</param>
         /// <param name="durationSeconds">The total duration that the receive operation took to complete, in seconds.</param>
+        /// <param name="maximumBatchSize">The maximum number of events to include in the batch.</param>
+        /// <param name="maximumWaitTime">The maximum time to wait when no events are available, in seconds.</param>
         ///
-        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Duration: '{6:0.00}' seconds; Starting sequence number: '{7}', Ending sequence number: '{8}'.")]
+        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Duration: '{6:0.00}' seconds; Starting sequence number: '{7}', Ending sequence number: '{8}'; Maximum batch size: '{9}'; Maximum wait time: '{10:0.00}'.")]
         public virtual void EventReceiveComplete(string eventHubName,
                                                  string consumerGroup,
                                                  string partitionId,
@@ -185,11 +188,13 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                                                  int eventCount,
                                                  double durationSeconds,
                                                  string startingSequenceNumber,
-                                                 string endingSequenceNumber)
+                                                 string endingSequenceNumber,
+                                                 int maximumBatchSize,
+                                                 double maximumWaitTime)
         {
             if (IsEnabled())
             {
-                EventReceiveCompleteCore(7, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, retryCount, eventCount, durationSeconds, startingSequenceNumber ?? string.Empty, endingSequenceNumber ?? string.Empty);
+                EventReceiveCompleteCore(7, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, retryCount, eventCount, durationSeconds, startingSequenceNumber ?? string.Empty, endingSequenceNumber ?? string.Empty, maximumBatchSize, maximumWaitTime);
             }
         }
 
@@ -840,16 +845,18 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="durationSeconds">The duration that the end-to-end stop operation took for the partition, in seconds.</param>
         ///
-        [Event(42, Level = EventLevel.Verbose, Message = "Completed stopping processing for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        [Event(42, Level = EventLevel.Verbose, Message = "Completed stopping processing for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}. Duration: '{4:0.00}' seconds.")]
         public virtual void EventProcessorPartitionProcessingStopComplete(string partitionId,
                                                                           string identifier,
                                                                           string eventHubName,
-                                                                          string consumerGroup)
+                                                                          string consumerGroup,
+                                                                          double durationSeconds)
         {
             if (IsEnabled())
             {
-                WriteEvent(42, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+                WriteEvent(42, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, durationSeconds);
             }
         }
 
@@ -2525,20 +2532,20 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
         /// <param name="partitionId">The identifier of the partition that the handler was invoked for.</param>
         /// <param name="operationId">An artificial identifier for the publishing operation.</param>
-        /// <param name="backoffSeconds">The number of seconds that the back-off will delay.</param>
-        /// <param name="backoffCount">The message for the exception that occurred.</param>
+        /// <param name="backOffSeconds">The number of seconds that the back-off will delay.</param>
+        /// <param name="backOffCount">The message for the exception that occurred.</param>
         ///
         [Event(122, Level = EventLevel.Warning, Message = "The Event Hubs service is throttling the buffered producer instance with identifier '{0}' for Event Hub: {1}, Partition Id: '{2}', Operation Id: '{3}'.  To avoid overloading the service, publishing of this batch will delay for {4} seconds.  This batch has attempted a delay to avoid throttling {5} times.  This is non-fatal and publishing will continue to retry.")]
         public virtual void BufferedProducerThrottleDelay(string identifier,
                                                           string eventHubName,
                                                           string partitionId,
                                                           string operationId,
-                                                          double backoffSeconds,
-                                                          int backoffCount)
+                                                          double backOffSeconds,
+                                                          int backOffCount)
         {
             if (IsEnabled())
             {
-                WriteEvent(122, identifier ?? string.Empty, eventHubName ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, backoffSeconds, backoffCount);
+                WriteEvent(122, identifier ?? string.Empty, eventHubName ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, backOffSeconds, backOffCount);
             }
         }
 
@@ -2686,6 +2693,59 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that one cycle of reading from a partition and processing events has completed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition being processed.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="eventCount">The number of events that were read and processed.</param>
+        /// <param name="startingSequenceNumber">The starting sequence number of the batch that was passed to the processing handler.</param>
+        /// <param name="endingSequenceNumber">The ending sequence number of the batch that was passed to the processing handler.</param>
+        /// <param name="formattedCycleStartTime">The UTC date/time, formatted as a string, that the processing cycle started.</param>
+        /// <param name="formattedCycleEndTime">The UTC date/time, formatted as a string, that the processing cycle was completed.</param>
+        /// <param name="durationSeconds">The total duration that this cycle took, in seconds.</param>
+        ///
+        [Event(129, Level = EventLevel.Verbose, Message = "A processing cycle for partition '{0}' using processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3} has completed.  Events read: '{4}'; Starting Sequence Number: '{5}', Ending Sequence Number: '{6}'; Cycle Started: {7}, Cycle Ended: {8}; Total duration to read and process: '{9:0.00}' seconds.")]
+        public virtual void EventProcessorPartitionProcessingCycleComplete(string partitionId,
+                                                                           string identifier,
+                                                                           string eventHubName,
+                                                                           string consumerGroup,
+                                                                           int eventCount,
+                                                                           string startingSequenceNumber,
+                                                                           string endingSequenceNumber,
+                                                                           string formattedCycleStartTime,
+                                                                           string formattedCycleEndTime,
+                                                                           double durationSeconds)
+        {
+            if (IsEnabled())
+            {
+                EventProcessorPartitionProcessingCycleCompleteCore(
+                    129,
+                    partitionId ?? string.Empty,
+                    identifier ?? string.Empty,
+                    eventHubName ?? string.Empty,
+                    consumerGroup ?? string.Empty,
+                    eventCount,
+                    startingSequenceNumber ?? string.Empty,
+                    endingSequenceNumber ?? string.Empty,
+                    formattedCycleStartTime ?? string.Empty,
+                    formattedCycleEndTime ?? string.Empty,
+                    durationSeconds);
+            }
+        }
+
+        /// <summary>
+        ///   Gets the current value of <see cref="DateTimeOffset.UtcNow" /> formatted
+        ///   for use in logs.
+        /// </summary>
+        ///
+        /// <returns>The current UTC date/time stamp as a string, formatted for logging.</returns>
+        ///
+        public virtual string GetLogFormattedUtcNow() => DateTime.UtcNow.ToString("yyyy-mm-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+
+        /// <summary>
         ///   Indicates that the receiving of events has completed.
         /// </summary>
         ///
@@ -2699,6 +2759,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="durationSeconds">The total duration that the receive operation took to complete, in seconds.</param>
         /// <param name="startingSequenceNumber">The sequence number of the first event in the batch.</param>
         /// <param name="endingSequenceNumber">The sequence number of the last event in the batch.</param>
+        /// <param name="maximumBatchSize">The maximum number of events to include in the batch.</param>
+        /// <param name="maximumWaitTime">The maximum time to wait when no events are available, in seconds.</param>
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2711,7 +2773,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                                                      int eventCount,
                                                      double durationSeconds,
                                                      string startingSequenceNumber,
-                                                     string endingSequenceNumber)
+                                                     string endingSequenceNumber,
+                                                     int maximumBatchSize,
+                                                     double maximumWaitTime)
         {
             fixed (char* eventHubNamePtr = eventHubName)
             fixed (char* consumerGroupPtr = consumerGroup)
@@ -2720,7 +2784,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
             fixed (char* startingSequenceNumberPtr = startingSequenceNumber)
             fixed (char* endingSequenceNumberPtr = endingSequenceNumber)
             {
-                var eventPayload = stackalloc EventData[9];
+                var eventPayload = stackalloc EventData[11];
 
                 eventPayload[0].Size = (eventHubName.Length + 1) * sizeof(char);
                 eventPayload[0].DataPointer = (IntPtr)eventHubNamePtr;
@@ -2749,7 +2813,13 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                 eventPayload[8].Size = (endingSequenceNumber.Length + 1) * sizeof(char);
                 eventPayload[8].DataPointer = (IntPtr)endingSequenceNumberPtr;
 
-                WriteEventCore(eventId, 9, eventPayload);
+                eventPayload[9].Size = Unsafe.SizeOf<int>();
+                eventPayload[9].DataPointer = (IntPtr)Unsafe.AsPointer(ref maximumBatchSize);
+
+                eventPayload[10].Size = Unsafe.SizeOf<double>();
+                eventPayload[10].DataPointer = (IntPtr)Unsafe.AsPointer(ref maximumWaitTime);
+
+                WriteEventCore(eventId, 11, eventPayload);
             }
         }
 
@@ -3245,6 +3315,81 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that one cycle of reading from a partition and processing events has completed.
+        /// </summary>
+        ///
+        /// <param name="eventId">The identifier of the event.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition being processed.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="eventCount">The number of events that were read and processed.</param>
+        /// <param name="startingSequenceNumber">The starting sequence number of the batch that was passed to the processing handler.</param>
+        /// <param name="endingSequenceNumber">The ending sequence number of the batch that was passed to the processing handler.</param>
+        /// <param name="formattedCycleStartTime">The UTC date/time, formatted as a string, that the processing cycle started.</param>
+        /// <param name="formattedCycleEndTime">The UTC date/time, formatted as a string, that the processing cycle was completed.</param>
+        /// <param name="durationSeconds">The total duration that this cycle took, in seconds.</param>
+        ///
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void EventProcessorPartitionProcessingCycleCompleteCore(int eventId,
+                                                                               string partitionId,
+                                                                               string identifier,
+                                                                               string eventHubName,
+                                                                               string consumerGroup,
+                                                                               int eventCount,
+                                                                               string startingSequenceNumber,
+                                                                               string endingSequenceNumber,
+                                                                               string formattedCycleStartTime,
+                                                                               string formattedCycleEndTime,
+                                                                               double durationSeconds)
+        {
+            fixed (char* partitionIdPtr = partitionId)
+            fixed (char* identifierPtr = identifier)
+            fixed (char* eventHubNamePtr = eventHubName)
+            fixed (char* consumerGroupPtr = consumerGroup)
+            fixed (char* startingSequenceNumberIdPtr = startingSequenceNumber)
+            fixed (char* endingSequenceNumberIdPtr = endingSequenceNumber)
+            fixed (char* formattedCycleStartTimePtr = formattedCycleStartTime)
+            fixed (char* formattedCycleEndTimePtr = formattedCycleEndTime)
+            {
+                var eventPayload = stackalloc EventData[10];
+
+                eventPayload[0].Size = (partitionId.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)partitionIdPtr;
+
+                eventPayload[1].Size = (identifier.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)identifierPtr;
+
+                eventPayload[2].Size = (eventHubName.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)eventHubNamePtr;
+
+                eventPayload[3].Size = (consumerGroup.Length + 1) * sizeof(char);
+                eventPayload[3].DataPointer = (IntPtr)consumerGroupPtr;
+
+                eventPayload[4].Size = Unsafe.SizeOf<int>();
+                eventPayload[4].DataPointer = (IntPtr)Unsafe.AsPointer(ref eventCount);
+
+                eventPayload[5].Size = (startingSequenceNumber.Length + 1) * sizeof(char);
+                eventPayload[5].DataPointer = (IntPtr)startingSequenceNumberIdPtr;
+
+                eventPayload[6].Size = (endingSequenceNumber.Length + 1) * sizeof(char);
+                eventPayload[6].DataPointer = (IntPtr)endingSequenceNumberIdPtr;
+
+                eventPayload[7].Size = (formattedCycleStartTime.Length + 1) * sizeof(char);
+                eventPayload[7].DataPointer = (IntPtr)formattedCycleStartTimePtr;
+
+                eventPayload[8].Size = (formattedCycleEndTime.Length + 1) * sizeof(char);
+                eventPayload[8].DataPointer = (IntPtr)formattedCycleEndTimePtr;
+
+                eventPayload[9].Size = Unsafe.SizeOf<double>();
+                eventPayload[9].DataPointer = (IntPtr)Unsafe.AsPointer(ref durationSeconds);
+
+                WriteEventCore(eventId, 10, eventPayload);
+            }
+        }
+
+        /// <summary>
         ///   Writes an event with two string arguments and two value type arguments into a stack allocated
         ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
         /// </summary>
@@ -3385,6 +3530,54 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                 eventPayload[5].DataPointer = (IntPtr)arg6Ptr;
 
                 WriteEventCore(eventId, 6, eventPayload);
+            }
+        }
+
+        /// <summary>
+        ///   Writes an event with four string arguments and two value type arguments into a stack allocated
+        ///   <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation on the WriteEvent methods.
+        /// </summary>
+        ///
+        /// <param name="eventId">The identifier of the event.</param>
+        /// <param name="arg1">The first argument.</param>
+        /// <param name="arg2">The second argument.</param>
+        /// <param name="arg3">The third argument.</param>
+        /// <param name="arg4">The fourth argument.</param>
+        /// <param name="arg5">The fifth argument.</param>
+        ///
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteEvent<TValue1>(int eventId,
+                                                string arg1,
+                                                string arg2,
+                                                string arg3,
+                                                string arg4,
+                                                TValue1 arg5)
+            where TValue1 : struct
+        {
+            fixed (char* arg1Ptr = arg1)
+            fixed (char* arg2Ptr = arg2)
+            fixed (char* arg3Ptr = arg3)
+            fixed (char* arg4Ptr = arg4)
+            {
+                var eventPayload = stackalloc EventData[5];
+
+                eventPayload[0].Size = (arg1.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)arg1Ptr;
+
+                eventPayload[1].Size = (arg2.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)arg2Ptr;
+
+                eventPayload[2].Size = (arg3.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)arg3Ptr;
+
+                eventPayload[3].Size = (arg4.Length + 1) * sizeof(char);
+                eventPayload[3].DataPointer = (IntPtr)arg4Ptr;
+
+                eventPayload[4].Size = Unsafe.SizeOf<TValue1>();
+                eventPayload[4].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg5);
+
+                WriteEventCore(eventId, 5, eventPayload);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -661,7 +661,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 });
 
             mockLogger
-                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<double>()))
                 .Callback(() =>
                 {
                     if (Interlocked.Increment(ref stopProcessingCalls) >= expectedProcessingCalls)
@@ -753,7 +753,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     firstPartiton,
                     mockProcessor.Object.Identifier,
                     mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup),
+                    mockProcessor.Object.ConsumerGroup,
+                    It.IsAny<double>()),
                 Times.Once);
 
             mockProcessor
@@ -768,7 +769,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     secondPartition,
                     mockProcessor.Object.Identifier,
                     mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup),
+                    mockProcessor.Object.ConsumerGroup,
+                    It.IsAny<double>()),
                 Times.Once);
 
             cancellationSource.Cancel();
@@ -798,7 +800,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
 
             mockLogger
-                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<double>()))
                 .Callback(() => stopCompletionSource.TrySetResult(true));
 
             mockLoadBalancer
@@ -906,7 +908,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     mockProcessor.Object.Identifier,
                     mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup),
+                    mockProcessor.Object.ConsumerGroup,
+                    It.IsAny<double>()),
                 Times.Once);
 
             cancellationSource.Cancel();
@@ -936,7 +939,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
 
             mockLogger
-                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<double>()))
                 .Callback(() => completionSource.TrySetResult(true));
 
             mockLoadBalancer
@@ -1609,7 +1612,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
 
             mockLogger
-                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<double>()))
                 .Callback(() => stopCompletionSource.TrySetResult(true));
 
             mockLoadBalancer
@@ -1688,7 +1691,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     partitionId,
                     mockProcessor.Object.Identifier,
                     mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup),
+                    mockProcessor.Object.ConsumerGroup,
+                    It.IsAny<double>()),
                  Times.Once);
 
             mockProcessor
@@ -1724,7 +1728,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
 
             mockLogger
-                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(log => log.EventProcessorPartitionProcessingStopComplete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<double>()))
                 .Callback(() => stopCompletionSource.TrySetResult(true));
 
             mockLoadBalancer
@@ -2489,7 +2493,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.IsAny<string>()))
+                    It.IsAny<string>(),
+                    It.IsAny<double>()))
                 .Callback(() => stopCompletionSource.TrySetResult(true));
 
             mockLogger

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -892,6 +892,100 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task CreatePartitionProcessorProcessingLogsEachCycle()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var startdDateString = "start-date";
+            var endDateString = "end-date";
+            var startSequenceNumber = "4444";
+            var endSequenceNumber = "8888";
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            var eventBatch = new List<EventData>
+            {
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), offset: 0, sequenceNumber: long.Parse(startSequenceNumber)),
+                EventHubsModelFactory.EventData(new BinaryData(Array.Empty<byte>()), offset: 1, sequenceNumber: long.Parse(endSequenceNumber))
+            };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(eventBatch);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>(), It.IsAny<bool>()))
+                .Returns(mockConsumer.Object);
+
+            mockLogger
+                .SetupSequence(logger => logger.GetLogFormattedUtcNow())
+                .Returns(startdDateString)
+                .Returns(endDateString);
+
+            mockLogger
+                .Setup(logger => logger.EventProcessorPartitionProcessingCycleComplete(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<double>()))
+                .Callback(() => completionSource.TrySetResult(true));
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, cancellationSource, position);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            mockProcessor
+                 .Verify(processor => processor.ProcessEventBatchAsync(
+                     partition,
+                     It.IsAny<IReadOnlyList<EventData>>(),
+                     It.IsAny<bool>(),
+                     cancellationSource.Token),
+                 Times.AtLeastOnce);
+
+            mockLogger
+                .Verify(logger => logger.EventProcessorPartitionProcessingCycleComplete(
+                    partition.PartitionId,
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup,
+                    eventBatch.Count,
+                    startSequenceNumber,
+                    endSequenceNumber,
+                    startdDateString,
+                    endDateString,
+                    It.IsAny<double>()),
+                Times.AtLeastOnce);
+
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
         public async Task CreatePartitionProcessorProcessingTaskDispatchesExceptionsWhenCreatingTheConnectionFails()
         {
             using var cancellationSource = new CancellationTokenSource();


### PR DESCRIPTION
# Summary

The focus of these changes is to enhance logging for some key scenarios. Changes include:

  - The addition of the MaxWaitTime and MaxBatchSize when reading events.

  - The addition of the end-to-end duration that it took to stop processing for a partition, including execution of the background continuation.

  - A new log that captures information for the partition processing cycle, including time taken to read events and process them.  This also contains a normalized start/end timestamp to allow for easier understanding of whether the host is unable to keep background tasks running without pauses.