### PR TITLE
[Messaging] Disable Mooncake for weekly test runs

### DIFF
--- a/sdk/eventhub/tests.data.yml
+++ b/sdk/eventhub/tests.data.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: data
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,Canary'

--- a/sdk/eventhub/tests.functions.yml
+++ b/sdk/eventhub/tests.functions.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: functions
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: client
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,Canary'

--- a/sdk/servicebus/tests.data.yml
+++ b/sdk/servicebus/tests.data.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: data
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,Canary'

--- a/sdk/servicebus/tests.functions.yml
+++ b/sdk/servicebus/tests.functions.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: functions
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,Canary'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -8,4 +8,4 @@ extends:
     SDKType: client
     TimeoutInMinutes: 240
     Clouds: 'Public,Canary'
-    SupportedClouds: 'Public,UsGov,China,Canary'
+    SupportedClouds: 'Public,UsGov,Canary'


### PR DESCRIPTION
# Summary

The focus of these changes is to disable the Mooncake (China) region for weekly test runs, as the tests have been consistently timing out for the last 6 months.  This is believed to be due to the latency when running in our DevOps environment and targeting Azure resources in Mooncake.  Until we have the ability to run within the same cloud being tested, there's no value in having the cloud enabled.