### PR TITLE
OpenAI: CHANGELOG updates for pending beta releases

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI.Assistants/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2024-02-01)
 
 ### Features Added
 

--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release History
 
-## 1.0.0-beta.13 (Unreleased)
-
-### Features Added
+## 1.0.0-beta.13 (2024-02-01)
 
 ### Breaking Changes
 
@@ -11,8 +9,6 @@
 ### Bugs Fixed
 
 - Addressed an issue with the public constructor for `ChatCompletionsFunctionToolCall` that failed to set the tool call type in the corresponding request.
-
-### Other Changes
 
 ## 1.0.0-beta.12 (2023-12-15)
 


### PR DESCRIPTION
This is the combined flush of `prepare-release.ps1` output for OpenAI library updates; we're doing this concurrently purely as an opportunistic measure:

- beta.1 for Azure.AI.OpenAI.Assistants will be the first, brand-new release of the .NET library for OpenAI Assistants
- beta.13 for Azure.AI.OpenAI is an incremental bug-fix update -- this is not yet the update for new preview features, but we want to get the important bug fix for function tool calling into public packages