### PR TITLE
[Event Hubs] Processor improvements

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -23,11 +23,21 @@
 
 - Fixed an issue with event processor validation where an exception for quota exceeded may inappropriately be surfaced when starting the processor.
 
+- In the rare case that an event processor's load balancing and health monitoring task cannot recover from an error, it will now properly surrender ownership when processing stops.
+
 ### Other Changes
 
 - Updated the `Microsoft.Azure.Amqp` dependency to 2.6.4, which enables support for TLS 1.3.
 
 - Removed the custom sizes for the AMQP sending and receiving buffers, allowing the optimized defaults of the host platform to be used.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  Windows performance remains unchanged as the default and custom buffer sizes are equivalent.
+
+- Improved efficiency of partition management during load balancing, reducing the number of operations performed and deferring waiting for lost partitions until the processor is stopped or the partition is reclaimed.  Allocations were also non-trivially reduced.
+
+- Improved the approach used by the processor to manage the background tasks for partition processing and load balancing.  These tasks are now marked as long-running and have improved error recovery.
+
+- Initialization of the load balancing task is now performed in the background and will no longer cause delays when starting the processor.
+
+- In the rare case that an event processor's load balancing and health monitoring task cannot recover from an error, the processor now signals the error handler with a wrapped exception that makes clear that processing will terminate.  Previously, the source exception was surfaced to the error handler and the impact was not clear.
 
 ## 5.10.0 (2023-11-08)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_EventProcessorConfiguration.md
@@ -32,6 +32,12 @@ Because of this, it is important to carefully consider how many `EventProcessorC
 
 As part of its normal operation, an `EventProcessorClient` needs to enumerate the blobs in its container on a recurring basis.  In order to guarantee that this performs well and doesn't interfere with the processor's operation, it is strongly recommended that you disable blob versioning and soft delete on the Azure Storage account used by the `EventProcessorClient`.  It is also recommended that you use a unique blob container for each Event Hub and consumer group; this container should not contain other blobs nor be shared with processors working in a different context.
 
+## Controlling processor identity
+
+When constructing an `EventProcessorClient`, it is recommended that you set a stable unique identifier for the instance.  This can be done by setting the [Identifier](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventprocessorclientoptions.identifier?view=azure-dotnet#azure-messaging-eventhubs-eventprocessorclientoptions-identifier) property of  [EventProcessorClientOptions](https://learn.microsoft.com/dotnet/api/azure.messaging.eventhubs.eventprocessorclientoptions) and passing the options to the constructor.  
+
+A stable identifier allows the processor to recover partition ownership when an application or host instance is restarted.  It also aids readability in Azure SDK logs and allows for more easily correlating logs to a specific processor instance.
+
 ## Influencing load balancing behavior
 
 To scale event processing, you can run multiple instances of the `EventProcessorClient` and they will coordinate to balance work between them. The responsibility for processing is distributed among each of the active processors configured to read from the same Event Hub and using the same consumer group.  To balance work, each active `EventProcessorClient` instance will assume responsibility for processing a set of Event Hub partitions, referred to as "owning" the partitions.  The processors collaborate on ownership using storage as a central point of coordination.  

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -334,6 +334,17 @@ namespace Azure.Messaging.EventHubs
         ///   A unique name used to identify this event processor.
         /// </summary>
         ///
+        /// <remarks>
+        ///   The identifier can be set using the <see cref="EventProcessorClientOptions.Identifier"/> property on the
+        ///   <see cref="EventProcessorClientOptions"/> passed when constructing the processor.  If not specified, a
+        ///   random identifier will be generated.
+        ///
+        ///   It is recommended that you set a stable unique identifier for processor instances, as this allows
+        ///   the processor to recover partition ownership when an application or host instance is restarted.  It
+        ///   also aids readability in Azure SDK logs and allows for more easily correlating logs to a specific
+        ///   processor instance.
+        /// </remarks>
+        ///
         public new string Identifier => base.Identifier;
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClientOptions.cs
@@ -50,6 +50,13 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value>If not specified, a random unique identifier will be generated.</value>
         ///
+        /// <remarks>
+        ///   It is recommended that you set a stable unique identifier for processor instances, as this allows
+        ///   the processor to recover partition ownership when an application or host instance is restarted.  It
+        ///   also aids readability in Azure SDK logs and allows for more easily correlating logs to a specific
+        ///   processor instance.
+        /// </remarks>
+        ///
         public string Identifier { get; set; }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -871,6 +871,17 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to FATAL: The processor has experienced a fatal error in its load balancing and health check task.  Recovery is NOT possible; the processor is shutting down.   Error message: {0}.
+        /// </summary>
+        internal static string ProcessorLoadBalancingFatalErrorMask
+        {
+            get
+            {
+                return ResourceManager.GetString("ProcessorLoadBalancingFatalErrorMask", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Events cannot be enqueued processing without the {0} handler set..
         /// </summary>
         internal static string CannotEnqueueEventWithoutHandler

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -352,6 +352,6 @@
     <value>The buffered producer took too long to start.</value>
   </data>
   <data name="ProcessorLoadBalancingFatalErrorMask" xml:space="preserve">
-    <value>FATAL: The processor has experienced a fatal error in its load balancing and health check task.  Recovery is NOT possible; the processor is shutting down.   Error message: {0}</value>
+    <value>FATAL: The processor has experienced a fatal error in its load balancing and health check task.  Recovery is NOT possible; the processor is shutting down.  Error message: {0}</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -351,4 +351,7 @@
   <data name="BufferedProducerStartupTimeout1" xml:space="preserve">
     <value>The buffered producer took too long to start.</value>
   </data>
+  <data name="ProcessorLoadBalancingFatalErrorMask" xml:space="preserve">
+    <value>FATAL: The processor has experienced a fatal error in its load balancing and health check task.  Recovery is NOT possible; the processor is shutting down.   Error message: {0}</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 - Fixed an issue with event processor validation where an exception for quota exceeded may inappropriately be surfaced when starting the processor.
 
+- In the rare case that an event processor's load balancing and health monitoring task cannot recover from an error, it will now properly surrender ownership when processing stops.
+
 - Reduced the timeout for transient service failures when starting the buffered producer. This ixed an issue where the buffered producer appeared to hang for an extended period of time when starting if it had issues querying Event Hub metadata for the first time.
 
 - Fixed the logic used to set the TimeToLive value of the AmqpMessageHeader for received messages to be based on the difference of the AbsoluteExpiryTime and CreationTime properties of the AmqpMessageProperties.
@@ -39,6 +41,12 @@
 - Removed the custom sizes for the AMQP sending and receiving buffers, allowing the optimized defaults of the host platform to be used.  This offers non-trivial performance increase on Linux-based platforms and a minor improvement on macOS.  Windows performance remains unchanged as the default and custom buffer sizes are equivalent.
 
 - Improved efficiency of partition management during load balancing, reducing the number of operations performed and deferring waiting for lost partitions until the processor is stopped or the partition is reclaimed.  Allocations were also non-trivially reduced.
+
+- Improved the approach used by the processor to manage the background tasks for partition processing and load balancing.  These tasks are now marked as long-running and have improved error recovery.
+
+- Initialization of the load balancing task is now performed in the background and will no longer cause delays when starting the processor.
+
+- In the rare case that an event processor's load balancing and health monitoring task cannot recover from an error, the processor now signals the error handler with a wrapped exception that makes clear that processing will terminate.  Previously, the source exception was surfaced to the error handler and the impact was not clear.
 
 - The "Event Receive Completed" log now includes the maximum batch size and wait time that were used for the operation.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -179,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="maximumBatchSize">The maximum number of events to include in the batch.</param>
         /// <param name="maximumWaitTime">The maximum time to wait when no events are available, in seconds.</param>
         ///
-        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Duration: '{6:0.00}' seconds; Starting sequence number: '{7}', Ending sequence number: '{8}'; Maximum batch size: '{9}'; Maximum wait time: '{10:0.00}'.")]
+        [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'); Operation Id: '{3}'.  Service Retry Count: {4}; Event Count: {5}; Duration: '{6:0.00}' seconds; Starting sequence number: '{7}', Ending sequence number: '{8}'; Maximum batch size: '{9}'; Maximum wait time: '{10:0.00}' seconds.")]
         public virtual void EventReceiveComplete(string eventHubName,
                                                  string consumerGroup,
                                                  string partitionId,
@@ -2588,18 +2588,20 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
         /// <param name="operationId">An artificial identifier for the handler invocation.</param>
         /// <param name="durationSeconds">The total duration that the cycle took to complete, in seconds.</param>
+        /// <param name="eventCount">The number of events in the batch that was passed to the processing handler.</param>
         ///
-        [Event(124, Level = EventLevel.Verbose, Message = "Completed dispatching events to the processing handler for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2}, Consumer Group: {3}, and Operation Id: '{4}'.   Duration: '{5:0.00}' seconds.")]
+        [Event(124, Level = EventLevel.Verbose, Message = "Completed dispatching events to the processing handler for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2}, Consumer Group: {3}, and Operation Id: '{4}'.   Duration: '{5:0.00}' seconds, Event Count: '{6]'.")]
         public virtual void EventProcessorProcessingHandlerComplete(string partitionId,
                                                                     string identifier,
                                                                     string eventHubName,
                                                                     string consumerGroup,
                                                                     string operationId,
-                                                                    double durationSeconds)
+                                                                    double durationSeconds,
+                                                                    int eventCount)
         {
             if (IsEnabled())
             {
-                EventProcessorProcessingHandlerCompleteCore(124, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty, durationSeconds);
+                EventProcessorProcessingHandlerCompleteCore(124, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, operationId ?? string.Empty, durationSeconds, eventCount);
             }
         }
 
@@ -2680,7 +2682,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="loadBalancingIntervalSeconds">The interval, in seconds, that should pass between load balancing cycles.</param>
         /// <param name="ownershipIntervalSeconds">The interval, in seconds, that partition ownership is reserved for..</param>
         ///
-        [Event(128, Level = EventLevel.Warning, Message = "The 'PartitionOwnershipExpirationInterval' and 'LoadBalancingUpdateInterval' are configured using intervals that may cause stability issues with partition ownership for the processor instance with identifier '{0}' for Event Hub: {1}.  It is recommended that the 'PartitionOwnershipExpirationInterval' be at least 3 times greater than the 'LoadBalancingUpdateInterval' and very strongly advised that it should be no less than twice as long.  When these intervals are too close together, ownership may expire before it is renewed during load balancing which will cause partitions to migrate.  Consider adjusting the intervals in the processor options if you experience issues.  Load Balancing Interval '{2:0:00}' seconds.  Partition Ownership Interval '{3:0:00}' seconds.  {4}")]
+        [Event(128, Level = EventLevel.Warning, Message = "The 'PartitionOwnershipExpirationInterval' and 'LoadBalancingUpdateInterval' are configured using intervals that may cause stability issues with partition ownership for the processor instance with identifier '{0}' for Event Hub: {1}.  It is recommended that the 'PartitionOwnershipExpirationInterval' be at least 3 times greater than the 'LoadBalancingUpdateInterval' and very strongly advised that it should be no less than twice as long.  When these intervals are too close together, ownership may expire before it is renewed during load balancing which will cause partitions to migrate.  Consider adjusting the intervals in the processor options if you experience issues.  Load Balancing Interval '{2:0.00}' seconds.  Partition Ownership Interval '{3:0.00}' seconds.  {4}")]
         public virtual void ProcessorLoadBalancingIntervalsTooCloseWarning(string identifier,
                                                                            string eventHubName,
                                                                            double loadBalancingIntervalSeconds,
@@ -2733,6 +2735,28 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                     formattedCycleStartTime ?? string.Empty,
                     formattedCycleEndTime ?? string.Empty,
                     durationSeconds);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has encountered an fatal error during load balancing
+        ///   and cannot recover.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(110, Level = EventLevel.Error, Message = "A fatal exception occurred during load balancing for processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.  The processor cannot recover and has stopped.  Error Message: '{3}'")]
+        public virtual void EventProcessorFatalTaskError(string identifier,
+                                                         string eventHubName,
+                                                         string consumerGroup,
+                                                         string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(110, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
             }
         }
 
@@ -3231,6 +3255,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
         /// <param name="operationId">An artificial identifier for the handler invocation.</param>
         /// <param name="durationSeconds">The total duration that the cycle took to complete, in seconds.</param>
+        /// <param name="eventCount">The number of events in the batch that was passed to the processing handler.</param>
         ///
         [NonEvent]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -3240,7 +3265,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                                                                         string eventHubName,
                                                                         string consumerGroup,
                                                                         string operationId,
-                                                                        double durationSeconds)
+                                                                        double durationSeconds,
+                                                                        int eventCount)
         {
             fixed (char* partitionIdPtr = partitionId)
             fixed (char* identifierPtr = identifier)
@@ -3248,7 +3274,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
             fixed (char* consumerGroupPtr = consumerGroup)
             fixed (char* operationIdPtr = operationId)
             {
-                var eventPayload = stackalloc EventData[6];
+                var eventPayload = stackalloc EventData[7];
 
                 eventPayload[0].Size = (partitionId.Length + 1) * sizeof(char);
                 eventPayload[0].DataPointer = (IntPtr)partitionIdPtr;
@@ -3268,7 +3294,10 @@ namespace Azure.Messaging.EventHubs.Diagnostics
                 eventPayload[5].Size = Unsafe.SizeOf<double>();
                 eventPayload[5].DataPointer = (IntPtr)Unsafe.AsPointer(ref durationSeconds);
 
-                WriteEventCore(eventId, 6, eventPayload);
+                eventPayload[6].Size = Unsafe.SizeOf<int>();
+                eventPayload[6].DataPointer = (IntPtr)Unsafe.AsPointer(ref eventCount);
+
+                WriteEventCore(eventId, 7, eventPayload);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -986,7 +986,7 @@ namespace Azure.Messaging.EventHubs.Primitives
 
             // Start processing in the background and return the processor metadata.  Since the task is
             // expected to run continually until the processor is stopped or ownership changes, mark it as
-            // long-running.  Other than the long-running designation, use the options used intentionally match
+            // long-running.  Other than the long-running designation, the options used intentionally match
             // the recommended defaults used by Task.Run.
             //
             // For more context, see: https://devblogs.microsoft.com/pfxteam/task-run-vs-task-factory-startnew/
@@ -1373,7 +1373,7 @@ namespace Azure.Messaging.EventHubs.Primitives
 
                 // Start processing in the background. Since the task is expected to run continually
                 // until the processor is stopped or ownership changes, mark it as long-running.
-                // Other than the long-running designation, use the options used intentionally match
+                // Other than the long-running designation, the options used intentionally match
                 // the recommended defaults used by Task.Run.
                 //
                 // For more context, see: https://devblogs.microsoft.com/pfxteam/task-run-vs-task-factory-startnew/

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +19,6 @@ using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Processor;
-using Microsoft.Azure.Amqp.Framing;
 
 namespace Azure.Messaging.EventHubs.Primitives
 {
@@ -56,10 +54,10 @@ namespace Azure.Messaging.EventHubs.Primitives
         private const bool InvalidateConsumerWhenPartitionIsStolen = true;
 
         /// <summary>The minimum duration to allow for a delay between load balancing cycles.</summary>
-        private readonly TimeSpan MinimumLoadBalancingDelay = TimeSpan.FromMilliseconds(15);
+        private static readonly TimeSpan MinimumLoadBalancingDelay = TimeSpan.FromMilliseconds(15);
 
         /// <summary>Defines the warning threshold for the upper limit percentage of total ownership interval spent on load balancing.</summary>
-        private readonly double LoadBalancingDurationWarnThreshold = 0.70;
+        private static readonly double LoadBalancingDurationWarnThreshold = 0.70;
 
         /// <summary>The primitive for synchronizing access when starting and stopping the processor.</summary>
         private readonly SemaphoreSlim ProcessorRunningGuard = new SemaphoreSlim(1, 1);
@@ -106,6 +104,17 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <summary>
         ///   A unique name used to identify this event processor.
         /// </summary>
+        ///
+        /// <remarks>
+        ///   The identifier can be set using the <see cref="EventProcessorOptions.Identifier"/> property on the
+        ///   <see cref="EventProcessorOptions"/> passed when constructing the processor.  If not specified, a
+        ///   random identifier will be generated.
+        ///
+        ///   It is recommended that you set a stable unique identifier for processor instances, as this allows
+        ///   the processor to recover partition ownership when an application or host instance is restarted.  It
+        ///   also aids readability in Azure SDK logs and allows for more easily correlating logs to a specific
+        ///   processor instance.
+        /// </remarks>
         ///
         public string Identifier { get; }
 
@@ -693,7 +702,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             }
             finally
             {
-                Logger.EventProcessorProcessingHandlerComplete(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation, watch.GetElapsedTime().TotalSeconds);
+                Logger.EventProcessorProcessingHandlerComplete(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, operation, watch.GetElapsedTime().TotalSeconds, eventBatch.Count);
             }
         }
 
@@ -975,12 +984,16 @@ namespace Azure.Messaging.EventHubs.Primitives
                 throw new TaskCanceledException();
             }
 
-            // Start processing in the background and return the processor
-            // metadata.
+            // Start processing in the background and return the processor metadata.  Since the task is
+            // expected to run continually until the processor is stopped or ownership changes, mark it as
+            // long-running.  Other than the long-running designation, use the options used intentionally match
+            // the recommended defaults used by Task.Run.
+            //
+            // For more context, see: https://devblogs.microsoft.com/pfxteam/task-run-vs-task-factory-startnew/
 
             return new PartitionProcessor
             (
-                Task.Run(performProcessing),
+                Task.Factory.StartNew(performProcessing, cancellationSource.Token, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).Unwrap(),
                 partition,
                 readLastEnqueuedEventProperties,
                 cancellationSource
@@ -1093,6 +1106,11 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="offset">The offset to associate with the checkpoint, intended as informational metadata. This will only be used for positioning if there is no value provided for <paramref name="sequenceNumber"/>.</param>
         /// <param name="sequenceNumber">The sequence number to associate with the checkpoint, indicating that a processor should begin reading from the next event in the stream.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal a request to cancel the operation.</param>
+        ///
+        /// <remarks>
+        ///   This overload exists to preserve backwards compatibility; it is highly recommended that <see cref="UpdateCheckpointAsync(string, CheckpointPosition, CancellationToken)" />
+        ///   be called instead.
+        /// </remarks>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual Task UpdateCheckpointAsync(string partitionId,
@@ -1336,8 +1354,6 @@ namespace Azure.Messaging.EventHubs.Primitives
                     ProcessorRunningGuard.Wait(cancellationToken);
                 }
 
-                _statusOverride = EventProcessorStatus.Starting;
-
                 // If the processor is already running, then it was started before the
                 // semaphore was acquired; there is no work to be done.
 
@@ -1346,6 +1362,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                     return;
                 }
 
+                _statusOverride = EventProcessorStatus.Starting;
+
                 // There should be no cancellation source, but guard against leaking resources in the
                 // event of a processing crash or other exception.
 
@@ -1353,10 +1371,15 @@ namespace Azure.Messaging.EventHubs.Primitives
                 _runningProcessorCancellationSource?.Dispose();
                 _runningProcessorCancellationSource = new CancellationTokenSource();
 
-                // Start processing events.
+                // Start processing in the background. Since the task is expected to run continually
+                // until the processor is stopped or ownership changes, mark it as long-running.
+                // Other than the long-running designation, use the options used intentionally match
+                // the recommended defaults used by Task.Run.
+                //
+                // For more context, see: https://devblogs.microsoft.com/pfxteam/task-run-vs-task-factory-startnew/
 
                 ActivePartitionProcessors.Clear();
-                _runningProcessorTask = RunProcessingAsync(_runningProcessorCancellationSource.Token);
+                _runningProcessorTask = Task.Factory.StartNew(() => RunProcessingAsync(_runningProcessorCancellationSource.Token), _runningProcessorCancellationSource.Token, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).Unwrap();
 
                 // Validate the processor configuration and ensuring basic permissions are held for
                 // service operations.
@@ -1482,8 +1505,6 @@ namespace Azure.Messaging.EventHubs.Primitives
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.EventProcessorStop(Identifier, EventHubName, ConsumerGroup);
 
-            var processingException = default(Exception);
-
             try
             {
                 // Acquire the semaphore used to synchronize processor starts and stops, respecting
@@ -1541,16 +1562,9 @@ namespace Azure.Messaging.EventHubs.Primitives
 #pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
                     }
                 }
-                catch (TaskCanceledException)
+                catch
                 {
-                    // This is expected; no action is needed.
-                }
-                catch (Exception ex)
-                {
-                    // Preserve the exception to surface once the tasks needed to fully stop are complete;
-                    // logging and invoking of the error handler will have already taken place.
-
-                    processingException = ex;
+                    // No action is needed.  The task logs and surfaces the exception itself.
                 }
 
                 // With the processing task having completed, perform the necessary cleanup of partition processing tasks
@@ -1609,14 +1623,6 @@ namespace Azure.Messaging.EventHubs.Primitives
                     ProcessorRunningGuard.Release();
                 }
             }
-
-            // Surface any exception that was captured when the processing task was
-            // initially awaited.
-
-            if (processingException != default)
-            {
-                ExceptionDispatchInfo.Capture(processingException).Throw();
-            }
         }
 
         /// <summary>
@@ -1668,34 +1674,56 @@ namespace Azure.Messaging.EventHubs.Primitives
                     // Execute the current load balancing cycle.
 
                     Logger.EventProcessorLoadBalancingCycleStart(Identifier, EventHubName, partitionIds?.Length ?? 0, startingOwnedPartitionCount);
+                    TimeSpan remainingTimeUntilNextCycle;
 
-                    var totalPartitions = partitionIds?.Length ?? 0;
-                    var remainingTimeUntilNextCycle = await PerformLoadBalancingAsync(cycleDuration, partitionIds, cancellationToken).ConfigureAwait(false);
-                    var endingOwnedPartitionCount = LoadBalancer.OwnedPartitionCount;
-                    var cycleElapsedSeconds = cycleDuration.GetElapsedTime().TotalSeconds;
-
-                    Logger.EventProcessorLoadBalancingCycleComplete(Identifier, EventHubName, totalPartitions, endingOwnedPartitionCount, cycleElapsedSeconds, remainingTimeUntilNextCycle.TotalSeconds);
-
-                    // If the duration of the load balancing cycle was long enough to potentially impact ownership stability,
-                    // emit warnings.  This is impactful enough that the error handler will be pinged to ensure visibility for the
-                    // host application.
-
-                    if (cycleElapsedSeconds >= LoadBalancingCycleMaximumExecutionSeconds)
+                    try
                     {
-                        var ownershipIntervalSeconds = LoadBalancer.OwnershipExpirationInterval.TotalSeconds;
-                        Logger.EventProcessorLoadBalancingCycleSlowWarning(Identifier, EventHubName, cycleElapsedSeconds, ownershipIntervalSeconds);
+                        var totalPartitions = partitionIds?.Length ?? 0;
+                        remainingTimeUntilNextCycle = await PerformLoadBalancingAsync(cycleDuration, partitionIds, cancellationToken).ConfigureAwait(false);
 
-                        var message = string.Format(CultureInfo.InvariantCulture, Resources.ProcessorLoadBalancingCycleSlowMask, cycleElapsedSeconds, ownershipIntervalSeconds);
-                        var slowException = new EventHubsException(true, EventHubName, message, EventHubsException.FailureReason.GeneralError);
-                        _ = InvokeOnProcessingErrorAsync(slowException, null, Resources.OperationEventProcessingLoop, CancellationToken.None);
+                        var endingOwnedPartitionCount = LoadBalancer.OwnedPartitionCount;
+                        var cycleElapsedSeconds = cycleDuration.GetElapsedTime().TotalSeconds;
+
+                        Logger.EventProcessorLoadBalancingCycleComplete(Identifier, EventHubName, totalPartitions, endingOwnedPartitionCount, cycleElapsedSeconds, remainingTimeUntilNextCycle.TotalSeconds);
+
+                        // If the duration of the load balancing cycle was long enough to potentially impact ownership stability,
+                        // emit warnings.  This is impactful enough that the error handler will be pinged to ensure visibility for the
+                        // host application.
+
+                        if (cycleElapsedSeconds >= LoadBalancingCycleMaximumExecutionSeconds)
+                        {
+                            var ownershipIntervalSeconds = LoadBalancer.OwnershipExpirationInterval.TotalSeconds;
+                            Logger.EventProcessorLoadBalancingCycleSlowWarning(Identifier, EventHubName, cycleElapsedSeconds, ownershipIntervalSeconds);
+
+                            var message = string.Format(CultureInfo.InvariantCulture, Resources.ProcessorLoadBalancingCycleSlowMask, cycleElapsedSeconds, ownershipIntervalSeconds);
+                            var slowException = new EventHubsException(true, EventHubName, message, EventHubsException.FailureReason.GeneralError);
+                            _ = InvokeOnProcessingErrorAsync(slowException, null, Resources.OperationEventProcessingLoop, CancellationToken.None);
+                        }
+
+                        // If the number of partitions owned has changed since the cycle started and is above maximum advisable set, emit a warning.  This is
+                        // a loose heuristic and does not apply to all workloads.  The error handler will not be pinged to avoid false positive notifications.
+
+                        if ((startingOwnedPartitionCount != endingOwnedPartitionCount) && (endingOwnedPartitionCount > MaximumAdvisedOwnedPartitions))
+                        {
+                            Logger.EventProcessorHighPartitionOwnershipWarning(Identifier, EventHubName, totalPartitions, endingOwnedPartitionCount, MaximumAdvisedOwnedPartitions);
+                        }
                     }
-
-                    // If the number of partitions owned has changed since the cycle started and is above maximum advisable set, emit a warning.  This is
-                    // a loose heuristic and does not apply to all workloads.  The error handler will not be pinged to avoid false positive notifications.
-
-                    if ((startingOwnedPartitionCount != endingOwnedPartitionCount) && (endingOwnedPartitionCount > MaximumAdvisedOwnedPartitions))
+                    catch (Exception ex) when ((ex.IsNotType<TaskCanceledException>()) && (!ex.IsFatalException()))
                     {
-                        Logger.EventProcessorHighPartitionOwnershipWarning(Identifier, EventHubName, totalPartitions, endingOwnedPartitionCount, MaximumAdvisedOwnedPartitions);
+                        // Do not invoke the error handler when the processor is stopping.  Instead, signal cancellation to
+                        // short-circuit and avoid trying to run another load balancing cycle.
+
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            throw new TaskCanceledException();
+                        }
+
+                        _ = InvokeOnProcessingErrorAsync(ex, null, Resources.OperationGetPartitionIds, CancellationToken.None);
+                        Logger.EventProcessorTaskError(Identifier, EventHubName, ConsumerGroup, ex.Message);
+
+                        // In the case of a load balancing failure, run another cycle again with minimal delay.
+
+                        remainingTimeUntilNextCycle = MinimumLoadBalancingDelay;
                     }
 
                     // Evaluate the time remaining before the next cycle and delay.
@@ -1717,6 +1745,9 @@ namespace Azure.Messaging.EventHubs.Primitives
             }
             catch (Exception ex) when (ex.IsFatalException())
             {
+                // It is not safe to allocate or log here, as this class of errors includes those such as
+                // OutOfMemoryException and StackOverflowException.  It is assumed the process is crashing.
+
                 throw;
             }
             catch (Exception ex)
@@ -1724,10 +1755,26 @@ namespace Azure.Messaging.EventHubs.Primitives
                 // The error handler is invoked as a fire-and-forget task; the processor does not assume responsibility
                 // for observing or surfacing exceptions that may occur in the handler.
 
-                _ = InvokeOnProcessingErrorAsync(ex, null, Resources.OperationEventProcessingLoop, CancellationToken.None);
-                Logger.EventProcessorTaskError(Identifier, EventHubName, ConsumerGroup, ex.Message);
+                var fatalException = new EventHubsException(false, EventHubName, string.Format(CultureInfo.InvariantCulture, Resources.ProcessorLoadBalancingFatalErrorMask, ex.Message), EventHubsException.FailureReason.InvalidClientState, ex);
+                _ = InvokeOnProcessingErrorAsync(fatalException, null, Resources.OperationEventProcessingLoop, CancellationToken.None);
 
-                throw;
+                Logger.EventProcessorFatalTaskError(Identifier, EventHubName, ConsumerGroup, ex.Message);
+
+                // Attempt to stop the processor as a best effort.  This needs to take place in the background
+                // as it awaits the task that this method is running in and will otherwise deadlock.
+
+                _ = Task.Run(() =>
+                {
+                    StopProcessingInternalAsync(true, CancellationToken.None)
+                        .ContinueWith(stopTask =>
+                        {
+                            var stopEx = stopTask.Exception.Flatten().InnerException;
+                            _ = InvokeOnProcessingErrorAsync(stopEx, null, Resources.OperationLoadBalancing, CancellationToken.None);
+                        },
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.RunContinuationsAsynchronously);
+                });
+
+                throw fatalException;
             }
         }
 
@@ -2005,22 +2052,9 @@ namespace Azure.Messaging.EventHubs.Primitives
                 Logger.EventProcessorPartitionProcessingStop(partitionId, Identifier, EventHubName, ConsumerGroup);
                 partition = partitionProcessor.Partition;
 
-                // If developer code in a handler registered a callback for cancellation, it is possible that
-                // the attempt to cancel will throw.  Capture this as a warning and do not prevent the partition processing
-                // task from being cleaned up.
-
-                try
-                {
-                    partitionProcessor.CancellationSource.Cancel();
-                }
-                catch (Exception ex)
-                {
-                    Logger.PartitionProcessorStoppingCancellationWarning(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
-                }
-
                 // To ensure that callers do not have to wait until the processing task has fully stopped,
-                // schedule an explicit continuation for the task and return immediately.  This allows the
-                // cleanup to happen in the background.
+                // schedule an explicit continuation for the task.  This allows the cleanup to happen in the
+                // background, if desired, and be awaited via the partition processor task at a later time.
 
                 var stopContinuation = partitionProcessor.ProcessingTask.ContinueWith(async (task, state) =>
                 {
@@ -2104,12 +2138,26 @@ namespace Azure.Messaging.EventHubs.Primitives
                     {
                         disposeProcessor.Dispose();
                     }
-                }, (partitionId, reason, stopWatch), default, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Current);
+                }, (partitionId, reason, stopWatch), default, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Default);
 
                 // Set the processing task to the continuation, which allows it to be awaited when the processor is
                 // stopping or otherwise needs to be ensure completion.
 
                 partitionProcessor.RegisterCleanupTask(stopContinuation);
+
+                // If developer code in a handler registered a callback for cancellation, it is possible that
+                // the attempt to cancel will throw.  Capture this as a warning and do not prevent the partition processing
+                // task from being cleaned up.
+
+                try
+                {
+                    partitionProcessor.CancellationSource.Cancel();
+                }
+                catch (Exception ex)
+                {
+                    Logger.PartitionProcessorStoppingCancellationWarning(partitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                }
+
                 return stopContinuation;
             }
             catch (Exception ex) when (ex.IsNotType<TaskCanceledException>())

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorOptions.cs
@@ -241,6 +241,13 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <value>If not specified, a random unique identifier will be generated.</value>
         ///
+        /// <remarks>
+        ///   It is recommended that you set a stable unique identifier for processor instances, as this allows
+        ///   the processor to recover partition ownership when an application or host instance is restarted.  It
+        ///   also aids readability in Azure SDK logs and allows for more easily correlating logs to a specific
+        ///   processor instance.
+        /// </remarks>
+        ///
         public string Identifier { get; set; }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsActivitySourceTests.cs
@@ -420,7 +420,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task EventProcesorCreatesScopeForEventProcessing()
+        public async Task EventProcessorCreatesScopeForEventProcessing()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
@@ -520,7 +520,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task EventProcesorAddsAttributesToLinkedActivitiesForBatchEventProcessing()
+        public async Task EventProcessorAddsAttributesToLinkedActivitiesForBatchEventProcessing()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -193,12 +193,21 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var partitionIds = new[] { "0", "1" };
             var expectedException = new DivideByZeroException("BOOM!");
-            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var logCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventProcessorOptions { LoadBalancingStrategy = LoadBalancingStrategy.Balanced };
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
             var mockConnection = new Mock<EventHubConnection>();
             var mockProcessor = new Mock<MinimalProcessorMock>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockLogger
+                .Setup(log => log.EventProcessorLoadBalancingError(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => logCompletionSource.TrySetResult(true));
 
             mockLoadBalancer
                 .Setup(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
@@ -217,12 +226,12 @@ namespace Azure.Messaging.EventHubs.Tests
             mockProcessor
                .Protected()
                .Setup<Task>("OnProcessingErrorAsync", expectedException, ItExpr.IsAny<EventProcessorPartition>(), ItExpr.IsAny<string>(), ItExpr.IsAny<CancellationToken>())
-               .Callback(() => completionSource.TrySetResult(true))
+               .Callback(() => handlerCompletionSource.TrySetResult(true))
                .Returns(Task.CompletedTask);
 
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
 
-            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            await Task.WhenAny(Task.WhenAll(logCompletionSource.Task, handlerCompletionSource.Task), Task.Delay(Timeout.Infinite, cancellationSource.Token));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
             Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should not fault if a load balancing cycle fails.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -162,7 +162,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     mockProcessor.Object.EventHubName,
                     mockProcessor.Object.ConsumerGroup,
                     It.IsAny<string>(),
-                    It.IsAny<double>()),
+                    It.IsAny<double>(),
+                    eventBatch.Length),
                 Times.Once);
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
@@ -40,7 +40,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public void StartProcessingRespectsACancelledToken(bool async)
+        public void StartProcessingRespectsACanceledToken(bool async)
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
@@ -180,10 +180,12 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockProcessor = new Mock<MinimalProcessorMock>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
+                .Callback(() => completionSource.TrySetResult(true))
                 .Returns(Mock.Of<EventHubConnection>());
 
             mockProcessor
@@ -198,6 +200,8 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 mockProcessor.Object.StartProcessing(cancellationSource.Token);
             }
+
+            await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(mockProcessor.Object.IsRunning, Is.True, "The processor should report that it is running.");
             Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor status should report that it is running.");
@@ -790,7 +794,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public void StopProcessingRespectsACancelledToken(bool async)
+        public void StopProcessingRespectsACanceledToken(bool async)
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
@@ -1046,52 +1050,6 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public async Task StopProcessingSurfacesExceptions(bool async)
-        {
-            using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
-
-            var expectedException = new DivideByZeroException("BOOM!");
-            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var mockProcessor = new Mock<MinimalProcessorMock>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
-
-            mockProcessor
-                .Setup(processor => processor.CreateConnection())
-                .Callback(() => completionSource.TrySetResult(true))
-                .Throws(expectedException);
-
-            mockProcessor
-                .Setup(processor => processor.ValidateProcessingPreconditions(It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
-            await completionSource.Task;
-
-            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Faulted), "The processor status should report that it is in a faulted state.");
-
-            if (async)
-            {
-                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The asynchronous close call should bubble the exception.");
-            }
-            else
-            {
-                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The synchronous close call should bubble the exception.");
-            }
-
-            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation source should not have been triggered.");
-            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should report that it is stopped.");
-            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.NotRunning), "The processor status should report that it is not running.");
-            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(true)]
-        [TestCase(false)]
         public async Task StopProcessingResetsState(bool async)
         {
             using var cancellationSource = new CancellationTokenSource();
@@ -1109,31 +1067,23 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(processor => processor.ValidateProcessingPreconditions(It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            // Starting the processor should result in an exception on the first call, which should leave it in a faulted state.
-
             await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+
+            // In a real scenario, the processor would fail validation in the cases that would cause a background task
+            // fault and be observable by the call to start processing.  Because the test is injecting a mock fault in
+            // a very specific location, only the background task will fail but it may not be observable immediately.
+            // Spin with a short delay to allow the fault to be observed.
+
+            while ((!cancellationSource.IsCancellationRequested) && (GetRunningProcessorTask(mockProcessor.Object) != null))
+            {
+                await Task.Delay(75, cancellationSource.Token);
+            }
+
+            // Starting the processor should result in an exception on the first call, which will fault and cause it to stop and
+            // reset state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation source should not have been triggered.");
             Assert.That(mockProcessor.Object.IsRunning, Is.False, "The start call should have triggered an exception.");
-            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Faulted), "The processor status should report that it is faulted.");
-            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsFaulted, Is.True, "The task for processing should be faulted.");
-
-            // The processor should not reset the faulted state when calling start a second time.
-
-            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
-            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The start call should not have been able to reset the failure state.");
-            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsFaulted, Is.True, "The task for processing should be faulted.");
-            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsFaulted, Is.True, "The task for processing should be faulted.");
-
-            // Stopping the processor should clear the faulted state, as well as surface the fault.
-
-            if (async)
-            {
-                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The asynchronous close call should bubble the exception.");
-            }
-            else
-            {
-                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The synchronous close call should bubble the exception.");
-            }
-
             Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
 
             // After stopping, the processor state should be reset and it should be able to start.
@@ -1276,71 +1226,6 @@ namespace Azure.Messaging.EventHubs.Tests
                    mockProcessor.Object.EventHubName,
                    mockProcessor.Object.ConsumerGroup,
                    It.IsAny<string>()),
-               Times.Once);
-
-            mockEventSource
-                .Verify(log => log.EventProcessorStopComplete(
-                    mockProcessor.Object.Identifier,
-                    mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup),
-                Times.Once);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task StopProcessingLogsFaultedTaskDuringShutdown(bool async)
-        {
-            using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
-
-            var expectedException = new DivideByZeroException("BOOM!");
-            var mockEventSource = new Mock<EventHubsEventSource>();
-            var mockProcessor = new Mock<MinimalProcessorMock>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
-
-            mockProcessor.Object.Logger = mockEventSource.Object;
-
-            mockProcessor
-                .Setup(processor => processor.CreateConnection())
-                .Throws(expectedException);
-
-            mockProcessor
-                .Setup(processor => processor.ValidateProcessingPreconditions(It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
-            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should have faulted during startup.");
-            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsFaulted, Is.True, "The task for processing should be faulted.");
-
-            if (async)
-            {
-                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Exception, "The asynchronous close call should encounter an exception.");
-            }
-            else
-            {
-                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Exception, "The synchronous close call should encounter an exception.");
-            }
-
-            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-
-            mockEventSource
-                .Verify(log => log.EventProcessorStop(
-                    mockProcessor.Object.Identifier,
-                    mockProcessor.Object.EventHubName,
-                    mockProcessor.Object.ConsumerGroup),
-                Times.Once);
-
-            mockEventSource
-               .Verify(log => log.EventProcessorTaskError(
-                   mockProcessor.Object.Identifier,
-                   mockProcessor.Object.EventHubName,
-                   mockProcessor.Object.ConsumerGroup,
-                   expectedException.Message),
                Times.Once);
 
             mockEventSource


### PR DESCRIPTION
# Summary

The focus of these changes was to improve the approach used to spawn and manage background tasks.  Going forward, the load balancing and partition tasks are run in a task spawned with an explicit long-running flag set, as they are based on infinite loops that will not complete until processing is stopped or ownership is lost.  Improvements were also made to the structure of the load balancing loop to detect and recover from a rare corner case when a load balancing operation fails in an unexpected way and an exception is thrown.

In addition, Load balancing is now initialized in the background, preventing it from blocking startup.  While not visible by the caller, this introduced an additional degree in non-determinism for processor startup which required adjustments to many of the startup/shutdown tests which could no longer predict when the processor was fully initialized.

Also included:

  - The processor doc comments now suggest assigning a stable identifier to processor instances as a best practice.

  - Fixed typos in formatting for a couple of logged durations; they were previously formatted as timespans rather than decimals.

  - Added the count of events in the batch to the log emitted when the processing handler has completed a cycle.