### PR TITLE
Mark Azure.ResourceManager.Redis for release

### DIFF
--- a/sdk/redis/Azure.ResourceManager.Redis/CHANGELOG.md
+++ b/sdk/redis/Azure.ResourceManager.Redis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0 (2024-01-19)
+## 1.3.0 (2024-01-23)
 
 ### Other Changes
 

--- a/sdk/redis/Azure.ResourceManager.Redis/CHANGELOG.md
+++ b/sdk/redis/Azure.ResourceManager.Redis/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.3.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.0 (2024-01-19)
 
 ### Other Changes
+
+- Mark prerelease Azure.ResourceManager.Redis 1.3.0-beta.1 for release
 
 ## 1.3.0-beta.1 (2023-12-15)
 

--- a/sdk/redis/Azure.ResourceManager.Redis/src/Azure.ResourceManager.Redis.csproj
+++ b/sdk/redis/Azure.ResourceManager.Redis/src/Azure.ResourceManager.Redis.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta.2</Version>
+    <Version>1.3.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Redis</PackageId>


### PR DESCRIPTION
# Contributing to the Azure SDK

Marks prerelease Azure.ResourceManager.Redis 1.3.0-beta.1 for release by changing version

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
