### PR TITLE
[ACS] The identifier serializer updates in the Shared package 

### DIFF
--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
@@ -42,6 +42,16 @@ namespace Azure.Communication
                       rawId);
             }
 
+            if (kind == CommunicationIdentifierModelKind.MicrosoftTeamsApp
+                 && identifier.MicrosoftTeamsApp is not null)
+            {
+                var app = identifier.MicrosoftTeamsApp;
+                return new MicrosoftTeamsAppIdentifier(
+                      AssertNotNull(app.AppId, nameof(app.AppId), nameof(MicrosoftTeamsAppIdentifierModel)),
+                      Deserialize(AssertNotNull(app.Cloud, nameof(app.Cloud), nameof(MicrosoftTeamsAppIdentifierModel))),
+                      rawId);
+            }
+
             return new UnknownIdentifier(rawId);
 
             static void AssertMaximumOneNestedModel(CommunicationIdentifierModel identifier)
@@ -53,6 +63,8 @@ namespace Azure.Communication
                     presentProperties.Add(nameof(identifier.PhoneNumber));
                 if (identifier.MicrosoftTeamsUser is not null)
                     presentProperties.Add(nameof(identifier.MicrosoftTeamsUser));
+                if (identifier.MicrosoftTeamsApp is not null)
+                    presentProperties.Add(nameof(identifier.MicrosoftTeamsApp));
 
                 if (presentProperties.Count > 1)
                     throw new JsonException($"Only one of the properties in {{{string.Join(", ", presentProperties)}}} should be present.");
@@ -74,6 +86,11 @@ namespace Azure.Communication
             if (identifier.MicrosoftTeamsUser is not null)
             {
                 return CommunicationIdentifierModelKind.MicrosoftTeamsUser;
+            }
+
+            if (identifier.MicrosoftTeamsApp is not null)
+            {
+                return CommunicationIdentifierModelKind.MicrosoftTeamsApp;
             }
 
             return CommunicationIdentifierModelKind.Unknown;
@@ -110,6 +127,14 @@ namespace Azure.Communication
                     MicrosoftTeamsUser = new MicrosoftTeamsUserIdentifierModel(u.UserId)
                     {
                         IsAnonymous = u.IsAnonymous,
+                        Cloud = Serialize(u.Cloud),
+                    }
+                },
+                MicrosoftTeamsAppIdentifier app => new CommunicationIdentifierModel
+                {
+                    RawId = app.RawId,
+                    MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(app.AppId)
+                    {
                         Cloud = Serialize(u.Cloud),
                     }
                 },

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs
@@ -48,8 +48,7 @@ namespace Azure.Communication
                 var app = identifier.MicrosoftTeamsApp;
                 return new MicrosoftTeamsAppIdentifier(
                       AssertNotNull(app.AppId, nameof(app.AppId), nameof(MicrosoftTeamsAppIdentifierModel)),
-                      Deserialize(AssertNotNull(app.Cloud, nameof(app.Cloud), nameof(MicrosoftTeamsAppIdentifierModel))),
-                      rawId);
+                      Deserialize(AssertNotNull(app.Cloud, nameof(app.Cloud), nameof(MicrosoftTeamsAppIdentifierModel))));
             }
 
             return new UnknownIdentifier(rawId);
@@ -135,7 +134,7 @@ namespace Azure.Communication
                     RawId = app.RawId,
                     MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(app.AppId)
                     {
-                        Cloud = Serialize(u.Cloud),
+                        Cloud = Serialize(app.Cloud),
                     }
                 },
                 UnknownIdentifier u => new CommunicationIdentifierModel

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
@@ -300,6 +300,7 @@ namespace Azure.Communication
             Assert.AreEqual(expectedIdentifier, identifier);
         }
 
+        [Test]
         public void SerializeMicrosoftTeamsApp()
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
@@ -13,6 +13,7 @@ namespace Azure.Communication
         private const string TestPhoneNumber = "+12223334444";
         private const string TestPhoneNumberRawId = "4:+12223334444";
         private const string TestTeamsUserId = "Microsoft Teams User Id";
+        private const string TestTeamsAppId = "Microsoft Teams App Id";
         private const string TestTeamsCloud = "gcch";
 
         [Test]
@@ -38,6 +39,24 @@ namespace Azure.Communication
                     PhoneNumber = new PhoneNumberIdentifierModel(TestPhoneNumber),
                     MicrosoftTeamsUser = new MicrosoftTeamsUserIdentifierModel(TestTeamsUserId, isAnonymous: true, CommunicationCloudEnvironmentModel.Public),
                 },
+                new CommunicationIdentifierModel
+                {
+                    RawId = TestRawId,
+                    CommunicationUser = new CommunicationUserIdentifierModel(TestTeamsAppId),
+                    MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(TestTeamsAppId, CommunicationCloudEnvironmentModel.Public),
+                },
+                new CommunicationIdentifierModel
+                {
+                    RawId = TestRawId,
+                    CommunicationUser = new CommunicationUserIdentifierModel(TestTeamsAppId),
+                    MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(TestTeamsAppId, CommunicationCloudEnvironmentModel.Dod),
+                },
+                new CommunicationIdentifierModel
+                {
+                    RawId = TestRawId,
+                    CommunicationUser = new CommunicationUserIdentifierModel(TestTeamsAppId),
+                    MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(TestTeamsAppId, CommunicationCloudEnvironmentModel.Gcch),
+                },
             };
 
             foreach (CommunicationIdentifierModel item in modelsWithTooManyNestedObjects)
@@ -52,6 +71,7 @@ namespace Azure.Communication
                 new CommunicationIdentifierModel(), // Missing RawId
                 new CommunicationIdentifierModel { RawId = TestRawId, MicrosoftTeamsUser = new MicrosoftTeamsUserIdentifierModel(TestTeamsUserId) { Cloud = CommunicationCloudEnvironmentModel.Public } }, // Missing IsAnonymous
                 new CommunicationIdentifierModel { RawId = TestRawId, MicrosoftTeamsUser = new MicrosoftTeamsUserIdentifierModel(TestTeamsUserId) { IsAnonymous = true, } }, // Missing Cloud
+                new CommunicationIdentifierModel { RawId = TestRawId, MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(TestTeamsUserId)  } // Missing cloud
             };
 
             foreach (CommunicationIdentifierModel item in modelsWithMissingMandatoryProperty)
@@ -271,6 +291,78 @@ namespace Azure.Communication
                 new CommunicationIdentifierModel
                 {
                     Kind = CommunicationIdentifierModelKind.MicrosoftTeamsUser,
+                    RawId = TestRawId,
+                });
+
+            UnknownIdentifier expectedIdentifier = new(TestRawId);
+
+            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            Assert.AreEqual(expectedIdentifier, identifier);
+        }
+
+
+        [TestCase(null)]
+        [TestCase(TestRawId)]
+        public void SerializeMicrosoftTeamsApp(string? rawId)
+        {
+            CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(
+                new MicrosoftTeamsAppIdentifier(TestTeamsAppId, CommunicationCloudEnvironment.Dod, rawId));
+
+            Assert.AreEqual(TestTeamsAppId, model.MicrosoftTeamsApp.AppId);
+            Assert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsUser.Cloud);
+            Assert.AreEqual(rawId ?? $"8:dod:{TestTeamsAppId}", model.RawId);
+        }
+
+        [Test]
+        public void DeserializeMicrosoftTeamsApp()
+        {
+            MicrosoftTeamsUserIdentifier identifier = (MicrosoftTeamsAppIdentifier)CommunicationIdentifierSerializer.Deserialize(
+                new CommunicationIdentifierModel
+                {
+                    MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(TestTeamsAppId)
+                    {
+                        Cloud = TestTeamsCloud,
+                    },
+                    RawId = TestRawId,
+                });
+
+            MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch, TestRawId);
+
+            Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
+            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
+            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            Assert.AreEqual(expectedIdentifier, identifier);
+        }
+
+        [Test]
+        public void DeserializeMicrosoftTeamsApp_WithKind_DeserializesSuccessfully()
+        {
+            MicrosoftTeamsAppIdentifier identifier = (MicrosoftTeamsAppIdentifier)CommunicationIdentifierSerializer.Deserialize(
+                new CommunicationIdentifierModel
+                {
+                    Kind = CommunicationIdentifierModelKind.MicrosoftTeamsApp,
+                    MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(TestTeamsAppId)
+                    {
+                        Cloud = TestTeamsCloud,
+                    },
+                    RawId = TestRawId,
+                });
+
+            MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, false, CommunicationCloudEnvironment.Gcch, TestRawId);
+
+            Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
+            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
+            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            Assert.AreEqual(expectedIdentifier, identifier);
+        }
+
+        [Test]
+        public void DeserializeMicrosoftTeamsApp_WithKindAndNoUser_DeserializesUnknownIdentifier()
+        {
+            UnknownIdentifier identifier = (UnknownIdentifier)CommunicationIdentifierSerializer.Deserialize(
+                new CommunicationIdentifierModel
+                {
+                    Kind = CommunicationIdentifierModelKind.MicrosoftTeamsApp,
                     RawId = TestRawId,
                 });
 

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
@@ -300,23 +300,20 @@ namespace Azure.Communication
             Assert.AreEqual(expectedIdentifier, identifier);
         }
 
-
-        [TestCase(null)]
-        [TestCase(TestRawId)]
-        public void SerializeMicrosoftTeamsApp(string? rawId)
+        public void SerializeMicrosoftTeamsApp()
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(
-                new MicrosoftTeamsAppIdentifier(TestTeamsAppId, CommunicationCloudEnvironment.Dod, rawId));
+                new MicrosoftTeamsAppIdentifier(TestTeamsAppId, CommunicationCloudEnvironment.Dod));
 
             Assert.AreEqual(TestTeamsAppId, model.MicrosoftTeamsApp.AppId);
-            Assert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsUser.Cloud);
-            Assert.AreEqual(rawId ?? $"8:dod:{TestTeamsAppId}", model.RawId);
+            Assert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsApp.Cloud);
+            Assert.AreEqual($"28:dod:{TestTeamsAppId}", model.RawId);
         }
 
         [Test]
         public void DeserializeMicrosoftTeamsApp()
         {
-            MicrosoftTeamsUserIdentifier identifier = (MicrosoftTeamsAppIdentifier)CommunicationIdentifierSerializer.Deserialize(
+            MicrosoftTeamsAppIdentifier identifier = (MicrosoftTeamsAppIdentifier)CommunicationIdentifierSerializer.Deserialize(
                 new CommunicationIdentifierModel
                 {
                     MicrosoftTeamsApp = new MicrosoftTeamsAppIdentifierModel(TestTeamsAppId)
@@ -326,7 +323,7 @@ namespace Azure.Communication
                     RawId = TestRawId,
                 });
 
-            MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch, TestRawId);
+            MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch);
 
             Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
             Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
@@ -348,7 +345,7 @@ namespace Azure.Communication
                     RawId = TestRawId,
                 });
 
-            MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, false, CommunicationCloudEnvironment.Gcch, TestRawId);
+            MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch);
 
             Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
             Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);


### PR DESCRIPTION
# Description
As a part of the new MicrosoftTeamsAppIdentifier introduction and making it GA we are making sure the [CommunicationIdentifierSerializer](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Shared/src/CommunicationIdentifierSerializer.cs) is updated regarding the new identifier

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
