### PR TITLE
Update version of Azure.ClientSdk.Analyzers

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -203,7 +203,7 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20240118.1" PrivateAssets="All" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20231116.1" PrivateAssets="All" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20240122.1" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="All" />

--- a/sdk/devcenter/Azure.Developer.DevCenter/src/GlobalSuppressions.cs
+++ b/sdk/devcenter/Azure.Developer.DevCenter/src/GlobalSuppressions.cs
@@ -3,6 +3,5 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "AZC0001:Use one of the following pre-approved namespace groups (https://azure.github.io/azure-sdk/registered_namespaces.html): Azure.AI, Azure.Analytics, Azure.Communication, Azure.Data, Azure.DigitalTwins, Azure.IoT, Azure.Learn, Azure.Media, Azure.Management, Azure.Messaging, Azure.ResourceManager, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure", Justification = "Temporary while awaiting namespace group approval", Scope = "namespace", Target = "~N:Azure.Developer.DevCenter")]
 [assembly: SuppressMessage("Usage", "AZC0007:DO provide a minimal constructor that takes only the parameters required to connect to the service.", Justification = "False positives on minimal constructors", Scope = "namespaceanddescendants", Target = "~N:Azure.Developer.DevCenter")]
 [assembly: SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "False positives on options constructors", Scope = "namespaceanddescendants", Target = "~N:Azure.Developer.DevCenter")]


### PR DESCRIPTION
The updated version of Azure.ClientSdk.Analyzers includes "Azure.Developer" as an approved namespace prefix, which means that we can now remove the suppression of AZC0001 from Azure.Developer.DevCenter.

More info here: https://github.com/Azure/azure-sdk-tools/pull/7554