### PR TITLE
ClientModel: Shared HttpClient in PipelineTransport, and a couple more updates

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -111,6 +111,7 @@ namespace System.ClientModel.Primitives
         public HttpClientPipelineTransport(System.Net.Http.HttpClient client) { }
         protected override System.ClientModel.Primitives.PipelineMessage CreateMessageCore() { throw null; }
         public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
         protected virtual void OnReceivedResponse(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpResponseMessage httpResponse) { }
         protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpRequestMessage httpRequest) { }
         protected sealed override void ProcessCore(System.ClientModel.Primitives.PipelineMessage message) { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -111,7 +111,6 @@ namespace System.ClientModel.Primitives
         public HttpClientPipelineTransport(System.Net.Http.HttpClient client) { }
         protected override System.ClientModel.Primitives.PipelineMessage CreateMessageCore() { throw null; }
         public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
         protected virtual void OnReceivedResponse(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpResponseMessage httpResponse) { }
         protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpRequestMessage httpRequest) { }
         protected sealed override void ProcessCore(System.ClientModel.Primitives.PipelineMessage message) { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -100,9 +100,9 @@ namespace System.ClientModel.Primitives
         protected virtual bool ShouldRetryCore(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryCoreAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         public void Wait(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.ValueTask WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected virtual void WaitCore(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        protected virtual System.Threading.Tasks.ValueTask WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected virtual System.Threading.Tasks.Task WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class HttpClientPipelineTransport : System.ClientModel.Primitives.PipelineTransport, System.IDisposable
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -111,6 +111,7 @@ namespace System.ClientModel.Primitives
         public HttpClientPipelineTransport(System.Net.Http.HttpClient client) { }
         protected override System.ClientModel.Primitives.PipelineMessage CreateMessageCore() { throw null; }
         public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
         protected virtual void OnReceivedResponse(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpResponseMessage httpResponse) { }
         protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpRequestMessage httpRequest) { }
         protected sealed override void ProcessCore(System.ClientModel.Primitives.PipelineMessage message) { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -111,7 +111,6 @@ namespace System.ClientModel.Primitives
         public HttpClientPipelineTransport(System.Net.Http.HttpClient client) { }
         protected override System.ClientModel.Primitives.PipelineMessage CreateMessageCore() { throw null; }
         public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
         protected virtual void OnReceivedResponse(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpResponseMessage httpResponse) { }
         protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpRequestMessage httpRequest) { }
         protected sealed override void ProcessCore(System.ClientModel.Primitives.PipelineMessage message) { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -100,9 +100,9 @@ namespace System.ClientModel.Primitives
         protected virtual bool ShouldRetryCore(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryCoreAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         public void Wait(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.ValueTask WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected virtual void WaitCore(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        protected virtual System.Threading.Tasks.ValueTask WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected virtual System.Threading.Tasks.Task WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class HttpClientPipelineTransport : System.ClientModel.Primitives.PipelineTransport, System.IDisposable
     {

--- a/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
+++ b/sdk/core/System.ClientModel/src/Message/BinaryContent.cs
@@ -114,7 +114,7 @@ public abstract class BinaryContent : IDisposable
         {
             get
             {
-                if (_model is IJsonModel<T> && _options.Format == "J")
+                if (ModelReaderWriter.ShouldWriteAsJson(_model, _options))
                 {
                     throw new InvalidOperationException("Should use ModelWriter instead of _model.Write with IJsonModel.");
                 }
@@ -126,7 +126,7 @@ public abstract class BinaryContent : IDisposable
 
         public override bool TryComputeLength(out long length)
         {
-            if (_model is IJsonModel<T> && _options.Format == "J")
+            if (ModelReaderWriter.ShouldWriteAsJson(_model, _options))
             {
                 return Writer.TryComputeLength(out length);
             }
@@ -142,7 +142,7 @@ public abstract class BinaryContent : IDisposable
 
         public override void WriteTo(Stream stream, CancellationToken cancellation)
         {
-            if (_model is IJsonModel<T> && _options.Format == "J")
+            if (ModelReaderWriter.ShouldWriteAsJson(_model, _options))
             {
                 Writer.CopyTo(stream, cancellation);
                 return;
@@ -157,7 +157,7 @@ public abstract class BinaryContent : IDisposable
 
         public override async Task WriteToAsync(Stream stream, CancellationToken cancellation)
         {
-            if (_model is IJsonModel<T> && _options.Format == "J")
+            if (ModelReaderWriter.ShouldWriteAsJson(_model, _options))
             {
                 await Writer.CopyToAsync(stream, cancellation).ConfigureAwait(false);
                 return;

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -31,7 +31,7 @@ public static class ModelReaderWriter
 
         options ??= ModelReaderWriterOptions.Json;
 
-        if (ShouldWriteAsJson(model, options, out IJsonModel<T> jsonModel))
+        if (ShouldWriteAsJson(model, options, out IJsonModel<T>? jsonModel))
         {
             using (ModelWriter<T> writer = new ModelWriter<T>(jsonModel, options))
             {
@@ -133,21 +133,6 @@ public static class ModelReaderWriter
         return GetInstance(returnType).Create(data, options);
     }
 
-    internal static bool ShouldWriteAsJson<T>(IPersistableModel<T> model, ModelReaderWriterOptions options)
-        => ShouldWriteAsJson(model, options, out _);
-
-    internal static bool ShouldWriteAsJson<T>(IPersistableModel<T> model, ModelReaderWriterOptions options, out IJsonModel<T> jsonModel)
-    {
-        if (IsJsonFormatRequested(model, options) && model is IJsonModel<T> iJsonModel)
-        {
-            jsonModel = iJsonModel;
-            return true;
-        }
-
-        jsonModel = default!;
-        return false;
-    }
-
     private static IPersistableModel<object> GetInstance([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type returnType)
     {
         var model = GetObjectInstance(returnType) as IPersistableModel<object>;
@@ -185,6 +170,23 @@ public static class ModelReaderWriter
             throw new InvalidOperationException($"Unable to create instance of {typeToActivate.Name}.");
         }
         return obj;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ShouldWriteAsJson<T>(IPersistableModel<T> model, ModelReaderWriterOptions options)
+        => ShouldWriteAsJson(model, options, out _);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ShouldWriteAsJson<T>(IPersistableModel<T> model, ModelReaderWriterOptions options, [MaybeNullWhen(false)] out IJsonModel<T> jsonModel)
+    {
+        if (IsJsonFormatRequested(model, options) && model is IJsonModel<T> iJsonModel)
+        {
+            jsonModel = iJsonModel;
+            return true;
+        }
+
+        jsonModel = default;
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -68,7 +68,7 @@ public static class ModelReaderWriter
             throw new InvalidOperationException($"{model.GetType().Name} does not implement {nameof(IPersistableModel<object>)}");
         }
 
-        if (IsJsonFormatRequested(iModel, options) && model is IJsonModel<object> jsonModel)
+        if (ShouldWriteAsJson(iModel, options, out IJsonModel<object>? jsonModel))
         {
             using (ModelWriter<object> writer = new ModelWriter<object>(jsonModel, options))
             {
@@ -188,6 +188,10 @@ public static class ModelReaderWriter
         jsonModel = default;
         return false;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ShouldWriteAsJson(IPersistableModel<object> model, ModelReaderWriterOptions options, [MaybeNullWhen(false)] out IJsonModel<object> jsonModel)
+        => ShouldWriteAsJson<object>(model, options, out jsonModel);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsJsonFormatRequested<T>(IPersistableModel<T> model, ModelReaderWriterOptions options)

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/ModelReaderWriter.cs
@@ -31,7 +31,7 @@ public static class ModelReaderWriter
 
         options ??= ModelReaderWriterOptions.Json;
 
-        if (IsJsonFormatRequested(model, options) && model is IJsonModel<T> jsonModel)
+        if (ShouldWriteAsJson(model, options, out IJsonModel<T> jsonModel))
         {
             using (ModelWriter<T> writer = new ModelWriter<T>(jsonModel, options))
             {
@@ -131,6 +131,21 @@ public static class ModelReaderWriter
         options ??= ModelReaderWriterOptions.Json;
 
         return GetInstance(returnType).Create(data, options);
+    }
+
+    internal static bool ShouldWriteAsJson<T>(IPersistableModel<T> model, ModelReaderWriterOptions options)
+        => ShouldWriteAsJson(model, options, out _);
+
+    internal static bool ShouldWriteAsJson<T>(IPersistableModel<T> model, ModelReaderWriterOptions options, out IJsonModel<T> jsonModel)
+    {
+        if (IsJsonFormatRequested(model, options) && model is IJsonModel<T> iJsonModel)
+        {
+            jsonModel = iJsonModel;
+            return true;
+        }
+
+        jsonModel = default!;
+        return false;
     }
 
     private static IPersistableModel<object> GetInstance([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type returnType)

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
@@ -182,10 +182,10 @@ public class ClientRetryPolicy : PipelinePolicy
         return TimeSpan.FromMilliseconds((1 << (tryCount - 1)) * _initialDelay.TotalMilliseconds);
     }
 
-    public async ValueTask WaitAsync(TimeSpan time, CancellationToken cancellationToken)
+    public async Task WaitAsync(TimeSpan time, CancellationToken cancellationToken)
         => await WaitCoreAsync(time, cancellationToken).ConfigureAwait(false);
 
-    protected virtual async ValueTask WaitCoreAsync(TimeSpan time, CancellationToken cancellationToken)
+    protected virtual async Task WaitCoreAsync(TimeSpan time, CancellationToken cancellationToken)
     {
         await Task.Delay(time, cancellationToken).ConfigureAwait(false);
     }

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
@@ -11,14 +11,14 @@ namespace System.ClientModel.Primitives;
 
 public partial class HttpClientPipelineTransport : PipelineTransport, IDisposable
 {
+    private static readonly object _lock = new object();
+    private static HttpClient? SharedDefaultClient;
+    private static int _sharedClientRefCount;
+
     /// <summary>
     /// A shared instance of <see cref="HttpClientPipelineTransport"/> with default parameters.
     /// </summary>
     public static readonly HttpClientPipelineTransport Shared = new();
-
-    private static HttpClient? SharedDefaultClient;
-    private static object _lock = new object();
-    private static int _sharedClientRefCount;
 
     private readonly bool _ownsClient;
     private readonly HttpClient _httpClient;

--- a/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs
@@ -180,10 +180,17 @@ public partial class HttpClientPipelineTransport : PipelineTransport, IDisposabl
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
         // We don't dispose the Shared static transport instance, and if the
         // custom HttpClient constructor was called, then it is the caller's
         // responsibility to dispose the passed-in HttpClient.  As such, Dispose
-        // for this implementation is a no-op.
+        // for this implementation is a no-op.  We retain the protected method
+        // to allow subtypes to provide an implementation.
     }
 
     #endregion


### PR DESCRIPTION
This PR contains three changes:

### 1. Use a shared HttpClient instance in HttpClientPipelineTransport
Requested in [this PR comment](https://github.com/Azure/azure-sdk-for-net/pull/41223#discussion_r1450977662), this change was postponed because it complicates HttpClientPipelineTransport's Dispose method given the need to do reference counting on the shared HttpClient used by possibly multiple transport instances.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/41301

### 2. Change ClientRetryPolicy.WaitAsync method return types to Task
Since ValueTask is slower if the method does not return synchronously, and the Wait* methods are expected to wait some time interval before returning, changing these methods to return Task instead to get the perf benefit in the majority case.

### 3. Isolating "should write as JSON" logic to a single place
Addressing feedback from [this PR comment](https://github.com/Azure/azure-sdk-for-net/pull/41085#discussion_r1462153525).  This moves the logic to decide whether to write a persistable model as JSON to a single place and gives a higher hit rate on the high-performance model-writing path from BinaryContent.