### PR TITLE
[AzureMonitorExporter] small refactor

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -13,9 +11,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class RemoteDependencyData
     {
-        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes
-        internal static readonly HashSet<string?> s_sqlDbs = new HashSet<string?>() { "mssql" };
-
         public RemoteDependencyData(int version, Activity activity, ref ActivityTagsProcessor activityTagsProcessor) : base(version)
         {
             string? dependencyName = null;
@@ -99,7 +94,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Data = dbAttributeTagObjects[0]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Data_MaxLength);
             var (DbName, DbTarget) = dbTagObjects.GetDbDependencyTargetAndName();
             Target = DbTarget?.Truncate(SchemaConstants.RemoteDependencyData_Target_MaxLength);
-            Type = s_sqlDbs.Contains(dbAttributeTagObjects[1]?.ToString()) ? "SQL" : dbAttributeTagObjects[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
+            Type = AzMonListExtensions.s_dbSystems.Contains(dbAttributeTagObjects[1]?.ToString()) ? "SQL" : dbAttributeTagObjects[1]?.ToString().Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
 
             // special case for db.name
             var sanitizedDbName = DbName?.Truncate(SchemaConstants.KVP_MaxValueLength);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/RemoteDependencyData.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Globalization;
-
 using Azure.Core;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -15,6 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         /// Recognized database systems.
         /// <see href="https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md#connection-level-attributes"/>.
         /// </summary>
+        // TODO: This single item HashSet is used to map "mssql" to "SQL". This could be replaced with a helper method.
         internal static readonly HashSet<string?> s_dbSystems = new HashSet<string?>() { "mssql" };
 
         ///<summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
@@ -10,6 +11,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal static class AzMonListExtensions
     {
+        /// <summary>
+        /// Recognized database systems.
+        /// <see href="https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md#connection-level-attributes"/>.
+        /// </summary>
+        internal static readonly HashSet<string?> s_dbSystems = new HashSet<string?>() { "mssql" };
+
         ///<summary>
         /// Gets http request url from activity tag objects.
         ///</summary>
@@ -382,7 +389,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 case OperationType.Db:
                     {
                         var dbSystem = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString();
-                        return RemoteDependencyData.s_sqlDbs.Contains(dbSystem) ? "SQL" : dbSystem?.Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
+                        return AzMonListExtensions.s_dbSystems.Contains(dbSystem) ? "SQL" : dbSystem?.Truncate(SchemaConstants.RemoteDependencyData_Type_MaxLength);
                     }
                 case OperationType.Rpc:
                     {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzMonListExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/OperationType.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/OperationType.cs
@@ -16,6 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         Http = 16,
         Messaging = 32,
         Rpc = 64,
+        // TODO: "V2" is no longer needed and should be removed.
         // TODO: https://github.com/Azure/azure-sdk-for-net/pull/37357/files#r1253383825
         // Check if V2 could be moved outside of this Enum.
         V2 = 128

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/RemoteDependencyDataTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
 
             var remoteDependencyDataType = new RemoteDependencyData(2, activity, ref activityTagsProcessor).Type;
-            var expectedType = RemoteDependencyData.s_sqlDbs.Contains(dbSystem) ? "SQL" : dbSystem;
+            var expectedType = AzMonListExtensions.s_dbSystems.Contains(dbSystem) ? "SQL" : dbSystem;
 
             Assert.Equal(expectedType, remoteDependencyDataType);
         }


### PR DESCRIPTION
My other PR is getting large so I'm pulling out some smaller changes.
This PR does some minor cleanup in the Exporter project.

### Changes
- LiveMetrics needs to use the `ActivityTagsProcessor` class. This has a dependency on a static HashSet in the `RemoteDependencyData` model. It's not appropriate to import the Exporter's models into LiveMetrics, so I'm moving this HashSet to a different extensions class.
- left some minor todos. We should rewrite some parts. Left a TODO to save that for another day.