### PR TITLE
[AppConfig] Auth Policy Fix

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
@@ -80,7 +80,7 @@ namespace Azure.Data.AppConfiguration
             const string signedHeaders = "date;host;x-ms-content-sha256"; // Semicolon separated header names
 
             var uri = request.Uri.ToUri();
-            var host = uri.Host;
+            var host = uri.Authority;
             var pathAndQuery = uri.PathAndQuery;
             var method = request.Method.Method;
 


### PR DESCRIPTION
The focus of these changes is to adjust the authorization policy to make use of the Authority when computing the auth signature, as this is what is represented in the host header used to validate service-side.  This works by coincidence when the standard HTTP ports are used, as they do not appear in the host header, but becomes an issue when a non-standard port is needed.