### PR TITLE
#41628 Use conditional packages in Azure.Core

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
+++ b/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -20,13 +20,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory.Data" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="System.Numerics.Vectors" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="System.Numerics.Vectors" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Text.Encodings.Web" />
-    <PackageReference Include="System.Memory.Data" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Microsoft.Azure.Core.Spatial.csproj
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Microsoft.Azure.Core.Spatial.csproj
@@ -7,12 +7,14 @@
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure SDK Spatial System Text Json</PackageTags>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net6.0</TargetFrameworks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Spatial" />
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Spatial" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/sdk/core/System.ClientModel/src/System.ClientModel.csproj
+++ b/sdk/core/System.ClientModel/src/System.ClientModel.csproj
@@ -15,6 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory.Data" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
This merge adds that Azure.Core uses conditional packages so that the below packages can be excluded for net 6 due to being part of the framework.

- Microsoft.Bcl.AsyncInterfaces
- System.Diagnostics.DiagnosticSource
- System.Memory
- System.Numerics.Vectors
- System.Text.Json
- System.Text.Encodings.Web
- System.Threading.Tasks.Extensions

Closes

- #41628 