### PR TITLE
Add experimental support for log sampling

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -18,7 +18,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private readonly string _instrumentationKey;
         private AzureMonitorResource? _resource;
         private bool _disposed;
-        private bool _shouldSample;
+        private bool _enableSampling;
 
         public AzureMonitorLogExporter(AzureMonitorExporterOptions options) : this(TransmitterFactory.Instance.Get(options), new DefaultPlatform())
         {
@@ -32,7 +32,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var enableLogSampling = defaultPlatform?.GetEnvironmentVariable(EnvironmentVariableConstants.ENABLE_LOG_SAMPLING);
             if (string.Equals(enableLogSampling, "true", StringComparison.OrdinalIgnoreCase))
             {
-                _shouldSample = true;
+                _enableSampling = true;
             }
         }
 
@@ -48,7 +48,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey, _shouldSample);
+                var telemetryItems = LogsHelper.OtelToAzureMonitorLogs(batch, LogResource, _instrumentationKey, _enableSampling);
                 if (telemetryItems.Count > 0)
                 {
                     exportResult = _transmitter.TrackAsync(telemetryItems, TelemetryItemOrigin.AzureMonitorLogExporter, false, CancellationToken.None).EnsureCompleted();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -24,17 +24,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
         }
 
-        internal AzureMonitorLogExporter(ITransmitter transmitter, IPlatform? defaultPlatform = null)
+        internal AzureMonitorLogExporter(ITransmitter transmitter, IPlatform defaultPlatform)
         {
             _transmitter = transmitter;
             _instrumentationKey = transmitter.InstrumentationKey;
-            if (defaultPlatform != null)
+
+            var enableLogSampling = defaultPlatform?.GetEnvironmentVariable(EnvironmentVariableConstants.ENABLE_LOG_SAMPLING);
+            if (string.Equals(enableLogSampling, "true", StringComparison.OrdinalIgnoreCase))
             {
-                var enableLogSampling = defaultPlatform?.GetEnvironmentVariable(EnvironmentVariableConstants.ENABLE_LOG_SAMPLING);
-                if (string.Equals(enableLogSampling, "true", StringComparison.OrdinalIgnoreCase))
-                {
-                    _shouldSample = true;
-                }
+                _shouldSample = true;
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -47,14 +47,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         };
 
-        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey, bool shouldSample = false)
+        internal static List<TelemetryItem> OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey, bool enableSampling = false)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
 
             foreach (var logRecord in batchLogRecord)
             {
-                if (!shouldSample || logRecord.SpanId == default || logRecord.TraceFlags == ActivityTraceFlags.Recorded)
+                if (!enableSampling || logRecord.SpanId == default || logRecord.TraceFlags == ActivityTraceFlags.Recorded)
                 {
                     try
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -54,7 +54,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             foreach (var logRecord in batchLogRecord)
             {
-                if (!shouldSample || logRecord.SpanId == default || (shouldSample && logRecord.TraceFlags == ActivityTraceFlags.Recorded))
+                if (!shouldSample || logRecord.SpanId == default || logRecord.TraceFlags == ActivityTraceFlags.Recorded)
                 {
                     try
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -65,5 +65,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// When set to true, exporter will emit resources as metric telemetry.
         /// </summary>
         public const string EXPORT_RESOURCE_METRIC = "OTEL_DOTNET_AZURE_MONITOR_ENABLE_RESOURCE_METRICS";
+
+        /// <summary>
+        /// When set to true, exporter will sample the logs based on configured sampling rate.
+        /// </summary>
+        public const string ENABLE_LOG_SAMPLING = "OTEL_DOTNET_AZURE_MONITOR_ENABLE_LOG_SAMPLING";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -69,6 +69,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// <summary>
         /// When set to true, exporter will sample the logs based on configured sampling rate.
         /// </summary>
-        public const string ENABLE_LOG_SAMPLING = "OTEL_DOTNET_AZURE_MONITOR_ENABLE_LOG_SAMPLING";
+        public const string ENABLE_LOG_SAMPLING = "OTEL_DOTNET_AZURE_MONITOR_EXPERIMENTAL_ENABLE_LOG_SAMPLING";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/AzureMonitorExporterTestExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
@@ -20,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
         /// <summary>
         /// Extension methods to simplify registering of <see cref="AzureMonitorLogExporter"/> with <see cref="MockTransmitter"/> for unit tests.
         /// </summary>
-        internal static OpenTelemetryLoggerOptions AddAzureMonitorLogExporterForTest(this OpenTelemetryLoggerOptions loggerOptions, out List<TelemetryItem> telemetryItems)
+        internal static OpenTelemetryLoggerOptions AddAzureMonitorLogExporterForTest(this OpenTelemetryLoggerOptions loggerOptions, IPlatform platform, out List<TelemetryItem> telemetryItems)
         {
             if (loggerOptions == null)
             {
@@ -29,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
 
             telemetryItems = new List<TelemetryItem>();
 
-            return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(new AzureMonitorLogExporter(new MockTransmitter(telemetryItems))));
+            return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(new AzureMonitorLogExporter(new MockTransmitter(telemetryItems), platform)));
         }
 
         /// <summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -151,13 +151,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
         [InlineData(false, true, false)]
         [InlineData(false, false, true)]
         [InlineData(false, true, true)]
-        public void ValidateLogSampling(bool logWithinActivityContext, bool shouldSample, bool sampledIn)
+        public void ValidateLogSampling(bool logWithinActivityContext, bool enableSampling, bool sampledIn)
         {
             List<TelemetryItem>? telemetryLogItems = null;
             List<TelemetryItem>? telemetryActivityItems = null;
             MockPlatform platform = new MockPlatform();
 
-            platform.SetEnvironmentVariable(EnvironmentVariableConstants.ENABLE_LOG_SAMPLING, shouldSample ? "true" : "false");
+            platform.SetEnvironmentVariable(EnvironmentVariableConstants.ENABLE_LOG_SAMPLING, enableSampling ? "true" : "false");
 
             // SETUP
             var loggerFactory = LoggerFactory.Create(builder =>
@@ -215,7 +215,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             // flush logs
             loggerFactory.Dispose();
 
-            if (shouldSample && logWithinActivityContext)
+            if (enableSampling && logWithinActivityContext)
             {
                 if (!sampledIn)
                 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/LogsTests.cs
@@ -212,6 +212,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                    args: new object[] { "World" });
             }
 
+            // flush logs
+            loggerFactory.Dispose();
+
             if (shouldSample && logWithinActivityContext)
             {
                 if (!sampledIn)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/TracesTests.cs
@@ -220,7 +220,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
                     .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, logLevel)
                     .AddOpenTelemetry(options =>
                     {
-                        options.AddAzureMonitorLogExporterForTest(out logTelemetryItems);
+                        options.AddAzureMonitorLogExporterForTest(new MockPlatform(), out logTelemetryItems);
                     });
             });
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -225,7 +225,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
                 RoleName = "roleName",
                 RoleInstance = "roleInstance"
             };
-            var telemetryItem = LogsHelper.OtelToAzureMonitorLogs(new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count), logResource, "Ikey");
+            var telemetryItem = LogsHelper.OtelToAzureMonitorLogs
+                (new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count), logResource, "Ikey");
 
             Assert.Equal(type, telemetryItem[0].Data.BaseType);
             Assert.Equal("Ikey", telemetryItem[0].InstrumentationKey);


### PR DESCRIPTION
`OTEL_DOTNET_AZURE_MONITOR_EXPERIMENTAL_ENABLE_LOG_SAMPLING` when set to true will sample the logs that are emitted within the context of an activity. The sampling will done based on the SampleRate configured by user for traces.