### PR TITLE
ClientModel: Make ClientPipelineOptions freezable and make freeze APIs on RequestOptions explicit

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -80,6 +80,8 @@ namespace System.ClientModel.Primitives
         public System.ClientModel.Primitives.PipelinePolicy? RetryPolicy { get { throw null; } set { } }
         public System.ClientModel.Primitives.PipelineTransport? Transport { get { throw null; } set { } }
         public void AddPolicy(System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelinePosition position) { }
+        protected void AssertNotFrozen() { }
+        public virtual void Freeze() { }
     }
     public partial class ClientRetryPolicy : System.ClientModel.Primitives.PipelinePolicy
     {
@@ -250,6 +252,8 @@ namespace System.ClientModel.Primitives
         public System.ClientModel.Primitives.ClientErrorBehaviors ErrorOptions { get { throw null; } set { } }
         public void AddHeader(string name, string value) { }
         public void AddPolicy(System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelinePosition position) { }
+        protected void AssertNotFrozen() { }
+        public virtual void Freeze() { }
         public void SetHeader(string name, string value) { }
     }
     public partial class ResponseBufferingPolicy : System.ClientModel.Primitives.PipelinePolicy

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -80,6 +80,8 @@ namespace System.ClientModel.Primitives
         public System.ClientModel.Primitives.PipelinePolicy? RetryPolicy { get { throw null; } set { } }
         public System.ClientModel.Primitives.PipelineTransport? Transport { get { throw null; } set { } }
         public void AddPolicy(System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelinePosition position) { }
+        protected void AssertNotFrozen() { }
+        public virtual void Freeze() { }
     }
     public partial class ClientRetryPolicy : System.ClientModel.Primitives.PipelinePolicy
     {
@@ -249,6 +251,8 @@ namespace System.ClientModel.Primitives
         public System.ClientModel.Primitives.ClientErrorBehaviors ErrorOptions { get { throw null; } set { } }
         public void AddHeader(string name, string value) { }
         public void AddPolicy(System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelinePosition position) { }
+        protected void AssertNotFrozen() { }
+        public virtual void Freeze() { }
         public void SetHeader(string name, string value) { }
     }
     public partial class ResponseBufferingPolicy : System.ClientModel.Primitives.PipelinePolicy

--- a/sdk/core/System.ClientModel/src/Options/ClientPipelineOptions.cs
+++ b/sdk/core/System.ClientModel/src/Options/ClientPipelineOptions.cs
@@ -16,17 +16,50 @@ public class ClientPipelineOptions
     private static readonly ClientPipelineOptions _defaultOptions = new();
     internal static ClientPipelineOptions Default => _defaultOptions;
 
+    private bool _frozen;
+
+    private PipelinePolicy? _retryPolicy;
+    private PipelineTransport? _transport;
+    private TimeSpan? _timeout;
+
     #region Pipeline creation: Overrides of default pipeline policies
 
-    public PipelinePolicy? RetryPolicy { get; set; }
+    public PipelinePolicy? RetryPolicy
+    {
+        get => _retryPolicy;
+        set
+        {
+            AssertNotFrozen();
 
-    public PipelineTransport? Transport { get; set; }
+            _retryPolicy = value;
+        }
+    }
+
+    public PipelineTransport? Transport
+    {
+        get => _transport;
+        set
+        {
+            AssertNotFrozen();
+
+            _transport = value;
+        }
+    }
 
     #endregion
 
     #region Pipeline creation: Policy settings
 
-    public TimeSpan? NetworkTimeout { get; set; }
+    public TimeSpan? NetworkTimeout
+    {
+        get => _timeout;
+        set
+        {
+            AssertNotFrozen();
+
+            _timeout = value;
+        }
+    }
 
     #endregion
 
@@ -41,6 +74,7 @@ public class ClientPipelineOptions
     public void AddPolicy(PipelinePolicy policy, PipelinePosition position)
     {
         Argument.AssertNotNull(policy, nameof(policy));
+        AssertNotFrozen();
 
         switch (position)
         {
@@ -76,4 +110,14 @@ public class ClientPipelineOptions
     }
 
     #endregion
+
+    public virtual void Freeze() => _frozen = true;
+
+    protected void AssertNotFrozen()
+    {
+        if (_frozen)
+        {
+            throw new InvalidOperationException("Cannot change a ClientPipelineOptions instance after it has been used to create a ClientPipeline.");
+        }
+    }
 }

--- a/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
+++ b/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
@@ -16,6 +16,9 @@ public class RequestOptions
 {
     private bool _frozen;
 
+    private CancellationToken _cancellationToken = CancellationToken.None;
+    private ClientErrorBehaviors _errorOptions = ClientErrorBehaviors.Default;
+
     private PipelinePolicy[]? _perCallPolicies;
     private PipelinePolicy[]? _perTryPolicies;
     private PipelinePolicy[]? _beforeTransportPolicies;
@@ -24,13 +27,29 @@ public class RequestOptions
 
     public RequestOptions()
     {
-        CancellationToken = CancellationToken.None;
-        ErrorOptions = ClientErrorBehaviors.Default;
     }
 
-    public CancellationToken CancellationToken { get; set; }
+    public CancellationToken CancellationToken
+    {
+        get => _cancellationToken;
+        set
+        {
+            AssertNotFrozen();
 
-    public ClientErrorBehaviors ErrorOptions { get; set; }
+            _cancellationToken = value;
+        }
+    }
+
+    public ClientErrorBehaviors ErrorOptions
+    {
+        get => _errorOptions;
+        set
+        {
+            AssertNotFrozen();
+
+            _errorOptions = value;
+        }
+    }
 
     public void AddHeader(string name, string value)
     {

--- a/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
+++ b/sdk/core/System.ClientModel/src/Options/RequestOptions.cs
@@ -79,7 +79,7 @@ public class RequestOptions
     // Set options on the message before sending it through the pipeline.
     internal void Apply(PipelineMessage message)
     {
-        _frozen = true;
+        Freeze();
 
         // Set the cancellation token on the message so pipeline policies
         // will have access to it as the message flows through the pipeline.
@@ -119,7 +119,9 @@ public class RequestOptions
         }
     }
 
-    private void AssertNotFrozen()
+    public virtual void Freeze() => _frozen = true;
+
+    protected void AssertNotFrozen()
     {
         if (_frozen)
         {

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientPipeline.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientPipeline.cs
@@ -58,6 +58,8 @@ public sealed partial class ClientPipeline
     {
         Argument.AssertNotNull(options, nameof(options));
 
+        options.Freeze();
+
         // Add length of client-specific policies.
         int pipelineLength = perCallPolicies.Length + perTryPolicies.Length + beforeTransportPolicies.Length;
 

--- a/sdk/core/System.ClientModel/tests/Options/ClientPipelineOptionsTests.cs
+++ b/sdk/core/System.ClientModel/tests/Options/ClientPipelineOptionsTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using ClientModel.Tests;
 using ClientModel.Tests.Mocks;
 using NUnit.Framework;
-using System.ClientModel.Primitives;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.ClientModel.Tests.Options;
 

--- a/sdk/core/System.ClientModel/tests/Options/RequestOptionsTests.cs
+++ b/sdk/core/System.ClientModel/tests/Options/RequestOptionsTests.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure;
-using ClientModel.Tests.Mocks;
-using NUnit.Framework;
 using System.ClientModel.Primitives;
 using System.Threading;
+using ClientModel.Tests.Mocks;
+using NUnit.Framework;
 
 namespace System.ClientModel.Tests.Options;
 

--- a/sdk/core/System.ClientModel/tests/Options/RequestOptionsTests.cs
+++ b/sdk/core/System.ClientModel/tests/Options/RequestOptionsTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure;
 using ClientModel.Tests.Mocks;
 using NUnit.Framework;
 using System.ClientModel.Primitives;
+using System.Threading;
 
 namespace System.ClientModel.Tests.Options;
 
@@ -140,6 +142,21 @@ public class RequestOptionsTests
         RequestOptions options = new RequestOptions();
         message.Apply(options);
 
+        Assert.Throws<InvalidOperationException>(() => options.CancellationToken = CancellationToken.None);
+        Assert.Throws<InvalidOperationException>(() => options.ErrorOptions = ClientErrorBehaviors.NoThrow);
+        Assert.Throws<InvalidOperationException>(() => options.AddHeader("A", "B"));
+        Assert.Throws<InvalidOperationException>(()
+            => options.AddPolicy(new ObservablePolicy("A"), PipelinePosition.PerCall));
+    }
+
+    [Test]
+    public void CannotModifyOptionsAfterExplicitlyFrozen()
+    {
+        RequestOptions options = new RequestOptions();
+        options.Freeze();
+
+        Assert.Throws<InvalidOperationException>(() => options.CancellationToken = CancellationToken.None);
+        Assert.Throws<InvalidOperationException>(() => options.ErrorOptions = ClientErrorBehaviors.NoThrow);
         Assert.Throws<InvalidOperationException>(() => options.AddHeader("A", "B"));
         Assert.Throws<InvalidOperationException>(() => options.AddPolicy(
             new ObservablePolicy("A"), PipelinePosition.PerCall));


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/41200

Prior to this PR, we also explored how the Azure.Core 2.0 integration would look in this PR: https://github.com/Azure/azure-sdk-for-net/pull/41428:

Essentially, types derived from ClientPipelineOptions and RequestOptions must implement any custom freezing, and can use the AssertNotFrozen method provided on the base options type.  ClientPipelineOptions must be frozen explicitly by the client for derived types that don't use ClientModel's ClientPipeline so that new Azure.Core-based libraries can freeze options in the future without introducing breaking changes to existing Azure.Core-based clients.