### PR TITLE
[LiveMetricsExporter] refactor rest client

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Customizations/QuickPulseSDKClientAPIsRestClient.cs
@@ -8,7 +8,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Threading;
-using Azure.Core;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics
@@ -28,7 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
         /// <param name="monitoringDataPoint"> Data contract between SDK and QuickPulse. /QuickPulseService.svc/ping uses this as a backup source of machine name, instance name and invariant version. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="ikey"/> is null. </exception>
-        public ResponseWithHeaders<object, QuickPulseSDKClientAPIsPingHeaders> PingCustom(string ikey, string apikey = null, int? xMsQpsTransmissionTime = null, string xMsQpsMachineName = null, string xMsQpsInstanceName = null, string xMsQpsStreamId = null, string xMsQpsRoleName = null, string xMsQpsInvariantVersion = null, string xMsQpsConfigurationEtag = null, MonitoringDataPoint monitoringDataPoint = null, CancellationToken cancellationToken = default)
+        public QuickPulseResponse CustomPing(string ikey, string apikey = null, int? xMsQpsTransmissionTime = null, string xMsQpsMachineName = null, string xMsQpsInstanceName = null, string xMsQpsStreamId = null, string xMsQpsRoleName = null, string xMsQpsInvariantVersion = null, string xMsQpsConfigurationEtag = null, MonitoringDataPoint monitoringDataPoint = null, CancellationToken cancellationToken = default)
         {
             if (ikey == null)
             {
@@ -45,10 +46,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                         CollectionConfigurationInfo value = default;
                         if (message.Response.Headers.ContentLength != 0)
                         {
+                            // TODO: This deserialization was auto generated. I assume this is used for filtering.
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = CollectionConfigurationInfo.DeserializeCollectionConfigurationInfo(document.RootElement);
                         }
-                        return ResponseWithHeaders.FromValue<object, QuickPulseSDKClientAPIsPingHeaders>(value, headers, message.Response);
+                        return new QuickPulseResponse(success: true, message.Response.Headers);
                     }
                 case 400:
                 case 401:
@@ -62,10 +64,12 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                         {
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = ServiceError.DeserializeServiceError(document.RootElement);
+                            LiveMetricsExporterEventSource.Log.PingFailedWithServiceError(message.Response.Status, value);
                         }
 
                         Debug.WriteLine($"{DateTime.Now}: Ping FAILED: {message.Response.Status} {message.Response.ReasonPhrase}.");
-                        return ResponseWithHeaders.FromValue<object, QuickPulseSDKClientAPIsPingHeaders>(value, headers, message.Response);
+                        LiveMetricsExporterEventSource.Log.PingFailed(message.Response);
+                        return new QuickPulseResponse(success: false);
                     }
                 default:
                     throw new RequestFailedException(message.Response);
@@ -80,7 +84,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
         /// <param name="monitoringDataPoints"> Data contract between SDK and QuickPulse. /QuickPulseService.svc/post uses this to publish metrics and documents to the backend QuickPulse server. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="ikey"/> is null. </exception>
-        public ResponseWithHeaders<object, QuickPulseSDKClientAPIsPostHeaders> PostCustom(string ikey, string apikey = null, string xMsQpsConfigurationEtag = null, int? xMsQpsTransmissionTime = null, IEnumerable<MonitoringDataPoint> monitoringDataPoints = null, CancellationToken cancellationToken = default)
+        public QuickPulseResponse CustomPost(string ikey, string apikey = null, string xMsQpsConfigurationEtag = null, int? xMsQpsTransmissionTime = null, IEnumerable<MonitoringDataPoint> monitoringDataPoints = null, CancellationToken cancellationToken = default)
         {
             if (ikey == null)
             {
@@ -97,10 +101,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                         CollectionConfigurationInfo value = default;
                         if (message.Response.Headers.ContentLength != 0)
                         {
+                            // TODO: This deserialization was auto generated. I assume this is used for filtering.
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = CollectionConfigurationInfo.DeserializeCollectionConfigurationInfo(document.RootElement);
                         }
-                        return ResponseWithHeaders.FromValue<object, QuickPulseSDKClientAPIsPostHeaders>(value, headers, message.Response);
+                        return new QuickPulseResponse(success: true, message.Response.Headers);
                     }
                 case 400:
                 case 401:
@@ -114,10 +119,12 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                         {
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
                             value = ServiceError.DeserializeServiceError(document.RootElement);
+                            LiveMetricsExporterEventSource.Log.PostFailedWithServiceError(message.Response.Status, value);
                         }
 
                         Debug.WriteLine($"{DateTime.Now}: Post FAILED: {message.Response.Status} {message.Response.ReasonPhrase}.");
-                        return ResponseWithHeaders.FromValue<object, QuickPulseSDKClientAPIsPostHeaders>(value, headers, message.Response);
+                        LiveMetricsExporterEventSource.Log.PostFailed(message.Response);
+                        return new QuickPulseResponse(success: false);
                     }
                 default:
                     throw new RequestFailedException(message.Response);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
 {
@@ -107,5 +108,68 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
 
         [Event(7, Message = "HttpPipelineBuilder is built with AAD Credentials. TokenCredential: {0} Scope: {1}", Level = EventLevel.Informational)]
         public void SetAADCredentialsToPipeline(string credentialTypeName, string scope) => WriteEvent(7, credentialTypeName, scope);
+
+        [NonEvent]
+        public void PingFailed(Response response)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ServiceFailed(name: "Ping", response.Status, response.ReasonPhrase);
+            }
+        }
+
+        [NonEvent]
+        public void PostFailed(Response response)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ServiceFailed(name: "Post", response.Status, response.ReasonPhrase);
+            }
+        }
+
+        [NonEvent]
+        public void PingFailedWithUnknownException(Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ServiceFailedWithUnknownException(name: "Ping", ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
+        public void PostFailedWithUnknownException(Exception ex)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ServiceFailedWithUnknownException(name: "Post", ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
+        public void PingFailedWithServiceError(int statusCode, ServiceError serviceError)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ServiceFailedWithServiceError(name: "Ping", statusCode, serviceError.Code, serviceError.Exception, serviceError.Message);
+            }
+        }
+
+        [NonEvent]
+        public void PostFailedWithServiceError(int statusCode, ServiceError serviceError)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                ServiceFailedWithServiceError(name: "Post", statusCode, serviceError.Code, serviceError.Exception, serviceError.Message);
+            }
+        }
+
+        [Event(8, Message = "Service failed. Name: {0}. Status Code: {1} Reason: {2}.", Level = EventLevel.Error)]
+        public void ServiceFailed(string name, int statusCode, string reasonPhrase) => WriteEvent(8, name, statusCode, reasonPhrase);
+
+        [Event(9, Message = "Service failed with exception. Name: {0}. Exception: {1}", Level = EventLevel.Error)]
+        public void ServiceFailedWithUnknownException(string name, string exceptionMessage) => WriteEvent(9, name, exceptionMessage);
+
+        [Event(10, Message = "Service failed. Name: {0}. Status Code: {1}. Code: {2}. Message: {3}. Exception: {4}.", Level = EventLevel.Error)]
+        public void ServiceFailedWithServiceError(string name, int statusCode, string code, string message, string exception) => WriteEvent(10, name, statusCode, code, message, exception);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
@@ -114,7 +114,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceFailed(name: "Ping", response.Status, response.ReasonPhrase);
+                ServiceCallFailed(name: "Ping", response.Status, response.ReasonPhrase);
             }
         }
 
@@ -123,7 +123,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceFailed(name: "Post", response.Status, response.ReasonPhrase);
+                ServiceCallFailed(name: "Post", response.Status, response.ReasonPhrase);
             }
         }
 
@@ -132,7 +132,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceFailedWithUnknownException(name: "Ping", ex.ToInvariantString());
+                ServiceCallFailedWithUnknownException(name: "Ping", ex.ToInvariantString());
             }
         }
 
@@ -141,7 +141,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceFailedWithUnknownException(name: "Post", ex.ToInvariantString());
+                ServiceCallFailedWithUnknownException(name: "Post", ex.ToInvariantString());
             }
         }
 
@@ -150,7 +150,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceFailedWithServiceError(name: "Ping", statusCode, serviceError.Code, serviceError.Exception, serviceError.Message);
+                ServiceCallFailedWithServiceError(name: "Ping", statusCode, serviceError.Code, serviceError.Exception, serviceError.Message);
             }
         }
 
@@ -159,17 +159,17 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         {
             if (IsEnabled(EventLevel.Error))
             {
-                ServiceFailedWithServiceError(name: "Post", statusCode, serviceError.Code, serviceError.Exception, serviceError.Message);
+                ServiceCallFailedWithServiceError(name: "Post", statusCode, serviceError.Code, serviceError.Exception, serviceError.Message);
             }
         }
 
-        [Event(8, Message = "Service failed. Name: {0}. Status Code: {1} Reason: {2}.", Level = EventLevel.Error)]
-        public void ServiceFailed(string name, int statusCode, string reasonPhrase) => WriteEvent(8, name, statusCode, reasonPhrase);
+        [Event(8, Message = "Service call failed. Name: {0}. Status Code: {1} Reason: {2}.", Level = EventLevel.Error)]
+        public void ServiceCallFailed(string name, int statusCode, string reasonPhrase) => WriteEvent(8, name, statusCode, reasonPhrase);
 
-        [Event(9, Message = "Service failed with exception. Name: {0}. Exception: {1}", Level = EventLevel.Error)]
-        public void ServiceFailedWithUnknownException(string name, string exceptionMessage) => WriteEvent(9, name, exceptionMessage);
+        [Event(9, Message = "Service call failed with exception. Name: {0}. Exception: {1}", Level = EventLevel.Error)]
+        public void ServiceCallFailedWithUnknownException(string name, string exceptionMessage) => WriteEvent(9, name, exceptionMessage);
 
-        [Event(10, Message = "Service failed. Name: {0}. Status Code: {1}. Code: {2}. Message: {3}. Exception: {4}.", Level = EventLevel.Error)]
-        public void ServiceFailedWithServiceError(string name, int statusCode, string code, string message, string exception) => WriteEvent(10, name, statusCode, code, message, exception);
+        [Event(10, Message = "Service call failed. Name: {0}. Status Code: {1}. Code: {2}. Message: {3}. Exception: {4}.", Level = EventLevel.Error)]
+        public void ServiceCallFailedWithServiceError(string name, int statusCode, string code, string message, string exception) => WriteEvent(10, name, statusCode, code, message, exception);
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -45,7 +45,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                 {
                     _lastSuccessfulPing = DateTimeOffset.UtcNow;
 
-                    if (response.ConfigurationEtag!= null && response.ConfigurationEtag != _etag)
+                    if (response.ConfigurationEtag != null && response.ConfigurationEtag != _etag)
                     {
                         Debug.WriteLine($"OnPing: updated etag: {response.ConfigurationEtag}");
                         _etag = response.ConfigurationEtag;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -99,7 +99,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 
                 if (response.Success)
                 {
-                    _lastSuccessfulPing = DateTimeOffset.UtcNow;
+                    _lastSuccessfulPost = DateTimeOffset.UtcNow;
 
                     if (response.ConfigurationEtag != null && response.ConfigurationEtag != _etag)
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
@@ -27,7 +28,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
             {
                 Debug.WriteLine($"{DateTime.Now}: OnPing invoked.");
 
-                var response = _quickPulseSDKClientAPIsRestClient.PingCustom(
+                var response = _quickPulseSDKClientAPIsRestClient.CustomPing(
                     ikey: _connectionVars.InstrumentationKey,
                     apikey: null,
                     xMsQpsTransmissionTime: null,
@@ -40,29 +41,26 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     monitoringDataPoint: null,
                     cancellationToken: default);
 
-                if (IsResponseSuccess(response))
+                if (response.Success)
                 {
                     _lastSuccessfulPing = DateTimeOffset.UtcNow;
 
-                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                    if (response.ConfigurationEtag!= null && response.ConfigurationEtag != _etag)
                     {
-                        Debug.WriteLine($"OnPing: updated etag: {etagValue}");
-                        _etag = etagValue;
+                        Debug.WriteLine($"OnPing: updated etag: {response.ConfigurationEtag}");
+                        _etag = response.ConfigurationEtag;
                     }
 
-                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && Convert.ToBoolean(subscribedValue))
+                    if (response.Subscribed)
                     {
-                        Debug.WriteLine($"OnPing: Subscribed: {subscribedValue}");
+                        Debug.WriteLine($"OnPing: Subscribed: {response.Subscribed}");
                         SetPostState();
                     }
-                }
-                else
-                {
-                    // TODO: NEED TO INSPECT THE ServiceError OBJECT AND LOG.
                 }
             }
             catch (Exception ex)
             {
+                LiveMetricsExporterEventSource.Log.PingFailedWithUnknownException(ex);
                 Debug.WriteLine(ex);
             }
         }
@@ -91,7 +89,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
 
                 var dataPoint = GetDataPoint();
 
-                var response = _quickPulseSDKClientAPIsRestClient.PostCustom(
+                var response = _quickPulseSDKClientAPIsRestClient.CustomPost(
                     ikey: _connectionVars.InstrumentationKey,
                     apikey: null,
                     xMsQpsConfigurationEtag: _etag,
@@ -99,38 +97,29 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     monitoringDataPoints: new MonitoringDataPoint[] { dataPoint }, // TODO: CHECK WITH SERVICE TEAM. WHY DOES THIS NEED TO BE A COLLECITON?
                     cancellationToken: default);
 
-                if (IsResponseSuccess(response))
+                if (response.Success)
                 {
-                    _lastSuccessfulPost = DateTimeOffset.UtcNow;
+                    _lastSuccessfulPing = DateTimeOffset.UtcNow;
 
-                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) && etagValue != _etag)
+                    if (response.ConfigurationEtag != null && response.ConfigurationEtag != _etag)
                     {
-                        Debug.WriteLine($"OnPost: updated etag: {etagValue}");
-                        _etag = etagValue;
+                        Debug.WriteLine($"OnPost: updated etag: {response.ConfigurationEtag}");
+                        _etag = response.ConfigurationEtag;
                     }
 
-                    if (response.GetRawResponse().Headers.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) && !Convert.ToBoolean(subscribedValue))
+                    if (response.Subscribed)
                     {
-                        Debug.WriteLine($"OnPost: Subscribed: {subscribedValue}");
+                        Debug.WriteLine($"OnPost: Subscribed: {response.Subscribed}");
                         _etag = string.Empty;
                         SetPingState();
                     }
                 }
-                else
-                {
-                    // TODO: NEED TO INSPECT THE ServiceError OBJECT AND LOG.
-                }
             }
             catch (Exception ex)
             {
+                LiveMetricsExporterEventSource.Log.PostFailedWithUnknownException(ex);
                 Debug.WriteLine(ex);
             }
-        }
-
-        private bool IsResponseSuccess(Response response)
-        {
-            // TODO: COULD THIS BE MOVED INTO THE REST CLIENT CUSTOMIZATION? ie: avoid checking Status code twice?
-            return response.Status >= 200 && response.Status < 300;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/QuickPulseResponse.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/QuickPulseResponse.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
+{
+    internal readonly struct QuickPulseResponse
+    {
+        public QuickPulseResponse(bool success, ResponseHeaders? responseHeaders = null)
+        {
+            Success = success;
+
+            if (success)
+            {
+                if (responseHeaders?.TryGetValue("x-ms-qps-configuration-etag", out string? etagValue) ?? false)
+                {
+                    ConfigurationEtag = etagValue;
+                }
+
+                if (responseHeaders?.TryGetValue("x-ms-qps-subscribed", out string? subscribedValue) ?? false)
+                {
+                    Subscribed = Convert.ToBoolean(subscribedValue);
+                }
+            }
+        }
+
+        public bool Success { get; }
+        public string? ConfigurationEtag { get; }
+        public bool Subscribed { get; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/QuickPulseResponse.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/QuickPulseResponse.cs
@@ -29,5 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
         public bool Success { get; }
         public string? ConfigurationEtag { get; }
         public bool Subscribed { get; }
+
+        // TODO: Filtering parameters can be added here.
     }
 }


### PR DESCRIPTION
Refactoring the POC. Previously the service response would be evaluated twice. The autogenerated client would inspect for pass/fail and then return either a config or error object (boxed as `object`). Then our implementation would inspect the response the second time to adjust behavior (ping/post). Lastly, our implementation would have to unbox the response to get information for logging. 

This new implementation customizes the autogenerated client to do its own logging (no need to return extra information). Secondly this returns a single object for both pass/fail scenarios. 


## Changes
- Change the customized RestClient
  - return a single object `readonly struct QuickPulseResponse` instead of boxing two possible objects.
    - previous implementation was returning a new `class ResponseWithHeaders` for every ping/post.
  - RestClient will now do it's own logging. This removes need to return extra information.