### PR TITLE
Replace Azure AD references

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/MigrationGuideApplicationInsights.md
+++ b/sdk/monitor/Azure.Monitor.Query/MigrationGuideApplicationInsights.md
@@ -1,4 +1,4 @@
-﻿# Guide for migrating from Microsoft.Azure.ApplicationInsights.Query v1.0.0 to Azure.Monitor.Query v1.0.x
+# Guide for migrating from Microsoft.Azure.ApplicationInsights.Query v1.0.0 to Azure.Monitor.Query v1.0.x
 
 This guide assists you in the migration from [Microsoft.Azure.ApplicationInsights.Query](https://www.nuget.org/packages/Microsoft.Azure.ApplicationInsights.Query) v0.1.0 to [Azure.Monitor.Query](https://www.nuget.org/packages/Azure.Monitor.Query/) v1.0.x. Side-by-side comparisons are provided for similar operations between the two packages.
 
@@ -39,7 +39,7 @@ There are a variety of new features in version 1.0 of the `Azure.Monitor.Query` 
 - The ability to configure the retry policy used by the operations on the client.
 - The ability to map a Logs query result to a strongly typed model.
 - The ability to retrieve by column name instead of by column index.
-- Authentication with Azure Active Directory (Azure AD) credentials using [`Azure.Identity`](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity#readme).
+- Authentication with Microsoft Entra credentials using [`Azure.Identity`](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity#readme).
 
 For more new features, changes, and bug fixes, see the [CHANGELOG](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Monitor.Query_1.0.1/sdk/monitor/Azure.Monitor.Query/CHANGELOG.md).
 
@@ -47,11 +47,11 @@ For more new features, changes, and bug fixes, see the [CHANGELOG](https://githu
 
 ### Resource mode support
 
-The Azure Monitor Query library doesn't support Application Insights resources using the [classic resource mode](https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource). To use this library with a classic Application Insights resource, you must first [migrate to a workspace-based resource](https://docs.microsoft.com/azure/azure-monitor/app/convert-classic-resource).
+The Azure Monitor Query library doesn't support Application Insights resources using the [classic resource mode](https://learn.microsoft.com/azure/azure-monitor/app/create-new-resource). To use this library with a classic Application Insights resource, you must first [migrate to a workspace-based resource](https://learn.microsoft.com/azure/azure-monitor/app/convert-classic-resource).
 
 ### The client
 
-To provide a more intuitive experience, the top-level client to query logs was renamed to `LogsQueryClient` from `ApplicationInsightsDataClient`. `LogsQueryClient` can be authenticated using Azure AD. This client is the single entry point to execute a single Kusto query or a batch of Kusto queries.
+To provide a more intuitive experience, the top-level client to query logs was renamed to `LogsQueryClient` from `ApplicationInsightsDataClient`. `LogsQueryClient` can be authenticated using Microsoft Entra ID. This client is the single entry point to execute a single Kusto query or a batch of Kusto queries.
 
 #### Consistency
 
@@ -95,7 +95,7 @@ ServiceClientCredentials credentials = ApplicationTokenProvider.LoginSilentAsync
 var client = new ApplicationInsightsDataClient(credentials);
 ```
 
-In `Azure.Monitor.Query` v1.0.x, Azure AD token-based authentication is required. In fact, the underlying Azure Log Analytics service doesn't support API keys. For a list of `TokenCredential` types that satisfy this token-based authentication requirement, see [Credential Classes](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credential-classes). For example:
+In `Azure.Monitor.Query` v1.0.x, Microsoft Entra token-based authentication is required. In fact, the underlying Azure Log Analytics service doesn't support API keys. For a list of `TokenCredential` types that satisfy this token-based authentication requirement, see [Credential Classes](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credential-classes). For example:
 
 ```csharp
 using Azure.Identity;

--- a/sdk/monitor/Azure.Monitor.Query/MigrationGuideOperationalInsights.md
+++ b/sdk/monitor/Azure.Monitor.Query/MigrationGuideOperationalInsights.md
@@ -1,4 +1,4 @@
-﻿# Guide for migrating from Microsoft.Azure.OperationalInsights v1.1.0 to Azure.Monitor.Query v1.0.x
+# Guide for migrating from Microsoft.Azure.OperationalInsights v1.1.0 to Azure.Monitor.Query v1.0.x
 
 This guide assists you in the migration from [Microsoft.Azure.OperationalInsights](https://www.nuget.org/packages/Microsoft.Azure.OperationalInsights/) v1.1.0 to [Azure.Monitor.Query](https://www.nuget.org/packages/Azure.Monitor.Query/) v1.0.x. Side-by-side comparisons are provided for similar operations between the two client libraries.
 
@@ -39,7 +39,7 @@ There are a variety of new features in version 1.0 of the `Azure.Monitor.Query` 
 - The ability to configure the retry policy used by the operations on the client.
 - The ability to map a Logs query result to a strongly typed model.
 - The ability to retrieve by column name instead of by column index.
-- Authentication with Azure Active Directory (Azure AD) credentials using [`Azure.Identity`](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity#readme).
+- Authentication with Microsoft Entra credentials using [`Azure.Identity`](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity#readme).
 
 For more new features, changes, and bug fixes, see the [CHANGELOG](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Monitor.Query_1.0.1/sdk/monitor/Azure.Monitor.Query/CHANGELOG.md).
 
@@ -47,7 +47,7 @@ For more new features, changes, and bug fixes, see the [CHANGELOG](https://githu
 
 ### The client
 
-To provide a more intuitive experience, the top-level client to query logs was renamed to `LogsQueryClient` from `OperationalInsightsDataClient`. `LogsQueryClient` can be authenticated using Azure AD. This client is the single entry point to execute a single Kusto query or a batch of Kusto queries.
+To provide a more intuitive experience, the top-level client to query logs was renamed to `LogsQueryClient` from `OperationalInsightsDataClient`. `LogsQueryClient` can be authenticated using Microsoft Entra ID. This client is the single entry point to execute a single Kusto query or a batch of Kusto queries.
 
 #### Consistency
 
@@ -164,7 +164,7 @@ IReadOnlyList<LogsTableRow> rows = table.Rows;
 foreach (LogsTableRow row in rows)
 {
     Console.WriteLine(row.GetString(0)); // Access a particular element with index
-    Console.WriteLine(row.GetTimeSpan(1)); 
+    Console.WriteLine(row.GetTimeSpan(1));
     Console.WriteLine(row.ToString());
 }
 ```

--- a/sdk/monitor/Azure.Monitor.Query/TROUBLESHOOTING.md
+++ b/sdk/monitor/Azure.Monitor.Query/TROUBLESHOOTING.md
@@ -21,9 +21,9 @@ This troubleshooting guide contains instructions to diagnose frequently encounte
 
 ## General troubleshooting
 
-The Azure Monitor Query library raises exceptions defined in the [Azure Core](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/README.md) library. For example, [RequestFailedException](https://docs.microsoft.com/dotnet/api/azure.requestfailedexception?view=azure-dotnet).
+The Azure Monitor Query library raises exceptions defined in the [Azure Core](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/README.md) library. For example, [RequestFailedException](https://learn.microsoft.com/dotnet/api/azure.requestfailedexception?view=azure-dotnet).
 
-When you interact with the library, errors returned by the service correspond to the same HTTP status codes returned for [REST API](https://docs.microsoft.com/rest/api/monitor/) requests. For example, if you submit an invalid logs query, an HTTP 400 error is returned, indicating "Bad Request".
+When you interact with the library, errors returned by the service correspond to the same HTTP status codes returned for [REST API](https://learn.microsoft.com/rest/api/monitor/) requests. For example, if you submit an invalid logs query, an HTTP 400 error is returned, indicating "Bad Request".
 
 ```C# Snippet:BadRequest
 string workspaceId = "<workspace_id>";
@@ -56,9 +56,9 @@ Content:
 
 To troubleshoot issues with the library, first enable logging to monitor the behavior of the application. The errors and warnings in the logs generally provide useful insights into what went wrong and sometimes include corrective actions to fix issues.
 
-This library uses the standard [logging](https://docs.microsoft.com/dotnet/azure/sdk/logging) library. Basic information about HTTP sessions, such as URLs and headers, is logged at the `INFO` level.
+This library uses the standard [logging](https://learn.microsoft.com/dotnet/azure/sdk/logging) library. Basic information about HTTP sessions, such as URLs and headers, is logged at the `INFO` level.
 
-The simplest way to see the logs is to enable console logging. To create an Azure SDK log listener that outputs messages to the console, use the [AzureEventSourceListener.CreateConsoleLogger](https://docs.microsoft.com/dotnet/api/azure.core.diagnostics.azureeventsourcelistener.createconsolelogger?view=azure-dotnet) method:
+The simplest way to see the logs is to enable console logging. To create an Azure SDK log listener that outputs messages to the console, use the [AzureEventSourceListener.CreateConsoleLogger](https://learn.microsoft.com/dotnet/api/azure.core.diagnostics.azureeventsourcelistener.createconsolelogger?view=azure-dotnet) method:
 
 ```csharp
 using Azure.Core.Diagnostics;
@@ -71,7 +71,7 @@ To learn about other logging mechanisms, see [Azure SDK diagnostics](https://git
 
 ### Authentication errors
 
-Azure Monitor Query supports Azure Active Directory authentication. Both `LogsQueryClient` and `MetricsQueryClient` have methods to set the credential. To provide a valid credential, you can use the `Azure.Identity` package. For more information on getting started, see the [Azure Monitor Query library's README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/README.md#authenticate-the-client). For details on the credential types supported in `Azure.Identity`, see the [Azure Identity library's documentation](https://docs.microsoft.com/dotnet/api/overview/azure/Identity-readme).
+Azure Monitor Query supports Microsoft Entra authentication. Both `LogsQueryClient` and `MetricsQueryClient` have methods to set the credential. To provide a valid credential, you can use the `Azure.Identity` package. For more information on getting started, see the [Azure Monitor Query library's README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/README.md#authenticate-the-client). For details on the credential types supported in `Azure.Identity`, see the [Azure Identity library's documentation](https://learn.microsoft.com/dotnet/api/overview/azure/Identity-readme).
 
 For more help with troubleshooting authentication errors, see the Azure Identity client library [troubleshooting guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/TROUBLESHOOTING.md).
 
@@ -87,8 +87,8 @@ If you get an HTTP error with status code 403 (Forbidden), it means the provided
 
 Confirm that:
 
-1. Sufficient permissions have been granted to the application or user making the request. For more information, see [manage access to workspaces](https://docs.microsoft.com/azure/azure-monitor/logs/manage-access#manage-access-using-workspace-permissions).
-1. You're authenticating as that user or application if the user or application is granted sufficient privileges to query the workspace.  If you're authenticating using the [DefaultAzureCredential](https://docs.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet), check the logs to verify the credential used is the one you expected. To enable logging, see the [Enable client logging](#enable-client-logging) section.
+1. Sufficient permissions have been granted to the application or user making the request. For more information, see [manage access to workspaces](https://learn.microsoft.com/azure/azure-monitor/logs/manage-access#manage-access-using-workspace-permissions).
+1. You're authenticating as that user or application if the user or application is granted sufficient privileges to query the workspace.  If you're authenticating using the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet), check the logs to verify the credential used is the one you expected. To enable logging, see the [Enable client logging](#enable-client-logging) section.
 
 For more help on troubleshooting authentication errors, see the Azure Identity client library [troubleshooting guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/TROUBLESHOOTING.md).
 
@@ -110,7 +110,7 @@ Inner error: {
 }
 ```
 
-The error message in `innererror` may include the location where the Kusto query has an error. You may also refer to the [Kusto Query Language](https://docs.microsoft.com/azure/data-explorer/kusto/query) (KQL) reference docs to learn more about querying logs using KQL.
+The error message in `innererror` may include the location where the Kusto query has an error. You may also refer to the [Kusto Query Language](https://learn.microsoft.com/azure/data-explorer/kusto/query) (KQL) reference docs to learn more about querying logs using KQL.
 
 ### Troubleshooting empty log query results
 
@@ -197,8 +197,8 @@ If you get an HTTP error with status code 403 (Forbidden), it means the provided
 
 Confirm that:
 
-1. Sufficient permissions have been granted to the application or user making the request. For more information, see [manage access to workspaces](https://docs.microsoft.com/azure/azure-monitor/logs/manage-access#manage-access-using-workspace-permissions).
-1. You're authenticating as that user or application if the user or application is granted sufficient privileges to query the workspace. If you're authenticating using the [DefaultAzureCredential](https://docs.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet), check the logs to verify the credential used is the one you expected. To enable logging, see the [Enable client logging](#enable-client-logging) section.
+1. Sufficient permissions have been granted to the application or user making the request. For more information, see [manage access to workspaces](https://learn.microsoft.com/azure/azure-monitor/logs/manage-access#manage-access-using-workspace-permissions).
+1. You're authenticating as that user or application if the user or application is granted sufficient privileges to query the workspace. If you're authenticating using the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet), check the logs to verify the credential used is the one you expected. To enable logging, see the [Enable client logging](#enable-client-logging) section.
 
 For more help with troubleshooting authentication errors, see the Azure Identity client library [troubleshooting guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/TROUBLESHOOTING.md).
 


### PR DESCRIPTION
**Summary of changes**
- Replace Azure AD references with Entra, per the guidance at https://learn.microsoft.com/entra/fundamentals/how-to-rename-azure-ad
- Replace docs.microsoft.com links with learn.microsoft.com links