### PR TITLE
Diagnostic Scope: AddTag function should be NoOp for Sampled out activity

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -195,16 +195,19 @@ namespace Azure.Core.Pipeline
 
             public void AddTag(string name, object value)
             {
-                if (_currentActivity == null)
+                if (_sampleOutActivity == null)
                 {
-                    // Activity is not started yet, add the value to the collection
-                    // that is going to be passed to StartActivity
-                    _tagCollection ??= new ActivityTagsCollection();
-                    _tagCollection[name] = value!;
-                }
-                else
-                {
-                    AddObjectTag(name, value);
+                    if (_currentActivity == null)
+                    {
+                        // Activity is not started yet, add the value to the collection
+                        // that is going to be passed to StartActivity
+                        _tagCollection ??= new ActivityTagsCollection();
+                        _tagCollection[name] = value!;
+                    }
+                    else
+                    {
+                        AddObjectTag(name, value);
+                    }
                 }
             }
 
@@ -429,6 +432,9 @@ namespace Azure.Core.Pipeline
                 _diagnosticSource.Write(_activityName + ".Stop", _diagnosticSourceArgs);
 
                 activity.Dispose();
+
+                _currentActivity = null;
+                _sampleOutActivity = null;
             }
         }
     }


### PR DESCRIPTION
As part of this PR, making sure `AddTag` should add information in the activity, only if it is not sample out activity otherwise it should be `NoOp`.