### PR TITLE
Rename profiling.session to profile_id_experimental

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/Profiling/ProfilingSessionTraceProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/Profiling/ProfilingSessionTraceProcessor.cs
@@ -19,7 +19,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.Profiling
         /// </summary>
         /// <remarks>
         /// Experimental until formalization of OTEP profiles data format.
-        /// See https://github.com/open-telemetry/oteps/pull/239.
+        /// See <see href="https://github.com/open-telemetry/oteps/pull/239" />.
         /// </remarks>
         internal const string TagName = "profile_id_experimental";
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/Profiling/ProfilingSessionTraceProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Internals/Profiling/ProfilingSessionTraceProcessor.cs
@@ -17,7 +17,11 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Internals.Profiling
         /// Name of the Tag (and subsequent OpenTelemetry attribute) that
         /// records the profiling session ID.
         /// </summary>
-        internal const string TagName = "profiling.session";
+        /// <remarks>
+        /// Experimental until formalization of OTEP profiles data format.
+        /// See https://github.com/open-telemetry/oteps/pull/239.
+        /// </remarks>
+        internal const string TagName = "profile_id_experimental";
 
         /// <inheritdoc/>
         public override void OnEnd(Activity activity)


### PR DESCRIPTION
The [OTEP proposal for profiling](https://github.com/open-telemetry/oteps/pull/239) uses `profile_id` to represent the profile file.
To align with that, we'll use the name `profile_id_experimental` until that proposal is formalized.