### PR TITLE
[Core] Annotate TokenCredential for auditing

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Shared\AzureKeyCredentialPolicy.cs" />
     <Compile Include="Shared\AzureSasCredentialSynchronousPolicy.cs" />
     <Compile Include="Shared\Base64Url.cs" />
+    <Compile Include="Shared\CallerShouldAuditAttribute.cs" />
     <Compile Include="Shared\ClientDiagnostics.cs" />
     <Compile Include="Shared\ContentTypeUtilities.cs" />
     <Compile Include="Shared\DiagnosticScope.cs" />

--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core.Pipeline;
 
 namespace Azure.Core
 {
@@ -20,6 +18,7 @@ namespace Azure.Core
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>A valid <see cref="AccessToken"/>.</returns>
         /// <remarks>Caching and management of the lifespan for the <see cref="AccessToken"/> is considered the responsibility of the caller: each call should request a fresh token being requested.</remarks>
+        [CallerShouldAudit("https://aka.ms/azsdk/callershouldaudit/identity")]
         public abstract ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken);
 
         /// <summary>
@@ -29,6 +28,7 @@ namespace Azure.Core
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>A valid <see cref="AccessToken"/>.</returns>
         /// <remarks>Caching and management of the lifespan for the <see cref="AccessToken"/> is considered the responsibility of the caller: each call should request a fresh token being requested.</remarks>
+        [CallerShouldAudit("https://aka.ms/azsdk/callershouldaudit/identity")]
         public abstract AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to annotate the `TokenCredential` methods that acquire a token as participants in security-related operations which callers may wish to consider auditing.

## References and related

- [Adding basic [CallerShouldAudit] support and initial support for Storage and Tables (#39345)](https://github.com/Azure/azure-sdk-for-net/pull/39345)


