### PR TITLE
[Event Hubs] Non-TLS Fix

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -1246,10 +1246,18 @@ namespace Azure.Messaging.EventHubs.Amqp
                 ReceiveBufferSize = receiveBufferSizeBytes,
             };
 
-            return new TlsTransportSettings(tcpSettings)
+            // If TLS is explicitly disabled, then use the TCP settings as-is.  Otherwise,
+            // wrap them for TLS usage.
+
+            return useTls switch
             {
-                TargetHost = connectionEndpoint.Host,
-                CertificateValidationCallback = certificateValidationCallback
+                false => tcpSettings,
+
+                _ => new TlsTransportSettings(tcpSettings)
+                {
+                    TargetHost = connectionEndpoint.Host,
+                    CertificateValidationCallback = certificateValidationCallback
+                }
             };
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to ensure that the transport used by the AMQP connection respects the scheme specified and does not enable TLS when it has been explicitly disabled.
