### PR TITLE
[Search] Add a sample to show case how to use SessionId to create sticky sessions

### DIFF
--- a/sdk/search/Azure.Search.Documents/CHANGELOG.md
+++ b/sdk/search/Azure.Search.Documents/CHANGELOG.md
@@ -8,8 +8,6 @@
 ### Bugs Fixed
 - Removed the unintentional addition of the abstract keyword to the `KnowledgeStoreProjectionSelector` and `KnowledgeStoreStorageProjectionSelector` types.
 
-### Other Changes
-
 ## 11.6.0-beta.1 (2024-01-17)
 
 ### Features Added

--- a/sdk/search/Azure.Search.Documents/CHANGELOG.md
+++ b/sdk/search/Azure.Search.Documents/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Release History
 
-## 11.6.0-beta.2 (Unreleased)
+## 11.6.0-beta.2 (2024-02-05)
 
 ### Features Added
-
-### Breaking Changes
+- Publicly exposed HttpPipeline for all search clients.
 
 ### Bugs Fixed
+- Removed the unintentional addition of the abstract keyword to the `KnowledgeStoreProjectionSelector` and `KnowledgeStoreStorageProjectionSelector` types.
 
 ### Other Changes
 

--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -3469,8 +3469,12 @@ namespace Azure.Search.Documents.Models
         public static Azure.Search.Documents.Indexes.Models.SearchIndexStatistics SearchIndexStatistics(long documentCount = (long)0, long storageSize = (long)0, long vectorIndexSize = (long)0) { throw null; }
         public static Azure.Search.Documents.Indexes.Models.SearchResourceCounter SearchResourceCounter(long usage, long? quota) { throw null; }
         public static Azure.Search.Documents.Models.SearchResultsPage<T> SearchResultsPage<T>(Azure.Search.Documents.Models.SearchResults<T> results) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Search.Documents.Models.SearchResults<T> SearchResults<T>(System.Collections.Generic.IEnumerable<Azure.Search.Documents.Models.SearchResult<T>> values, long? totalCount, System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<Azure.Search.Documents.Models.FacetResult>> facets, double? coverage, Azure.Response rawResponse) { throw null; }
+        public static Azure.Search.Documents.Models.SearchResults<T> SearchResults<T>(System.Collections.Generic.IEnumerable<Azure.Search.Documents.Models.SearchResult<T>> values, long? totalCount, System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<Azure.Search.Documents.Models.FacetResult>> facets, double? coverage, Azure.Response rawResponse, Azure.Search.Documents.Models.SemanticSearchResults semanticSearch) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Search.Documents.Models.SearchResult<T> SearchResult<T>(T document, double? score, System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>> highlights) { throw null; }
+        public static Azure.Search.Documents.Models.SearchResult<T> SearchResult<T>(T document, double? score, System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>> highlights, Azure.Search.Documents.Models.SemanticSearchResult semanticSearch) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.Search.Documents.Indexes.Models.SearchServiceCounters SearchServiceCounters(Azure.Search.Documents.Indexes.Models.SearchResourceCounter documentCounter, Azure.Search.Documents.Indexes.Models.SearchResourceCounter indexCounter, Azure.Search.Documents.Indexes.Models.SearchResourceCounter indexerCounter, Azure.Search.Documents.Indexes.Models.SearchResourceCounter dataSourceCounter, Azure.Search.Documents.Indexes.Models.SearchResourceCounter storageSizeCounter, Azure.Search.Documents.Indexes.Models.SearchResourceCounter synonymMapCounter) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -3482,6 +3486,8 @@ namespace Azure.Search.Documents.Models
         public static Azure.Search.Documents.Indexes.Models.SearchServiceStatistics SearchServiceStatistics(Azure.Search.Documents.Indexes.Models.SearchServiceCounters counters, Azure.Search.Documents.Indexes.Models.SearchServiceLimits limits) { throw null; }
         public static Azure.Search.Documents.Models.SearchSuggestion<T> SearchSuggestion<T>(T document, string text) { throw null; }
         public static Azure.Search.Documents.Models.SemanticDebugInfo SemanticDebugInfo(Azure.Search.Documents.Models.QueryResultDocumentSemanticField titleField = null, System.Collections.Generic.IEnumerable<Azure.Search.Documents.Models.QueryResultDocumentSemanticField> contentFields = null, System.Collections.Generic.IEnumerable<Azure.Search.Documents.Models.QueryResultDocumentSemanticField> keywordFields = null, Azure.Search.Documents.Models.QueryResultDocumentRerankerInput rerankerInput = null) { throw null; }
+        public static Azure.Search.Documents.Models.SemanticSearchResult SemanticSearchResult(double? rerankerScore, System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.QueryCaptionResult> captions) { throw null; }
+        public static Azure.Search.Documents.Models.SemanticSearchResults SemanticSearchResults(System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.QueryAnswerResult> answers, Azure.Search.Documents.Models.SemanticErrorReason? errorReason, Azure.Search.Documents.Models.SemanticSearchResultsType? resultsType) { throw null; }
         public static Azure.Search.Documents.Indexes.Models.SimilarityAlgorithm SimilarityAlgorithm(string oDataType) { throw null; }
         public static Azure.Search.Documents.Models.SuggestResults<T> SuggestResults<T>(System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.SearchSuggestion<T>> results, double? coverage) { throw null; }
         public static Azure.Search.Documents.Indexes.Models.TokenFilter TokenFilter(string oDataType, string name) { throw null; }
@@ -3606,13 +3612,13 @@ namespace Azure.Search.Documents.Models
     }
     public partial class SemanticSearchResult
     {
-        public SemanticSearchResult() { }
+        internal SemanticSearchResult() { }
         public System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.QueryCaptionResult> Captions { get { throw null; } }
         public double? RerankerScore { get { throw null; } }
     }
     public partial class SemanticSearchResults
     {
-        public SemanticSearchResults() { }
+        internal SemanticSearchResults() { }
         public System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.QueryAnswerResult> Answers { get { throw null; } }
         public Azure.Search.Documents.Models.SemanticErrorReason? ErrorReason { get { throw null; } }
         public Azure.Search.Documents.Models.SemanticSearchResultsType? ResultsType { get { throw null; } }

--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -3612,13 +3612,13 @@ namespace Azure.Search.Documents.Models
     }
     public partial class SemanticSearchResult
     {
-        internal SemanticSearchResult() { }
+        public SemanticSearchResult() { }
         public System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.QueryCaptionResult> Captions { get { throw null; } }
         public double? RerankerScore { get { throw null; } }
     }
     public partial class SemanticSearchResults
     {
-        internal SemanticSearchResults() { }
+        public SemanticSearchResults() { }
         public System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.QueryAnswerResult> Answers { get { throw null; } }
         public Azure.Search.Documents.Models.SemanticErrorReason? ErrorReason { get { throw null; } }
         public Azure.Search.Documents.Models.SemanticSearchResultsType? ResultsType { get { throw null; } }

--- a/sdk/search/Azure.Search.Documents/assets.json
+++ b/sdk/search/Azure.Search.Documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/search/Azure.Search.Documents",
-  "Tag": "net/search/Azure.Search.Documents_3d6cfbeb64"
+  "Tag": "net/search/Azure.Search.Documents_e768c1243b"
 }

--- a/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch_UsingSemanticHybridQuery.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch_UsingSemanticHybridQuery.md
@@ -132,7 +132,7 @@ public static Hotel[] GetHotelDocuments()
             Description = "Cheapest hotel in town. Infact, a motel.",
             DescriptionVector = GetEmbeddings("Cheapest hotel in town. Infact, a motel."),
             Category = "Budget",
-            CategoryVector = GetEmbeddings("Luxury")
+            CategoryVector = GetEmbeddings("Budget")
         },
         // Add more hotel documents here...
     };

--- a/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch_UsingVectorizableTextQuery.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch_UsingVectorizableTextQuery.md
@@ -130,7 +130,7 @@ public static Hotel[] GetHotelDocuments()
             Description = "Cheapest hotel in town. Infact, a motel.",
             DescriptionVector = GetEmbeddings("Cheapest hotel in town. Infact, a motel."),
             Category = "Budget",
-            CategoryVector = GetEmbeddings("Luxury")
+            CategoryVector = GetEmbeddings("Budget")
         },
         // Add more hotel documents here...
     };

--- a/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch_UsingVectorizedQuery.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample07_VectorSearch_UsingVectorizedQuery.md
@@ -114,7 +114,7 @@ public static Hotel[] GetHotelDocuments()
             Description = "Cheapest hotel in town. Infact, a motel.",
             DescriptionVector = GetEmbeddings("Cheapest hotel in town. Infact, a motel."),
             Category = "Budget",
-            CategoryVector = GetEmbeddings("Luxury")
+            CategoryVector = GetEmbeddings("Budget")
         },
         // Add more hotel documents here...
     };

--- a/sdk/search/Azure.Search.Documents/samples/Sample09_QuerySession.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample09_QuerySession.md
@@ -8,29 +8,18 @@ AzureKeyCredential credential = new AzureKeyCredential(Environment.GetEnvironmen
 string indexName = Environment.GetEnvironmentVariable("SEARCH_INDEX");
 
 SearchClient searchClient = new SearchClient(endpoint, indexName, credential);
-SearchResults<Hotel> results = await searchClient.SearchAsync<Hotel>(
+SearchResults<Hotel> response = await searchClient.SearchAsync<Hotel>(
         new SearchOptions
         {
             Filter = "Rating gt 2",
             SessionId = "Session-1"
         });
 
-int totalDocsCount = 0;
-int pageCount = 0;
-await foreach (Page<SearchResult<Hotel>> page in results.GetResultsAsync().AsPages())
+await foreach (SearchResult<Hotel> result in response.GetResultsAsync())
 {
-    pageCount++;
-    foreach (SearchResult<Hotel> result in page.Values)
-    {
-        totalDocsCount++;
-
-        Hotel hotel = result.Document;
-        Console.WriteLine($"{hotel.HotelName} ({hotel.HotelId})");
-    }
+    Hotel hotel = result.Document;
+    Console.WriteLine($"{hotel.HotelName} ({hotel.HotelId})");
 }
-
-Console.WriteLine($"Number of documents retrieved: {totalDocsCount}");
-Console.WriteLine($"Total page count: {pageCount}");
 ```
 
 By consistently using the same sessionId, the system makes a best-effort attempt to target the same replica, improving the overall consistency of search results for users within the specified session. This approach is useful for scenarios where maintaining result consistency throughout a user's session is essential. For more details, please refer the [documentation](https://learn.microsoft.com/azure/search/index-similarity-and-scoring#scoring-statistics-and-sticky-sessions).

--- a/sdk/search/Azure.Search.Documents/samples/Sample09_QuerySession.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample09_QuerySession.md
@@ -33,4 +33,4 @@ Console.WriteLine($"Number of documents retrieved: {totalDocsCount}");
 Console.WriteLine($"Total page count: {pageCount}");
 ```
 
-By consistently using the same sessionId, the system makes a best-effort attempt to target the same replica, improving the overall consistency of search results for users within the specified session. This approach is useful for scenarios where maintaining result consistency throughout a user's session is essential. For more details, please refer the [documentation](https://learn.microsoft.com/en-us/azure/search/index-similarity-and-scoring#scoring-statistics-and-sticky-sessions).
+By consistently using the same sessionId, the system makes a best-effort attempt to target the same replica, improving the overall consistency of search results for users within the specified session. This approach is useful for scenarios where maintaining result consistency throughout a user's session is essential. For more details, please refer the [documentation](https://learn.microsoft.com/azure/search/index-similarity-and-scoring#scoring-statistics-and-sticky-sessions).

--- a/sdk/search/Azure.Search.Documents/samples/Sample09_QuerySession.md
+++ b/sdk/search/Azure.Search.Documents/samples/Sample09_QuerySession.md
@@ -1,0 +1,36 @@
+# Azure.Search.Documents Samples - Query Session
+
+To ensure more consistent and unique search results within a user's session, you can use session id. Simply include the sessionId parameter in your queries to create a unique identifier for each user session. This ensures a uniform experience for users throughout their "query session".
+
+```C# Snippet:Azure_Search_Tests_Samples_QuerySession
+Uri endpoint = new Uri(Environment.GetEnvironmentVariable("SEARCH_ENDPOINT"));
+AzureKeyCredential credential = new AzureKeyCredential(Environment.GetEnvironmentVariable("SEARCH_API_KEY"));
+string indexName = Environment.GetEnvironmentVariable("SEARCH_INDEX");
+
+SearchClient searchClient = new SearchClient(endpoint, indexName, credential);
+SearchResults<Hotel> results = await searchClient.SearchAsync<Hotel>(
+        new SearchOptions
+        {
+            Filter = "Rating gt 2",
+            SessionId = "Session-1"
+        });
+
+int totalDocsCount = 0;
+int pageCount = 0;
+await foreach (Page<SearchResult<Hotel>> page in results.GetResultsAsync().AsPages())
+{
+    pageCount++;
+    foreach (SearchResult<Hotel> result in page.Values)
+    {
+        totalDocsCount++;
+
+        Hotel hotel = result.Document;
+        Console.WriteLine($"{hotel.HotelName} ({hotel.HotelId})");
+    }
+}
+
+Console.WriteLine($"Number of documents retrieved: {totalDocsCount}");
+Console.WriteLine($"Total page count: {pageCount}");
+```
+
+By consistently using the same sessionId, the system makes a best-effort attempt to target the same replica, improving the overall consistency of search results for users within the specified session. This approach is useful for scenarios where maintaining result consistency throughout a user's session is essential. For more details, please refer the [documentation](https://learn.microsoft.com/en-us/azure/search/index-similarity-and-scoring#scoring-statistics-and-sticky-sessions).

--- a/sdk/search/Azure.Search.Documents/src/Models/SearchResult.cs
+++ b/sdk/search/Azure.Search.Documents/src/Models/SearchResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
@@ -168,6 +169,20 @@ namespace Azure.Search.Documents.Models
     /// </summary>
     public class SemanticSearchResult
     {
+        /// <summary> Initializes a new instance of <see cref="SemanticSearchResult"/>. </summary>
+        internal SemanticSearchResult()
+        {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="SemanticSearchResult"/>. </summary>
+        /// <param name="rerankerScore"> The relevance score computed by the semantic ranker for the top search results. </param>
+        /// <param name="captions"> Captions are the most representative passages from the document relatively to the search query. </param>
+        internal SemanticSearchResult(double? rerankerScore, IReadOnlyList<QueryCaptionResult> captions)
+        {
+            RerankerScore = rerankerScore;
+            Captions = captions;
+        }
+
         /// <summary>
         /// The relevance score computed by the semantic ranker for the top search results.
         /// <para>Search results are sorted by the <see cref="RerankerScore"/> first and then by the <see cref="SearchResult{T}.Score"/>.
@@ -200,6 +215,7 @@ namespace Azure.Search.Documents.Models
         /// was not enabled for the query.
         /// </param>
         /// <returns>A new SearchResult instance for mocking.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static SearchResult<T> SearchResult<T>(
             T document,
             double? score,
@@ -208,6 +224,46 @@ namespace Azure.Search.Documents.Models
             {
                 Score = score,
                 Highlights = highlights,
-                Document = document };
+                Document = document
+            };
+
+        /// <summary> Initializes a new instance of SearchResult. </summary>
+        /// <typeparam name="T">
+        /// The .NET type that maps to the index schema. Instances of this type can
+        /// be retrieved as documents from the index.
+        /// </typeparam>
+        /// <param name="document">The document found by the search query.</param>
+        /// <param name="score">
+        /// The relevance score of the document compared to other documents
+        /// returned by the query.
+        /// </param>
+        /// <param name="highlights">
+        /// Text fragments from the document that indicate the matching search
+        /// terms, organized by each applicable field; null if hit highlighting
+        /// was not enabled for the query.
+        /// </param>
+        /// <param name="semanticSearch">The semantic search result.</param>
+        /// <returns>A new SearchResult instance for mocking.</returns>
+        public static SearchResult<T> SearchResult<T>(
+            T document,
+            double? score,
+            IDictionary<string, IList<string>> highlights,
+            SemanticSearchResult semanticSearch) =>
+            new SearchResult<T>()
+            {
+                Score = score,
+                Highlights = highlights,
+                Document = document,
+                SemanticSearch = semanticSearch
+            };
+
+        /// <summary> Initializes a new instance of <see cref="SemanticSearchResult"/>. </summary>
+        /// <param name="rerankerScore"> The relevance score computed by the semantic ranker for the top search results. </param>
+        /// <param name="captions"> Captions are the most representative passages from the document relatively to the search query. </param>
+        /// <returns> A new <see cref="Models.SemanticSearchResult"/> instance for mocking. </returns>
+        public static SemanticSearchResult SemanticSearchResult(
+            double? rerankerScore,
+            IReadOnlyList<QueryCaptionResult> captions) =>
+          new SemanticSearchResult(rerankerScore, captions);
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Models/SearchResult.cs
+++ b/sdk/search/Azure.Search.Documents/src/Models/SearchResult.cs
@@ -170,7 +170,7 @@ namespace Azure.Search.Documents.Models
     public class SemanticSearchResult
     {
         /// <summary> Initializes a new instance of <see cref="SemanticSearchResult"/>. </summary>
-        internal SemanticSearchResult()
+        public SemanticSearchResult()
         {
         }
 

--- a/sdk/search/Azure.Search.Documents/src/Models/SearchResult.cs
+++ b/sdk/search/Azure.Search.Documents/src/Models/SearchResult.cs
@@ -169,20 +169,6 @@ namespace Azure.Search.Documents.Models
     /// </summary>
     public class SemanticSearchResult
     {
-        /// <summary> Initializes a new instance of <see cref="SemanticSearchResult"/>. </summary>
-        public SemanticSearchResult()
-        {
-        }
-
-        /// <summary> Initializes a new instance of <see cref="SemanticSearchResult"/>. </summary>
-        /// <param name="rerankerScore"> The relevance score computed by the semantic ranker for the top search results. </param>
-        /// <param name="captions"> Captions are the most representative passages from the document relatively to the search query. </param>
-        internal SemanticSearchResult(double? rerankerScore, IReadOnlyList<QueryCaptionResult> captions)
-        {
-            RerankerScore = rerankerScore;
-            Captions = captions;
-        }
-
         /// <summary>
         /// The relevance score computed by the semantic ranker for the top search results.
         /// <para>Search results are sorted by the <see cref="RerankerScore"/> first and then by the <see cref="SearchResult{T}.Score"/>.
@@ -264,6 +250,10 @@ namespace Azure.Search.Documents.Models
         public static SemanticSearchResult SemanticSearchResult(
             double? rerankerScore,
             IReadOnlyList<QueryCaptionResult> captions) =>
-          new SemanticSearchResult(rerankerScore, captions);
+          new SemanticSearchResult()
+          {
+              RerankerScore = rerankerScore,
+              Captions = captions
+          };
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Models/SearchResults.cs
+++ b/sdk/search/Azure.Search.Documents/src/Models/SearchResults.cs
@@ -283,22 +283,6 @@ namespace Azure.Search.Documents.Models
     /// </summary>
     public class SemanticSearchResults
     {
-        /// <summary> Initializes a new instance of <see cref="SemanticSearchResults"/>. </summary>
-        public SemanticSearchResults()
-        {
-        }
-
-        /// <summary> Initializes a new instance of <see cref="SemanticSearchResults"/>. </summary>
-        /// <param name="answers"> The answers query results for the search operation. </param>
-        /// <param name="errorReason"> Reason that a partial response was returned for a semantic search request. </param>
-        /// <param name="resultsType"> Type of partial response that was returned for a semantic search request. </param>
-        internal SemanticSearchResults(IReadOnlyList<QueryAnswerResult> answers, SemanticErrorReason? errorReason, SemanticSearchResultsType? resultsType)
-        {
-            Answers = answers;
-            ErrorReason = errorReason;
-            ResultsType = resultsType;
-        }
-
         /// <summary> The answers query results for the search operation;
         /// <c>null</c> if the <see cref="QueryAnswer.AnswerType"/> parameter was not specified or set to <see cref="QueryAnswerType.None"/>. </summary>
         public IReadOnlyList<QueryAnswerResult> Answers { get; internal set; }
@@ -519,7 +503,12 @@ namespace Azure.Search.Documents.Models
             IReadOnlyList<QueryAnswerResult> answers,
             SemanticErrorReason? errorReason,
             SemanticSearchResultsType? resultsType) =>
-            new SemanticSearchResults(answers, errorReason, resultsType);
+            new SemanticSearchResults()
+            {
+                Answers = answers,
+                ErrorReason = errorReason,
+                ResultsType = resultsType
+            };
 
         /// <summary> Initializes a new instance of SearchResultsPage. </summary>
         /// <typeparam name="T">

--- a/sdk/search/Azure.Search.Documents/src/Models/SearchResults.cs
+++ b/sdk/search/Azure.Search.Documents/src/Models/SearchResults.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
@@ -282,6 +283,22 @@ namespace Azure.Search.Documents.Models
     /// </summary>
     public class SemanticSearchResults
     {
+        /// <summary> Initializes a new instance of <see cref="SemanticSearchResults"/>. </summary>
+        internal SemanticSearchResults()
+        {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="SemanticSearchResults"/>. </summary>
+        /// <param name="answers"> The answers query results for the search operation. </param>
+        /// <param name="errorReason"> Reason that a partial response was returned for a semantic search request. </param>
+        /// <param name="resultsType"> Type of partial response that was returned for a semantic search request. </param>
+        internal SemanticSearchResults(IReadOnlyList<QueryAnswerResult> answers, SemanticErrorReason? errorReason, SemanticSearchResultsType? resultsType)
+        {
+            Answers = answers;
+            ErrorReason = errorReason;
+            ResultsType = resultsType;
+        }
+
         /// <summary> The answers query results for the search operation;
         /// <c>null</c> if the <see cref="QueryAnswer.AnswerType"/> parameter was not specified or set to <see cref="QueryAnswerType.None"/>. </summary>
         public IReadOnlyList<QueryAnswerResult> Answers { get; internal set; }
@@ -442,6 +459,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="coverage">A value indicating the percentage of the index that was included in the query</param>
         /// <param name="rawResponse">The raw Response that obtained these results from the service.</param>
         /// <returns>A new SearchResults instance for mocking.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static SearchResults<T> SearchResults<T>(
             IEnumerable<SearchResult<T>> values,
             long? totalCount,
@@ -459,6 +477,49 @@ namespace Azure.Search.Documents.Models
             results.Values.AddRange(values);
             return results;
         }
+
+        /// <summary> Initializes a new instance of SearchResults. </summary>
+        /// <typeparam name="T">
+        /// The .NET type that maps to the index schema. Instances of this type can
+        /// be retrieved as documents from the index.
+        /// </typeparam>
+        /// <param name="values">The search result values.</param>
+        /// <param name="totalCount">The total count of results found by the search operation.</param>
+        /// <param name="facets">The facet query results for the search operation.</param>
+        /// <param name="coverage">A value indicating the percentage of the index that was included in the query</param>
+        /// <param name="rawResponse">The raw Response that obtained these results from the service.</param>
+        /// <param name="semanticSearch">The semantic search result.</param>
+        /// <returns>A new SearchResults instance for mocking.</returns>
+        public static SearchResults<T> SearchResults<T>(
+            IEnumerable<SearchResult<T>> values,
+            long? totalCount,
+            IDictionary<string, IList<FacetResult>> facets,
+            double? coverage,
+            Response rawResponse,
+            SemanticSearchResults semanticSearch)
+        {
+            var results = new SearchResults<T>()
+            {
+                TotalCount = totalCount,
+                Coverage = coverage,
+                Facets = facets,
+                RawResponse = rawResponse,
+                SemanticSearch = semanticSearch
+            };
+            results.Values.AddRange(values);
+            return results;
+        }
+
+        /// <summary> Initializes a new instance of <see cref="SemanticSearchResults"/>. </summary>
+        /// <param name="answers"> The answers query results for the search operation. </param>
+        /// <param name="errorReason"> Reason that a partial response was returned for a semantic search request. </param>
+        /// <param name="resultsType"> Type of partial response that was returned for a semantic search request. </param>
+        /// <returns> A new <see cref="Models.SemanticSearchResults"/> instance for mocking. </returns>
+        public static SemanticSearchResults SemanticSearchResults(
+            IReadOnlyList<QueryAnswerResult> answers,
+            SemanticErrorReason? errorReason,
+            SemanticSearchResultsType? resultsType) =>
+            new SemanticSearchResults(answers, errorReason, resultsType);
 
         /// <summary> Initializes a new instance of SearchResultsPage. </summary>
         /// <typeparam name="T">

--- a/sdk/search/Azure.Search.Documents/src/Models/SearchResults.cs
+++ b/sdk/search/Azure.Search.Documents/src/Models/SearchResults.cs
@@ -284,7 +284,7 @@ namespace Azure.Search.Documents.Models
     public class SemanticSearchResults
     {
         /// <summary> Initializes a new instance of <see cref="SemanticSearchResults"/>. </summary>
-        internal SemanticSearchResults()
+        public SemanticSearchResults()
         {
         }
 

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
@@ -466,5 +466,62 @@ namespace Azure.Search.Documents.Tests.Samples
             Console.WriteLine($"Search index {indexName} has {count.Value} documents.");
             #endregion Snippet:Azure_Search_Tests_Samples_GetCountAsync
         }
+
+        [Test]
+        public async Task QuerySession()
+        {
+            const int size = 150;
+            await using SearchResources resources = await SearchResources.CreateLargeHotelsIndexAsync(this, size, false, true);
+            Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
+            Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
+            Environment.SetEnvironmentVariable("SEARCH_INDEX", resources.IndexName);
+
+            HashSet<string> uniqueDocuments = new HashSet<string>();
+            bool hasDuplicates = false;
+
+            #region Snippet:Azure_Search_Tests_Samples_QuerySession
+            Uri endpoint = new Uri(Environment.GetEnvironmentVariable("SEARCH_ENDPOINT"));
+            AzureKeyCredential credential = new AzureKeyCredential(Environment.GetEnvironmentVariable("SEARCH_API_KEY"));
+            string indexName = Environment.GetEnvironmentVariable("SEARCH_INDEX");
+
+            SearchClient searchClient = new SearchClient(endpoint, indexName, credential);
+#if !SNIPPET
+            searchClient = InstrumentClient(new SearchClient(endpoint, indexName, credential, GetSearchClientOptions()));
+#endif
+            SearchResults<Hotel> results = await searchClient.SearchAsync<Hotel>(
+                    new SearchOptions
+                    {
+                        Filter = "Rating gt 2",
+                        SessionId = "Session-1"
+                    });
+
+            int totalDocsCount = 0;
+            int pageCount = 0;
+            await foreach (Page<SearchResult<Hotel>> page in results.GetResultsAsync().AsPages())
+            {
+                pageCount++;
+                foreach (SearchResult<Hotel> result in page.Values)
+                {
+                    totalDocsCount++;
+
+                    Hotel hotel = result.Document;
+#if !SNIPPET
+                    if (!uniqueDocuments.Add(hotel.HotelId))
+                    {
+                        hasDuplicates = true;
+                    }
+#endif
+                    Console.WriteLine($"{hotel.HotelName} ({hotel.HotelId})");
+                }
+            }
+
+            Console.WriteLine($"Number of documents retrieved: {totalDocsCount}");
+            Console.WriteLine($"Total page count: {pageCount}");
+            #endregion Snippet:Azure_Search_Tests_Samples_QuerySession
+
+            Assert.False(hasDuplicates, "Duplicate documents found.");
+            Assert.LessOrEqual(totalDocsCount, 150);
+            Assert.GreaterOrEqual(pageCount, 2);
+        }
     }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample01_HelloWorld.cs
@@ -488,40 +488,27 @@ namespace Azure.Search.Documents.Tests.Samples
 #if !SNIPPET
             searchClient = InstrumentClient(new SearchClient(endpoint, indexName, credential, GetSearchClientOptions()));
 #endif
-            SearchResults<Hotel> results = await searchClient.SearchAsync<Hotel>(
+            SearchResults<Hotel> response = await searchClient.SearchAsync<Hotel>(
                     new SearchOptions
                     {
                         Filter = "Rating gt 2",
                         SessionId = "Session-1"
                     });
 
-            int totalDocsCount = 0;
-            int pageCount = 0;
-            await foreach (Page<SearchResult<Hotel>> page in results.GetResultsAsync().AsPages())
+            await foreach (SearchResult<Hotel> result in response.GetResultsAsync())
             {
-                pageCount++;
-                foreach (SearchResult<Hotel> result in page.Values)
-                {
-                    totalDocsCount++;
-
-                    Hotel hotel = result.Document;
+                Hotel hotel = result.Document;
 #if !SNIPPET
-                    if (!uniqueDocuments.Add(hotel.HotelId))
-                    {
-                        hasDuplicates = true;
-                    }
-#endif
-                    Console.WriteLine($"{hotel.HotelName} ({hotel.HotelId})");
+                if (!uniqueDocuments.Add(hotel.HotelId))
+                {
+                    hasDuplicates = true;
                 }
+#endif
+                Console.WriteLine($"{hotel.HotelName} ({hotel.HotelId})");
             }
-
-            Console.WriteLine($"Number of documents retrieved: {totalDocsCount}");
-            Console.WriteLine($"Total page count: {pageCount}");
             #endregion Snippet:Azure_Search_Tests_Samples_QuerySession
 
             Assert.False(hasDuplicates, "Duplicate documents found.");
-            Assert.LessOrEqual(totalDocsCount, 150);
-            Assert.GreaterOrEqual(pageCount, 2);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample07_VectorSearchCommons.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample07_VectorSearchCommons.cs
@@ -68,7 +68,7 @@ namespace Azure.Search.Documents.Tests.Samples.VectorSearch
 #if !SNIPPET
                     CategoryVector = VectorSearchEmbeddings.BudgetVectorizeCategory
 #else
-                    CategoryVector = GetEmbeddings("Luxury")
+                    CategoryVector = GetEmbeddings("Budget")
 #endif
                 },
 #if !SNIPPET

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
@@ -308,7 +308,8 @@ namespace Azure.Search.Documents.Tests
             }
             else
             {
-                hotels = hotelIds.Select(id => new SearchDocument { ["hotelId"] = id }).ToList();
+                Random random = new();
+                hotels = hotelIds.Select(id => new SearchDocument { ["hotelId"] = id, ["rating"] = random.Next(1, 6) }).ToList();
             }
 
             // Upload the empty hotels in batches of 1000 until we're complete


### PR DESCRIPTION
This PR includes the following:
* A sample to show case how to use SessionId to create sticky sessions. Fixes: https://github.com/Azure/azure-sdk-for-net/issues/41413
* Missing parameters in `SearchModelFactory.SearchResults<T>` and `SearchModelFactory.SearchResult<T>` for mocking. Fixes: https://github.com/Azure/azure-sdk-for-net/issues/39196
