### PR TITLE
[LiveMetricsrExporter] fix for ambiguous reference

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/DocumentIngress.Serialization.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/DocumentIngress.Serialization.cs
@@ -15,11 +15,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Optional.IsDefined(DocumentType))
-            {
-                writer.WritePropertyName("DocumentType"u8);
-                writer.WriteStringValue(DocumentType.Value.ToString());
-            }
+            writer.WritePropertyName("DocumentType"u8);
+            writer.WriteStringValue(DocumentType.ToString());
             if (Optional.IsCollectionDefined(DocumentStreamIds))
             {
                 writer.WritePropertyName("DocumentStreamIds"u8);
@@ -39,11 +36,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                     writer.WriteObjectValue(item);
                 }
                 writer.WriteEndArray();
-            }
-            if (Optional.IsDefined(AdditionalProperties))
-            {
-                writer.WritePropertyName("additionalProperties"u8);
-                writer.WriteStringValue(AdditionalProperties);
             }
             writer.WriteEndObject();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/DocumentIngress.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/DocumentIngress.cs
@@ -10,11 +10,15 @@ using Azure.Core;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
-    /// <summary> Base class of the specific document types. </summary>
-    internal partial class DocumentIngress
+    /// <summary>
+    /// Base class of the specific document types.
+    /// Please note <see cref="DocumentIngress"/> is the base class. According to the scenario, a derived class of the base class might need to be assigned here, or this property needs to be casted to one of the possible derived classes.
+    /// The available derived classes include <see cref="Event"/>, <see cref="Exception"/>, <see cref="RemoteDependency"/>, <see cref="Request"/> and <see cref="Trace"/>.
+    /// </summary>
+    internal abstract partial class DocumentIngress
     {
         /// <summary> Initializes a new instance of <see cref="DocumentIngress"/>. </summary>
-        public DocumentIngress()
+        protected DocumentIngress()
         {
             DocumentStreamIds = new ChangeTrackingList<string>();
             Properties = new ChangeTrackingList<KeyValuePairString>();
@@ -24,22 +28,18 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
         /// <param name="documentType"> Telemetry type. Types not defined in enum will get replaced with a 'Unknown' type. </param>
         /// <param name="documentStreamIds"> An array of document streaming ids. Each id identifies a flow of documents customized by UX customers. </param>
         /// <param name="properties"> Collection of custom properties. </param>
-        /// <param name="additionalProperties"> Additional properties to be provided by a child type of DocumentIngress. </param>
-        internal DocumentIngress(DocumentIngressDocumentType? documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string additionalProperties)
+        internal DocumentIngress(DocumentIngressDocumentType documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties)
         {
             DocumentType = documentType;
             DocumentStreamIds = documentStreamIds;
             Properties = properties;
-            AdditionalProperties = additionalProperties;
         }
 
         /// <summary> Telemetry type. Types not defined in enum will get replaced with a 'Unknown' type. </summary>
-        public DocumentIngressDocumentType? DocumentType { get; set; }
+        internal DocumentIngressDocumentType DocumentType { get; set; }
         /// <summary> An array of document streaming ids. Each id identifies a flow of documents customized by UX customers. </summary>
         public IList<string> DocumentStreamIds { get; }
         /// <summary> Collection of custom properties. </summary>
         public IList<KeyValuePairString> Properties { get; }
-        /// <summary> Additional properties to be provided by a child type of DocumentIngress. </summary>
-        public string AdditionalProperties { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Event.Serialization.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Event.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
-    internal partial class RequestDocumentIngress : IUtf8JsonSerializable
+    internal partial class Event : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
@@ -20,26 +20,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                 writer.WritePropertyName("Name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (Optional.IsDefined(Url))
-            {
-                writer.WritePropertyName("Url"u8);
-                writer.WriteStringValue(Url);
-            }
-            if (Optional.IsDefined(ResponseCode))
-            {
-                writer.WritePropertyName("ResponseCode"u8);
-                writer.WriteStringValue(ResponseCode);
-            }
-            if (Optional.IsDefined(Duration))
-            {
-                writer.WritePropertyName("Duration"u8);
-                writer.WriteStringValue(Duration);
-            }
-            if (Optional.IsDefined(DocumentType))
-            {
-                writer.WritePropertyName("DocumentType"u8);
-                writer.WriteStringValue(DocumentType.Value.ToString());
-            }
+            writer.WritePropertyName("DocumentType"u8);
+            writer.WriteStringValue(DocumentType.ToString());
             if (Optional.IsCollectionDefined(DocumentStreamIds))
             {
                 writer.WritePropertyName("DocumentStreamIds"u8);
@@ -59,11 +41,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                     writer.WriteObjectValue(item);
                 }
                 writer.WriteEndArray();
-            }
-            if (Optional.IsDefined(AdditionalProperties))
-            {
-                writer.WritePropertyName("additionalProperties"u8);
-                writer.WriteStringValue(AdditionalProperties);
             }
             writer.WriteEndObject();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Event.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Event.cs
@@ -10,22 +10,23 @@ using System.Collections.Generic;
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
     /// <summary> Event type document. </summary>
-    internal partial class EventDocumentIngress : DocumentIngress
+    internal partial class Event : DocumentIngress
     {
-        /// <summary> Initializes a new instance of <see cref="EventDocumentIngress"/>. </summary>
-        public EventDocumentIngress()
+        /// <summary> Initializes a new instance of <see cref="Event"/>. </summary>
+        public Event()
         {
+            DocumentType = DocumentIngressDocumentType.Event;
         }
 
-        /// <summary> Initializes a new instance of <see cref="EventDocumentIngress"/>. </summary>
+        /// <summary> Initializes a new instance of <see cref="Event"/>. </summary>
         /// <param name="documentType"> Telemetry type. Types not defined in enum will get replaced with a 'Unknown' type. </param>
         /// <param name="documentStreamIds"> An array of document streaming ids. Each id identifies a flow of documents customized by UX customers. </param>
         /// <param name="properties"> Collection of custom properties. </param>
-        /// <param name="additionalProperties"> Additional properties to be provided by a child type of DocumentIngress. </param>
         /// <param name="name"> Event name. </param>
-        internal EventDocumentIngress(DocumentIngressDocumentType? documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string additionalProperties, string name) : base(documentType, documentStreamIds, properties, additionalProperties)
+        internal Event(DocumentIngressDocumentType documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string name) : base(documentType, documentStreamIds, properties)
         {
             Name = name;
+            DocumentType = documentType;
         }
 
         /// <summary> Event name. </summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Exception.Serialization.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Exception.Serialization.cs
@@ -10,36 +10,23 @@ using Azure.Core;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
-    internal partial class RemoteDependencyDocumentIngress : IUtf8JsonSerializable
+    internal partial class Exception : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Optional.IsDefined(Name))
+            if (Optional.IsDefined(ExceptionType))
             {
-                writer.WritePropertyName("Name"u8);
-                writer.WriteStringValue(Name);
+                writer.WritePropertyName("ExceptionType"u8);
+                writer.WriteStringValue(ExceptionType);
             }
-            if (Optional.IsDefined(CommandName))
+            if (Optional.IsDefined(ExceptionMessage))
             {
-                writer.WritePropertyName("CommandName"u8);
-                writer.WriteStringValue(CommandName);
+                writer.WritePropertyName("ExceptionMessage"u8);
+                writer.WriteStringValue(ExceptionMessage);
             }
-            if (Optional.IsDefined(ResultCode))
-            {
-                writer.WritePropertyName("ResultCode"u8);
-                writer.WriteStringValue(ResultCode);
-            }
-            if (Optional.IsDefined(Duration))
-            {
-                writer.WritePropertyName("Duration"u8);
-                writer.WriteStringValue(Duration);
-            }
-            if (Optional.IsDefined(DocumentType))
-            {
-                writer.WritePropertyName("DocumentType"u8);
-                writer.WriteStringValue(DocumentType.Value.ToString());
-            }
+            writer.WritePropertyName("DocumentType"u8);
+            writer.WriteStringValue(DocumentType.ToString());
             if (Optional.IsCollectionDefined(DocumentStreamIds))
             {
                 writer.WritePropertyName("DocumentStreamIds"u8);
@@ -59,11 +46,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                     writer.WriteObjectValue(item);
                 }
                 writer.WriteEndArray();
-            }
-            if (Optional.IsDefined(AdditionalProperties))
-            {
-                writer.WritePropertyName("additionalProperties"u8);
-                writer.WriteStringValue(AdditionalProperties);
             }
             writer.WriteEndObject();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Exception.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Exception.cs
@@ -10,24 +10,25 @@ using System.Collections.Generic;
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
     /// <summary> Exception type document. </summary>
-    internal partial class ExceptionDocumentIngress : DocumentIngress
+    internal partial class Exception : DocumentIngress
     {
-        /// <summary> Initializes a new instance of <see cref="ExceptionDocumentIngress"/>. </summary>
-        public ExceptionDocumentIngress()
+        /// <summary> Initializes a new instance of <see cref="Exception"/>. </summary>
+        public Exception()
         {
+            DocumentType = DocumentIngressDocumentType.Exception;
         }
 
-        /// <summary> Initializes a new instance of <see cref="ExceptionDocumentIngress"/>. </summary>
+        /// <summary> Initializes a new instance of <see cref="Exception"/>. </summary>
         /// <param name="documentType"> Telemetry type. Types not defined in enum will get replaced with a 'Unknown' type. </param>
         /// <param name="documentStreamIds"> An array of document streaming ids. Each id identifies a flow of documents customized by UX customers. </param>
         /// <param name="properties"> Collection of custom properties. </param>
-        /// <param name="additionalProperties"> Additional properties to be provided by a child type of DocumentIngress. </param>
         /// <param name="exceptionType"> Exception type name. </param>
         /// <param name="exceptionMessage"> Exception message. </param>
-        internal ExceptionDocumentIngress(DocumentIngressDocumentType? documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string additionalProperties, string exceptionType, string exceptionMessage) : base(documentType, documentStreamIds, properties, additionalProperties)
+        internal Exception(DocumentIngressDocumentType documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string exceptionType, string exceptionMessage) : base(documentType, documentStreamIds, properties)
         {
             ExceptionType = exceptionType;
             ExceptionMessage = exceptionMessage;
+            DocumentType = documentType;
         }
 
         /// <summary> Exception type name. </summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/MonitoringDataPoint.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/MonitoringDataPoint.cs
@@ -35,7 +35,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
         /// <param name="isWebApp"> True if the current application is an Azure Web App. </param>
         /// <param name="performanceCollectionSupported"> True if performance counters collection is supported. </param>
         /// <param name="metrics"> An array of meric data points. </param>
-        /// <param name="documents"> An array of documents of a specific type {RequestDocumentIngress}, {RemoteDependencyDocumentIngress}, {ExceptionDocumentIngress}, {EventDocumentIngress}, or {TraceDocumentIngress}. </param>
+        /// <param name="documents">
+        /// An array of documents of a specific type {Request}, {RemoteDependency}, {Exception}, {Event}, or {Trace}
+        /// Please note <see cref="DocumentIngress"/> is the base class. According to the scenario, a derived class of the base class might need to be assigned here, or this property needs to be casted to one of the possible derived classes.
+        /// The available derived classes include <see cref="Event"/>, <see cref="Exception"/>, <see cref="RemoteDependency"/>, <see cref="Request"/> and <see cref="Trace"/>.
+        /// </param>
         /// <param name="topCpuProcesses"> An array of top cpu consumption data point. </param>
         /// <param name="collectionConfigurationErrors"> An array of error while parsing and applying . </param>
         internal MonitoringDataPoint(string version, int? invariantVersion, string instance, string roleName, string machineName, string streamId, DateTimeOffset? timestamp, DateTimeOffset? transmissionTime, bool? isWebApp, bool? performanceCollectionSupported, IList<MetricPoint> metrics, IList<DocumentIngress> documents, IList<ProcessCpuData> topCpuProcesses, IList<CollectionConfigurationError> collectionConfigurationErrors)
@@ -78,7 +82,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
         public bool? PerformanceCollectionSupported { get; set; }
         /// <summary> An array of meric data points. </summary>
         public IList<MetricPoint> Metrics { get; }
-        /// <summary> An array of documents of a specific type {RequestDocumentIngress}, {RemoteDependencyDocumentIngress}, {ExceptionDocumentIngress}, {EventDocumentIngress}, or {TraceDocumentIngress}. </summary>
+        /// <summary>
+        /// An array of documents of a specific type {Request}, {RemoteDependency}, {Exception}, {Event}, or {Trace}
+        /// Please note <see cref="DocumentIngress"/> is the base class. According to the scenario, a derived class of the base class might need to be assigned here, or this property needs to be casted to one of the possible derived classes.
+        /// The available derived classes include <see cref="Event"/>, <see cref="Exception"/>, <see cref="RemoteDependency"/>, <see cref="Request"/> and <see cref="Trace"/>.
+        /// </summary>
         public IList<DocumentIngress> Documents { get; }
         /// <summary> An array of top cpu consumption data point. </summary>
         public IList<ProcessCpuData> TopCpuProcesses { get; }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/RemoteDependency.Serialization.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/RemoteDependency.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
-    internal partial class EventDocumentIngress : IUtf8JsonSerializable
+    internal partial class RemoteDependency : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
@@ -20,11 +20,23 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                 writer.WritePropertyName("Name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (Optional.IsDefined(DocumentType))
+            if (Optional.IsDefined(CommandName))
             {
-                writer.WritePropertyName("DocumentType"u8);
-                writer.WriteStringValue(DocumentType.Value.ToString());
+                writer.WritePropertyName("CommandName"u8);
+                writer.WriteStringValue(CommandName);
             }
+            if (Optional.IsDefined(ResultCode))
+            {
+                writer.WritePropertyName("ResultCode"u8);
+                writer.WriteStringValue(ResultCode);
+            }
+            if (Optional.IsDefined(Duration))
+            {
+                writer.WritePropertyName("Duration"u8);
+                writer.WriteStringValue(Duration);
+            }
+            writer.WritePropertyName("DocumentType"u8);
+            writer.WriteStringValue(DocumentType.ToString());
             if (Optional.IsCollectionDefined(DocumentStreamIds))
             {
                 writer.WritePropertyName("DocumentStreamIds"u8);
@@ -44,11 +56,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                     writer.WriteObjectValue(item);
                 }
                 writer.WriteEndArray();
-            }
-            if (Optional.IsDefined(AdditionalProperties))
-            {
-                writer.WritePropertyName("additionalProperties"u8);
-                writer.WriteStringValue(AdditionalProperties);
             }
             writer.WriteEndObject();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/RemoteDependency.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/RemoteDependency.cs
@@ -10,28 +10,29 @@ using System.Collections.Generic;
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
     /// <summary> Dependency type document. </summary>
-    internal partial class RemoteDependencyDocumentIngress : DocumentIngress
+    internal partial class RemoteDependency : DocumentIngress
     {
-        /// <summary> Initializes a new instance of <see cref="RemoteDependencyDocumentIngress"/>. </summary>
-        public RemoteDependencyDocumentIngress()
+        /// <summary> Initializes a new instance of <see cref="RemoteDependency"/>. </summary>
+        public RemoteDependency()
         {
+            DocumentType = DocumentIngressDocumentType.RemoteDependency;
         }
 
-        /// <summary> Initializes a new instance of <see cref="RemoteDependencyDocumentIngress"/>. </summary>
+        /// <summary> Initializes a new instance of <see cref="RemoteDependency"/>. </summary>
         /// <param name="documentType"> Telemetry type. Types not defined in enum will get replaced with a 'Unknown' type. </param>
         /// <param name="documentStreamIds"> An array of document streaming ids. Each id identifies a flow of documents customized by UX customers. </param>
         /// <param name="properties"> Collection of custom properties. </param>
-        /// <param name="additionalProperties"> Additional properties to be provided by a child type of DocumentIngress. </param>
         /// <param name="name"> Name of the command initiated with this dependency call, e.g., GET /username. </param>
         /// <param name="commandName"> URL of the dependency call to the target, with all query string parameters. </param>
         /// <param name="resultCode"> Result code of a dependency call. Examples are SQL error code and HTTP status code. </param>
         /// <param name="duration"> Request duration in ISO 8601 duration format, i.e., P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W. </param>
-        internal RemoteDependencyDocumentIngress(DocumentIngressDocumentType? documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string additionalProperties, string name, string commandName, string resultCode, string duration) : base(documentType, documentStreamIds, properties, additionalProperties)
+        internal RemoteDependency(DocumentIngressDocumentType documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string name, string commandName, string resultCode, string duration) : base(documentType, documentStreamIds, properties)
         {
             Name = name;
             CommandName = commandName;
             ResultCode = resultCode;
             Duration = duration;
+            DocumentType = documentType;
         }
 
         /// <summary> Name of the command initiated with this dependency call, e.g., GET /username. </summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Request.Serialization.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Request.Serialization.cs
@@ -10,26 +10,33 @@ using Azure.Core;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
-    internal partial class ExceptionDocumentIngress : IUtf8JsonSerializable
+    internal partial class Request : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Optional.IsDefined(ExceptionType))
+            if (Optional.IsDefined(Name))
             {
-                writer.WritePropertyName("ExceptionType"u8);
-                writer.WriteStringValue(ExceptionType);
+                writer.WritePropertyName("Name"u8);
+                writer.WriteStringValue(Name);
             }
-            if (Optional.IsDefined(ExceptionMessage))
+            if (Optional.IsDefined(Url))
             {
-                writer.WritePropertyName("ExceptionMessage"u8);
-                writer.WriteStringValue(ExceptionMessage);
+                writer.WritePropertyName("Url"u8);
+                writer.WriteStringValue(Url);
             }
-            if (Optional.IsDefined(DocumentType))
+            if (Optional.IsDefined(ResponseCode))
             {
-                writer.WritePropertyName("DocumentType"u8);
-                writer.WriteStringValue(DocumentType.Value.ToString());
+                writer.WritePropertyName("ResponseCode"u8);
+                writer.WriteStringValue(ResponseCode);
             }
+            if (Optional.IsDefined(Duration))
+            {
+                writer.WritePropertyName("Duration"u8);
+                writer.WriteStringValue(Duration);
+            }
+            writer.WritePropertyName("DocumentType"u8);
+            writer.WriteStringValue(DocumentType.ToString());
             if (Optional.IsCollectionDefined(DocumentStreamIds))
             {
                 writer.WritePropertyName("DocumentStreamIds"u8);
@@ -49,11 +56,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                     writer.WriteObjectValue(item);
                 }
                 writer.WriteEndArray();
-            }
-            if (Optional.IsDefined(AdditionalProperties))
-            {
-                writer.WritePropertyName("additionalProperties"u8);
-                writer.WriteStringValue(AdditionalProperties);
             }
             writer.WriteEndObject();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Request.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Request.cs
@@ -10,28 +10,29 @@ using System.Collections.Generic;
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
     /// <summary> Request type document. </summary>
-    internal partial class RequestDocumentIngress : DocumentIngress
+    internal partial class Request : DocumentIngress
     {
-        /// <summary> Initializes a new instance of <see cref="RequestDocumentIngress"/>. </summary>
-        public RequestDocumentIngress()
+        /// <summary> Initializes a new instance of <see cref="Request"/>. </summary>
+        public Request()
         {
+            DocumentType = DocumentIngressDocumentType.Request;
         }
 
-        /// <summary> Initializes a new instance of <see cref="RequestDocumentIngress"/>. </summary>
+        /// <summary> Initializes a new instance of <see cref="Request"/>. </summary>
         /// <param name="documentType"> Telemetry type. Types not defined in enum will get replaced with a 'Unknown' type. </param>
         /// <param name="documentStreamIds"> An array of document streaming ids. Each id identifies a flow of documents customized by UX customers. </param>
         /// <param name="properties"> Collection of custom properties. </param>
-        /// <param name="additionalProperties"> Additional properties to be provided by a child type of DocumentIngress. </param>
         /// <param name="name"> Name of the request, e.g., 'GET /values/{id}'. </param>
         /// <param name="url"> Request URL with all query string parameters. </param>
         /// <param name="responseCode"> Result of a request execution. For http requestss, it could be some HTTP status code. </param>
         /// <param name="duration"> Request duration in ISO 8601 duration format, i.e., P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W. </param>
-        internal RequestDocumentIngress(DocumentIngressDocumentType? documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string additionalProperties, string name, string url, string responseCode, string duration) : base(documentType, documentStreamIds, properties, additionalProperties)
+        internal Request(DocumentIngressDocumentType documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string name, string url, string responseCode, string duration) : base(documentType, documentStreamIds, properties)
         {
             Name = name;
             Url = url;
             ResponseCode = responseCode;
             Duration = duration;
+            DocumentType = documentType;
         }
 
         /// <summary> Name of the request, e.g., 'GET /values/{id}'. </summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Trace.Serialization.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Trace.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
-    internal partial class TraceDocumentIngress : IUtf8JsonSerializable
+    internal partial class Trace : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
@@ -20,11 +20,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                 writer.WritePropertyName("Message"u8);
                 writer.WriteStringValue(Message);
             }
-            if (Optional.IsDefined(DocumentType))
-            {
-                writer.WritePropertyName("DocumentType"u8);
-                writer.WriteStringValue(DocumentType.Value.ToString());
-            }
+            writer.WritePropertyName("DocumentType"u8);
+            writer.WriteStringValue(DocumentType.ToString());
             if (Optional.IsCollectionDefined(DocumentStreamIds))
             {
                 writer.WritePropertyName("DocumentStreamIds"u8);
@@ -44,11 +41,6 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
                     writer.WriteObjectValue(item);
                 }
                 writer.WriteEndArray();
-            }
-            if (Optional.IsDefined(AdditionalProperties))
-            {
-                writer.WritePropertyName("additionalProperties"u8);
-                writer.WriteStringValue(AdditionalProperties);
             }
             writer.WriteEndObject();
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Trace.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Generated/Models/Trace.cs
@@ -10,22 +10,23 @@ using System.Collections.Generic;
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Models
 {
     /// <summary> Trace type name. </summary>
-    internal partial class TraceDocumentIngress : DocumentIngress
+    internal partial class Trace : DocumentIngress
     {
-        /// <summary> Initializes a new instance of <see cref="TraceDocumentIngress"/>. </summary>
-        public TraceDocumentIngress()
+        /// <summary> Initializes a new instance of <see cref="Trace"/>. </summary>
+        public Trace()
         {
+            DocumentType = DocumentIngressDocumentType.Trace;
         }
 
-        /// <summary> Initializes a new instance of <see cref="TraceDocumentIngress"/>. </summary>
+        /// <summary> Initializes a new instance of <see cref="Trace"/>. </summary>
         /// <param name="documentType"> Telemetry type. Types not defined in enum will get replaced with a 'Unknown' type. </param>
         /// <param name="documentStreamIds"> An array of document streaming ids. Each id identifies a flow of documents customized by UX customers. </param>
         /// <param name="properties"> Collection of custom properties. </param>
-        /// <param name="additionalProperties"> Additional properties to be provided by a child type of DocumentIngress. </param>
         /// <param name="message"> Trace message. </param>
-        internal TraceDocumentIngress(DocumentIngressDocumentType? documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string additionalProperties, string message) : base(documentType, documentStreamIds, properties, additionalProperties)
+        internal Trace(DocumentIngressDocumentType documentType, IList<string> documentStreamIds, IList<KeyValuePairString> properties, string message) : base(documentType, documentStreamIds, properties)
         {
             Message = message;
+            DocumentType = documentType;
         }
 
         /// <summary> Trace message. </summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
@@ -68,7 +68,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         public void FailedToReadEnvironmentVariables(string errorMessage) => WriteEvent(2, errorMessage);
 
         [NonEvent]
-        public void AccessingEnvironmentVariableFailedWarning(string environmentVariable, Exception ex)
+        public void AccessingEnvironmentVariableFailedWarning(string environmentVariable, System.Exception ex)
         {
             if (IsEnabled(EventLevel.Warning))
             {
@@ -95,7 +95,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         public void VersionStringUnexpectedLength(string typeName, string value) => WriteEvent(5, typeName, value);
 
         [NonEvent]
-        public void ErrorInitializingPartOfSdkVersion(string typeName, Exception ex)
+        public void ErrorInitializingPartOfSdkVersion(string typeName, System.Exception ex)
         {
             if (IsEnabled(EventLevel.Warning))
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Diagnostics/LiveMetricsExporterEventSource.cs
@@ -44,7 +44,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         private bool IsEnabled(EventLevel eventLevel) => IsEnabled(eventLevel, EventKeywords.All);
 
         [NonEvent]
-        public void FailedToParseConnectionString(Exception ex)
+        public void FailedToParseConnectionString(System.Exception ex)
         {
             if (IsEnabled(EventLevel.Error))
             {
@@ -56,7 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         public void FailedToParseConnectionString(string exceptionMessage) => WriteEvent(1, exceptionMessage);
 
         [NonEvent]
-        public void FailedToReadEnvironmentVariables(Exception ex)
+        public void FailedToReadEnvironmentVariables(System.Exception ex)
         {
             if (IsEnabled(EventLevel.Warning))
             {
@@ -80,7 +80,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         public void AccessingEnvironmentVariableFailedWarning(string environmentVariable, string exceptionMessage) => WriteEvent(3, environmentVariable, exceptionMessage);
 
         [NonEvent]
-        public void SdkVersionCreateFailed(Exception ex)
+        public void SdkVersionCreateFailed(System.Exception ex)
         {
             if (IsEnabled(EventLevel.Warning))
             {
@@ -128,7 +128,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         }
 
         [NonEvent]
-        public void PingFailedWithUnknownException(Exception ex)
+        public void PingFailedWithUnknownException(System.Exception ex)
         {
             if (IsEnabled(EventLevel.Error))
             {
@@ -137,7 +137,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Diagnostics
         }
 
         [NonEvent]
-        public void PostFailedWithUnknownException(Exception ex)
+        public void PostFailedWithUnknownException(System.Exception ex)
         {
             if (IsEnabled(EventLevel.Error))
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.Metrics.cs
@@ -141,7 +141,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     s_isAzureWebApp = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSiteEnvironmentVariable)) &&
                                     Environment.GetEnvironmentVariable(WebSiteIsolationEnvironmentVariable) != WebSiteIsolationHyperV;
                 }
-                catch (Exception ex)
+                catch (System.Exception ex)
                 {
                     LiveMetricsExporterEventSource.Log.AccessingEnvironmentVariableFailedWarning(WebSiteEnvironmentVariable, ex);
                     return false;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Manager.RestClient.cs
@@ -58,7 +58,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     }
                 }
             }
-            catch (Exception ex)
+            catch (System.Exception ex)
             {
                 LiveMetricsExporterEventSource.Log.PingFailedWithUnknownException(ex);
                 Debug.WriteLine(ex);
@@ -115,7 +115,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                     }
                 }
             }
-            catch (Exception ex)
+            catch (System.Exception ex)
             {
                 LiveMetricsExporterEventSource.Log.PostFailedWithUnknownException(ex);
                 Debug.WriteLine(ex);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/LiveMetricsExtractionProcessor.cs
@@ -10,6 +10,8 @@ using Azure.Monitor.OpenTelemetry.LiveMetrics.Internals;
 using Azure.Monitor.OpenTelemetry.LiveMetrics.Models;
 using OpenTelemetry;
 
+using ExceptionDocument = Azure.Monitor.OpenTelemetry.LiveMetrics.Models.Exception;
+
 namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 {
     internal sealed class LiveMetricsExtractionProcessor : BaseProcessor<Activity>
@@ -95,7 +97,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
                     try
                     {
                     }
-                    catch (Exception)
+                    catch (System.Exception)
                     {
                     }
                 }
@@ -108,7 +110,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 
         private void AddExceptionDocument(string? exceptionType, string? exceptionMessage)
         {
-            ExceptionDocumentIngress exceptionDocumentIngress = new()
+            ExceptionDocument exceptionDocumentIngress = new()
             {
                 ExceptionType = exceptionType,
                 ExceptionMessage = exceptionMessage,
@@ -122,7 +124,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 
         private void AddRemoteDependencyDocument(Activity activity, string? statusCodeAttributeValue)
         {
-            RemoteDependencyDocumentIngress remoteDependencyDocumentIngress = new()
+            RemoteDependency remoteDependencyDocumentIngress = new()
             {
                 Name = activity.DisplayName,
                 // TODO: Implementation needs to be copied from Exporter.
@@ -146,7 +148,7 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics
 
         private void AddRequestDocument(Activity activity, string? statusCodeAttributeValue)
         {
-            RequestDocumentIngress requestDocumentIngress = new()
+            Request requestDocumentIngress = new()
             {
                 Name = activity.DisplayName,
                 // TODO: Implementation needs to be copied from Exporter.


### PR DESCRIPTION
The swagger was updated. This is a fix for ambiguous reference between `System.Exception` and `Azure.Monitor.OpenTelemetry.LiveMetrics.Models.Exception`.

## Changes
- updated Generated classes.
- use fully qualified class names where necessary