### PR TITLE
fix the protected ctor issue in resourcemanager

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
@@ -611,6 +611,7 @@ namespace Azure.ResourceManager.Models
     }
     public partial class OperationStatusResult : System.ClientModel.Primitives.IJsonModel<Azure.ResourceManager.Models.OperationStatusResult>, System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.Models.OperationStatusResult>
     {
+        protected OperationStatusResult() { }
         protected OperationStatusResult(Azure.Core.ResourceIdentifier id, string name, string status, float? percentComplete, System.DateTimeOffset? startOn, System.DateTimeOffset? endOn, System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.Models.OperationStatusResult> operations, Azure.ResponseError error) { }
         public OperationStatusResult(string status) { }
         public System.DateTimeOffset? EndOn { get { throw null; } }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/OperationStatusResult.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/OperationStatusResult.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+namespace Azure.ResourceManager.Models
+{
+    public partial class OperationStatusResult
+    {
+        /// <summary> Initializes a new instance of <see cref="OperationStatusResult"/> for deserialization. </summary>
+        protected OperationStatusResult()
+        {
+        }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Generated/Models/OperationStatusResult.cs
@@ -50,11 +50,6 @@ namespace Azure.ResourceManager.Models
             Error = error;
         }
 
-        /// <summary> Initializes a new instance of <see cref="OperationStatusResult"/> for deserialization. </summary>
-        internal OperationStatusResult()
-        {
-        }
-
         /// <summary> Fully qualified ID for the async operation. </summary>
         public ResourceIdentifier Id { get; }
         /// <summary> Name of the async operation. </summary>


### PR DESCRIPTION
For all the types that might be inherited by other libraries in resourcemanager, they should have a protected ctor instead of internal ctor.
Internal ctor cannot be inherited and when you inherit it, you will get the following compilation error:
```
error CS1729: 'OperationStatusResult' does not contain a constructor that takes 0 arguments
```