### PR TITLE
[Monitor] Remove unnecessary suppressions of AZC0001

### DIFF
--- a/sdk/monitor/Azure.Monitor.Ingestion/src/GlobalSuppressions.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Usage", "AZC0001:Use one of the following pre-approved namespace groups (https://azure.github.io/azure-sdk/registered_namespaces.html): Azure.AI, Azure.Analytics, Azure.Communication, Azure.Data, Azure.DigitalTwins, Azure.IoT, Azure.Learn, Azure.Media, Azure.Management, Azure.Messaging, Azure.ResourceManager, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure", Justification = "https://github.com/Azure/azure-sdk-tools/issues/3483", Scope = "namespace", Target = "~N:Azure.Monitor.Ingestion")]

--- a/sdk/monitor/Azure.Monitor.Query/src/Azure.Monitor.Query.csproj
+++ b/sdk/monitor/Azure.Monitor.Query/src/Azure.Monitor.Query.csproj
@@ -8,7 +8,6 @@
     <PackageTags>Azure Monitor Query</PackageTags>
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);AZC0001</NoWarn>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
   </PropertyGroup>
 


### PR DESCRIPTION
Analyzer rule AZC0001 checks that a namespace uses an approved prefix. I noticed that several libraries are suppressing this rule even though they are using approved prefixes. This change removes those unnecessary suppressions from Azure.Monitor.*.