### PR TITLE
ClientModel: API Updates from architect feedback

### DIFF
--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -79,7 +79,7 @@ namespace System.ClientModel.Primitives
     {
         public static readonly System.ClientModel.Primitives.ClientRetryPolicy Default;
         public ClientRetryPolicy(int maxRetries = 3) { }
-        protected virtual System.TimeSpan GetNextDelayCore(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
+        protected virtual System.TimeSpan GetNextDelay(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
         protected virtual void OnRequestSent(System.ClientModel.Primitives.PipelineMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask OnRequestSentAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
         protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message) { }
@@ -87,10 +87,10 @@ namespace System.ClientModel.Primitives
         protected virtual void OnTryComplete(System.ClientModel.Primitives.PipelineMessage message) { }
         public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
-        protected virtual bool ShouldRetryCore(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryCoreAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        protected virtual void WaitCore(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        protected virtual System.Threading.Tasks.Task WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected virtual bool ShouldRetry(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
+        protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
+        protected virtual void Wait(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
+        protected virtual System.Threading.Tasks.Task WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class HttpClientPipelineTransport : System.ClientModel.Primitives.PipelineTransport, System.IDisposable
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net6.0.cs
@@ -79,7 +79,6 @@ namespace System.ClientModel.Primitives
     {
         public static readonly System.ClientModel.Primitives.ClientRetryPolicy Default;
         public ClientRetryPolicy(int maxRetries = 3) { }
-        public System.TimeSpan GetNextDelay(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
         protected virtual System.TimeSpan GetNextDelayCore(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
         protected virtual void OnRequestSent(System.ClientModel.Primitives.PipelineMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask OnRequestSentAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
@@ -88,12 +87,8 @@ namespace System.ClientModel.Primitives
         protected virtual void OnTryComplete(System.ClientModel.Primitives.PipelineMessage message) { }
         public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
-        public bool ShouldRetry(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        public System.Threading.Tasks.ValueTask<bool> ShouldRetryAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         protected virtual bool ShouldRetryCore(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryCoreAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        public void Wait(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.Task WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected virtual void WaitCore(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
         protected virtual System.Threading.Tasks.Task WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -147,10 +142,10 @@ namespace System.ClientModel.Primitives
         protected internal PipelineMessage(System.ClientModel.Primitives.PipelineRequest request) { }
         public bool BufferResponse { get { throw null; } set { } }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } protected internal set { } }
-        public System.ClientModel.Primitives.PipelineMessageClassifier MessageClassifier { get { throw null; } set { } }
         public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
         public System.ClientModel.Primitives.PipelineRequest Request { get { throw null; } }
         public System.ClientModel.Primitives.PipelineResponse? Response { get { throw null; } protected internal set { } }
+        public System.ClientModel.Primitives.PipelineMessageClassifier ResponseClassifier { get { throw null; } set { } }
         public void Apply(System.ClientModel.Primitives.RequestOptions options) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -79,7 +79,7 @@ namespace System.ClientModel.Primitives
     {
         public static readonly System.ClientModel.Primitives.ClientRetryPolicy Default;
         public ClientRetryPolicy(int maxRetries = 3) { }
-        protected virtual System.TimeSpan GetNextDelayCore(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
+        protected virtual System.TimeSpan GetNextDelay(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
         protected virtual void OnRequestSent(System.ClientModel.Primitives.PipelineMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask OnRequestSentAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
         protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message) { }
@@ -87,10 +87,10 @@ namespace System.ClientModel.Primitives
         protected virtual void OnTryComplete(System.ClientModel.Primitives.PipelineMessage message) { }
         public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
-        protected virtual bool ShouldRetryCore(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryCoreAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        protected virtual void WaitCore(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        protected virtual System.Threading.Tasks.Task WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected virtual bool ShouldRetry(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
+        protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
+        protected virtual void Wait(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
+        protected virtual System.Threading.Tasks.Task WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class HttpClientPipelineTransport : System.ClientModel.Primitives.PipelineTransport, System.IDisposable
     {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -79,7 +79,6 @@ namespace System.ClientModel.Primitives
     {
         public static readonly System.ClientModel.Primitives.ClientRetryPolicy Default;
         public ClientRetryPolicy(int maxRetries = 3) { }
-        public System.TimeSpan GetNextDelay(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
         protected virtual System.TimeSpan GetNextDelayCore(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
         protected virtual void OnRequestSent(System.ClientModel.Primitives.PipelineMessage message) { }
         protected virtual System.Threading.Tasks.ValueTask OnRequestSentAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
@@ -88,12 +87,8 @@ namespace System.ClientModel.Primitives
         protected virtual void OnTryComplete(System.ClientModel.Primitives.PipelineMessage message) { }
         public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
         public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
-        public bool ShouldRetry(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        public System.Threading.Tasks.ValueTask<bool> ShouldRetryAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         protected virtual bool ShouldRetryCore(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
         protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryCoreAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
-        public void Wait(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.Task WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected virtual void WaitCore(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
         protected virtual System.Threading.Tasks.Task WaitCoreAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
@@ -146,10 +141,10 @@ namespace System.ClientModel.Primitives
         protected internal PipelineMessage(System.ClientModel.Primitives.PipelineRequest request) { }
         public bool BufferResponse { get { throw null; } set { } }
         public System.Threading.CancellationToken CancellationToken { get { throw null; } protected internal set { } }
-        public System.ClientModel.Primitives.PipelineMessageClassifier MessageClassifier { get { throw null; } set { } }
         public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
         public System.ClientModel.Primitives.PipelineRequest Request { get { throw null; } }
         public System.ClientModel.Primitives.PipelineResponse? Response { get { throw null; } protected internal set { } }
+        public System.ClientModel.Primitives.PipelineMessageClassifier ResponseClassifier { get { throw null; } set { } }
         public void Apply(System.ClientModel.Primitives.RequestOptions options) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }

--- a/sdk/core/System.ClientModel/src/Message/PipelineMessage.cs
+++ b/sdk/core/System.ClientModel/src/Message/PipelineMessage.cs
@@ -19,7 +19,7 @@ public class PipelineMessage : IDisposable
         _propertyBag = new ArrayBackedPropertyBag<ulong, object>();
 
         BufferResponse = true;
-        MessageClassifier = PipelineMessageClassifier.Default;
+        ResponseClassifier = PipelineMessageClassifier.Default;
     }
 
     public PipelineRequest Request { get; }
@@ -65,7 +65,7 @@ public class PipelineMessage : IDisposable
     // the client-provided classifier or compose a chain of classification
     // handlers that preserve the functionality of the client-provided classifier
     // at the end of the chain.
-    public PipelineMessageClassifier MessageClassifier { get; set; }
+    public PipelineMessageClassifier ResponseClassifier { get; set; }
 
     public void Apply(RequestOptions options)
     {

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
@@ -133,10 +133,10 @@ public class ClientRetryPolicy : PipelinePolicy
 
     protected virtual void OnTryComplete(PipelineMessage message) { }
 
-    public bool ShouldRetry(PipelineMessage message, Exception? exception)
+    internal bool ShouldRetry(PipelineMessage message, Exception? exception)
         => ShouldRetrySyncOrAsync(message, exception, async: false).EnsureCompleted();
 
-    public async ValueTask<bool> ShouldRetryAsync(PipelineMessage message, Exception? exception)
+    internal async ValueTask<bool> ShouldRetryAsync(PipelineMessage message, Exception? exception)
         => await ShouldRetrySyncOrAsync(message, exception, async: true).ConfigureAwait(false);
 
     private async ValueTask<bool> ShouldRetrySyncOrAsync(PipelineMessage message, Exception? exception, bool async)
@@ -165,7 +165,7 @@ public class ClientRetryPolicy : PipelinePolicy
             return false;
         }
 
-        if (!message.MessageClassifier.TryClassify(message, exception, out bool isRetriable))
+        if (!message.ResponseClassifier.TryClassify(message, exception, out bool isRetriable))
         {
             bool classified = PipelineMessageClassifier.Default.TryClassify(message, exception, out isRetriable);
 
@@ -178,7 +178,7 @@ public class ClientRetryPolicy : PipelinePolicy
     protected virtual ValueTask<bool> ShouldRetryCoreAsync(PipelineMessage message, Exception? exception)
         => new(ShouldRetryCore(message, exception));
 
-    public TimeSpan GetNextDelay(PipelineMessage message, int tryCount)
+    internal TimeSpan GetNextDelay(PipelineMessage message, int tryCount)
         => GetNextDelayCore(message, tryCount);
 
     protected virtual TimeSpan GetNextDelayCore(PipelineMessage message, int tryCount)
@@ -187,7 +187,7 @@ public class ClientRetryPolicy : PipelinePolicy
         return TimeSpan.FromMilliseconds((1 << (tryCount - 1)) * _initialDelay.TotalMilliseconds);
     }
 
-    public async Task WaitAsync(TimeSpan time, CancellationToken cancellationToken)
+    internal async Task WaitAsync(TimeSpan time, CancellationToken cancellationToken)
         => await WaitCoreAsync(time, cancellationToken).ConfigureAwait(false);
 
     protected virtual async Task WaitCoreAsync(TimeSpan time, CancellationToken cancellationToken)
@@ -195,7 +195,7 @@ public class ClientRetryPolicy : PipelinePolicy
         await Task.Delay(time, cancellationToken).ConfigureAwait(false);
     }
 
-    public void Wait(TimeSpan time, CancellationToken cancellationToken)
+    internal void Wait(TimeSpan time, CancellationToken cancellationToken)
         => WaitCore(time, cancellationToken);
 
     protected virtual void WaitCore(TimeSpan time, CancellationToken cancellationToken)

--- a/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/PipelineTransport.cs
@@ -43,7 +43,7 @@ public abstract class PipelineTransport : PipelinePolicy
 
     private static bool ClassifyResponse(PipelineMessage message)
     {
-        if (!message.MessageClassifier.TryClassify(message, out bool isError))
+        if (!message.ResponseClassifier.TryClassify(message, out bool isError))
         {
             bool classified = PipelineMessageClassifier.Default.TryClassify(message, out isError);
 

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
@@ -345,7 +345,7 @@ public class ClientRetryPolicyTests : SyncAsyncTestBase
     [Test]
     public void WaitThrowsOnCancellation()
     {
-        ClientRetryPolicy retryPolicy = new();
+        MockRetryPolicy retryPolicy = new();
 
         CancellationTokenSource cts = new CancellationTokenSource();
 

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ClientModel.Primitives;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ClientModel.Tests.Mocks;
@@ -94,4 +95,10 @@ public class MockRetryPolicy : ClientRetryPolicy
 
         return base.GetNextDelayCore(message, tryCount);
     }
+
+    public async Task WaitAsync(TimeSpan time, CancellationToken cancellationToken)
+    => await WaitCoreAsync(time, cancellationToken).ConfigureAwait(false);
+
+    public void Wait(TimeSpan time, CancellationToken cancellationToken)
+        => WaitCore(time, cancellationToken);
 }

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockRetryPolicy.cs
@@ -25,11 +25,11 @@ public class MockRetryPolicy : ClientRetryPolicy
         _delayFactory = delayFactory;
     }
 
-    public Exception? LastException {  get; private set; }
+    public Exception? LastException { get; private set; }
 
     public bool ShouldRetryCalled { get; private set; }
 
-    public bool OnRequestSentCalled {  get; private set; }
+    public bool OnRequestSentCalled { get; private set; }
 
     public bool OnSendingRequestCalled { get; private set; }
 
@@ -42,20 +42,20 @@ public class MockRetryPolicy : ClientRetryPolicy
         OnRequestSentCalled = false;
     }
 
-    protected override bool ShouldRetryCore(PipelineMessage message, Exception? exception)
+    protected override bool ShouldRetry(PipelineMessage message, Exception? exception)
     {
         ShouldRetryCalled = true;
         LastException = exception;
 
-        return base.ShouldRetryCore(message, exception);
+        return base.ShouldRetry(message, exception);
     }
 
-    protected override ValueTask<bool> ShouldRetryCoreAsync(PipelineMessage message, Exception? exception)
+    protected override ValueTask<bool> ShouldRetryAsync(PipelineMessage message, Exception? exception)
     {
         ShouldRetryCalled = true;
         LastException = exception;
 
-        return base.ShouldRetryCoreAsync(message, exception);
+        return base.ShouldRetryAsync(message, exception);
     }
 
     protected override void OnRequestSent(PipelineMessage message)
@@ -86,19 +86,19 @@ public class MockRetryPolicy : ClientRetryPolicy
         return base.OnSendingRequestAsync(message);
     }
 
-    protected override TimeSpan GetNextDelayCore(PipelineMessage message, int tryCount)
+    protected override TimeSpan GetNextDelay(PipelineMessage message, int tryCount)
     {
         if (_delayFactory is not null)
         {
             return _delayFactory(tryCount);
         }
 
-        return base.GetNextDelayCore(message, tryCount);
+        return base.GetNextDelay(message, tryCount);
     }
 
-    public async Task WaitAsync(TimeSpan time, CancellationToken cancellationToken)
-    => await WaitCoreAsync(time, cancellationToken).ConfigureAwait(false);
+    public void DoWait(TimeSpan time, CancellationToken cancellationToken)
+        => Wait(time, cancellationToken);
 
-    public void Wait(TimeSpan time, CancellationToken cancellationToken)
-        => WaitCore(time, cancellationToken);
+    public async Task DoWaitAsync(TimeSpan time, CancellationToken cancellationToken)
+        => await WaitAsync(time, cancellationToken).ConfigureAwait(false);
 }

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockSyncAsyncExtensions.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockSyncAsyncExtensions.cs
@@ -73,7 +73,7 @@ public static class MockSyncAsyncExtensions
         }
     }
 
-    public static async Task WaitSyncOrAsync(this ClientRetryPolicy policy, TimeSpan delay, CancellationToken cancellationToken, bool isAsync)
+    public static async Task WaitSyncOrAsync(this MockRetryPolicy policy, TimeSpan delay, CancellationToken cancellationToken, bool isAsync)
     {
         if (isAsync)
         {

--- a/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockSyncAsyncExtensions.cs
+++ b/sdk/core/System.ClientModel/tests/TestFramework/Mocks/MockSyncAsyncExtensions.cs
@@ -77,11 +77,11 @@ public static class MockSyncAsyncExtensions
     {
         if (isAsync)
         {
-            await policy.WaitAsync(delay, cancellationToken).ConfigureAwait(false);
+            await policy.DoWaitAsync(delay, cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            policy.Wait(delay, cancellationToken);
+            policy.DoWait(delay, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
- Removes non-Core APIs not intended to be called by end-users from ClientRetryPolicy
- Changes the name of PipelineMessage.MessageClassifier to RequestClassifier to enable better Azure.Core integration