### PR TITLE
Fixing target base scale instance concurrency for queues

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueTargetScaler.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueTargetScaler.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
         internal TargetScalerResult GetScaleResultInternal(TargetScalerContext context, int queueLength)
         {
-            int concurrency = !context.InstanceConcurrency.HasValue ? _options.BatchSize : context.InstanceConcurrency.Value;
+            int concurrency = !context.InstanceConcurrency.HasValue ? _options.BatchSize + _options.NewBatchThreshold : context.InstanceConcurrency.Value;
 
             if (concurrency < 0)
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTargetScalerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTargetScalerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
         [TestCase(160, 20, 8)]
         public void QueueTargetScaler_Returns_Expected(int queueLength, int? concurrency, int expectedTargetWorkerCount)
         {
-            QueuesOptions options = new QueuesOptions { BatchSize = 16 };
+            QueuesOptions options = new QueuesOptions { BatchSize = 8, NewBatchThreshold = 8 };
 
             TargetScalerContext context = new TargetScalerContext
             {


### PR DESCRIPTION
Currently Azure Queues, we’re using `BatchSize` as per instance concurrency. The actual per instance concurrency is given by the formula C = NewBatchThreshhold + BatchSize. For example, when only BatchSize is set to 16 (the maximum value), the instance concurrency is 24. However if both BatchSize=16 and NewBatchThreshold=200, then instance concurrency is 216. Given this, current TBS model is overscale.
