### PR TITLE
[ResourceManager] Remove subscription cache when get api version for GenericResource

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/CHANGELOG.md
+++ b/sdk/resourcemanager/Azure.ResourceManager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed [the issue](https://github.com/Azure/azure-sdk-for-net/issues/38154) that sdk caches wrong subscription provider.
+
 ### Other Changes
 
 ## 1.10.0 (2024-01-12)

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmCollection.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmCollection.cs
@@ -68,17 +68,5 @@ namespace Azure.ResourceManager
         /// <param name="resourceType"> The resource type to get the version for. </param>
         /// <param name="apiVersion"> The api version to variable to set. </param>
         protected bool TryGetApiVersion(ResourceType resourceType, out string apiVersion) => Client.TryGetApiVersion(resourceType, out apiVersion);
-
-        /// <summary>
-        /// Gets a cached client to use for extension methods.
-        /// </summary>
-        /// <typeparam name="T"> The type of client to get. </typeparam>
-        /// <param name="clientFactory"> The constructor factory for the client. </param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual T GetCachedClient<T>(Func<ArmClient, T> clientFactory)
-            where T : class
-        {
-            return _clientCache.GetOrAdd(typeof(T), (type) => { return clientFactory(Client); }) as T;
-        }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmCollection.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmCollection.cs
@@ -68,5 +68,17 @@ namespace Azure.ResourceManager
         /// <param name="resourceType"> The resource type to get the version for. </param>
         /// <param name="apiVersion"> The api version to variable to set. </param>
         protected bool TryGetApiVersion(ResourceType resourceType, out string apiVersion) => Client.TryGetApiVersion(resourceType, out apiVersion);
+
+        /// <summary>
+        /// Gets a cached client to use for extension methods.
+        /// </summary>
+        /// <typeparam name="T"> The type of client to get. </typeparam>
+        /// <param name="clientFactory"> The constructor factory for the client. </param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual T GetCachedClient<T>(Func<ArmClient, T> clientFactory)
+            where T : class
+        {
+            return _clientCache.GetOrAdd(typeof(T), (type) => { return clientFactory(Client); }) as T;
+        }
     }
 }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/GenericResourceCollection.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/GenericResourceCollection.cs
@@ -238,7 +238,8 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentException("Only resource id in a subscription is supported", nameof(resourceId));
             }
-            string version = GetProviderCollectionForSubscription(subscription).GetApiVersion(resourceId.ResourceType, cancellationToken);
+            ResourceProviderCollection collection = new ResourceProviderCollection(Client, subscription);
+            string version = collection.GetApiVersion(resourceId.ResourceType, cancellationToken);
             if (version is null)
             {
                 throw new InvalidOperationException($"An invalid resource id was given {resourceId}");
@@ -253,15 +254,13 @@ namespace Azure.ResourceManager.Resources
             {
                 throw new ArgumentException("Only resource id in a subscription is supported", nameof(resourceId));
             }
-            string version = await GetProviderCollectionForSubscription(subscription).GetApiVersionAsync(resourceId.ResourceType, cancellationToken).ConfigureAwait(false);
+            ResourceProviderCollection collection = new ResourceProviderCollection(Client, subscription);
+            string version = await collection.GetApiVersionAsync(resourceId.ResourceType, cancellationToken).ConfigureAwait(false);
             if (version is null)
             {
                 throw new InvalidOperationException($"An invalid resource id was given {resourceId}");
             }
             return version;
         }
-
-        private ResourceProviderCollection GetProviderCollectionForSubscription(ResourceIdentifier subscriptionId)
-            => GetCachedClient((client) => { return new ResourceProviderCollection(client, subscriptionId); });
     }
 }


### PR DESCRIPTION
Thi is the fix for issue #38154 
The issue is about when we get a `GenericResource` under subscprtion, a` GetApiVersion()` operation will be called, this method will use cached `ResourceProviderCollection` (which consumes subscription id) if exists. 
Then if we put a wrong subscription id at fist place, it will always fail on the Api version verify step.
This fix removes cache logic. It maybe not the best apporach, feel free to bring up any new ideas.
