### PR TITLE
ClientModel Prototype: Make classifier composable

### DIFF
--- a/sdk/core/Azure.Core/src/ResponseClassifier.cs
+++ b/sdk/core/Azure.Core/src/ResponseClassifier.cs
@@ -57,6 +57,9 @@ namespace Azure.Core
         /// Specifies if the response contained in the <paramref name="message"/> is not successful.
         /// </summary>
         public virtual bool IsErrorResponse(HttpMessage message)
-            => base.IsErrorResponse(message);
+        {
+            TryClassifyResponse(message, out bool isError);
+            return isError;
+        }
     }
 }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -160,7 +160,7 @@ namespace System.ClientModel.Primitives
     {
         protected internal PipelineMessageClassifier() { }
         public static System.ClientModel.Primitives.PipelineMessageClassifier Create(System.ReadOnlySpan<ushort> successStatusCodes) { throw null; }
-        public virtual bool IsErrorResponse(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+        public virtual bool TryClassifyResponse(System.ClientModel.Primitives.PipelineMessage message, out bool isError) { throw null; }
     }
     public partial class PipelineMessageDelay
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -159,7 +159,7 @@ namespace System.ClientModel.Primitives
     {
         protected internal PipelineMessageClassifier() { }
         public static System.ClientModel.Primitives.PipelineMessageClassifier Create(System.ReadOnlySpan<ushort> successStatusCodes) { throw null; }
-        public virtual bool IsErrorResponse(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+        public virtual bool TryClassifyResponse(System.ClientModel.Primitives.PipelineMessage message, out bool isError) { throw null; }
     }
     public partial class PipelineMessageDelay
     {

--- a/sdk/core/System.ClientModel/src/Options/ResponseStatusClassifier.cs
+++ b/sdk/core/System.ClientModel/src/Options/ResponseStatusClassifier.cs
@@ -24,14 +24,17 @@ namespace System.ClientModel.Primitives
             }
         }
 
-        public sealed override bool IsErrorResponse(PipelineMessage message)
+        public override bool TryClassifyResponse(PipelineMessage message, out bool isError)
         {
             if (message.Response is null)
             {
                 throw new InvalidOperationException("Response is not set on message.");
             }
 
-            return !_successCodes[message.Response.Status];
+            isError = !_successCodes[message.Response.Status];
+
+            // Always terminate any classifier-chain.
+            return true;
         }
 
         private void AddClassifier(int statusCode, bool isError)

--- a/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
@@ -41,9 +41,13 @@ public abstract class PipelineTransport : PipelinePolicy
         message.Response.SetIsError(ClassifyResponse(message));
     }
 
-    private static bool ClassifyResponse(PipelineMessage message) =>
-        message.MessageClassifier?.IsErrorResponse(message) ??
-        PipelineMessageClassifier.Default.IsErrorResponse(message);
+    private static bool ClassifyResponse(PipelineMessage message)
+    {
+        Debug.Assert(message.MessageClassifier is not null);
+
+        message.MessageClassifier!.TryClassifyResponse(message, out bool isError);
+        return isError;
+    }
 
     protected abstract void ProcessCore(PipelineMessage message);
 

--- a/sdk/core/System.ClientModel/tests/Options/PipelineMessageClassifierTests.cs
+++ b/sdk/core/System.ClientModel/tests/Options/PipelineMessageClassifierTests.cs
@@ -23,7 +23,9 @@ public class PipelineMessageClassifierTests
                 MockPipelineMessage message = new MockPipelineMessage();
                 message.SetResponse(new MockPipelineResponse(code));
 
-                bool isNonError = !classifier.IsErrorResponse(message);
+                classifier.TryClassifyResponse(message, out bool isError);
+
+                bool isNonError = !isError;
 
                 if (nonError == code)
                 {
@@ -50,6 +52,7 @@ public class PipelineMessageClassifierTests
         MockPipelineMessage message = new MockPipelineMessage();
         message.SetResponse(new MockPipelineResponse(code));
 
-        Assert.AreEqual(isError, classifier.IsErrorResponse(message));
+        classifier.TryClassifyResponse(message, out bool error);
+        Assert.AreEqual(isError, error);
     }
 }

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockMessageClassifier.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockMessageClassifier.cs
@@ -29,21 +29,21 @@ public class MockMessageClassifier : PipelineMessageClassifier
 
     public string Id { get; set; }
 
-    public override bool IsErrorResponse(PipelineMessage message)
+    public override bool TryClassifyResponse(PipelineMessage message, out bool isError)
     {
+        isError = false;
+
         if (_successCodes is not null)
         {
             foreach (var code in _successCodes)
             {
                 if (message.Response!.Status == code)
                 {
-                    return true;
+                    isError = true;
                 }
             }
-
-            return false;
         }
 
-        return base.IsErrorResponse(message);
+        return true;
     }
 }


### PR DESCRIPTION
First try at reworking the PipelineMessageClassifier API to make it possible to compose the message with other classifiers.