### PR TITLE
[Storage] [DataMovement] Fix Download Directory Tests

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/src/DataMovementBlobsExtensions.cs
@@ -158,6 +158,11 @@ namespace Azure.Storage.DataMovement.Blobs
                 range = ContentRange.ToHttpRange(contentRange);
                 size = contentRange.Size;
             }
+            else if (result.Details.ContentLength > 0)
+            {
+                range = new HttpRange(0, result.Details.ContentLength);
+                size = result.Details.ContentLength;
+            }
 
             return new StorageResourceReadStreamResult(
                 content: result.Content,

--- a/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceReadStreamResult.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StorageResourceReadStreamResult.cs
@@ -44,7 +44,7 @@ namespace Azure.Storage.DataMovement
             StorageResourceItemProperties properties)
         {
             Content = content;
-            ContentLength = range.Length;
+            ContentLength = range != default ? range.Length : 0;
             ResourceLength = properties.ResourceLength;
             ETag = properties.ETag;
         }


### PR DESCRIPTION
Broke the download directory tests from this PR https://github.com/Azure/azure-sdk-for-net/pull/41225 I merged.

This PR is to fix when we know the length of the download storage resource at the start of the download.

Changelog doesn't need to be updated since we haven't released yet.