### PR TITLE
Adding interruptCallMediaOperation to PlayToAll operation.

### DIFF
--- a/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/api/Azure.Communication.CallAutomation.netstandard2.0.cs
@@ -1002,6 +1002,7 @@ namespace Azure.Communication.CallAutomation
     {
         public PlayToAllOptions(Azure.Communication.CallAutomation.PlaySource playSource) { }
         public PlayToAllOptions(System.Collections.Generic.IEnumerable<Azure.Communication.CallAutomation.PlaySource> playSources) { }
+        public bool InterruptCallMediaOperation { get { throw null; } set { } }
         public bool Loop { get { throw null; } set { } }
         public System.Uri OperationCallbackUri { get { throw null; } set { } }
         public string OperationContext { get { throw null; } set { } }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/CallMedia.cs
@@ -175,7 +175,7 @@ namespace Azure.Communication.CallAutomation
 
             if (options != null)
             {
-                request.PlayOptions = new PlayOptionsInternal(options.Loop);
+                request.PlayOptions = new PlayOptionsInternal(options.Loop, options.InterruptCallMediaOperation);
                 request.OperationContext = options.OperationContext;
                 request.OperationCallbackUri = options.OperationCallbackUri?.AbsoluteUri;
             }
@@ -204,6 +204,7 @@ namespace Azure.Communication.CallAutomation
                 playOptions.OperationContext = options.OperationContext;
                 playOptions.Loop = options.Loop;
                 playOptions.OperationCallbackUri = options.OperationCallbackUri;
+                playOptions.InterruptCallMediaOperation = options.InterruptCallMediaOperation;
                 return await PlayAsync(playOptions, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayOptionsInternal.Serialization.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayOptionsInternal.Serialization.cs
@@ -17,6 +17,11 @@ namespace Azure.Communication.CallAutomation
             writer.WriteStartObject();
             writer.WritePropertyName("loop"u8);
             writer.WriteBooleanValue(Loop);
+            if (Optional.IsDefined(InterruptCallMediaOperation))
+            {
+                writer.WritePropertyName("interruptCallMediaOperation"u8);
+                writer.WriteBooleanValue(InterruptCallMediaOperation.Value);
+            }
             writer.WriteEndObject();
         }
     }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayOptionsInternal.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Generated/Models/PlayOptionsInternal.cs
@@ -17,7 +17,18 @@ namespace Azure.Communication.CallAutomation
             Loop = loop;
         }
 
+        /// <summary> Initializes a new instance of <see cref="PlayOptionsInternal"/>. </summary>
+        /// <param name="loop"> The option to play the provided audio source in loop when set to true. </param>
+        /// <param name="interruptCallMediaOperation"> If set play can barge into other existing queued-up/currently-processing requests. </param>
+        internal PlayOptionsInternal(bool loop, bool? interruptCallMediaOperation)
+        {
+            Loop = loop;
+            InterruptCallMediaOperation = interruptCallMediaOperation;
+        }
+
         /// <summary> The option to play the provided audio source in loop when set to true. </summary>
         public bool Loop { get; }
+        /// <summary> If set play can barge into other existing queued-up/currently-processing requests. </summary>
+        public bool? InterruptCallMediaOperation { get; set; }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayOptions.cs
@@ -39,6 +39,11 @@ namespace Azure.Communication.CallAutomation
         public Uri OperationCallbackUri { get; set; }
 
         /// <summary>
+        /// If set play can barge into other existing queued-up/currently-processing requests.
+        /// </summary>
+        internal bool InterruptCallMediaOperation { get; set; }
+
+        /// <summary>
         /// Creates a new PlayOptions object.
         /// </summary>
         public PlayOptions(IEnumerable<PlaySource> playSources, IEnumerable<CommunicationIdentifier> playTo)

--- a/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayToAllOptions.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/Models/PlayToAllOptions.cs
@@ -23,6 +23,11 @@ namespace Azure.Communication.CallAutomation
         public bool Loop { get; set; }
 
         /// <summary>
+        /// If set play can barge into other existing queued-up/currently-processing requests.
+        /// </summary>
+        public bool InterruptCallMediaOperation { get; set; }
+
+        /// <summary>
         /// The Operation Context.
         /// </summary>
         public string OperationContext { get; set; }

--- a/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
@@ -10,7 +10,7 @@ model-namespace: false
 tag: package-2023-10-03-preview
 
 require:
-    - https://github.com/Azure/azure-rest-api-specs/blob/b0684b1e4e3b621cb4caeebadb26c636a7702937/specification/communication/data-plane/CallAutomation/readme.md
+    - https://github.com/Azure/azure-rest-api-specs/blob/d8da22ab2945def549943e7f44e00bc20bf32943/specification/communication/data-plane/CallAutomation/readme.md
 
 
 title: Azure Communication Services

--- a/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
+++ b/sdk/communication/Azure.Communication.CallAutomation/src/autorest.md
@@ -10,7 +10,7 @@ model-namespace: false
 tag: package-2023-10-03-preview
 
 require:
-    - https://github.com/Azure/azure-rest-api-specs/blob/d8da22ab2945def549943e7f44e00bc20bf32943/specification/communication/data-plane/CallAutomation/readme.md
+    - https://github.com/Azure/azure-rest-api-specs/blob/e512ec327a8a5c8a5edc3b72a5aafa4425d16248/specification/communication/data-plane/CallAutomation/readme.md
 
 
 title: Azure Communication Services

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
@@ -255,6 +255,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
+        [TestCaseSource(nameof(TestData_PlayOperations_WithBargeIn))]
+        public void MediaOperationsWithBargeIn_Return202Accepted(Func<CallMedia, Response<PlayResult>> operation)
+        {
+            _callMedia = GetCallMedia(202);
+            var result = operation(_callMedia);
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+        }
+
         [TestCaseSource(nameof(TestData_CancelOperations))]
         public void CancelOperations_Return202Accepted(Func<CallMedia, Response<CancelAllMediaOperationsResult>> operation)
         {
@@ -562,6 +571,34 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 new Func<CallMedia, Task<Response<PlayResult>>>?[]
                 {
                    callMedia => callMedia.PlayToAllAsync(_ssmlPlayToAllOptions)
+                },
+            };
+        }
+
+        private static IEnumerable<object?[]> TestData_PlayOperations_WithBargeIn()
+        {
+            return new[]
+            {
+                new Func<CallMedia, Response<PlayResult>>?[]
+                {
+                   callMedia => {
+                       _filePlayToAllOptions.InterruptCallMediaOperation = true;
+                       return callMedia.PlayToAll(_filePlayToAllOptions);
+                    }
+                },
+                new Func<CallMedia, Response<PlayResult>>?[]
+                {
+                   callMedia => {
+                       _textPlayToAllOptions.InterruptCallMediaOperation = true;
+                       return callMedia.PlayToAll(_textPlayToAllOptions);
+                    }
+                },
+                new Func<CallMedia, Response<PlayResult>>?[]
+                {
+                   callMedia => {
+                       _ssmlPlayToAllOptions.InterruptCallMediaOperation = true;
+                       return callMedia.PlayToAll(_ssmlPlayToAllOptions);
+                    }
                 },
             };
         }


### PR DESCRIPTION
Tested on [this CFV](https://ngc.skype.net/call/dce5e8cf-1087-4495-a0ae-0861f9bd7b09/) with the following sequence:
* PlayTo participant. (PlayCompleted)
* PlayToAll without the new flag. (PlayCompleted)
* PlayToAll with the flag set to false. (Queued and then PlayCanceled)
* PlayToAll with the flag set to true. (PlayCompleted)


# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
