### PR TITLE
[Azure OpenAI] Remove the setter of the `Functions` property of `ChatCompletionsOptions`

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Removed the setter of the `Functions` property of the `ChatCompletionsOptions` class as per the guidelines for collection properties.
+
 ### Bugs Fixed
 
 - Addressed an issue with the public constructor for `ChatCompletionsFunctionToolCall` that failed to set the tool call type in the corresponding request.

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -331,7 +331,7 @@ namespace Azure.AI.OpenAI
         public string DeploymentName { get { throw null; } set { } }
         public float? FrequencyPenalty { get { throw null; } set { } }
         public Azure.AI.OpenAI.FunctionDefinition FunctionCall { get { throw null; } set { } }
-        public System.Collections.Generic.IList<Azure.AI.OpenAI.FunctionDefinition> Functions { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.AI.OpenAI.FunctionDefinition> Functions { get { throw null; } }
         public int? MaxTokens { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.AI.OpenAI.ChatRequestMessage> Messages { get { throw null; } }
         public float? NucleusSamplingFactor { get { throw null; } set { } }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatCompletionsOptions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/ChatCompletions/ChatCompletionsOptions.cs
@@ -156,7 +156,7 @@ public partial class ChatCompletionsOptions
     public IDictionary<int, int> TokenSelectionBiases { get; }
 
     /// <summary> A list of functions the model may generate JSON inputs for. </summary>
-    public IList<FunctionDefinition> Functions { get; set; }
+    public IList<FunctionDefinition> Functions { get; }
 
     /// <summary>
     /// Controls how the model will use provided Functions.


### PR DESCRIPTION
Removed the setter of the `Functions` property of the `ChatCompletionsOptions` class as per the guidelines for collection properties.  More info here:
🔗 https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/guidelines-for-collections#collection-properties-and-return-values