### PR TITLE
Structured Message Encoding

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);netstandard2.1;net6.0</TargetFrameworks>
   </PropertyGroup>
@@ -89,6 +89,8 @@
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageTelemetryPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageVersionExtensions.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StructuredMessage.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StructuredMessageEncodingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriQueryParamsCollection.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UserDelegationKeyProperties.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
@@ -84,7 +84,7 @@ namespace Azure.Storage
         {
             if (buffer.Length < minSize)
             {
-                throw new ArgumentException($"Expected buffer Length at least {minSize}. Got {buffer.Length}.", paramName);
+                throw new ArgumentException($"Expected buffer Length of at least {minSize} bytes. Got {buffer.Length}.", paramName);
             }
         }
 
@@ -92,7 +92,7 @@ namespace Azure.Storage
         {
             if (buffer.Length != size)
             {
-                throw new ArgumentException($"Expected buffer Length exactly {size}. Got {buffer.Length}.", paramName);
+                throw new ArgumentException($"Expected buffer Length of exactly {size} bytes. Got {buffer.Length}.", paramName);
             }
         }
 

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
@@ -80,6 +80,22 @@ namespace Azure.Storage
             }
         }
 
+        internal static void AssertBufferMinimumSize(Span<byte> buffer, int minSize, string paramName)
+        {
+            if (buffer.Length < minSize)
+            {
+                throw new ArgumentException($"Expected buffer Length at least {minSize}. Got {buffer.Length}.", paramName);
+            }
+        }
+
+        internal static void AssertBufferExactSize(Span<byte> buffer, int size, string paramName)
+        {
+            if (buffer.Length != size)
+            {
+                throw new ArgumentException($"Expected buffer Length exactly {size}. Got {buffer.Length}.", paramName);
+            }
+        }
+
         public static void ThrowIfParamNull(object obj, string paramName)
         {
             if (obj == null)

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
@@ -88,7 +88,7 @@ namespace Azure.Storage
             }
         }
 
-        internal static void AssertBufferExactSize(Span<byte> buffer, int size, string paramName)
+        internal static void AssertBufferExactSize(ReadOnlySpan<byte> buffer, int size, string paramName)
         {
             if (buffer.Length != size)
             {

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
@@ -101,7 +101,7 @@ internal static class StructuredMessage
         #endregion
 
         #region SegmentFooter
-        public static int WriteSegmentFooter(Span<byte> buffer, Span<byte> crc64 = default)
+        public static int WriteSegmentFooter(Span<byte> buffer, ReadOnlySpan<byte> crc64 = default)
         {
             int requiredSpace = 0;
             if (!crc64.IsEmpty)
@@ -130,7 +130,7 @@ internal static class StructuredMessage
         public static IDisposable GetSegmentFooterBytes(
             ArrayPool<byte> pool,
             out Memory<byte> bytes,
-            Span<byte> crc64 = default)
+            ReadOnlySpan<byte> crc64 = default)
         {
             Argument.AssertNotNull(pool, nameof(pool));
             IDisposable disposable = pool.RentAsMemoryDisposable(StreamHeaderLength, out bytes);

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using Azure.Core;
+
+namespace Azure.Storage.Shared;
+
+internal static class StructuredMessage
+{
+    public const int MD5Length = 16;
+    public const int Crc64Length = 8;
+
+    [Flags]
+    public enum Flags
+    {
+        None = 0,
+        CrcSegment = 1,
+        MD5Stream = 2,
+        ServerStats = 4,
+    }
+
+    public static class V1_0
+    {
+        public const byte MessageVersionByte = 1;
+
+        public const int StreamHeaderLength = 13;
+        public const int SegmentHeaderLength = 10;
+
+        public const int ServerStatsLength = 64;
+
+        #region Stream Header
+        public static int WriteStreamHeader(Span<byte> buffer, long messageLength, Flags flags, int totalSegments)
+        {
+            const int versionOffset = 0;
+            const int messageLengthOffset = 1;
+            const int flagsOffset = 9;
+            const int numSegmentsOffset = 11;
+
+            Errors.AssertBufferMinimumSize(buffer, StreamHeaderLength, nameof(buffer));
+
+            buffer[versionOffset] = MessageVersionByte;
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(messageLengthOffset, 8), (ulong)messageLength);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(flagsOffset, 2), (ushort)flags);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(numSegmentsOffset, 2), (ushort)totalSegments);
+
+            return StreamHeaderLength;
+        }
+
+        /// <summary>
+        /// Gets stream header in a buffer rented from the provided ArrayPool.
+        /// </summary>
+        /// <returns>
+        /// Disposable to return the buffer to the pool.
+        /// </returns>
+        public static IDisposable GetStreamHeaderBytes(
+            long messageLength,
+            Flags flags,
+            int totalSegments,
+            ArrayPool<byte> pool,
+            out Memory<byte> bytes)
+        {
+            Argument.AssertNotNull(pool, nameof(pool));
+            IDisposable disposable = pool.RentAsMemoryDisposable(StreamHeaderLength, out bytes);
+            WriteStreamHeader(bytes.Span, messageLength, flags, totalSegments);
+            return disposable;
+        }
+        #endregion
+
+        #region Stream Footer
+        public static int WriteStreamFooter(Span<byte> buffer, Span<byte> md5 = default, Span<byte> serverStats = default)
+        {
+            int requiredSpace = 0;
+            if (!md5.IsEmpty)
+            {
+                Errors.AssertBufferExactSize(md5, MD5Length, nameof(md5));
+                requiredSpace += MD5Length;
+            }
+            if (!serverStats.IsEmpty)
+            {
+                Errors.AssertBufferExactSize(serverStats, ServerStatsLength, nameof(serverStats));
+                requiredSpace += ServerStatsLength;
+            }
+
+            Errors.AssertBufferMinimumSize(buffer, requiredSpace, nameof(buffer));
+            int offset = 0;
+            if (!md5.IsEmpty)
+            {
+                md5.CopyTo(buffer.Slice(offset, MD5Length));
+                offset += MD5Length;
+            }
+            if (!serverStats.IsEmpty)
+            {
+                serverStats.CopyTo(buffer.Slice(offset, ServerStatsLength));
+                offset += ServerStatsLength;
+            }
+
+            return offset;
+        }
+
+        /// <summary>
+        /// Gets stream header in a buffer rented from the provided ArrayPool.
+        /// </summary>
+        /// <returns>
+        /// Disposable to return the buffer to the pool.
+        /// </returns>
+        public static IDisposable GetStreamFooterBytes(
+            ArrayPool<byte> pool,
+            out Memory<byte> bytes,
+            Span<byte> md5 = default,
+            Span<byte> serverStats = default)
+        {
+            Argument.AssertNotNull(pool, nameof(pool));
+            IDisposable disposable = pool.RentAsMemoryDisposable(80, out bytes);
+            WriteStreamFooter(bytes.Span, md5, serverStats);
+            return disposable;
+        }
+        #endregion
+
+        #region SegmentHeader
+        public static int WriteSegmentHeader(Span<byte> buffer, int segmentNum, long segmentLength)
+        {
+            const int segmentNumOffset = 0;
+            const int segmentLengthOffset = 2;
+
+            Errors.AssertBufferMinimumSize(buffer, SegmentHeaderLength, nameof(buffer));
+
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(segmentNumOffset, 2), (ushort)segmentNum);
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(segmentLengthOffset, 8), (ulong)segmentLength);
+
+            return SegmentHeaderLength;
+        }
+
+        /// <summary>
+        /// Gets segment header in a buffer rented from the provided ArrayPool.
+        /// </summary>
+        /// <returns>
+        /// Disposable to return the buffer to the pool.
+        /// </returns>
+        public static IDisposable GetSegmentHeaderBytes(
+            int segmentNum,
+            long segmentLength,
+            ArrayPool<byte> pool,
+            out Memory<byte> bytes)
+        {
+            Argument.AssertNotNull(pool, nameof(pool));
+            IDisposable disposable = pool.RentAsMemoryDisposable(SegmentHeaderLength, out bytes);
+            WriteSegmentHeader(bytes.Span, segmentNum, segmentLength);
+            return disposable;
+        }
+        #endregion
+
+        #region SegmentFooter
+        public static int WriteSegmentFooter(Span<byte> buffer, Span<byte> crc64 = default)
+        {
+            int requiredSpace = 0;
+            if (!crc64.IsEmpty)
+            {
+                Errors.AssertBufferExactSize(crc64, Crc64Length, nameof(crc64));
+                requiredSpace += Crc64Length;
+            }
+
+            Errors.AssertBufferMinimumSize(buffer, requiredSpace, nameof(buffer));
+            int offset = 0;
+            if (!crc64.IsEmpty)
+            {
+                crc64.CopyTo(buffer.Slice(offset, Crc64Length));
+                offset += Crc64Length;
+            }
+
+            return offset;
+        }
+
+        /// <summary>
+        /// Gets stream header in a buffer rented from the provided ArrayPool.
+        /// </summary>
+        /// <returns>
+        /// Disposable to return the buffer to the pool.
+        /// </returns>
+        public static IDisposable GetSegmentFooterBytes(
+            ArrayPool<byte> pool,
+            out Memory<byte> bytes,
+            Span<byte> crc64 = default)
+        {
+            Argument.AssertNotNull(pool, nameof(pool));
+            IDisposable disposable = pool.RentAsMemoryDisposable(StreamHeaderLength, out bytes);
+            WriteSegmentFooter(bytes.Span, crc64);
+            return disposable;
+        }
+        #endregion
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
@@ -28,7 +28,11 @@ internal static class StructuredMessage
         public const int SegmentHeaderLength = 10;
 
         #region Stream Header
-        public static int WriteStreamHeader(Span<byte> buffer, long messageLength, Flags flags, int totalSegments)
+        public static int WriteStreamHeader(
+            Span<byte> buffer,
+            long messageLength,
+            Flags flags,
+            int totalSegments)
         {
             const int versionOffset = 0;
             const int messageLengthOffset = 1;

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessage.cs
@@ -52,11 +52,11 @@ internal static class StructuredMessage
         /// Disposable to return the buffer to the pool.
         /// </returns>
         public static IDisposable GetStreamHeaderBytes(
+            ArrayPool<byte> pool,
+            out Memory<byte> bytes,
             long messageLength,
             Flags flags,
-            int totalSegments,
-            ArrayPool<byte> pool,
-            out Memory<byte> bytes)
+            int totalSegments)
         {
             Argument.AssertNotNull(pool, nameof(pool));
             IDisposable disposable = pool.RentAsMemoryDisposable(StreamHeaderLength, out bytes);
@@ -88,10 +88,10 @@ internal static class StructuredMessage
         /// Disposable to return the buffer to the pool.
         /// </returns>
         public static IDisposable GetSegmentHeaderBytes(
-            int segmentNum,
-            long segmentLength,
             ArrayPool<byte> pool,
-            out Memory<byte> bytes)
+            out Memory<byte> bytes,
+            int segmentNum,
+            long segmentLength)
         {
             Argument.AssertNotNull(pool, nameof(pool));
             IDisposable disposable = pool.RentAsMemoryDisposable(SegmentHeaderLength, out bytes);

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessageEncodingStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessageEncodingStream.cs
@@ -68,6 +68,12 @@ internal class StructuredMessageEncodingStream : Stream
 
     public override bool CanSeek => _innerStream.CanSeek;
 
+    public override bool CanTimeout => _innerStream.CanTimeout;
+
+    public override int ReadTimeout => _innerStream.ReadTimeout;
+
+    public override int WriteTimeout => _innerStream.WriteTimeout;
+
     public override long Length =>
         _streamHeaderLength + _streamFooterLength +
         (_segmentHeaderLength + _segmentFooterLength) * TotalSegments +

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessageEncodingStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StructuredMessageEncodingStream.cs
@@ -1,0 +1,445 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Storage.Shared;
+
+internal class StructuredMessageEncodingStream : Stream
+{
+    private readonly Stream _innerStream;
+    private long _maxInnerSeekPosition = 0;
+
+    private readonly int _streamHeaderLength;
+    private readonly int _streamFooterLength;
+    private readonly int _segmentHeaderLength;
+    private readonly int _segmentFooterLength;
+    private readonly int _segmentContentLength;
+
+    private readonly StructuredMessage.Flags _flags;
+
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets the 1-indexed segment number the underlying stream is currently positioned in.
+    /// 1-indexed to match segment labelling as specified by SM spec.
+    /// </summary>
+    private int CurrentSegment => (int)Math.Ceiling(_innerStream.Position / (float)_segmentContentLength);
+
+    /// <summary>
+    /// Segment length including header and footer.
+    /// </summary>
+    private int SegmentTotalLength => _segmentHeaderLength + _segmentContentLength + _segmentFooterLength;
+
+    private int TotalSegments => (int)Math.Ceiling(_innerStream.Length / (float)_segmentContentLength);
+
+    public override bool CanRead => true;
+
+    public override bool CanWrite => false;
+
+    public override bool CanSeek => _innerStream.CanSeek;
+
+    public override long Length =>
+        _streamHeaderLength + _streamFooterLength +
+        (_segmentHeaderLength + _segmentFooterLength) * TotalSegments +
+        _innerStream.Length;
+
+    #region Position
+    private enum SMRegion
+    {
+        StreamHeader,
+        StreamFooter,
+        SegmentHeader,
+        SegmentFooter,
+        SegmentContent,
+    }
+
+    private SMRegion _currentRegion = SMRegion.StreamHeader;
+    private int _currentRegionPosition = 0;
+
+    public override long Position
+    {
+        get
+        {
+            // in-between underlying content segments
+            if (_innerStream.Position % _segmentContentLength == 0)
+            {
+                switch (_currentRegion)
+                {
+                    case SMRegion.StreamHeader:
+                        return _currentRegionPosition;
+                    case SMRegion.StreamFooter:
+                        return _streamHeaderLength +
+                            TotalSegments * (_segmentHeaderLength + _segmentFooterLength) +
+                            _innerStream.Length +
+                            _currentRegionPosition;
+                    case SMRegion.SegmentHeader:
+                        return _innerStream.Position +
+                            _streamHeaderLength +
+                            (CurrentSegment - 1) * (_segmentHeaderLength + _segmentFooterLength) +
+                            _currentRegionPosition;
+                    case SMRegion.SegmentFooter:
+                        return _innerStream.Position +
+                            _streamHeaderLength +
+                            CurrentSegment * (_segmentHeaderLength + _segmentFooterLength) -
+                            _segmentFooterLength + _currentRegionPosition;
+                }
+                throw new InvalidDataException($"{nameof(StructuredMessageEncodingStream)} invalid state.");
+            }
+            // in underlying content
+            else
+            {
+                return _streamHeaderLength +
+                    CurrentSegment * (_segmentHeaderLength + _segmentFooterLength) -
+                    _segmentFooterLength;
+            }
+        }
+        set
+        {
+            Argument.AssertInRange(value, 0, Length, nameof(value));
+            if (value < _streamHeaderLength)
+            {
+                _currentRegion = SMRegion.StreamHeader;
+                _currentRegionPosition = (int)value;
+                _innerStream.Position = 0;
+                return;
+            }
+            if (value >= Length - _streamFooterLength)
+            {
+                _currentRegion = SMRegion.StreamFooter;
+                _currentRegionPosition = (int)(value - (Length - _streamFooterLength));
+                _innerStream.Position = _innerStream.Length;
+                return;
+            }
+            int segmentPosition = (int)(Position - _streamHeaderLength -
+                ((CurrentSegment - 1) * (_segmentHeaderLength + _segmentFooterLength + _segmentContentLength)));
+
+            if (segmentPosition < _segmentHeaderLength)
+            {
+                _currentRegion = SMRegion.SegmentHeader;
+                _currentRegionPosition = (int)((value - _streamHeaderLength) % SegmentTotalLength);
+                _innerStream.Position = (CurrentSegment - 1) * _segmentContentLength;
+                return;
+            }
+            if (segmentPosition < _segmentHeaderLength + _segmentContentLength)
+            {
+                _currentRegion = SMRegion.SegmentContent;
+                _currentRegionPosition = (int)((value - _streamHeaderLength) % SegmentTotalLength) -
+                    _segmentHeaderLength;
+                _innerStream.Position = (CurrentSegment - 1) * _segmentContentLength + _currentRegionPosition;
+                return;
+            }
+
+            _currentRegion = SMRegion.SegmentFooter;
+            _currentRegionPosition = (int)((value - _streamHeaderLength) % SegmentTotalLength) -
+                    _segmentHeaderLength - _segmentContentLength;
+            _innerStream.Position = CurrentSegment * _segmentContentLength;
+        }
+    }
+    #endregion
+
+    public StructuredMessageEncodingStream(
+        Stream innerStream,
+        int segmentContentLength,
+        StructuredMessage.Flags flags)
+    {
+        Argument.AssertNotNull(innerStream, nameof(innerStream));
+        if (innerStream.GetLengthOrDefault() == default)
+        {
+            throw new ArgumentException("Stream must have known length.", nameof(innerStream));
+        }
+        if (innerStream.Position != 0)
+        {
+            throw new ArgumentException("Stream must be at starting position.", nameof(innerStream));
+        }
+        // stream logic likely breaks down with segment length of 1; enforce >=2 rather than just positive number
+        // real world scenarios will probably use a minimum of tens of KB
+        Argument.AssertInRange(segmentContentLength, 2, int.MaxValue, nameof(segmentContentLength));
+
+        _innerStream = innerStream;
+        _segmentContentLength = segmentContentLength;
+        _flags = flags;
+
+        _streamHeaderLength = StructuredMessage.V1_0.StreamHeaderLength;
+        _streamFooterLength =
+            (flags.HasFlag(StructuredMessage.Flags.MD5Stream)
+                ? StructuredMessage.MD5Length : 0) +
+            (flags.HasFlag(StructuredMessage.Flags.ServerStats)
+                ? StructuredMessage.V1_0.ServerStatsLength : 0);
+        _segmentHeaderLength = StructuredMessage.V1_0.SegmentHeaderLength;
+        _segmentFooterLength = (flags & StructuredMessage.Flags.CrcSegment) == StructuredMessage.Flags.CrcSegment
+            ? StructuredMessage.Crc64Length : 0;
+    }
+
+    #region Write
+    public override void Flush() => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+    #endregion
+
+    public override int Read(byte[] buffer, int offset, int count)
+        => ReadInternal(buffer, offset, count, async: false, cancellationToken: default).EnsureCompleted();
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => await ReadInternal(buffer, offset, count, async: true, cancellationToken).ConfigureAwait(false);
+
+    private async ValueTask<int> ReadInternal(byte[] buffer, int offset, int count, bool async, CancellationToken cancellationToken)
+    {
+        int totalRead = 0;
+        while (totalRead < count)
+        {
+            int subreadOffset = offset + totalRead;
+            int subreadCount = count - totalRead;
+            switch (_currentRegion)
+            {
+                case SMRegion.StreamHeader:
+                    totalRead += ReadFromStreamHeader(new Span<byte>(buffer, subreadOffset, subreadCount));
+                    break;
+                case SMRegion.StreamFooter:
+                    totalRead += ReadFromStreamFooter(new Span<byte>(buffer, subreadOffset, subreadCount));
+                    break;
+                case SMRegion.SegmentHeader:
+                    totalRead += ReadFromSegmentHeader(new Span<byte>(buffer, subreadOffset, subreadCount));
+                    break;
+                case SMRegion.SegmentFooter:
+                    totalRead += ReadFromSegmentFooter(new Span<byte>(buffer, subreadOffset, subreadCount));
+                    break;
+                case SMRegion.SegmentContent:
+                    totalRead += await ReadFromInnerStreamInternal(
+                        buffer, subreadOffset, subreadCount, async, cancellationToken).ConfigureAwait(false);
+                    // don't loop after reading underlying stream
+                    return totalRead;
+                default:
+                    break;
+            }
+        }
+        return totalRead;
+    }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    public override int Read(Span<byte> buffer)
+    {
+        int totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            switch (_currentRegion)
+            {
+                case SMRegion.StreamHeader:
+                    totalRead += ReadFromStreamHeader(buffer.Slice(totalRead));
+                    break;
+                case SMRegion.StreamFooter:
+                    totalRead += ReadFromStreamFooter(buffer.Slice(totalRead));
+                    break;
+                case SMRegion.SegmentHeader:
+                    totalRead += ReadFromSegmentHeader(buffer.Slice(totalRead));
+                    break;
+                case SMRegion.SegmentFooter:
+                    totalRead += ReadFromSegmentFooter(buffer.Slice(totalRead));
+                    break;
+                case SMRegion.SegmentContent:
+                    totalRead += ReadFromInnerStream(buffer.Slice(totalRead));
+                    // don't loop after reading underlying stream
+                    return totalRead;
+                default:
+                    break;
+            }
+        }
+        return totalRead;
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        int totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            switch (_currentRegion)
+            {
+                case SMRegion.StreamHeader:
+                    totalRead += ReadFromStreamHeader(buffer.Slice(totalRead).Span);
+                    break;
+                case SMRegion.StreamFooter:
+                    totalRead += ReadFromStreamFooter(buffer.Slice(totalRead).Span);
+                    break;
+                case SMRegion.SegmentHeader:
+                    totalRead += ReadFromSegmentHeader(buffer.Slice(totalRead).Span);
+                    break;
+                case SMRegion.SegmentFooter:
+                    totalRead += ReadFromSegmentFooter(buffer.Slice(totalRead).Span);
+                    break;
+                case SMRegion.SegmentContent:
+                    totalRead += await ReadFromInnerStreamAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(false);
+                    // don't loop after reading underlying stream
+                    return totalRead;
+                default:
+                    break;
+            }
+        }
+        return totalRead;
+    }
+#endif
+
+    #region Read Headers/Footers
+    private int ReadFromStreamHeader(Span<byte> buffer)
+    {
+        int read = Math.Min(buffer.Length, _streamHeaderLength - _currentRegionPosition);
+        using IDisposable _ = StructuredMessage.V1_0.GetStreamHeaderBytes(
+            Length, _flags, TotalSegments, ArrayPool<byte>.Shared, out Memory<byte> headerBytes);
+        headerBytes.Slice(_currentRegionPosition, read).Span.CopyTo(buffer);
+        _currentRegionPosition += read;
+
+        if (_currentRegionPosition == _streamHeaderLength)
+        {
+            _currentRegion = SMRegion.SegmentHeader;
+            _currentRegionPosition = 0;
+        }
+
+        return read;
+    }
+
+    private int ReadFromStreamFooter(Span<byte> buffer)
+    {
+        int read = Math.Min(buffer.Length, _streamFooterLength - _currentRegionPosition);
+        using IDisposable _ = StructuredMessage.V1_0.GetStreamFooterBytes(
+            ArrayPool<byte>.Shared,
+            out Memory<byte> headerBytes,
+            md5: _flags.HasFlag(StructuredMessage.Flags.MD5Stream) ? new byte[StructuredMessage.MD5Length] : default, // TODO
+            serverStats: _flags.HasFlag(StructuredMessage.Flags.ServerStats) ? new byte[StructuredMessage.V1_0.ServerStatsLength] : default); // TODO);
+        headerBytes.Slice(_currentRegionPosition, read).Span.CopyTo(buffer);
+        _currentRegionPosition += read;
+
+        if (_currentRegionPosition == _streamFooterLength)
+        {
+            // end of stream, no need to change _currentRegion
+            _currentRegionPosition = 0;
+        }
+
+        return read;
+    }
+
+    private int ReadFromSegmentHeader(Span<byte> buffer)
+    {
+        int read = Math.Min(buffer.Length, _segmentHeaderLength - _currentRegionPosition);
+        using IDisposable _ = StructuredMessage.V1_0.GetSegmentHeaderBytes(
+            _segmentContentLength, CurrentSegment, ArrayPool<byte>.Shared, out Memory<byte> headerBytes);
+        headerBytes.Slice(_currentRegionPosition, read).Span.CopyTo(buffer);
+        _currentRegionPosition += read;
+
+        if (_currentRegionPosition == _segmentHeaderLength)
+        {
+            _currentRegion = SMRegion.SegmentContent;
+            _currentRegionPosition = 0;
+        }
+
+        return read;
+    }
+
+    private int ReadFromSegmentFooter(Span<byte> buffer)
+    {
+        int read = Math.Min(buffer.Length, _segmentFooterLength - _currentRegionPosition);
+        using IDisposable _ = StructuredMessage.V1_0.GetSegmentFooterBytes(
+            ArrayPool<byte>.Shared, out Memory<byte> headerBytes, crc64: default);
+        headerBytes.Slice(_currentRegionPosition, read).Span.CopyTo(buffer);
+        _currentRegionPosition += read;
+
+        if (_currentRegionPosition == _segmentFooterLength)
+        {
+            _currentRegion = _innerStream.Position == _innerStream.Length
+                ? SMRegion.StreamFooter : SMRegion.SegmentHeader;
+            _currentRegionPosition = 0;
+        }
+
+        return read;
+    }
+    #endregion
+
+    #region ReadUnderlyingStream
+    private int MaxInnerStreamRead => _segmentContentLength - _currentRegionPosition;
+
+    private void CleanupContentSegment()
+    {
+        if (_currentRegionPosition == _segmentContentLength)
+        {
+            _currentRegion = SMRegion.SegmentFooter;
+            _currentRegionPosition = 0;
+        }
+    }
+
+    private async ValueTask<int> ReadFromInnerStreamInternal(
+        byte[] buffer, int offset, int count, bool async, CancellationToken cancellationToken)
+    {
+        int read = async
+            ? await _innerStream.ReadAsync(buffer, offset, Math.Min(count, MaxInnerStreamRead)).ConfigureAwait(false)
+            : _innerStream.Read(buffer, offset, Math.Min(count, MaxInnerStreamRead));
+        _currentRegionPosition += read;
+        CleanupContentSegment();
+        return read;
+    }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    private int ReadFromInnerStream(Span<byte> buffer)
+    {
+        if (MaxInnerStreamRead < buffer.Length)
+        {
+            buffer = buffer.Slice(0, MaxInnerStreamRead);
+        }
+        int read = _innerStream.Read(buffer);
+        _currentRegionPosition += read;
+        CleanupContentSegment();
+        return read;
+    }
+
+    private async ValueTask<int> ReadFromInnerStreamAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        if (MaxInnerStreamRead < buffer.Length)
+        {
+            buffer = buffer.Slice(0, MaxInnerStreamRead);
+        }
+        int read = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        _currentRegionPosition += read;
+        CleanupContentSegment();
+        return read;
+    }
+#endif
+#endregion
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        switch (origin)
+        {
+            case SeekOrigin.Begin:
+                Position = offset;
+                break;
+            case SeekOrigin.Current:
+                Position += offset;
+                break;
+            case SeekOrigin.End:
+                Position  = Length + offset;
+                break;
+        }
+        return Position;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _innerStream.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -45,6 +45,8 @@
     <Compile Include="$(AzureStorageSharedSources)StorageServerTimeoutPolicy.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageWriteStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StreamExtensions.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StructuredMessage.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)StructuredMessageEncodingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" LinkBase="Shared" />
   </ItemGroup>
   <!-- Ensure an empty TestConfigurations.xml is always present so the build can copy it -->

--- a/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ExpectContinueTests.cs
@@ -135,6 +135,7 @@ namespace Azure.Storage.Tests
         public async Task ThrottlePolicyRevertsAfterBackoff()
         {
             TimeSpan backoff = TimeSpan.FromMilliseconds(10);
+            TimeSpan waitForBackoff = TimeSpan.FromMilliseconds(200);
             ExpectContinueOnThrottlePolicy policy = new()
             {
                 ThrottleInterval = backoff,
@@ -162,7 +163,7 @@ namespace Azure.Storage.Tests
             policy.OnReceivedResponse(message2);
 
             // wait out policy backoff
-            await Task.Delay(backoff);
+            await Task.Delay(waitForBackoff);
 
             // message3 doesn't get expect header
             HttpMessage message3 = new(MakeRequest(), null);

--- a/sdk/storage/Azure.Storage.Common/tests/StructuredMessageEncodingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StructuredMessageEncodingStreamTests.cs
@@ -5,35 +5,48 @@ using System;
 using System.IO;
 using Azure.Storage.Shared;
 using NUnit.Framework;
+using static Azure.Storage.Shared.StructuredMessage;
 
 namespace Azure.Storage.Tests
 {
     public class StructuredMessageEncodingStreamTests
     {
         [Test]
-        public void EncodesDataSingleSegment()
+        public void EncodesDataSingleSegment([Values(Flags.None, Flags.CrcSegment)] int flags)
         {
-            const int ExpectedHeaderExpansion = StructuredMessage.V1_0.StreamHeaderLength + StructuredMessage.V1_0.SegmentHeaderLength;
+            const int expectedHeaderLen = V1_0.StreamHeaderLength + V1_0.SegmentHeaderLength;
+            int expectedFooterLen = ((Flags)flags).HasFlag(Flags.CrcSegment) ? Crc64Length : 0;
+
             byte[] data = new byte[1024];
             new Random().NextBytes(data);
-            byte[] expectedOpening = new byte[ExpectedHeaderExpansion];
-            StructuredMessage.V1_0.WriteStreamHeader(
-                new Span<byte>(expectedOpening, 0, StructuredMessage.V1_0.StreamHeaderLength),
-                messageLength: data.Length + ExpectedHeaderExpansion,
-                StructuredMessage.Flags.None,
+            byte[] expectedHeader = new byte[expectedHeaderLen];
+            byte[] expectedFooter = new byte[expectedFooterLen];
+            V1_0.WriteStreamHeader(
+                new Span<byte>(expectedHeader, 0, V1_0.StreamHeaderLength),
+                messageLength: data.Length + expectedHeaderLen + expectedFooterLen,
+                (Flags)flags,
                 totalSegments: 1);
-            StructuredMessage.V1_0.WriteSegmentHeader(
-                new Span<byte>(expectedOpening, StructuredMessage.V1_0.StreamHeaderLength, StructuredMessage.V1_0.SegmentHeaderLength),
+            V1_0.WriteSegmentHeader(
+                new Span<byte>(expectedHeader, V1_0.StreamHeaderLength, V1_0.SegmentHeaderLength),
                 segmentNum: 1,
                 segmentLength: 1024);
+            if (((Flags)flags).HasFlag(Flags.CrcSegment))
+            {
+                V1_0.WriteSegmentFooter(expectedFooter, new byte[Crc64Length]); // TODO actual crc
+            }
 
-            Stream encodingStream = new StructuredMessageEncodingStream(new MemoryStream(data), 1024, StructuredMessage.Flags.None);
+            Stream encodingStream = new StructuredMessageEncodingStream(new MemoryStream(data), 1024, (Flags)flags);
             MemoryStream dest = new();
             encodingStream.CopyTo(dest);
             byte[] encodedData = dest.ToArray();
 
-            Assert.That(encodedData.Length, Is.EqualTo(data.Length + ExpectedHeaderExpansion));
-            Assert.That(new Span<byte>(encodedData, 0, ExpectedHeaderExpansion).SequenceEqual(expectedOpening), Is.True);
+            Assert.That(encodedData.Length, Is.EqualTo(data.Length + expectedHeaderLen + expectedFooterLen));
+            Assert.That(new Span<byte>(encodedData, 0, expectedHeaderLen).SequenceEqual(expectedHeader), Is.True);
+            if (((Flags)flags).HasFlag(Flags.CrcSegment))
+            {
+                Assert.That(new Span<byte>(encodedData, expectedHeaderLen + data.Length, expectedFooterLen)
+                    .SequenceEqual(expectedFooter), Is.True);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/StructuredMessageEncodingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StructuredMessageEncodingStreamTests.cs
@@ -2,51 +2,177 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Azure.Storage.Shared;
 using NUnit.Framework;
 using static Azure.Storage.Shared.StructuredMessage;
 
 namespace Azure.Storage.Tests
 {
+    [TestFixture(ReadMethod.SyncArray)]
+    [TestFixture(ReadMethod.AsyncArray)]
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    [TestFixture(ReadMethod.SyncSpan)]
+    [TestFixture(ReadMethod.AsyncMemory)]
+#endif
     public class StructuredMessageEncodingStreamTests
     {
-        [Test]
-        public void EncodesDataSingleSegment([Values(Flags.None, Flags.CrcSegment)] int flags)
+        // Cannot just implement as passthru in the stream
+        // Must test each one
+        public enum ReadMethod
         {
-            const int expectedHeaderLen = V1_0.StreamHeaderLength + V1_0.SegmentHeaderLength;
-            int expectedFooterLen = ((Flags)flags).HasFlag(Flags.CrcSegment) ? Crc64Length : 0;
+            SyncArray,
+            AsyncArray,
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            SyncSpan,
+            AsyncMemory
+#endif
+        }
 
-            byte[] data = new byte[1024];
+        public ReadMethod Method { get; }
+
+        public StructuredMessageEncodingStreamTests(ReadMethod method)
+        {
+            Method = method;
+        }
+
+        private async ValueTask CopyStream(Stream source, Stream destination, int bufferSize = 81920) // number default for CopyTo impl
+        {
+            byte[] buf = new byte[bufferSize];
+            int read;
+            switch (Method)
+            {
+                case ReadMethod.SyncArray:
+                    while ((read = source.Read(buf, 0, bufferSize)) > 0)
+                    {
+                        destination.Write(buf, 0, read);
+                    }
+                    break;
+                case ReadMethod.AsyncArray:
+                    while ((read = await source.ReadAsync(buf, 0, bufferSize)) > 0)
+                    {
+                        await destination.WriteAsync(buf, 0, read);
+                    }
+                    break;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+                case ReadMethod.SyncSpan:
+                    while ((read = source.Read(new Span<byte>(buf))) > 0)
+                    {
+                        destination.Write(new Span<byte>(buf, 0, read));
+                    }
+                    break;
+                case ReadMethod.AsyncMemory:
+                    while ((read = await source.ReadAsync(new Memory<byte>(buf))) > 0)
+                    {
+                        await destination.WriteAsync(new Memory<byte>(buf, 0, read));
+                    }
+                    break;
+#endif
+            }
+            destination.Flush();
+        }
+
+        [Test]
+        [Combinatorial]
+        public async Task EncodesDataSingleSegment(
+            [Values(Flags.None, Flags.CrcSegment)] int flagsInt,
+            [Values(1024, 1001)] int dataLength)
+        {
+            Flags flags = (Flags)flagsInt;
+            const int expectedHeaderLen = V1_0.StreamHeaderLength + V1_0.SegmentHeaderLength;
+            int expectedFooterLen = flags.HasFlag(Flags.CrcSegment) ? Crc64Length : 0;
+
+            byte[] data = new byte[dataLength];
             new Random().NextBytes(data);
             byte[] expectedHeader = new byte[expectedHeaderLen];
             byte[] expectedFooter = new byte[expectedFooterLen];
             V1_0.WriteStreamHeader(
                 new Span<byte>(expectedHeader, 0, V1_0.StreamHeaderLength),
                 messageLength: data.Length + expectedHeaderLen + expectedFooterLen,
-                (Flags)flags,
+                flags,
                 totalSegments: 1);
             V1_0.WriteSegmentHeader(
                 new Span<byte>(expectedHeader, V1_0.StreamHeaderLength, V1_0.SegmentHeaderLength),
                 segmentNum: 1,
-                segmentLength: 1024);
-            if (((Flags)flags).HasFlag(Flags.CrcSegment))
+                segmentLength: dataLength);
+            if (flags.HasFlag(Flags.CrcSegment))
             {
                 V1_0.WriteSegmentFooter(expectedFooter, new byte[Crc64Length]); // TODO actual crc
             }
 
-            Stream encodingStream = new StructuredMessageEncodingStream(new MemoryStream(data), 1024, (Flags)flags);
+            Stream encodingStream = new StructuredMessageEncodingStream(new MemoryStream(data), 1024, flags);
             MemoryStream dest = new();
-            encodingStream.CopyTo(dest);
+            await CopyStream(encodingStream, dest);
             byte[] encodedData = dest.ToArray();
 
             Assert.That(encodedData.Length, Is.EqualTo(data.Length + expectedHeaderLen + expectedFooterLen));
             Assert.That(new Span<byte>(encodedData, 0, expectedHeaderLen).SequenceEqual(expectedHeader), Is.True);
-            if (((Flags)flags).HasFlag(Flags.CrcSegment))
+            if (flags.HasFlag(Flags.CrcSegment))
             {
                 Assert.That(new Span<byte>(encodedData, expectedHeaderLen + data.Length, expectedFooterLen)
                     .SequenceEqual(expectedFooter), Is.True);
             }
+        }
+
+        [Test]
+        [Combinatorial]
+        public async Task EncodesDataMultiSegment(
+            [Values(Flags.None, Flags.CrcSegment)] int flagsInt,
+            [Values(2048, 2005)] int dataLength)
+        {
+            const int segmentLength = 512;
+            const int expectedNumSegments = 4;
+            Flags flags = (Flags)flagsInt;
+            int expectedSegFooterLen = flags.HasFlag(Flags.CrcSegment) ? Crc64Length : 0;
+            int expectedEncodedDataLen = V1_0.StreamHeaderLength +
+                (expectedNumSegments * (V1_0.SegmentHeaderLength + expectedSegFooterLen))
+                + dataLength;
+
+            byte[] data = new byte[dataLength];
+            new Random().NextBytes(data);
+
+            Stream encodingStream = new StructuredMessageEncodingStream(new MemoryStream(data), segmentLength, flags);
+            MemoryStream dest = new();
+            await CopyStream(encodingStream, dest);
+            byte[] encodedData = dest.ToArray();
+
+            Assert.That(encodedData.Length, Is.EqualTo(expectedEncodedDataLen));
+            AssertExpectedStreamHeader(new Span<byte>(encodedData, 0, V1_0.StreamHeaderLength),
+                dataLength, flags, expectedNumSegments);
+            foreach (int segNum in Enumerable.Range(1, expectedNumSegments))
+            {
+                int segOffset = V1_0.StreamHeaderLength + ((segNum - 1) * (V1_0.SegmentHeaderLength + segmentLength + expectedSegFooterLen));
+                int segContentLength = Math.Min(segmentLength, dataLength - ((segNum-1) * segmentLength));
+                AssertExpectedSegmentHeader(new Span<byte>(encodedData, segOffset, V1_0.SegmentHeaderLength), segNum, segContentLength);
+                Assert.That(new Span<byte>(encodedData, segOffset + V1_0.SegmentHeaderLength, segContentLength)
+                    .SequenceEqual(new Span<byte>(data, (segNum - 1) * segmentLength, segContentLength)), Is.True);
+                if (flags.HasFlag(Flags.CrcSegment))
+                {
+                    Assert.That(new Span<byte>(encodedData, segOffset + V1_0.SegmentHeaderLength + segContentLength, Crc64Length)
+                        .SequenceEqual(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }), Is.True); // TODO
+                }
+            }
+        }
+
+        private static void AssertExpectedStreamHeader(ReadOnlySpan<byte> actual, int originalDataLength, Flags flags, int expectedSegments)
+        {
+            int expectedFooterLen = flags.HasFlag(Flags.CrcSegment) ? Crc64Length : 0;
+
+            Assert.That(actual.Length, Is.EqualTo(V1_0.StreamHeaderLength));
+            Assert.That(actual[0], Is.EqualTo(1));
+            Assert.That(BinaryPrimitives.ReadInt64LittleEndian(actual.Slice(1, 8)),
+                Is.EqualTo(V1_0.StreamHeaderLength + expectedSegments * (V1_0.SegmentHeaderLength + expectedFooterLen) + originalDataLength));
+            Assert.That(BinaryPrimitives.ReadInt16LittleEndian(actual.Slice(9, 2)), Is.EqualTo((short)flags));
+            Assert.That(BinaryPrimitives.ReadInt16LittleEndian(actual.Slice(11, 2)), Is.EqualTo((short)expectedSegments));
+        }
+
+        private static void AssertExpectedSegmentHeader(ReadOnlySpan<byte> actual, int segmentNum, long contentLength)
+        {
+            Assert.That(BinaryPrimitives.ReadInt16LittleEndian(actual.Slice(0, 2)), Is.EqualTo((short) segmentNum));
+            Assert.That(BinaryPrimitives.ReadInt64LittleEndian(actual.Slice(2, 8)), Is.EqualTo(contentLength));
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/StructuredMessageEncodingStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StructuredMessageEncodingStreamTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using Azure.Storage.Shared;
+using NUnit.Framework;
+
+namespace Azure.Storage.Tests
+{
+    public class StructuredMessageEncodingStreamTests
+    {
+        [Test]
+        public void EncodesDataSingleSegment()
+        {
+            const int ExpectedHeaderExpansion = StructuredMessage.V1_0.StreamHeaderLength + StructuredMessage.V1_0.SegmentHeaderLength;
+            byte[] data = new byte[1024];
+            new Random().NextBytes(data);
+            byte[] expectedOpening = new byte[ExpectedHeaderExpansion];
+            StructuredMessage.V1_0.WriteStreamHeader(
+                new Span<byte>(expectedOpening, 0, StructuredMessage.V1_0.StreamHeaderLength),
+                messageLength: data.Length + ExpectedHeaderExpansion,
+                StructuredMessage.Flags.None,
+                totalSegments: 1);
+            StructuredMessage.V1_0.WriteSegmentHeader(
+                new Span<byte>(expectedOpening, StructuredMessage.V1_0.StreamHeaderLength, StructuredMessage.V1_0.SegmentHeaderLength),
+                segmentNum: 1,
+                segmentLength: 1024);
+
+            Stream encodingStream = new StructuredMessageEncodingStream(new MemoryStream(data), 1024, StructuredMessage.Flags.None);
+            MemoryStream dest = new();
+            encodingStream.CopyTo(dest);
+            byte[] encodedData = dest.ToArray();
+
+            Assert.That(encodedData.Length, Is.EqualTo(data.Length + ExpectedHeaderExpansion));
+            Assert.That(new Span<byte>(encodedData, 0, ExpectedHeaderExpansion).SequenceEqual(expectedOpening), Is.True);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/StructuredMessageTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StructuredMessageTests.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using NUnit.Framework;
+using static Azure.Storage.Shared.StructuredMessage;
+
+namespace Azure.Storage.Tests
+{
+    public class StructuredMessageTests
+    {
+        [TestCase(1024, Flags.None, 2)]
+        [TestCase(2000, Flags.CrcSegment, 4)]
+        public void EncodeStreamHeader(int messageLength, int flags, int numSegments)
+        {
+            Span<byte> encoding = new(new byte[V1_0.StreamHeaderLength]);
+            V1_0.WriteStreamHeader(encoding, messageLength, (Flags)flags, numSegments);
+
+            Assert.That(encoding[0], Is.EqualTo((byte)1));
+            Assert.That(BinaryPrimitives.ReadUInt64LittleEndian(encoding.Slice(1, 8)), Is.EqualTo(messageLength));
+            Assert.That(BinaryPrimitives.ReadUInt16LittleEndian(encoding.Slice(9, 2)), Is.EqualTo(flags));
+            Assert.That(BinaryPrimitives.ReadUInt16LittleEndian(encoding.Slice(11, 2)), Is.EqualTo(numSegments));
+        }
+
+        [TestCase(V1_0.StreamHeaderLength)]
+        [TestCase(V1_0.StreamHeaderLength + 1)]
+        [TestCase(V1_0.StreamHeaderLength - 1)]
+        public void EncodeStreamHeaderRejectBadBufferSize(int bufferSize)
+        {
+            Random r = new();
+            byte[] encoding = new byte[bufferSize];
+
+            void Action() => V1_0.WriteStreamHeader(encoding, r.Next(2, int.MaxValue), Flags.CrcSegment, r.Next(2, int.MaxValue));
+            if (bufferSize < V1_0.StreamHeaderLength)
+            {
+                Assert.That(Action, Throws.ArgumentException);
+            }
+            else
+            {
+                Assert.That(Action, Throws.Nothing);
+            }
+        }
+
+        [TestCase(1, 1024)]
+        [TestCase(5, 39578)]
+        public void EncodeSegmentHeader(int segmentNum, int contentLength)
+        {
+            Span<byte> encoding = new(new byte[V1_0.SegmentHeaderLength]);
+            V1_0.WriteSegmentHeader(encoding, segmentNum, contentLength);
+
+            Assert.That(BinaryPrimitives.ReadUInt16LittleEndian(encoding.Slice(0, 2)), Is.EqualTo(segmentNum));
+            Assert.That(BinaryPrimitives.ReadUInt64LittleEndian(encoding.Slice(2, 8)), Is.EqualTo(contentLength));
+        }
+
+        [TestCase(V1_0.SegmentHeaderLength)]
+        [TestCase(V1_0.SegmentHeaderLength + 1)]
+        [TestCase(V1_0.SegmentHeaderLength - 1)]
+        public void EncodeSegmentHeaderRejectBadBufferSize(int bufferSize)
+        {
+            Random r = new();
+            byte[] encoding = new byte[bufferSize];
+
+            void Action() => V1_0.WriteSegmentHeader(encoding, r.Next(1, int.MaxValue), r.Next(2, int.MaxValue));
+            if (bufferSize < V1_0.SegmentHeaderLength)
+            {
+                Assert.That(Action, Throws.ArgumentException);
+            }
+            else
+            {
+                Assert.That(Action, Throws.Nothing);
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void EncodeSegmentFooter(bool useCrc)
+        {
+            Span<byte> encoding = new(new byte[Crc64Length]);
+            Span<byte> crc = useCrc ? new Random().NextBytesInline(Crc64Length) : default;
+            V1_0.WriteSegmentFooter(encoding, crc);
+
+            if (useCrc)
+            {
+                Assert.That(encoding.SequenceEqual(crc), Is.True);
+            }
+            else
+            {
+                Assert.That(encoding.SequenceEqual(new Span<byte>(new byte[Crc64Length])), Is.True);
+            }
+        }
+
+        [TestCase(Crc64Length)]
+        [TestCase(Crc64Length + 1)]
+        [TestCase(Crc64Length - 1)]
+        public void EncodeSegmentFooterRejectBadBufferSize(int bufferSize)
+        {
+            byte[] encoding = new byte[bufferSize];
+            byte[] crc = new byte[Crc64Length];
+            new Random().NextBytes(crc);
+
+            void Action() => V1_0.WriteSegmentFooter(encoding, crc);
+            if (bufferSize < Crc64Length)
+            {
+                Assert.That(Action, Throws.ArgumentException);
+            }
+            else
+            {
+                Assert.That(Action, Throws.Nothing);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements the spec for encoding a structured message. Supports encoding through a Stream in read mode.

- Separately implements netstandard 2.0 and 2.1 read methods
- Prevents seeking past latest read position, ensuring proper CRC calculation but allowing for rewind in the case of a retry
- Supports an overall stream footer, but there is currently no content for it.