### PR TITLE
Azure OpenAI Assistants: CI (yaml) update for pipeline artifact

### DIFF
--- a/sdk/openai/ci.yml
+++ b/sdk/openai/ci.yml
@@ -33,3 +33,5 @@ extends:
     Artifacts:
     - name: Azure.AI.OpenAI
       safeName: AzureAIOpenAI
+    - name: Azure.AI.OpenAI.Assistants
+      safeName: AzureAIOpenAIAssistants


### PR DESCRIPTION
This very small change adds a distinct entry into the pipeline artifact definition for the `sdk\openai` CI import. The change achieves parity with the `Azure.AI.OpenAI` inference library and is intended to permit discrete release of the standalone Assistants library within the same service/feature tree.