### PR TITLE
[Event Hubs] Update system property types

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### Breaking Changes
 
+- The type of several existing values in the `EventData.SystemProperties` collection have been changed so that they are properly represented as .NET string types.  Previously, the underlying AMQP types were unintentionally returned, forcing callers to call `ToString()` to read the value.  
+
+  This is a behavioral breaking change that will impacts only those callers who were explicitly casting system property values to `AmqpAddress` or `AmqpMessageId` before calling `ToString`.   The affected system properties are:
+  - MessageId
+  - CorelationId
+  - To
+  - ReplyTo
+
 ### Bugs Fixed
 
 - Fixed a race condition that could lead to a synchronization primitive being double-released if `IsRunning` was called concurrently while starting or stopping the processor.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - The type of several existing values in the `EventData.SystemProperties` collection have been changed so that they are properly represented as .NET string types.  Previously, the underlying AMQP types were unintentionally returned, forcing callers to call `ToString()` to read the value.  
 
-  This is a behavioral breaking change that will impacts only those callers who were explicitly casting system property values to `AmqpAddress` or `AmqpMessageId` before calling `ToString`.   The affected system properties are:
+  This is a behavioral breaking change that will impacts only those callers who were explicitly casting system property values to `AmqpAddress` or `AmqpMessageId` before calling `ToString()`.   The affected system properties are:
   - MessageId
   - CorelationId
   - To

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - The type of several existing values in the `EventData.SystemProperties` collection have been changed so that they are properly represented as .NET string types.  Previously, the underlying AMQP types were unintentionally returned, forcing callers to call `ToString()` to read the value.  
 
-  This is a behavioral breaking change that will impacts only those callers who were explicitly casting system property values to `AmqpAddress` or `AmqpMessageId` before calling `ToString`.   The affected system properties are:
+  This is a behavioral breaking change that will impacts only those callers who were explicitly casting system property values to `AmqpAddress` or `AmqpMessageId` before calling `ToString()`.   The affected system properties are:
   - MessageId
   - CorelationId
   - To

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### Breaking Changes
 
+- The type of several existing values in the `EventData.SystemProperties` collection have been changed so that they are properly represented as .NET string types.  Previously, the underlying AMQP types were unintentionally returned, forcing callers to call `ToString()` to read the value.  
+
+  This is a behavioral breaking change that will impacts only those callers who were explicitly casting system property values to `AmqpAddress` or `AmqpMessageId` before calling `ToString`.   The affected system properties are:
+  - MessageId
+  - CorelationId
+  - To
+  - ReplyTo
+
 ### Bugs Fixed
 
 - Load balancing is no longer blocked when event processing for a lost partition does not honor the cancellation token.  Previously, long-running processing could cause delays in load balancing that resulted in ownership not being renewed for all partitions.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpSystemProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpSystemProperties.cs
@@ -64,7 +64,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 {
                     if (key == Properties.MessageIdName)
                     {
-                        return _amqpMessage.Properties.MessageId;
+                        return _amqpMessage.Properties.MessageId?.ToString();
                     }
 
                     if (key == Properties.UserIdName)
@@ -74,7 +74,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                     if (key == Properties.ToName)
                     {
-                        return _amqpMessage.Properties.To;
+                        return _amqpMessage.Properties.To?.ToString();
                     }
 
                     if (key == Properties.SubjectName)
@@ -84,12 +84,12 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                     if (key == Properties.ReplyToName)
                     {
-                        return _amqpMessage.Properties.ReplyTo;
+                        return _amqpMessage.Properties.ReplyTo?.ToString();
                     }
 
                     if (key == Properties.CorrelationIdName)
                     {
-                        return _amqpMessage.Properties.CorrelationId;
+                        return _amqpMessage.Properties.CorrelationId?.ToString();
                     }
 
                     if (key == Properties.ContentTypeName)
@@ -130,7 +130,12 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if (_amqpMessage.HasSection(AmqpMessageSection.MessageAnnotations))
                 {
-                   return _amqpMessage.MessageAnnotations[key];
+                    return _amqpMessage.MessageAnnotations[key] switch
+                    {
+                        AmqpMessageId id => id.ToString(),
+                        AmqpAddress address => address.ToString(),
+                        object value => value
+                    };
                 }
 
                 // If no section was available to delegate to, mimic the behavior of the standard dictionary implementation.

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bugs Fixed
 
+- The `SystemProperties` binding will now return certain item as string values instead of an AMQP structure that requires calling `ToString()` to read.  The affected system properties are:
+  - MessageId
+  - CorelationId
+  - To
+  - ReplyTo
+
 ### Other Changes
 
 - Updated the `Azure.Messaging.EventHubs` dependency, which includes optimized defaults of the host platform to be used for AMQP buffers.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  This update also enables support for TLS 1.3.


### PR DESCRIPTION
# Summary

 The focus of these changes is to update the type of several existing values in the `EventData.SystemProperties` collection so that they are properly represented as .NET string types.  Previously,
 the underlying AMQP types were unintentionally returned, forcing callers to call `ToString()` to read the value.  This is a behavioral breaking change that will impacts only those callers who were explicitly casting system property values to `AmqpAddress` or  `AmqpMessageId` before calling `ToString`.

  The affected system properties are:
  - MessageId
  - CorelationId
  - To
  - ReplyTo