### PR TITLE
Adding duration field to TranscriptionData object.

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -1405,9 +1405,10 @@ namespace Azure.Communication.CallAutomation
     {
         internal TranscriptionData() { }
         public double Confidence { get { throw null; } set { } }
+        public ulong Duration { get { throw null; } set { } }
         public Azure.Communication.CallAutomation.TextFormat Format { get { throw null; } set { } }
         public ulong Offset { get { throw null; } set { } }
-        public Azure.Communication.CommunicationUserIdentifier Participant { get { throw null; } set { } }
+        public Azure.Communication.CommunicationIdentifier Participant { get { throw null; } set { } }
         public Azure.Communication.CallAutomation.ResultStatus ResultStatus { get { throw null; } set { } }
         public string Text { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.WordData> Words { get { throw null; } set { } }
@@ -1607,6 +1608,8 @@ namespace Azure.Communication.CallAutomation
     public partial class WordData
     {
         public WordData() { }
+        [System.Text.Json.Serialization.JsonPropertyNameAttribute("duration")]
+        public ulong Duration { get { throw null; } set { } }
         [System.Text.Json.Serialization.JsonPropertyNameAttribute("offset")]
         public ulong Offset { get { throw null; } set { } }
         [System.Text.Json.Serialization.JsonPropertyNameAttribute("text")]

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Media/AudioData.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Media/AudioData.cs
@@ -16,7 +16,7 @@ namespace Azure.Communication.CallAutomation
             Timestamp = timestamp;
             if (participantId != null)
             {
-                Participant = new CommunicationUserIdentifier(participantId);
+                Participant = CommunicationIdentifier.FromRawId(participantId);;
             }
             IsSilent = silent;
         }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/StreamingDataParser.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/StreamingDataParser.cs
@@ -71,6 +71,7 @@ namespace Azure.Communication.CallAutomation
                         transcriptionDataInternal.Format,
                         transcriptionDataInternal.Confidence,
                         transcriptionDataInternal.Offset,
+                        transcriptionDataInternal.Duration,
                         transcriptionDataInternal.Words,
                         transcriptionDataInternal.ParticipantRawID,
                         transcriptionDataInternal.ResultStatus

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/TranscriptionData.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/TranscriptionData.cs
@@ -21,7 +21,7 @@ namespace Azure.Communication.CallAutomation
             Words = words;
             if (participantRawID != null)
             {
-                Participant = new CommunicationUserIdentifier(participantRawID);
+                Participant = CommunicationIdentifier.FromRawId(participantRawID);
             }
             ResultStatus = ConvertToResultStatusEnum(resultStatus);
         }
@@ -60,7 +60,7 @@ namespace Azure.Communication.CallAutomation
         /// <summary>
         /// The identified speaker based on participant raw ID
         /// </summary>
-        public CommunicationUserIdentifier Participant { get; set; }
+        public CommunicationIdentifier Participant { get; set; }
 
         /// <summary>
         /// Status of the result of transcription

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/TranscriptionData.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/TranscriptionData.cs
@@ -11,12 +11,13 @@ namespace Azure.Communication.CallAutomation
     /// </summary>
     public class TranscriptionData : StreamingData
     {
-        internal TranscriptionData(string text, string format, double confidence, ulong offset, IEnumerable<WordData> words, string participantRawID, string resultStatus)
+        internal TranscriptionData(string text, string format, double confidence, ulong offset, ulong duration, IEnumerable<WordData> words, string participantRawID, string resultStatus)
         {
             Text = text;
             Format = ConvertToTextFormatEnum(format);
             Confidence = confidence;
             Offset = offset;
+            Duration = duration;
             Words = words;
             if (participantRawID != null)
             {
@@ -45,6 +46,11 @@ namespace Azure.Communication.CallAutomation
         /// </summary>
 
         public ulong Offset { get; set; }
+
+        /// <summary>
+        /// Duration in ticks. 1 tick = 100 nanoseconds.
+        /// </summary>
+        public ulong Duration { get; set; }
 
         /// <summary>
         /// The result for each word of the phrase

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/TranscriptionDataInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/TranscriptionDataInternal.cs
@@ -37,6 +37,12 @@ namespace Azure.Communication.CallAutomation
         public ulong Offset { get; set; }
 
         /// <summary>
+        /// Duration in ticks. 1 tick = 100 nanoseconds.
+        /// </summary>
+        [JsonPropertyName("duration")]
+        public ulong Duration { get; set; }
+
+        /// <summary>
         /// The result for each word of the phrase
         /// </summary>
         [JsonPropertyName("words")]

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/WordData.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/Streaming/Transcription/WordData.cs
@@ -20,5 +20,11 @@ namespace Azure.Communication.CallAutomation
         /// </summary>
         [JsonPropertyName("offset")]
         public ulong Offset { get; set; }
+
+        /// <summary>
+        /// Duration in ticks. 1 tick = 100 nanoseconds.
+        /// </summary>
+        [JsonPropertyName("duration")]
+        public ulong Duration { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
@@ -165,12 +165,12 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
                     "[" +
                         "{" +
                             "\"text\":\"Hello\"," +
-                            "\"offset\":1" +
+                            "\"offset\":1," +
                             "\"duration\":1" +
                         "}," +
                         "{" +
                             "\"text\":\"World\"," +
-                            "\"offset\":6" +
+                            "\"offset\":6," +
                             "\"duration\":1" +
                         "}" +
                     "]," +

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
@@ -160,15 +160,18 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
                     "\"format\":\"display\"," +
                     "\"confidence\":0.98," +
                     "\"offset\":1," +
+                    "\"duration\":2," +
                     "\"words\":" +
                     "[" +
                         "{" +
                             "\"text\":\"Hello\"," +
                             "\"offset\":1" +
+                            "\"duration\":1" +
                         "}," +
                         "{" +
                             "\"text\":\"World\"," +
                             "\"offset\":6" +
+                            "\"duration\":1" +
                         "}" +
                     "]," +
                     "\"participantRawID\":\"abc12345\"," +
@@ -192,6 +195,7 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             jsonData["transcriptionData"]!["format"] = "display";
             jsonData["transcriptionData"]!["confidence"] = 0.98d;
             jsonData["transcriptionData"]!["offset"] = 1;
+            jsonData["transcriptionData"]!["duration"] = 2;
 
             JArray words = new();
             jsonData["transcriptionData"]!["words"] = words;
@@ -199,14 +203,16 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             JObject word0 = new()
             {
                 ["text"] = "Hello",
-                ["offset"] = 1
+                ["offset"] = 1,
+                ["duration"] = 1
             };
             words.Add(word0);
 
             JObject word1 = new()
             {
                 ["text"] = "World",
-                ["offset"] = 6
+                ["offset"] = 6,
+                ["duration"] = 1
             };
             words.Add(word1);
 
@@ -231,6 +237,7 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             jsonData["transcriptionData"]!["format"] = "display";
             jsonData["transcriptionData"]!["confidence"] = 0.98d;
             jsonData["transcriptionData"]!["offset"] = 1;
+            jsonData["transcriptionData"]!["duration"] = 2;
 
             JArray words = new();
             jsonData["transcriptionData"]!["words"] = words;
@@ -238,14 +245,16 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             JObject word0 = new()
             {
                 ["text"] = "Hello",
-                ["offset"] = 1
+                ["offset"] = 1,
+                ["duration"] = 1
             };
             words.Add(word0);
 
             JObject word1 = new()
             {
                 ["text"] = "World",
-                ["offset"] = 6
+                ["offset"] = 6,
+                ["duration"] = 1
             };
             words.Add(word1);
 
@@ -275,14 +284,17 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
             Assert.AreEqual(TextFormat.Display, transcription.Format);
             Assert.AreEqual(0.98d, transcription.Confidence);
             Assert.AreEqual(1, transcription.Offset);
+            Assert.AreEqual(2, transcription.Duration);
 
             // validate individual words
             IList<WordData> words = transcription.Words.ToList();
             Assert.AreEqual(2, words.Count);
             Assert.AreEqual("Hello", words[0].Text);
             Assert.AreEqual(1, words[0].Offset);
+            Assert.AreEqual(1, words[0].Duration);
             Assert.AreEqual("World", words[1].Text);
             Assert.AreEqual(6, words[1].Offset);
+            Assert.AreEqual(1, words[1].Duration);
 
             Assert.IsTrue(transcription.Participant is CommunicationIdentifier);
             Assert.AreEqual("abc12345", transcription.Participant.RawId);


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

---
This is the parsed data in my own websocket server:
```
Data:
        text: Oh no, it's raining again.
        format: Display
        confidence: 0.7479382753372192
        offset: 2516961655963232612
        duration: 30400000
        participantType: Phone Number
        participantId: +120644XXXXX
        words: - text: oh
                offset: 2516961655989632612
                duration: 4000000
               - text: no
                offset: 2516961655992032612
                duration: 5600000
               - text: it's
                offset: 2516961656000432612
                duration: 5600000
               - text: raining
                offset: 2516961656004832612
                duration: 6800000
               - text: again
                offset: 2516961656012832612
                duration: 5600000
```